### PR TITLE
feat: Allow scope param on user alias requests

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -192,6 +192,7 @@ export default function Identity(mpInstance) {
                     source_mpid: aliasRequest.sourceMpid,
                     start_unixtime_ms: aliasRequest.startTime,
                     end_unixtime_ms: aliasRequest.endTime,
+                    scope: aliasRequest.scope,
                     device_application_stamp: mpInstance._Store.deviceId,
                 },
             };

--- a/test/src/tests-identity.js
+++ b/test/src/tests-identity.js
@@ -2593,6 +2593,34 @@ describe('identity', function() {
         done();
     });
 
+    it('Alias request should include scope if specified', function(done) {
+        mockServer.requests = [];
+        var aliasRequest = {
+            destinationMpid: 1,
+            sourceMpid: 2,
+            startTime: 3,
+            endTime: 4,
+            scope: 'mpid',
+        };
+        mockServer.respondWith(urls.alias, [
+            200,
+            {},
+            JSON.stringify({}),
+        ]);
+
+        mParticle.Identity.aliasUsers(aliasRequest);
+        mockServer.requests.length.should.equal(1);
+
+        var request = mockServer.requests[0];
+        request.url.should.equal(urls.alias);
+
+        var requestBody = JSON.parse(request.requestBody);
+        var dataBody = requestBody['data'];
+        Should(dataBody['scope']).equal('mpid');
+
+        done();
+    });
+
     it('Should reject malformed Alias Requests', function(done) {
         mParticle.config.logLevel = 'verbose';
         var warnMessage = null;


### PR DESCRIPTION
## Summary
In some scenarios, it might be necessary to define the alias scope to something other than the default "device" option. This is not allowed on the web SDK at the moment, even though it is on the Identity API.

## Testing Plan
- Unit tested
- Tested on a local application that uses the SDK, with and without the scope param

I didn't change the `convertAliasToNative` method as I'm not aware if the native clients support this param.

## Questions
- What else needs change? Docs, TypeScript types, etc.
- Can someone review the TS type definitions? https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54813