### PR TITLE
ci: add archive npm logs task to workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,6 +38,13 @@ jobs:
 
             - name: Run Stub tests
               run: npm run test:stub
+              
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                name: npm-logs
+                path: ~/.npm/_logs
 
     dependabot-automerge:
         name: Rebase dependabot PRs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,13 @@ jobs:
             NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           run: |
             npx semantic-release
+            
+        - name: Archive npm failure logs
+          uses: actions/upload-artifact@v2
+          if: failure()
+          with:
+            name: npm-logs
+            path: ~/.npm/_logs
 
         - name: Push automated release commits to internal release branch
           if: ${{ github.event.inputs.dryRun == 'false' }}


### PR DESCRIPTION
## Summary
In some cases, we may have an npm error log that gets clobbered by Github Actions stdout. Github actions writes these to its file system but they can't be picked up by the UI. Archiving these logs as an artifact will allow us to pick them up.

## Testing Plan
This was tested as during sample apps development.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3626
