### PR TITLE
feat: add support for client side rules

### DIFF
--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -131,9 +131,16 @@ export class BatchUploader {
                 eventsBySession.set(sdkEvent.SessionId, events);
             }
             for (const entry of Array.from(eventsBySession.entries())) {
-                const upload = convertEvents(mpid, entry[1], mpInstance);
-                if (upload) {
-                    newUploads.push(upload);
+                let uploadBatchObject = convertEvents(mpid, entry[1], mpInstance);
+                const onCreateBatchCallback = mpInstance._Store.SDKConfig.onCreateBatch;
+
+                if (onCreateBatchCallback) {
+                    uploadBatchObject = onCreateBatchCallback(uploadBatchObject);
+                    uploadBatchObject.mutated = true;
+                }
+
+                if (uploadBatchObject) {
+                    newUploads.push(uploadBatchObject);
                 }
             }
         }

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -142,6 +142,7 @@ export interface SDKConfig {
         warning?(msg) 
         verbose?(msg) 
     };
+    onCreateBatch(batch: EventsApi.Batch): EventsApi.Batch;
     dataPlan: DataPlanConfig;
     appVersion?: string;
     flags?: { [key: string]: string | number };
@@ -202,6 +203,7 @@ export interface SDKConfigApi {
     v3SecureServiceUrl?: string;
     isDevelopmentMode: boolean;
     appVersion?: string;
+    onCreateBatch(batch: EventsApi.Batch): EventsApi.Batch
 }
 export interface MParticleUser {
     getMPID(): string;

--- a/src/store.js
+++ b/src/store.js
@@ -264,6 +264,18 @@ export default function Store(config, mpInstance) {
             }
         }
 
+        if (config.hasOwnProperty('onCreateBatch')) {
+            if (typeof config.onCreateBatch === 'function') {
+                this.SDKConfig.onCreateBatch = config.onCreateBatch;
+            } else {
+                mpInstance.Logger.error(
+                    'config.onCreateBatch must be a function'
+                );
+                // set to undefined because all items are set on createSDKConfig
+                this.SDKConfig.onCreateBatch = undefined;
+            }
+        }
+
         if (!config.hasOwnProperty('flags')) {
             this.SDKConfig.flags = {};
         }

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -910,6 +910,25 @@ describe('core SDK', function() {
             done();
         });
     });
+    
+    it('should add onCreateBatch to _Store.SDKConfig if onCreateBatch is provide on mParticle.config object', function(done) {
+        window.mParticle._resetForTests();
+        mParticle.config.onCreateBatch = function(batch) { return batch};
+        mParticle.init(apiKey, mParticle.config);
+        (typeof mParticle.getInstance()._Store.SDKConfig.onCreateBatch).should.equal('function');
+
+        done();
+    });
+
+    it('should not add onCreateBatch to _Store.SDKConfig if it is not a function', function(done) {
+        window.mParticle._resetForTests();
+        mParticle.config.onCreateBatch = 'not a function';
+        mParticle.init(apiKey, mParticle.config);
+
+        (typeof mParticle.getInstance()._Store.SDKConfig.onCreateBatch).should.equal('undefined');
+
+        done();
+    });
 
     it('should hit url with query parameter of env=1 for debug mode for forwarders', function(done) {
         mParticle._resetForTests(MPConfig);


### PR DESCRIPTION
## Summary
Add support for customer to mutate a batch before it gets uploaded.  This is exposed via the API `mParticle.config.onCreateBatch`.  The `batch` is passed to it before uploaded so that the developer can mutate it.  If the developer sets `onCreateBatch`, we set `batch.mutated = true`.

## Testing Plan
Add unit and integration tests.  Tested this manually via local app as well.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4036
