### PR TITLE
ci: Add action to report bundle size differences

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,162 @@
+name: Report Bundle Size Difference
+
+on:
+    workflow_run:
+        workflows:
+            - Web SDK Build & Test'
+            - Release SDK
+        types:
+            - completed
+
+jobs:
+    build-master:
+        name: Get Bundle Size from Master
+        runs-on: ubuntu-latest
+
+        outputs:
+            bundledMaster: ${{ steps.set-bundled-master.outputs.bundledMaster }}
+            bundledMasterHuman: ${{ steps.set-bundled-master.outputs.bundledMasterHuman }}
+            unbundledMaster: ${{ steps.set-unbundled-master.outputs.unbundledMaster }}
+            unbundledMasterHuman: ${{ steps.set-unbundled-master.outputs.unbundledMasterHuman }}
+
+        steps:
+            - name: Checkout Master
+              uses: actions/checkout@v2
+              with:
+                  ref: master
+
+            - name: NPM install
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 16.x
+
+            - name: Run NPM CI
+              run: npm ci
+
+            - name: Build Files
+              run: npm run build
+
+            - name: Create Bundle
+              run: npm run bundle
+
+            - name: Report Size
+              run: |
+                  echo "UNBUNDLED_MASTER=$(npm run report:unbundled)" >> $GITHUB_ENV
+                  echo "UNBUNDLED_MASTER_HUMAN=$(npm run report:unbundled:human)" >> $GITHUB_ENV
+                  echo "BUNDLED_MASTER=$(npm run report:bundled)" >> $GITHUB_ENV
+                  echo "BUNDLED_MASTER_HUMAN=$(npm run report:bundled:human)" >> $GITHUB_ENV
+
+            - name: Set Master Unbundled Size
+              id: set-unbundled-master
+              run: |
+                echo "::set-output name=unbundledMaster::${{ env.UNBUNDLED_MASTER }}"
+                echo "::set-output name=unbundledMasterHuman::${{ env.UNBUNDLED_MASTER_HUMAN }}"
+
+            - name: Set Master Bundled Size
+              id: set-bundled-master
+              run: |
+                echo "::set-output name=bundledMaster::${{ env.BUNDLED_MASTER }}"
+                echo "::set-output name=bundledMasterHuman::${{ env.BUNDLED_MASTER_HUMAN }}"
+
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                  name: npm-logs
+                  path: ~/.npm/_logs
+
+    build-local:
+        name: Get Bundle Size from Current Branch
+        runs-on: ubuntu-latest
+
+        outputs:
+            bundledLocal: ${{ steps.set-bundled-local.outputs.bundledLocal }}
+            bundledLocalHuman: ${{ steps.set-bundled-local.outputs.bundledLocalHuman }}
+            unbundledLocal: ${{ steps.set-unbundled-local.outputs.unbundledLocal }}
+            unbundledLocalHuman: ${{ steps.set-unbundled-local.outputs.unbundledLocalHuman }}
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: NPM install
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 16.x
+
+            - name: Run NPM CI
+              run: npm ci
+
+            - name: Build Files
+              run: npm run build
+
+            - name: Create Bundle
+              run: npm run bundle
+
+            - name: Report Size
+              run: |
+                  npm run report:unbundled
+                  npm run report:bundled
+            - name: Report Size
+              run: |
+                  echo "UNBUNDLED_LOCAL=$(npm run report:unbundled)" >> $GITHUB_ENV
+                  echo "UNBUNDLED_LOCAL_HUMAN=$(npm run report:unbundled:human)" >> $GITHUB_ENV
+                  echo "BUNDLED_LOCAL=$(npm run report:bundled)" >> $GITHUB_ENV
+                  echo "BUNDLED_LOCAL_HUMAN=$(npm run report:bundled:human)" >> $GITHUB_ENV
+
+            - name: Set Local Unbundled Size
+              id: set-unbundled-local
+              run: |
+                echo "::set-output name=unbundledLocal::${{ env.UNBUNDLED_LOCAL }}"
+                echo "::set-output name=unbundledLocalHuman::${{ env.UNBUNDLED_LOCAL_HUMAN }}"
+
+            - name: Set Local Bundled Size
+              id: set-bundled-local
+              run: |
+                echo "::set-output name=bundledLocal::${{ env.BUNDLED_LOCAL }}"
+                echo "::set-output name=bundledLocalHuman::${{ env.BUNDLED_LOCAL_HUMAN }}"
+
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                  name: npm-logs
+                  path: ~/.npm/_logs
+
+    calculate-unbundled:
+        name: Calculate Unbundled Diff
+        uses: ./.github/workflows/calculate-difference.yml
+        needs:
+            - build-master
+            - build-local
+
+        with:
+            initial_bundle_size: ${{ needs.build-master.outputs.unbundledMaster }}
+            updated_bundle_size: ${{ needs.build-local.outputs.unbundledLocal }}
+
+    calculate-bundled:
+        name: Calculate Bundled Diff
+        uses: ./.github/workflows/calculate-difference.yml
+        needs:
+            - build-master
+            - build-local
+        with:
+            initial_bundle_size: ${{ needs.build-master.outputs.bundledMaster }}
+            updated_bundle_size: ${{ needs.build-local.outputs.bundledLocal }}
+    
+    generate-report:
+        name: Generate Report
+        runs-on: ubuntu-latest
+        needs:
+          - build-master
+          - build-local
+          - calculate-bundled
+          - calculate-unbundled
+        steps:
+          - name: Adding Markdown
+            run: |
+                echo '### Calculate Bundle Size Difference' >> $GITHUB_STEP_SUMMARY
+                echo "|  | master | ${GITHUB_REF#refs/heads/} | % changed |" >> $GITHUB_STEP_SUMMARY
+                echo "|--|--|--|--|" >> $GITHUB_STEP_SUMMARY
+                echo "| unbundled | ${{ needs.build-master.outputs.unbundledMasterHuman }} | ${{ needs.build-local.outputs.unbundledLocalHuman }} | ${{ needs.calculate-unbundled.outputs.diff_percent }} |" >> $GITHUB_STEP_SUMMARY
+                echo "| bundled | ${{ needs.build-master.outputs.bundledMasterHuman }} | ${{ needs.build-local.outputs.bundledLocalHuman }} | ${{ needs.calculate-bundled.outputs.diff_percent }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Runs a Github Action to calculate the bundled and unbundled size of mparticle.js, and then generates a report of the size changes.
- Requires #314 and #318

## Testing Plan
- Test using local Github action

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3944
