### PR TITLE
ci: Add NPM Scripts to compress and log bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,12 @@
         "lint": "eslint src/ test/src/",
         "gts:check": "gts check",
         "gts:fix": "gts fix",
-        "prettier": "node_modules/.bin/prettier --check \"**/*.js\""
+        "prettier": "node_modules/.bin/prettier --check \"**/*.js\"",
+        "uglify": "npx uglify-js dist/mparticle.js --output dist/mparticle.min.js",
+        "gzip": "gzip -c dist/mparticle.min.js > dist/mparticle.min.js.gz",
+        "bundle": "npm run uglify && npm run gzip",
+        "report:unbundled": "ls -lh dist/mparticle.js | awk '{print $5}'",
+        "report:bundled": "ls -lh dist/mparticle.min.js.gz | awk '{print $5}'"
     },
     "pre-commit": [
         "lint"

--- a/package.json
+++ b/package.json
@@ -58,8 +58,10 @@
         "uglify": "npx uglify-js dist/mparticle.js --output dist/mparticle.min.js",
         "gzip": "gzip -c dist/mparticle.min.js > dist/mparticle.min.js.gz",
         "bundle": "npm run uglify && npm run gzip",
-        "report:unbundled": "ls -lh dist/mparticle.js | awk '{print $5}'",
-        "report:bundled": "ls -lh dist/mparticle.min.js.gz | awk '{print $5}'"
+        "report:unbundled": "ls -l dist/mparticle.js | awk '{print $5}'",
+        "report:unbundled:human": "ls -lh dist/mparticle.js | awk '{print $5}'",
+        "report:bundled": "ls -l dist/mparticle.min.js.gz | awk '{print $5}'",
+        "report:bundled:human": "ls -lh dist/mparticle.min.js.gz | awk '{print $5}'"
     },
     "pre-commit": [
         "lint"

--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
         "uglify": "npx uglify-js dist/mparticle.js --output dist/mparticle.min.js",
         "gzip": "gzip -c dist/mparticle.min.js > dist/mparticle.min.js.gz",
         "bundle": "npm run uglify && npm run gzip",
-        "report:unbundled": "ls -l dist/mparticle.js | awk '{print $5}'",
-        "report:unbundled:human": "ls -lh dist/mparticle.js | awk '{print $5}'",
         "report:bundled": "ls -l dist/mparticle.min.js.gz | awk '{print $5}'",
         "report:bundled:human": "ls -lh dist/mparticle.min.js.gz | awk '{print $5}'"
     },


### PR DESCRIPTION
## Summary
Add NPM Scripts that will allow us to compress the js bundle and report file size to be used in a later github action

## Testing Plan
N/A

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4316
