### PR TITLE
fix: Sending multiple UAC events for same value UA

### DIFF
--- a/dist/mparticle.js
+++ b/dist/mparticle.js
@@ -8138,7 +8138,7 @@ var mParticle = (function () {
       };
 
       this.createUserAttributeChange = function (key, newValue, previousUserAttributeValue, isNewAttribute, deleted, user) {
-        if (previousUserAttributeValue === undefined) {
+        if (!previousUserAttributeValue) {
           previousUserAttributeValue = null;
         }
 

--- a/dist/mparticle.js
+++ b/dist/mparticle.js
@@ -8138,7 +8138,7 @@ var mParticle = (function () {
       };
 
       this.createUserAttributeChange = function (key, newValue, previousUserAttributeValue, isNewAttribute, deleted, user) {
-        if (!previousUserAttributeValue) {
+        if (previousUserAttributeValue === undefined) {
           previousUserAttributeValue = null;
         }
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -1819,7 +1819,7 @@ export default function Identity(mpInstance) {
         deleted,
         user
     ) {
-        if (!previousUserAttributeValue) {
+        if (previousUserAttributeValue === undefined) {
             previousUserAttributeValue = null;
         }
         var userAttributeChangeEvent;

--- a/src/identity.js
+++ b/src/identity.js
@@ -1830,7 +1830,7 @@ export default function Identity(mpInstance) {
                     userAttributeChanges: {
                         UserAttributeName: key,
                         New: newValue,
-                        Old: previousUserAttributeValue || null,
+                        Old: previousUserAttributeValue,
                         Deleted: deleted,
                         IsNewAttribute: isNewAttribute,
                     },

--- a/src/identity.js
+++ b/src/identity.js
@@ -1819,7 +1819,7 @@ export default function Identity(mpInstance) {
         deleted,
         user
     ) {
-        if (previousUserAttributeValue === undefined) {
+        if (typeof previousUserAttributeValue === 'undefined') {
             previousUserAttributeValue = null;
         }
         var userAttributeChangeEvent;

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -1219,7 +1219,7 @@ describe('identities and attributes', function() {
         event3.event_type.should.equal('user_attribute_change');
         event3.data.new.should.equal('');
         (event3.data.old === null).should.equal(true);
-        event3.data.user_attribute_name.should.equal('testFalse');
+        event3.data.user_attribute_name.should.equal('testEmptyString');
         event3.data.deleted.should.equal(false);
         event3.data.is_new_attribute.should.equal(true);
 
@@ -1233,7 +1233,7 @@ describe('identities and attributes', function() {
         event4.event_type.should.equal('user_attribute_change');
         event4.data.new.should.equal(0);
         (event4.data.old === null).should.equal(true);
-        event4.data.user_attribute_name.should.equal('testFalse');
+        event4.data.user_attribute_name.should.equal('testZero');
         event4.data.deleted.should.equal(false);
         event4.data.is_new_attribute.should.equal(true);
         

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -1256,7 +1256,7 @@ describe('identities and attributes', function() {
         done()
     });
 
-    it('should send user attributes when setting different falsey values', function(done) {
+    it('should send user attribute change event when setting different falsey values', function(done) {
         mParticle._resetForTests(MPConfig);
 
         window.fetchMock.post(

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -1182,9 +1182,9 @@ describe('identities and attributes', function() {
         // set a new attribute, age
         window.fetchMock._calls = [];
         mParticle.Identity.getCurrentUser().setUserAttribute('age', '25');
-        var body = JSON.parse(window.fetchMock.lastOptions().body)
-        body.user_attributes.should.have.property('age', '25')
-        var event1 = body.events[0];
+        var body1 = JSON.parse(window.fetchMock.lastOptions().body)
+        body1.user_attributes.should.have.property('age', '25')
+        var event1 = body1.events[0];
         event1.should.be.ok();
         event1.event_type.should.equal('user_attribute_change');
         event1.data.new.should.equal('25');
@@ -1199,13 +1199,13 @@ describe('identities and attributes', function() {
         mParticle.Identity.getCurrentUser().setUserAttribute('testEmptyString', '');
         mParticle.Identity.getCurrentUser().setUserAttribute('testZero', 0);
 
-        var body = JSON.parse(window.fetchMock.lastOptions().body)
-        body.user_attributes.should.have.property('testFalse', false)
-        body.user_attributes.should.have.property('testEmptyString', '')
-        body.user_attributes.should.have.property('testZero', 0)
+        var body2 = JSON.parse(window.fetchMock.lastOptions().body)
+        body2.user_attributes.should.have.property('testFalse', false)
+        body2.user_attributes.should.have.property('testEmptyString', '')
+        body2.user_attributes.should.have.property('testZero', 0)
 
         // check for UAC event for testFalse: fasle when set for first time
-        var event2 = body.events[0];
+        var event2 = body2.events[0];
         event2.should.be.ok();
         event2.event_type.should.equal('user_attribute_change');
         event2.data.new.should.equal(false);
@@ -1215,7 +1215,7 @@ describe('identities and attributes', function() {
         event2.data.is_new_attribute.should.equal(true);
 
         // check for UAC event for testEmptyString: '' when set for first time
-        var event3 = body.events[1];
+        var event3 = body2.events[1];
         event3.should.be.ok();
         event3.event_type.should.equal('user_attribute_change');
         event3.data.new.should.equal('');
@@ -1225,7 +1225,7 @@ describe('identities and attributes', function() {
         event3.data.is_new_attribute.should.equal(true);
 
         // check for UAC event for testZero: 0 when set for first time
-        var event4 = body.events[2];
+        var event4 = body2.events[2];
         event4.should.be.ok();
         event4.event_type.should.equal('user_attribute_change');
         event4.data.new.should.equal(0);
@@ -1272,9 +1272,9 @@ describe('identities and attributes', function() {
         // set initial test attribute with 'falsey' value to 0 
         window.fetchMock._calls = [];
         mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', 0);
-        var body = JSON.parse(window.fetchMock.lastOptions().body)
-        body.user_attributes.should.have.property('testFalsey', 0)
-        var event1 = body.events[0];
+        var body1 = JSON.parse(window.fetchMock.lastOptions().body)
+        body1.user_attributes.should.have.property('testFalsey', 0)
+        var event1 = body1.events[0];
         event1.should.be.ok();
         event1.event_type.should.equal('user_attribute_change');
         event1.data.new.should.equal(0);
@@ -1286,9 +1286,9 @@ describe('identities and attributes', function() {
         // re-set same test attribute with 'falsey' value to ''
         window.fetchMock._calls = [];
         mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', '');
-        var body = JSON.parse(window.fetchMock.lastOptions().body)
-        body.user_attributes.should.have.property('testFalsey', '')
-        var event2 = body.events[0];
+        var body2 = JSON.parse(window.fetchMock.lastOptions().body)
+        body2.user_attributes.should.have.property('testFalsey', '')
+        var event2 = body2.events[0];
         event2.should.be.ok();
         event2.event_type.should.equal('user_attribute_change');
         event2.data.new.should.equal('');
@@ -1300,9 +1300,9 @@ describe('identities and attributes', function() {
         // re-set same test attribute with 'falsey' value to false
         window.fetchMock._calls = [];
         mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', false);
-        var body = JSON.parse(window.fetchMock.lastOptions().body)
-        body.user_attributes.should.have.property('testFalsey', false)
-        var event3 = body.events[0];
+        var body3 = JSON.parse(window.fetchMock.lastOptions().body)
+        body3.user_attributes.should.have.property('testFalsey', false)
+        var event3 = body3.events[0];
         event3.should.be.ok();
         event3.event_type.should.equal('user_attribute_change');
         event3.data.new.should.equal(false);
@@ -1314,9 +1314,9 @@ describe('identities and attributes', function() {
         // re-set same test attribute with 'falsey' value to original value 0
         window.fetchMock._calls = [];
         mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', '');
-        var body = JSON.parse(window.fetchMock.lastOptions().body)
-        body.user_attributes.should.have.property('testFalsey', 0)
-        var event4 = body.events[0];
+        var body4 = JSON.parse(window.fetchMock.lastOptions().body)
+        body4.user_attributes.should.have.property('testFalsey', 0)
+        var event4 = body4.events[0];
         event4.should.be.ok();
         event4.event_type.should.equal('user_attribute_change');
         event4.data.new.should.equal(0);

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -1194,17 +1194,12 @@ describe('identities and attributes', function() {
         event1.data.is_new_attribute.should.equal(true);
 
         // test setting attributes with 'false' values (i.e false, 0 and '')
-        window.fetchMock._calls = [];
-        mParticle.Identity.getCurrentUser().setUserAttribute('testFalse', false);
-        mParticle.Identity.getCurrentUser().setUserAttribute('testEmptyString', '');
-        mParticle.Identity.getCurrentUser().setUserAttribute('testZero', 0);
-
-        var body2 = JSON.parse(window.fetchMock.lastOptions().body)
-        body2.user_attributes.should.have.property('testFalse', false)
-        body2.user_attributes.should.have.property('testEmptyString', '')
-        body2.user_attributes.should.have.property('testZero', 0)
 
         // check for UAC event for testFalse: fasle when set for first time
+        window.fetchMock._calls = [];
+        mParticle.Identity.getCurrentUser().setUserAttribute('testFalse', false);
+        var body2 = JSON.parse(window.fetchMock.lastOptions().body)
+        body2.user_attributes.should.have.property('testFalse', false)
         var event2 = body2.events[0];
         event2.should.be.ok();
         event2.event_type.should.equal('user_attribute_change');
@@ -1215,26 +1210,33 @@ describe('identities and attributes', function() {
         event2.data.is_new_attribute.should.equal(true);
 
         // check for UAC event for testEmptyString: '' when set for first time
-        var event3 = body2.events[1];
+        window.fetchMock._calls = [];
+        mParticle.Identity.getCurrentUser().setUserAttribute('testEmptyString', '');
+        var body3 = JSON.parse(window.fetchMock.lastOptions().body)
+        body3.user_attributes.should.have.property('testEmptyString', '')
+        var event3 = body3.events[0];
         event3.should.be.ok();
         event3.event_type.should.equal('user_attribute_change');
         event3.data.new.should.equal('');
         (event3.data.old === null).should.equal(true);
-        event3.data.user_attribute_name.should.equal('testEmptyString');
+        event3.data.user_attribute_name.should.equal('testFalse');
         event3.data.deleted.should.equal(false);
         event3.data.is_new_attribute.should.equal(true);
 
         // check for UAC event for testZero: 0 when set for first time
-        var event4 = body2.events[2];
+        window.fetchMock._calls = [];
+        mParticle.Identity.getCurrentUser().setUserAttribute('testZero', 0);
+        var body4 = JSON.parse(window.fetchMock.lastOptions().body)
+        body4.user_attributes.should.have.property('testZero', 0)
+        var event4 = body4.events[0];
         event4.should.be.ok();
         event4.event_type.should.equal('user_attribute_change');
         event4.data.new.should.equal(0);
         (event4.data.old === null).should.equal(true);
-        event4.data.user_attribute_name.should.equal('testZero');
+        event4.data.user_attribute_name.should.equal('testFalse');
         event4.data.deleted.should.equal(false);
         event4.data.is_new_attribute.should.equal(true);
-
-
+        
         // confirm user attributes previously set already exist for user
         var userAttributes = mParticle.Identity.getCurrentUser().getAllUserAttributes();
         userAttributes.should.have.property('age');

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -1313,7 +1313,7 @@ describe('identities and attributes', function() {
 
         // re-set same test attribute with 'falsey' value to original value 0
         window.fetchMock._calls = [];
-        mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', '');
+        mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', 0);
         var body4 = JSON.parse(window.fetchMock.lastOptions().body)
         body4.user_attributes.should.have.property('testFalsey', 0)
         var event4 = body4.events[0];

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -1253,4 +1253,79 @@ describe('identities and attributes', function() {
 
         done()
     });
+
+    it('should send user attributes when setting different falsey values', function(done) {
+        mParticle._resetForTests(MPConfig);
+
+        window.fetchMock.post(
+            'https://jssdks.mparticle.com/v3/JS/test_key/events',
+            200
+        );
+
+        window.mParticle.config.flags = {
+            eventsV3: 100,
+            EventBatchingIntervalMillis: 0,
+        };
+
+        mParticle.init(apiKey, window.mParticle.config);
+
+        // set initial test attribute with 'falsey' value to 0 
+        window.fetchMock._calls = [];
+        mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', 0);
+        var body = JSON.parse(window.fetchMock.lastOptions().body)
+        body.user_attributes.should.have.property('testFalsey', 0)
+        var event1 = body.events[0];
+        event1.should.be.ok();
+        event1.event_type.should.equal('user_attribute_change');
+        event1.data.new.should.equal(0);
+        (event1.data.old === null).should.equal(true);
+        event1.data.user_attribute_name.should.equal('testFalsey');
+        event1.data.deleted.should.equal(false);
+        event1.data.is_new_attribute.should.equal(true);
+
+        // re-set same test attribute with 'falsey' value to ''
+        window.fetchMock._calls = [];
+        mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', '');
+        var body = JSON.parse(window.fetchMock.lastOptions().body)
+        body.user_attributes.should.have.property('testFalsey', '')
+        var event2 = body.events[0];
+        event2.should.be.ok();
+        event2.event_type.should.equal('user_attribute_change');
+        event2.data.new.should.equal('');
+        event2.data.old.should.equal(0);
+        event2.data.user_attribute_name.should.equal('testFalsey');
+        event2.data.deleted.should.equal(false);
+        event2.data.is_new_attribute.should.equal(false);
+
+        // re-set same test attribute with 'falsey' value to false
+        window.fetchMock._calls = [];
+        mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', false);
+        var body = JSON.parse(window.fetchMock.lastOptions().body)
+        body.user_attributes.should.have.property('testFalsey', false)
+        var event3 = body.events[0];
+        event3.should.be.ok();
+        event3.event_type.should.equal('user_attribute_change');
+        event3.data.new.should.equal(false);
+        event3.data.old.should.equal('');
+        event3.data.user_attribute_name.should.equal('testFalsey');
+        event3.data.deleted.should.equal(false);
+        event3.data.is_new_attribute.should.equal(false);
+
+        // re-set same test attribute with 'falsey' value to original value 0
+        window.fetchMock._calls = [];
+        mParticle.Identity.getCurrentUser().setUserAttribute('testFalsey', '');
+        var body = JSON.parse(window.fetchMock.lastOptions().body)
+        body.user_attributes.should.have.property('testFalsey', 0)
+        var event4 = body.events[0];
+        event4.should.be.ok();
+        event4.event_type.should.equal('user_attribute_change');
+        event4.data.new.should.equal(0);
+        event4.data.old.should.equal(false);
+        event4.data.user_attribute_name.should.equal('testFalsey');
+        event4.data.deleted.should.equal(false);
+        event4.data.is_new_attribute.should.equal(false);
+
+        done()
+    });
+
 });


### PR DESCRIPTION
## Summary
A client reported that UAC events are forwarded on initialization everytime for some attributes even though the values are not changed. Per investigating it seemed that values that are set to false are only affected by this issue, furthermore I was able to also confirm that values such as 0 and an empty string '' would have the same issue since Javascript recognize them as null values. The code change here is to only change previousUserAttributeValue when it comes in as undefined since this is the value when it is not seen before.

## Testing Plan
Tested locally with overrides in sample app and also added unit testing case
