### PR TITLE
ci: update indentation and job name in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,111 +20,111 @@ jobs:
     # the dist/ folder. Finally, the internal/release branch is merged back into public/master and syned back to internal/master
     # and internal/development before deleting the temporary internal/release branch.
 
-    create-release-branch:
-        name: Create release branch
-        runs-on: ubuntu-18.04
-        needs: confirm-master-branch
-        steps:
-          - name: Checkout internal development branch
-            uses: actions/checkout@v2
-            with:
-              repository: mparticle/mparticle-web-sdk-internal
-              token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-              ref: development
+  create-release-branch:
+      name: Create release branch
+      runs-on: ubuntu-18.04
+      needs: confirm-master-branch
+      steps:
+        - name: Checkout internal development branch
+          uses: actions/checkout@v2
+          with:
+            repository: mparticle/mparticle-web-sdk-internal
+            token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+            ref: development
 
-          - name: Create and push release branch to internal repository
-            run: |
-              git checkout -b release/${{ github.run_number }}
-              git push origin release/${{ github.run_number }}
+        - name: Create and push release branch to internal repository
+          run: |
+            git checkout -b release/${{ github.run_number }}
+            git push origin release/${{ github.run_number }}
 
-    release:
-        name: Perform Release
-        runs-on: ubuntu-18.04
-        needs: create-release-branch
-        env:
-          GIT_AUTHOR_NAME: mparticle-bot
-          GIT_AUTHOR_EMAIL: developers@mparticle.com
-          GIT_COMMITTER_NAME: mparticle-bot
-          GIT_COMMITTER_EMAIL: developers@mparticle.com
+  release:
+      name: Perform Release
+      runs-on: ubuntu-18.04
+      needs: create-release-branch
+      env:
+        GIT_AUTHOR_NAME: mparticle-bot
+        GIT_AUTHOR_EMAIL: developers@mparticle.com
+        GIT_COMMITTER_NAME: mparticle-bot
+        GIT_COMMITTER_EMAIL: developers@mparticle.com
 
-        steps:
-          - name: Checkout public master branch
-            uses: actions/checkout@v2
-            with:
-              fetch-depth: 0
-              repository: ${{ github.repository }}
-              token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-              ref: master
+      steps:
+        - name: Checkout public master branch
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            repository: ${{ github.repository }}
+            token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+            ref: master
 
-          - name: Merge internal release branch into public master branch
-            run: |
-              git remote add internal https://${{ secrets.MP_SEMANTIC_RELEASE_BOT }}@github.com/mparticle/mparticle-web-sdk-internal.git
-              git pull internal release/${{ github.run_number }}
+        - name: Merge internal release branch into public master branch
+          run: |
+            git remote add internal https://${{ secrets.MP_SEMANTIC_RELEASE_BOT }}@github.com/mparticle/mparticle-web-sdk-internal.git
+            git pull internal release/${{ github.run_number }}
 
-          - name: Setup Node.js
-            uses: actions/setup-node@v1
-            with:
-              node-version: 16.x
+        - name: Setup Node.js
+          uses: actions/setup-node@v1
+          with:
+            node-version: 16.x
 
-          - name: Install dependencies
-            run: npm ci
+        - name: Install dependencies
+          run: npm ci
 
-          - name: Run tests
-            run: npm run test
+        - name: Run tests
+          run: npm run test
 
-          - name: Release --dry-run
-            if: ${{ github.event.inputs.dryRun == 'true'}}
-            env:
-              GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-              NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-            run: |
-              npx semantic-release --dry-run
+        - name: Release --dry-run
+          if: ${{ github.event.inputs.dryRun == 'true'}}
+          env:
+            GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          run: |
+            npx semantic-release --dry-run
 
-          - name: Release
-            if: ${{ github.event.inputs.dryRun == 'false'}}
-            env:
-              GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-              NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-            run: |
-              npx semantic-release
+        - name: Release
+          if: ${{ github.event.inputs.dryRun == 'false'}}
+          env:
+            GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          run: |
+            npx semantic-release
 
