### PR TITLE
feat: add package to batch application info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3370,9 +3370,9 @@
             }
         },
         "@mparticle/event-models": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@mparticle/event-models/-/event-models-1.1.2.tgz",
-            "integrity": "sha512-+MH7jQRW7DrMMd0gq4fS0sbDXmIAWTYmuNZfQ/5QQvcM+vFGdukU+uztRX95LqmJcIAYwG4Qf1exoEyyAAsWyw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@mparticle/event-models/-/event-models-1.1.4.tgz",
+            "integrity": "sha512-Y4ggQqfc8nm02TxDOp3a50d/AzrfebqIMZ/cy33rmUemojW0drVp+XwT+5tR56FtCkRzuOb9OnJpwPvnEqjhdA==",
             "dev": true
         },
         "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "@babel/preset-env": "^7.6.0",
         "@babel/preset-typescript": "^7.6.0",
         "@mparticle/data-planning-models": "^0.1.0",
-        "@mparticle/event-models": "^1.1.2",
+        "@mparticle/event-models": "^1.1.4",
         "@rollup/plugin-json": "^4.1.0",
         "@semantic-release/changelog": "^5.0.1",
         "@semantic-release/exec": "^5.0.0",

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -24,7 +24,7 @@ export interface SDKEvent {
     CustomFlags?: { [key: string]: string };
     AppVersion?: string;
     AppName?: string;
-    PackageName?: string;
+    Package?: string;
     ConsentState?: SDKConsentState;
     IntegrationAttributes?: { [key: string]: { [key: string]: string } };
     ProductAction?: SDKProductAction;
@@ -145,7 +145,7 @@ export interface SDKConfig {
     };
     dataPlan: DataPlanConfig;
     appVersion?: string;
-    packageName?: string;
+    package?: string;
     flags?: { [key: string]: string | number };
     kitConfigs: any;
     appName?: string;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -24,6 +24,7 @@ export interface SDKEvent {
     CustomFlags?: { [key: string]: string };
     AppVersion?: string;
     AppName?: string;
+    PackageName?: string;
     ConsentState?: SDKConsentState;
     IntegrationAttributes?: { [key: string]: { [key: string]: string } };
     ProductAction?: SDKProductAction;
@@ -144,6 +145,7 @@ export interface SDKConfig {
     };
     dataPlan: DataPlanConfig;
     appVersion?: string;
+    packageName?: string;
     flags?: { [key: string]: string | number };
     kitConfigs: any;
     appName?: string;

--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -55,7 +55,7 @@ export function convertEvents(
         application_info: {
             application_version: lastEvent.AppVersion,
             application_name: lastEvent.AppName,
-            package: lastEvent.PackageName,
+            package: lastEvent.Package,
         },
         device_info: {
             platform: EventsApi.DeviceInformationPlatformEnum.web,

--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -55,6 +55,7 @@ export function convertEvents(
         application_info: {
             application_version: lastEvent.AppVersion,
             application_name: lastEvent.AppName,
+            package: lastEvent.PackageName,
         },
         device_info: {
             platform: EventsApi.DeviceInformationPlatformEnum.web,

--- a/src/serverModel.js
+++ b/src/serverModel.js
@@ -207,7 +207,7 @@ export default function ServerModel(mpInstance) {
                 ExpandedEventCount: 0,
                 AppVersion: mpInstance.getAppVersion(),
                 AppName: mpInstance.getAppName(),
-                PackageName: mpInstance._Store.SDKConfig.packageName,
+                Package: mpInstance._Store.SDKConfig.package,
                 ClientGeneratedId: mpInstance._Store.clientId,
                 DeviceId: mpInstance._Store.deviceId,
                 IntegrationAttributes: mpInstance._Store.integrationAttributes,

--- a/src/serverModel.js
+++ b/src/serverModel.js
@@ -207,6 +207,7 @@ export default function ServerModel(mpInstance) {
                 ExpandedEventCount: 0,
                 AppVersion: mpInstance.getAppVersion(),
                 AppName: mpInstance.getAppName(),
+                PackageName: mpInstance._Store.SDKConfig.packageName,
                 ClientGeneratedId: mpInstance._Store.clientId,
                 DeviceId: mpInstance._Store.deviceId,
                 IntegrationAttributes: mpInstance._Store.integrationAttributes,

--- a/src/store.js
+++ b/src/store.js
@@ -154,8 +154,8 @@ export default function Store(config, mpInstance) {
             this.SDKConfig.appName = config.appName;
         }
 
-        if (config.hasOwnProperty('packageName')) {
-            this.SDKConfig.packageName = config.packageName;
+        if (config.hasOwnProperty('package')) {
+            this.SDKConfig.package = config.package;
         }
 
         if (config.hasOwnProperty('integrationDelayTimeout')) {

--- a/src/store.js
+++ b/src/store.js
@@ -154,6 +154,10 @@ export default function Store(config, mpInstance) {
             this.SDKConfig.appName = config.appName;
         }
 
+        if (config.hasOwnProperty('packageName')) {
+            this.SDKConfig.packageName = config.packageName;
+        }
+
         if (config.hasOwnProperty('integrationDelayTimeout')) {
             this.SDKConfig.integrationDelayTimeout =
                 config.integrationDelayTimeout;

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -216,7 +216,7 @@ describe('core SDK', function() {
     });
 
     it('should set Package Name on Batch Payload', function (done) {
-        mParticle.config.packageName = 'my-web-package';
+        mParticle.config.package = 'my-web-package';
 
         mParticle.config.flags = {
             eventsV3: '100',

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -215,6 +215,30 @@ describe('core SDK', function() {
         done();
     });
 
+    it('should set Package Name on Batch Payload', function (done) {
+        mParticle.config.packageName = 'my-web-package';
+
+        mParticle.config.flags = {
+            eventsV3: '100',
+            eventBatchingIntervalMillis: 0,
+        }
+
+        mParticle.init(apiKey, mParticle.config);
+
+        window.fetchMock.post(
+            'https://jssdks.mparticle.com/v3/JS/test_key/events',
+            200
+        );
+
+        window.mParticle.logEvent('Test Event');
+        
+        var batch = JSON.parse(window.fetchMock.lastOptions().body);
+        
+        batch.should.have.property('application_info');
+        batch.application_info.should.have.property('package', 'my-web-package');
+        done();
+    });
+
     it('should sanitize event attributes', function(done) {
         mParticle.logEvent('sanitized event', 1, {
             key1: 'value1',


### PR DESCRIPTION
## Summary
Add Support for Bundle ID to Web SDK so that we can track Sample App or host app usage independent of workspace.

The expectation is that a user can pass in a `packageName` similar to our Native SDK and this will attach a `package` attribute to the `application_info` which can later be filtered along with `os` to determine app usage across three core platforms (Web, iOS and Android).

## Testing Plan
Manually test that web SDK continues to work with or without this new config attribute and run automated tests.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3728
