### PR TITLE
fix: Process queued events after there are no more integration delays

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -5,19 +5,15 @@ import { BatchUploader } from './batchUploader';
 var Messages = Constants.Messages;
 
 export default function APIClient(mpInstance, kitBlocker) {
-    var millis = mpInstance._Helpers.getFeatureFlag(
-        Constants.FeatureFlags.EventBatchingIntervalMillis
-    );
-    this.uploader = new BatchUploader(mpInstance, millis);
-    // this.uploader = null;
+    this.uploader = null;
     var self = this;
     this.queueEventForBatchUpload = function(event) {
-        // if (!this.uploader) {
-        //     var millis = mpInstance._Helpers.getFeatureFlag(
-        //         Constants.FeatureFlags.EventBatchingIntervalMillis
-        //     );
-        //     this.uploader = new BatchUploader(mpInstance, millis);
-        // }
+        if (!this.uploader) {
+            var millis = mpInstance._Helpers.getFeatureFlag(
+                Constants.FeatureFlags.EventBatchingIntervalMillis
+            );
+            this.uploader = new BatchUploader(mpInstance, millis);
+        }
         this.uploader.queueEvent(event);
 
         mpInstance._Persistence.update();

--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -5,15 +5,19 @@ import { BatchUploader } from './batchUploader';
 var Messages = Constants.Messages;
 
 export default function APIClient(mpInstance, kitBlocker) {
-    this.uploader = null;
+    var millis = mpInstance._Helpers.getFeatureFlag(
+        Constants.FeatureFlags.EventBatchingIntervalMillis
+    );
+    this.uploader = new BatchUploader(mpInstance, millis);
+    // this.uploader = null;
     var self = this;
     this.queueEventForBatchUpload = function(event) {
-        if (!this.uploader) {
-            var millis = mpInstance._Helpers.getFeatureFlag(
-                Constants.FeatureFlags.EventBatchingIntervalMillis
-            );
-            this.uploader = new BatchUploader(mpInstance, millis);
-        }
+        // if (!this.uploader) {
+        //     var millis = mpInstance._Helpers.getFeatureFlag(
+        //         Constants.FeatureFlags.EventBatchingIntervalMillis
+        //     );
+        //     this.uploader = new BatchUploader(mpInstance, millis);
+        // }
         this.uploader.queueEvent(event);
 
         mpInstance._Persistence.update();

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1233,7 +1233,7 @@ export default function mParticleInstance(instanceName) {
         // If the integration delay is set to false, check to see if there are any
         // other integration delays set to true.  It not, process the queued events/.
 
-        var integrationDelaysKeys = Object.keys(
+        const integrationDelaysKeys = Object.keys(
             self._preInit.integrationDelays
         );
 
@@ -1241,7 +1241,7 @@ export default function mParticleInstance(instanceName) {
             return;
         }
 
-        var hasIntegrationDelays = integrationDelaysKeys.some(function(
+        const hasIntegrationDelays = integrationDelaysKeys.some(function(
             integration
         ) {
             return self._preInit.integrationDelays[integration] === true;

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1219,7 +1219,6 @@ export default function mParticleInstance(instanceName) {
     this._setIntegrationDelay = function(module, boolean) {
         self._preInit.integrationDelays[module] = boolean;
 
-
         // If the integration delay is set to true, no further action needed
         if (boolean === true) {
             return;

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1219,12 +1219,12 @@ export default function mParticleInstance(instanceName) {
     this._setIntegrationDelay = function(module, boolean) {
         self._preInit.integrationDelays[module] = boolean;
 
-        
+
         // If the integration delay is set to true, no further action needed
         if (boolean === true) {
             return;
         }
-        // If the integration delay is set to false, check to see if there are any 
+        // If the integration delay is set to false, check to see if there are any
         // other integration delays set to true.  It not, process the queued events/.
         if (Object.keys(self._preInit.integrationDelays).length) {
             if (

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1207,6 +1207,21 @@ export default function mParticleInstance(instanceName) {
     };
     this._setIntegrationDelay = function(module, boolean) {
         self._preInit.integrationDelays[module] = boolean;
+
+        if (boolean === true) {
+            return;
+        }
+        if (Object.keys(self._preInit.integrationDelays).length) {
+            if (
+                Object.keys(self._preInit.integrationDelays).filter(function(
+                    singleInt
+                ) {
+                    return self._preInit.integrationDelays[singleInt] === true;
+                }).length === 0
+            ) {
+                self._APIClient.processQueuedEvents();
+            }
+        }
     };
 }
 

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1209,15 +1209,15 @@ export default function mParticleInstance(instanceName) {
         An integration delay is a workaround that prevents events from being sent when it is necessary to do so.
         Some server side integrations require a client side value to be included in the payload to successfully 
         forward.  This value can only be pulled from the client side partner SDK.
-        
+
         During the kit initialization, the kit:
         * sets an integration delay to `true`
         * grabs the required value from the partner SDK,
         * sets it via `setIntegrationAttribute`
         * sets the integration delay to `false`
-        
+
         The core SDK can then read via `isDelayedByIntegration` to no longer delay sending events.
-        
+
         This integration attribute is now on the batch payload for the server side to read.
 
         If there is no delay, then the events sent before an integration attribute is included would not

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1206,14 +1206,21 @@ export default function mParticleInstance(instanceName) {
         return self._preInit.integrationDelays;
     };
     /*
-        An integration delay prevents events from being sent.  Some server side integrations require a client 
-        side value to successfully forward.  This value can only be pulled from the client side partner SDK.
-        During the kit initialization, it sets an integration delay to true, grabs the required value from 
-        the partner SDK, sets it via `setIntegrationAttribute`, then sets the integration delay to false so that
-        the SDK then knows via `isDelayedByIntegration` to no longer delay sending events.  This integration
-        attribute is now on the batch payload for the server side to read.
+        An integration delay is a workaround that prevents events from being sent when it is necessary to do so.
+        Some server side integrations require a client side value to be included in the payload set to successfully 
+        forward.  This value can only be pulled from the client side partner SDK.
+        
+        During the kit initialization the kit:
+        * sets an integration delay to `true`
+        * grabs the required value from the partner SDK,
+        * sets it via `setIntegrationAttribute`
+        * sets the integration delay to `false`
+        
+        The core SDK can then read via `isDelayedByIntegration` to no longer delay sending events.
+        
+        This integration attribute is now on the batch payload for the server side to read.
 
-        If there is not delay, then the events sent before an integration attribute is included would not
+        If there is no delay, then the events sent before an integration attribute is included would not
         be forwarded successfully server side.
     */
     this._setIntegrationDelay = function(module, boolean) {

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1240,6 +1240,7 @@ export default function mParticleInstance(instanceName) {
         if (integrationDelaysKeys.length === 0) {
             return;
         }
+
         var hasIntegrationDelays = integrationDelaysKeys.some(function(
             integration
         ) {

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1207,7 +1207,7 @@ export default function mParticleInstance(instanceName) {
     };
     /*
         An integration delay is a workaround that prevents events from being sent when it is necessary to do so.
-        Some server side integrations require a client side value to be included in the payload set to successfully 
+        Some server side integrations require a client side value to be included in the payload to successfully 
         forward.  This value can only be pulled from the client side partner SDK.
         
         During the kit initialization the kit:

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1210,7 +1210,7 @@ export default function mParticleInstance(instanceName) {
         Some server side integrations require a client side value to be included in the payload to successfully 
         forward.  This value can only be pulled from the client side partner SDK.
         
-        During the kit initialization the kit:
+        During the kit initialization, the kit:
         * sets an integration delay to `true`
         * grabs the required value from the partner SDK,
         * sets it via `setIntegrationAttribute`

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1223,25 +1223,31 @@ export default function mParticleInstance(instanceName) {
         If there is no delay, then the events sent before an integration attribute is included would not
         be forwarded successfully server side.
     */
-    this._setIntegrationDelay = function(module, boolean) {
-        self._preInit.integrationDelays[module] = boolean;
+    this._setIntegrationDelay = function(module, shouldDelayIntegration) {
+        self._preInit.integrationDelays[module] = shouldDelayIntegration;
 
         // If the integration delay is set to true, no further action needed
-        if (boolean === true) {
+        if (shouldDelayIntegration === true) {
             return;
         }
         // If the integration delay is set to false, check to see if there are any
         // other integration delays set to true.  It not, process the queued events/.
-        if (Object.keys(self._preInit.integrationDelays).length) {
-            if (
-                Object.keys(self._preInit.integrationDelays).filter(function(
-                    singleInt
-                ) {
-                    return self._preInit.integrationDelays[singleInt] === true;
-                }).length === 0
-            ) {
-                self._APIClient.processQueuedEvents();
-            }
+
+        var integrationDelaysKeys = Object.keys(
+            self._preInit.integrationDelays
+        );
+
+        if (integrationDelaysKeys.length === 0) {
+            return;
+        }
+        var hasIntegrationDelays = integrationDelaysKeys.some(function(
+            integration
+        ) {
+            return self._preInit.integrationDelays[integration] === true;
+        });
+
+        if (!hasIntegrationDelays) {
+            self._APIClient.processQueuedEvents();
         }
     };
 }

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1208,6 +1208,11 @@ export default function mParticleInstance(instanceName) {
     this._setIntegrationDelay = function(module, boolean) {
         self._preInit.integrationDelays[module] = boolean;
 
+        // If the integration delay is set to true, no further action needed
+        // If the integration delay is set to false, check to see if all
+        // other integration delays are false, and if so, proceed with processing
+        // queued events
+
         if (boolean === true) {
             return;
         }

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2251,7 +2251,7 @@ describe('forwarders', function() {
     });
 
     it('integration test - after an integration delay is set to false, should fire an event after the event timeout', function(done) {
-        var clock = sinon.useFakeTimers();
+        const clock = sinon.useFakeTimers();
         mParticle._resetForTests(MPConfig);
         // this code will be put in each forwarder as each forwarder is initialized
         mParticle._setIntegrationDelay(128, true);

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2267,6 +2267,7 @@ describe('forwarders', function() {
         clock.tick(5001);
 
         mockServer.requests.length.should.equal(3);
+        clock.restore();
 
         done();
     });

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2250,6 +2250,27 @@ describe('forwarders', function() {
         done();
     });
 
+    it('integration test - after an integration delay is set to false, should fire an event after the event timeout', function(done) {
+        var clock = sinon.useFakeTimers();
+        mParticle._resetForTests(MPConfig);
+        // this code will be put in each forwarder as each forwarder is initialized
+        mParticle._setIntegrationDelay(128, true);
+        mParticle._setIntegrationDelay(24, false);
+        mParticle.init(apiKey, window.mParticle.config);
+        mockServer.requests = [];
+        mParticle.logEvent('test1');
+        mockServer.requests.length.should.equal(0);
+
+        // now that we set all integrations to false, the SDK should process queued events
+        mParticle._setIntegrationDelay(128, false);
+
+        clock.tick(5001);
+
+        mockServer.requests.length.should.equal(3);
+
+        done();
+    });
+
     it('parse and capture forwarderConfiguration properly from backend', function(done) {
         mParticle._resetForTests(MPConfig);
 


### PR DESCRIPTION
## Summary
There are cases (GA4 and Adobe) when a customer checks `forward web requests server side`, but the server needs additional information from the client to forward information properly. In the case of GA4, they need a `client_id`, and you can only get this client side from the GA4 SDKs.  We classify `client_id` as an `integration attribute` or `ia`.

([GA4 server side web kit](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/blob/master/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js) for example) is a simplified kit whose sole purpose is to grab the `client_id` and set it as an `ia` on a payload so that the server has all the required information before forwarding events.

The steps are:
1. [kit tells core SDK to delay sending events](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/blob/master/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js#L30).  Events must be delayed because `client_id` doesn't exist yet, so if events are sent without it, the server doesn't know what to do.
2. [kit grabs the integration attribute and sets it](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/blob/master/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js#L30-L71)
3. [kit tells core SDK to not delay sending events anymore for this specific kit](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/blob/master/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js#L72)

The bug is discovered in the following use case:
* user navigates to a website that has GA4 server side
* user does nothing else

In this scenario, no events are sent.  Events are queued between when the kit sets the delay to `true` and `false`.  There is no logic that says once all integration delays are `false`, go and process the queued events.  Only if the user takes a further action will it kick start the process to queue events.

This PR adds code that checks to see if we should process the queued events after an integration delay is set to `false`.

This bug is a long tail edge case, as it is likely that steps 1, 2, and 3 happen above pretty quickly and the user logs other events.

## Testing Plan
Integration test and manually tested

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4686