-          - name: Push automated release commits to internal release branch
-            if: ${{ github.event.inputs.dryRun == 'false' }}
-            run: |
-              git status
-              git push internal HEAD:release/${{ github.run_number }}    
+        - name: Push automated release commits to internal release branch
+          if: ${{ github.event.inputs.dryRun == 'false' }}
+          run: |
+            git status
+            git push internal HEAD:release/${{ github.run_number }}    
 
-    sync-repository:
-        name: Sync internal and public repositories
-        needs: release
-        runs-on: ubuntu-18.04
-        steps:
-          - name: Checkout public master branch
-            uses: actions/checkout@v2
-            with:
-              fetch-depth: 0
-              repository: ${{ github.repository }}
-              token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-              ref: master
+  sync-repository:
+      name: Sync internal and public repositories
+      needs: release
+      runs-on: ubuntu-18.04
+      steps:
+        - name: Checkout public master branch
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            repository: ${{ github.repository }}
+            token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+            ref: master
 
-          - name: Merge internal release branch into public master branch
-            if: ${{ github.event.inputs.dryRun == 'false' }}
-            run: |
-              git remote add internal https://${{ secrets.MP_SEMANTIC_RELEASE_BOT }}@github.com/mparticle/mparticle-web-sdk-internal.git
-              git pull internal release/${{ github.run_number }}
-              
-          - name: Push release commits to public master branch
-            if: ${{ github.event.inputs.dryRun == 'false'}}
-            run: |
-              git push origin HEAD:master
+        - name: Merge internal release branch into public master branch
+          if: ${{ github.event.inputs.dryRun == 'false' }}
+          run: |
+            git remote add internal https://${{ secrets.MP_SEMANTIC_RELEASE_BOT }}@github.com/mparticle/mparticle-web-sdk-internal.git
+            git pull internal release/${{ github.run_number }}
+            
+        - name: Push release commits to public master branch
+          if: ${{ github.event.inputs.dryRun == 'false'}}
+          run: |
+            git push origin HEAD:master
 
-          - name: Push release commits to internal master and development branches
-            if: ${{ github.event.inputs.dryRun == 'false' }}
-            run: |
-              git push internal HEAD:development
-              git push internal HEAD:master
+        - name: Push release commits to internal master and development branches
+          if: ${{ github.event.inputs.dryRun == 'false' }}
+          run: |
+            git push internal HEAD:development
+            git push internal HEAD:master
 
-          - name: Delete internal release branch
-            if: ${{ github.event.inputs.dryRun == 'false' }}
-            run: |
-              git push --delete internal release/${{ github.run_number }}
+        - name: Delete internal release branch
+          if: ${{ github.event.inputs.dryRun == 'false' }}
+          run: |
+            git push --delete internal release/${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,16 @@ jobs:
     name: "Confirm release is run from public/master branch"
     uses: mParticle/mparticle-workflows/.github/workflows/sdk-release-repo-branch-check.yml@stable
   
-    # All new code is stored in internal/development. Release from public/master will first create an internal/release branch
-    # based on the changes from internal/development and push it back to the internal repo, then run semantic-release on 
-    # the internal/release branch to update changelog and release notes. Before semantic-release publishes to npm, it builds 
-    # the dist/ folder. Finally, the internal/release branch is merged back into public/master and syned back to internal/master
-    # and internal/development before deleting the temporary internal/release branch.
+  # All new code is stored in internal/development. Release from public/master will first create an internal/release branch
+  # based on the changes from internal/development and push it back to the internal repo, then run semantic-release on 
+  # the internal/release branch to update changelog and release notes. Before semantic-release publishes to npm, it builds 
+  # the dist/ folder. Finally, the internal/release branch is merged back into public/master and syned back to internal/master
+  # and internal/development before deleting the temporary internal/release branch.
 
   create-release-branch:
       name: Create release branch
       runs-on: ubuntu-18.04
-      needs: confirm-master-branch
+      needs: confirm-public-repo-master-branch
       steps:
         - name: Checkout internal development branch
           uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
This release.yml file is not running due to an indentation error.  Also updating `confirm-master-branch` --> `confirm-public-repo-master-branch` as the job name was updated but the `needs` that depends on the job didn't update its name.