### PR TITLE
ci: update semantic release Node version to 16.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           - name: Setup Node.js
             uses: actions/setup-node@v1
             with:
-              node-version: 12.x
+              node-version: 16.x
 
           - name: Install dependencies
             run: npm ci


### PR DESCRIPTION
## Summary
Update semantic release Node version from 12.x to 16.x
