### PR TITLE
feat: Expose getEnvironment() for mParticle Instance

### DIFF
--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -189,6 +189,16 @@ export default function mParticleInstance(instanceName) {
         }
     };
     /**
+     * Returns the current mParticle environment setting
+     * @method getEnvironment
+     * @returns {String} mParticle environment setting
+     */
+    this.getEnvironment = function() {
+        return self._Store.SDKConfig.isDevelopmentMode
+            ? Types.Environment.Development
+            : Types.Environment.Production;
+    };
+    /**
      * Returns the mParticle SDK version number
      * @method getVersion
      * @return {String} mParticle SDK version number

--- a/src/mparticle-instance-manager.js
+++ b/src/mparticle-instance-manager.js
@@ -128,6 +128,9 @@ function mParticle() {
     this.getAppVersion = function() {
         return self.getInstance().getAppVersion();
     };
+    this.getEnvironment = function() {
+        return self.getInstance().getEnvironment();
+    };
     this.stopTrackingLocation = function() {
         self.getInstance().stopTrackingLocation();
     };

--- a/src/stub/mparticle.stub.js
+++ b/src/stub/mparticle.stub.js
@@ -3,6 +3,7 @@ let mParticle = {
     getAppName: returnString,
     getAppVersion: returnString,
     getDeviceId: returnString,
+    getEnvironment: returnString,
     getVersion: returnString,
     init: voidFunction,
     logError: voidFunction,

--- a/src/types.js
+++ b/src/types.js
@@ -361,6 +361,11 @@ var ApplicationTransitionType = {
     AppInit: 1,
 };
 
+const Environment = {
+    Production: 'production',
+    Development: 'development',
+};
+
 export default {
     MessageType: MessageType,
     EventType: EventType,
@@ -371,4 +376,5 @@ export default {
     ProductActionType: ProductActionType,
     PromotionActionType: PromotionActionType,
     TriggerUploadType: TriggerUploadType,
+    Environment,
 };

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -157,6 +157,30 @@ describe('core SDK', function() {
         done();
     });
 
+    it('should get environment setting when set to `production`', function(done) {
+        mParticle._resetForTests(MPConfig);
+        mParticle.init(apiKey, {
+            ...window.mParticle.config,
+            isDevelopmentMode: false,
+        });
+
+        mParticle.getEnvironment().should.equal('production');
+
+        done();
+    });
+
+    it('should get environment setting when set to `development`', function(done) {
+        mParticle._resetForTests(MPConfig);
+        mParticle.init(apiKey, {
+            ...window.mParticle.config,
+            isDevelopmentMode: true,
+        });
+
+        mParticle.getEnvironment().should.equal('development');
+
+        done();
+    });
+
     it('should get app version from config', function(done) {
         mParticle._resetForTests(MPConfig);
         window.mParticle.config.appName = "testAppName";

--- a/test/src/tests-types.js
+++ b/test/src/tests-types.js
@@ -8,7 +8,7 @@ var EventType = Types.EventType,
 
 describe('Types', function() {
     describe('Environment', function() {
-        it('should return Production', function() {
+        it('should return `production`', function() {
             mParticle.Types.Environment.Production.should.equal('production');
         });
 

--- a/test/src/tests-types.js
+++ b/test/src/tests-types.js
@@ -12,7 +12,7 @@ describe('Types', function() {
             mParticle.Types.Environment.Production.should.equal('production');
         });
 
-        it('should return Development', function() {
+        it('should return `development`', function() {
             mParticle.Types.Environment.Development.should.equal('development');
         });
     });

--- a/test/src/tests-types.js
+++ b/test/src/tests-types.js
@@ -7,6 +7,16 @@ var EventType = Types.EventType,
     IdentityType = Types.IdentityType;
 
 describe('Types', function() {
+    describe('Environment', function() {
+        it('should return Production', function() {
+            mParticle.Types.Environment.Production.should.equal('production');
+        });
+
+        it('should return Development', function() {
+            mParticle.Types.Environment.Development.should.equal('development');
+        });
+    });
+
     it('event type should return name', function(done) {
         mParticle.EventType.getName(EventType.Navigation).should.equal(
             'Navigation'

--- a/test/stub/tests-mParticle-stub.js
+++ b/test/stub/tests-mParticle-stub.js
@@ -6,6 +6,7 @@ describe('mParticle stubs', function() {
         mParticle.getAppName();
         mParticle.getAppVersion();
         mParticle.getDeviceId();
+        mParticle.getEnvironment();
         mParticle.getVersion();
         mParticle.init();
         mParticle.logError();


### PR DESCRIPTION
## Summary
- expose `getEnvironment()` function to mParticle Instance which will return the current environment setting in `Store`

## Testing Plan
- Run automated tests

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4725
