### PR TITLE
Exclude query parameters from mparticle request

### DIFF
--- a/src/serverModel.js
+++ b/src/serverModel.js
@@ -279,7 +279,8 @@ export default function ServerModel(mpInstance) {
             dto.fr = isFirstRun;
             dto.iu = false;
             dto.at = ApplicationTransitionType.AppInit;
-            dto.lr = window.location.href || null;
+            // Note(colin) exclude query parameters
+            dto.lr = window.location.href.split("?")[0] || null;
             dto.attrs = null;
         }
 


### PR DESCRIPTION
## Summary
Per security request, https://github.com/postmates/buyer-frontend/issues/5313, we need to exclude query parameters from mparticle requests. Mparticle is working on adding a configuration option for this, but we will fork and self-host the SDK until this configuration option is available. 
