### PR TITLE
fix: Prevent Batches from queuing empty events

### DIFF
--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -203,17 +203,18 @@ export class BatchUploader {
 
     private async upload(
         logger: SDKLoggerApi,
-        uploads: Batch[],
+        _uploads: Batch[],
         useBeacon: boolean
     ): Promise<Batch[]> {
         let uploader;
 
-        if (
-            isEmpty(uploads) ||
-            uploads.some(upload => isEmpty(upload.events))
-        ) {
+        // Filter out any batches that don't have events
+        const uploads = _uploads.filter(upload => !isEmpty(upload.events));
+
+        if (isEmpty(uploads)) {
             return null;
         }
+
         logger.verbose(`Uploading batches: ${JSON.stringify(uploads)}`);
         logger.verbose(`Batch count: ${uploads.length}`);
 

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -66,7 +66,7 @@ export class BatchUploader {
     }
 
     queueEvent(event: SDKEvent): void {
-        if (!isEmptyObject(event)) {
+        if (!isEmpty(event)) {
             this.pendingEvents.push(event);
             this.mpInstance.Logger.verbose(
                 `Queuing event: ${JSON.stringify(event)}`
@@ -132,15 +132,24 @@ export class BatchUploader {
                 eventsBySession.set(sdkEvent.SessionId, events);
             }
             for (const entry of Array.from(eventsBySession.entries())) {
-                let uploadBatchObject = convertEvents(mpid, entry[1], mpInstance);
-                const onCreateBatchCallback = mpInstance._Store.SDKConfig.onCreateBatch;
+                let uploadBatchObject = convertEvents(
+                    mpid,
+                    entry[1],
+                    mpInstance
+                );
+                const onCreateBatchCallback =
+                    mpInstance._Store.SDKConfig.onCreateBatch;
 
                 if (onCreateBatchCallback) {
-                    uploadBatchObject = onCreateBatchCallback(uploadBatchObject);
+                    uploadBatchObject = onCreateBatchCallback(
+                        uploadBatchObject
+                    );
                     if (uploadBatchObject) {
                         uploadBatchObject.modified = true;
                     } else {
-                        mpInstance.Logger.warning('Skiping batch upload because no batch was returned from onCreateBatch callback');
+                        mpInstance.Logger.warning(
+                            'Skiping batch upload because no batch was returned from onCreateBatch callback'
+                        );
                     }
                 }
 
@@ -198,7 +207,11 @@ export class BatchUploader {
         useBeacon: boolean
     ): Promise<Batch[]> {
         let uploader;
-        if (!uploads || uploads.length < 1) {
+
+        if (
+            isEmpty(uploads) ||
+            uploads.some(upload => isEmpty(upload.events))
+        ) {
             return null;
         }
         logger.verbose(`Uploading batches: ${JSON.stringify(uploads)}`);

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -7,7 +7,7 @@ import {
 } from './sdkRuntimeModels';
 import { convertEvents } from './sdkToEventsApiConverter';
 import Types from './types';
-import { isEmptyObject } from './utils';
+import { isEmpty } from './utils';
 
 export class BatchUploader {
     //we upload JSON, but this content type is required to avoid a CORS preflight request

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -7,6 +7,7 @@ import {
 } from './sdkRuntimeModels';
 import { convertEvents } from './sdkToEventsApiConverter';
 import Types from './types';
+import { isEmptyObject } from './utils';
 
 export class BatchUploader {
     //we upload JSON, but this content type is required to avoid a CORS preflight request
@@ -64,8 +65,8 @@ export class BatchUploader {
         return false;
     }
 
-    queueEvent(event: SDKEvent) {
-        if (event) {
+    queueEvent(event: SDKEvent): void {
+        if (!isEmptyObject(event)) {
             this.pendingEvents.push(event);
             this.mpInstance.Logger.verbose(
                 `Queuing event: ${JSON.stringify(event)}`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,6 +96,9 @@ const isDataPlanSlug = (str: string): boolean =>
 const isStringOrNumber = (value: any): boolean =>
     isString(value) || isNumber(value);
 
+const isEmptyObject = (val: Dictionary<any> | null | undefined): boolean =>
+    val == null || !(Object.keys(val) || val).length;
+
 export {
     valueof,
     converted,
@@ -111,4 +114,5 @@ export {
     isNumber,
     isFunction,
     isDataPlanSlug,
+    isEmptyObject,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,8 +96,8 @@ const isDataPlanSlug = (str: string): boolean =>
 const isStringOrNumber = (value: any): boolean =>
     isString(value) || isNumber(value);
 
-const isEmpty = (val: Dictionary<any> | null | undefined): boolean =>
-    val == null || !(Object.keys(val) || val).length;
+const isEmpty = (value: Dictionary<any> | null | undefined): boolean =>
+    value == null || !(Object.keys(value) || value).length;
 
 export {
     valueof,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,7 +96,7 @@ const isDataPlanSlug = (str: string): boolean =>
 const isStringOrNumber = (value: any): boolean =>
     isString(value) || isNumber(value);
 
-const isEmptyObject = (val: Dictionary<any> | null | undefined): boolean =>
+const isEmpty = (val: Dictionary<any> | null | undefined): boolean =>
     val == null || !(Object.keys(val) || val).length;
 
 export {
@@ -114,5 +114,5 @@ export {
     isNumber,
     isFunction,
     isDataPlanSlug,
-    isEmptyObject,
+    isEmpty,
 };

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -792,15 +792,6 @@ describe('batch uploader', () => {
             // HACK: Directly access uploader to Force an upload
             await (<any>uploader).upload(newLogger, testBatches, false);
 
-            window.fetchMock._calls.forEach(call =>
-                console.log('body events', JSON.parse(call[1].body).events)
-            );
-
-            console.log(
-                'fetch mock calls length',
-                window.fetchMock.calls().length
-            );
-
             expect(window.fetchMock.calls().length).to.equal(1);
 
             const actualBatchResult = JSON.parse(

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -82,8 +82,6 @@ describe('batch uploader', () => {
 
                 const uploader = new BatchUploader(mpInstance, 1000);
 
-                // debugger;
-
                 uploader.queueEvent(null);
                 uploader.queueEvent(({} as unknown) as SDKEvent);
 

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -4,7 +4,7 @@ import {
     findKeyInObject,
     inArray,
     isDataPlanSlug,
-    isEmptyObject,
+    isEmpty,
     isObject,
     isStringOrNumber,
     parseNumber,
@@ -167,17 +167,29 @@ describe('Utils', () => {
         });
     });
 
-    describe('#isEmptyObject', () => {
-        it('returns true if object is empty', () => {
-            expect(isEmptyObject([])).to.equal(true);
+    describe('#isEmpty', () => {
+        it('returns true if array is empty', () => {
+            expect(isEmpty([])).to.equal(true);
         });
 
-        it('returns false if object is not empty', () => {
-            expect(isEmptyObject([1, 2, 3])).to.equal(false);
+        it('returns false if array is not empty', () => {
+            expect(isEmpty([1, 2, 3])).to.equal(false);
+        });
+
+        it('returns true if object is empty', ()=> {
+            expect(isEmpty({})).to.equal(true);
+        });
+
+        it('returns false if object is not empty', ()=> {
+            expect(isEmpty({'foo': 'bar'})).to.equal(false);
         });
 
         it('returns true if object is null', () => {
-            expect(isEmptyObject(null)).to.equal(true);
+            expect(isEmpty(null)).to.equal(true);
+        });
+
+        it('returns true if object is null', () => {
+            expect(isEmpty(null)).to.equal(true);
         });
     });
 });

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -188,8 +188,8 @@ describe('Utils', () => {
             expect(isEmpty(null)).to.equal(true);
         });
 
-        it('returns true if object is null', () => {
-            expect(isEmpty(null)).to.equal(true);
+        it('returns true if object is undefined', () => {
+            expect(isEmpty(undefined)).to.equal(true);
         });
     });
 });

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -4,6 +4,7 @@ import {
     findKeyInObject,
     inArray,
     isDataPlanSlug,
+    isEmptyObject,
     isObject,
     isStringOrNumber,
     parseNumber,
@@ -163,6 +164,20 @@ describe('Utils', () => {
 
         it('handles numerical strings', function () {
             expect(isDataPlanSlug('42')).to.equal(true);
+        });
+    });
+
+    describe('#isEmptyObject', () => {
+        it('returns true if object is empty', () => {
+            expect(isEmptyObject([])).to.equal(true);
+        });
+
+        it('returns false if object is not empty', () => {
+            expect(isEmptyObject([1, 2, 3])).to.equal(false);
+        });
+
+        it('returns true if object is null', () => {
+            expect(isEmptyObject(null)).to.equal(true);
         });
     });
 });


### PR DESCRIPTION
## Summary
- Within `BatchUploader.queueEvent`, we are only checking if the event is `null`, but not if it is actually empty.
- We don't have reliable test data directly related to this bug report, and is unlikely that an event can get to this point in the code while being empty, but we should be more defensive, just in case.

## Testing Plan
- Using the browser debugger, manually send events into the batch uploader and verify that batches without events are not created.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4737
