### PR TITLE
refactor: Move parseStringOrNumber into Utils

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -398,14 +398,6 @@ export default function Helpers(mpInstance) {
         return false;
     };
 
-    this.parseStringOrNumber = function(value) {
-        if (Validators.isStringOrNumber(value)) {
-            return value;
-        } else {
-            return null;
-        }
-    };
-
     this.generateHash = function(name) {
         var hash = 0,
             i = 0,
@@ -512,6 +504,7 @@ export default function Helpers(mpInstance) {
     this.isObject = utils.isObject;
     this.decoded = utils.decoded;
     this.returnConvertedBoolean = utils.returnConvertedBoolean;
+    this.parseStringOrNumber = utils.parseStringOrNumber;
 
     // Imported Validators
     this.Validators = Validators;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,6 +49,16 @@ const parseNumber = (value: string | number): number => {
     return isNaN(floatValue) ? 0 : floatValue;
 };
 
+const parseStringOrNumber = (
+    value: string | number
+): string | number | null => {
+    if (isStringOrNumber(value)) {
+        return value;
+    } else {
+        return null;
+    }
+};
+
 // FIXME: REFACTOR for V3
 // only used in store.js to sanitize server-side formatting of
 // booleans when checking for `isDevelopmentMode`
@@ -93,11 +103,12 @@ export {
     findKeyInObject,
     inArray,
     isObject,
+    isStringOrNumber,
     parseNumber,
+    parseStringOrNumber,
     returnConvertedBoolean,
     isString,
     isNumber,
     isFunction,
-    isStringOrNumber,
     isDataPlanSlug,
 };

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,8 +1,7 @@
 import Types from './types';
-import { isFunction, isNumber, isObject, isStringOrNumber } from './utils';
+import { isFunction, isNumber, isObject, isStringOrNumber, valueof } from './utils';
 import Constants from './constants';
 import { IdentityApiData } from '@mparticle/web-sdk';
-import { valueof } from './utils';
 
 type IdentityAPIMethod = 'login' | 'logout' | 'identify' | 'modify';
 
@@ -13,6 +12,7 @@ type ValidationIdentitiesReturn = {
 
 const Validators = {
     // From ./utils
+    // Utility Functions for backwards compatability
     isNumber,
     isFunction,
     isStringOrNumber,
@@ -21,6 +21,7 @@ const Validators = {
         return value !== undefined && !isObject(value) && !Array.isArray(value);
     },
 
+    // Validator Functions
     // Neither null nor undefined can be a valid Key
     isValidKeyValue: function(key: any): boolean {
         return Boolean(

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -5,7 +5,9 @@ import {
     inArray,
     isDataPlanSlug,
     isObject,
+    isStringOrNumber,
     parseNumber,
+    parseStringOrNumber,
     returnConvertedBoolean
 } from '../../src/utils';
 import { expect } from 'chai';
@@ -31,6 +33,19 @@ describe('Utils', () => {
 
     });
 
+    describe('#isStringOrNumber', () => {
+        it(' should correctly validate a string or number', ()=> {
+            expect(isStringOrNumber(42)).to.eq(true);
+            expect(isStringOrNumber('42')).to.eq(true);
+
+            expect(isStringOrNumber(null)).to.eq(false);
+            expect(isStringOrNumber(undefined)).to.eq(false);
+            expect(isStringOrNumber([])).to.eq(false);
+            expect(isStringOrNumber({})).to.eq(false);
+            expect(isStringOrNumber(function (){})).to.eq(false);
+        });
+    });
+
     describe('#parseNumber', () => {
         it('should parse a number into a number', () => {
             expect(parseNumber('42')).to.eq(42);
@@ -41,6 +56,16 @@ describe('Utils', () => {
             expect(parseNumber('not an number')).to.eq(0);
             expect(parseNumber('3.50')).to.eq(3.5);
         });
+    });
+
+    describe('#parseStringOrNumber', ()=> {
+        it('should correctly parse string or number', ()=> {
+            expect(parseStringOrNumber('abc')).to.eq('abc');
+            expect(parseStringOrNumber(123)).to.eq(123);
+            expect(parseStringOrNumber({} as unknown as string)).to.eq(null);
+            expect(parseStringOrNumber([] as unknown as string)).to.eq(null);
+            expect(parseStringOrNumber(null as unknown as string)).to.eq(null);
+        })
     });
 
     describe('#returnConvertedBoolean', () => {


### PR DESCRIPTION
## Summary
- Move `parseStringOrNumber` into Utils for better organization of utility functions

## Testing Plan
- Run automated tests

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4656
