### PR TITLE
fix: Process queued events after there are no more integration delays

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -5,19 +5,15 @@ import { BatchUploader } from './batchUploader';
 var Messages = Constants.Messages;
 
 export default function APIClient(mpInstance, kitBlocker) {
-    var millis = mpInstance._Helpers.getFeatureFlag(
-        Constants.FeatureFlags.EventBatchingIntervalMillis
-    );
-    this.uploader = new BatchUploader(mpInstance, millis);
-    // this.uploader = null;
+    this.uploader = null;
     var self = this;
     this.queueEventForBatchUpload = function(event) {
-        // if (!this.uploader) {
-        //     var millis = mpInstance._Helpers.getFeatureFlag(
-        //         Constants.FeatureFlags.EventBatchingIntervalMillis
-        //     );
-        //     this.uploader = new BatchUploader(mpInstance, millis);
-        // }
+        if (!this.uploader) {
+            var millis = mpInstance._Helpers.getFeatureFlag(
+                Constants.FeatureFlags.EventBatchingIntervalMillis
+            );
+            this.uploader = new BatchUploader(mpInstance, millis);
+        }
         this.uploader.queueEvent(event);
 
         mpInstance._Persistence.update();

--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -5,15 +5,19 @@ import { BatchUploader } from './batchUploader';
 var Messages = Constants.Messages;
 
 export default function APIClient(mpInstance, kitBlocker) {
-    this.uploader = null;
+    var millis = mpInstance._Helpers.getFeatureFlag(
+        Constants.FeatureFlags.EventBatchingIntervalMillis
+    );
+    this.uploader = new BatchUploader(mpInstance, millis);
+    // this.uploader = null;
     var self = this;
     this.queueEventForBatchUpload = function(event) {
-        if (!this.uploader) {
-            var millis = mpInstance._Helpers.getFeatureFlag(
-                Constants.FeatureFlags.EventBatchingIntervalMillis
-            );
-            this.uploader = new BatchUploader(mpInstance, millis);
-        }
+        // if (!this.uploader) {
+        //     var millis = mpInstance._Helpers.getFeatureFlag(
+        //         Constants.FeatureFlags.EventBatchingIntervalMillis
+        //     );
+        //     this.uploader = new BatchUploader(mpInstance, millis);
+        // }
         this.uploader.queueEvent(event);
 
         mpInstance._Persistence.update();

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1207,6 +1207,21 @@ export default function mParticleInstance(instanceName) {
     };
     this._setIntegrationDelay = function(module, boolean) {
         self._preInit.integrationDelays[module] = boolean;
+
+        if (boolean === true) {
+            return;
+        }
+        if (Object.keys(self._preInit.integrationDelays).length) {
+            if (
+                Object.keys(self._preInit.integrationDelays).filter(function(
+                    singleInt
+                ) {
+                    return self._preInit.integrationDelays[singleInt] === true;
+                }).length === 0
+            ) {
+                self._APIClient.processQueuedEvents();
+            }
+        }
     };
 }
 

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2250,6 +2250,27 @@ describe('forwarders', function() {
         done();
     });
 
+    it('integration test - after an integration delay is set to false, should fire an event after the event timeout', function(done) {
+        var clock = sinon.useFakeTimers();
+        mParticle._resetForTests(MPConfig);
+        // this code will be put in each forwarder as each forwarder is initialized
+        mParticle._setIntegrationDelay(128, true);
+        mParticle._setIntegrationDelay(24, false);
+        mParticle.init(apiKey, window.mParticle.config);
+        mockServer.requests = [];
+        mParticle.logEvent('test1');
+        mockServer.requests.length.should.equal(0);
+
+        // now that we set all integrations to false, the SDK should process queued events
+        mParticle._setIntegrationDelay(128, false);
+
+        clock.tick(5001);
+
+        mockServer.requests.length.should.equal(3);
+
+        done();
+    });
+
     it('parse and capture forwarderConfiguration properly from backend', function(done) {
         mParticle._resetForTests(MPConfig);
 


### PR DESCRIPTION
## Summary
There are cases (GA4 and Adobe) when a customer checks `forward web requests server side`, but the server needs additional information from the client to forward information properly. In the case of GA4, they need a `client_id`, and you can only get this client side from the GA4 SDKs.  We classify `client_id` as an `integration attribute` or `ia`.

([GA4 server side web kit](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/blob/master/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js) for example) is a simplified kit whose sole purpose is to grab the `client_id` and set it as an `ia` on a payload so that the server has all the required information before forwarding events.

The steps are:
1. [kit tells core SDK to delay sending events](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/blob/master/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js#L30).  Events must be delayed because `client_id` doesn't exist yet, so if events are sent without it, the server doesn't know what to do.
2. [kit grabs the integration attribute and sets it](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/blob/master/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js#L30-L71)
3. [kit tells core SDK to not delay sending events anymore for this specific kit](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/blob/master/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js#L72)

The bug is discovered in the following use case:
* user navigates to a website that has GA4 server side
* user does nothing else

In this scenario, no events are sent.  Events are queued between when the kit sets the delay to `true` and `false`.  There is no logic that says once all integration delays are `false`, go and process the queued events.  Only if the user takes a further action will it kick start the process to queue events.

This PR adds code that checks to see if we should process the queued events after an integration delay is set to `false`.

This bug is a long tail edge case, as it is likely that steps 1, 2, and 3 happen above pretty quickly and the user logs other events.

## Testing Plan
Integration test and manually tested

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4686