### PR TITLE
fix: Add wrapper SDK name/version setter for diagnostics

### DIFF
--- a/src/mockBatchCreator.ts
+++ b/src/mockBatchCreator.ts
@@ -69,6 +69,11 @@ export default class _BatchValidator {
                 kits: {},
                 configuredForwarders: [],
                 pixelConfigurations: [],
+                wrapperSDKInfo: {
+                    name: 'none',
+                    version: null,
+                    isInfoSet: false,
+                },
                 SDKConfig: {
                     isDevelopmentMode: false,
                     onCreateBatch: mockFunction,
@@ -102,7 +107,7 @@ export default class _BatchValidator {
             logLevel: 'none',
             setPosition: mockFunction,
             upload: mockFunction,
-        };
+        } as MParticleWebSDK;
     }
 
     returnBatch(event: BaseEvent) {

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1261,6 +1261,26 @@ export default function mParticleInstance(instanceName) {
             self._APIClient.processQueuedEvents();
         }
     };
+
+    // Internal use only. Used by our wrapper SDKs to identify themselves during initialization.
+    this._setWrapperSDKInfo = function(name, version) {
+        var queued = queueIfNotInitialized(function() {
+            self._setWrapperSDKInfo(name, version);
+        }, self);
+
+        if (queued) return;
+
+        if (
+            self._Store.wrapperSDKInfo === undefined ||
+            !self._Store.wrapperSDKInfo.isInfoSet
+        ) {
+            self._Store.wrapperSDKInfo = {
+                name: name,
+                version: version,
+                isInfoSet: true,
+            };
+        }
+    };
 }
 
 // Some (server) config settings need to be returned before they are set on SDKConfig in a self hosted environment

--- a/src/mparticle-instance-manager.js
+++ b/src/mparticle-instance-manager.js
@@ -472,6 +472,9 @@ function mParticle() {
     this._getActiveForwarders = function() {
         return self.getInstance()._getActiveForwarders();
     };
+    this._setWrapperSDKInfo = function(name, version) {
+        self.getInstance()._setWrapperSDKInfo(name, version);
+    };
 }
 
 var mparticleInstance = new mParticle();

--- a/src/store.ts
+++ b/src/store.ts
@@ -102,6 +102,14 @@ export type PixelConfiguration = Dictionary;
 export type MigrationData = Dictionary;
 export type ServerSettings = Dictionary;
 
+type WrapperSDKTypes = 'flutter' | 'none';
+interface WrapperSDKInfo {
+    name: WrapperSDKTypes;
+    version: string | null;
+    isInfoSet: boolean;
+}
+
+
 // Temporary Interface until Store can be refactored as a class
 export interface IStore {
     isEnabled: boolean;
@@ -144,6 +152,7 @@ export interface IStore {
     pixelConfigurations: PixelConfiguration[];
     integrationDelayTimeoutStart: number; // UNIX Timestamp
     webviewBridgeEnabled?: boolean;
+    wrapperSDKInfo: WrapperSDKInfo;
 }
 
 // TODO: Merge this with SDKStoreApi in sdkRuntimeModels
@@ -191,6 +200,11 @@ export default function Store(
         kits: {},
         configuredForwarders: [],
         pixelConfigurations: [],
+        wrapperSDKInfo: {
+            name: 'none',
+            version: null,
+            isInfoSet: false,
+        },
     };
 
     for (var key in defaultStore) {

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -1143,7 +1143,7 @@ describe('core SDK', function() {
         done();
     });
 
-    it('should set the wrapper sdk info in store when mParticle._setWrapperSDKInfo() method is called and init is called', function(done) {
+    it('should set the wrapper sdk info in Store when mParticle._setWrapperSDKInfo() method is called after init is called', function(done) {
         mParticle._resetForTests(MPConfig);
 
         mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -1119,7 +1119,7 @@ describe('core SDK', function() {
         done();
     });
 
-    it('should not set the wrapper sdk info in store when mParticle._setWrapperSDKInfo() method is called if init not called', function(done) {
+    it('should not set the wrapper sdk info in Store when mParticle._setWrapperSDKInfo() method is called if init not called', function(done) {
         mParticle._resetForTests(MPConfig);
 
         mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -1122,7 +1122,7 @@ describe('core SDK', function() {
     it('should not set the wrapper sdk info in Store when mParticle._setWrapperSDKInfo() method is called if init not called', function(done) {
         mParticle._resetForTests(MPConfig);
 
-        mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');
+        mParticle._setWrapperSDKInfo('flutter', '1.0.3');
 
         mParticle.getInstance()._Store.wrapperSDKInfo.name.should.equal('none');
         (mParticle.getInstance()._Store.wrapperSDKInfo.version === null).should.equal(true);
@@ -1146,7 +1146,7 @@ describe('core SDK', function() {
     it('should set the wrapper sdk info in Store when mParticle._setWrapperSDKInfo() method is called after init is called', function(done) {
         mParticle._resetForTests(MPConfig);
 
-        mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');
+        mParticle._setWrapperSDKInfo('flutter', '1.0.3');
 
         mParticle.init(apiKey, window.mParticle.config);
 
@@ -1160,11 +1160,11 @@ describe('core SDK', function() {
     it('should not set the wrapper sdk info in Store after it has previously been set', function(done) {
         mParticle._resetForTests(MPConfig);
 
-        mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');
+        mParticle._setWrapperSDKInfo('flutter', '1.0.3');
 
         mParticle.init(apiKey, window.mParticle.config);
 
-        mParticle.getInstance()._setWrapperSDKInfo('none', '2.0.5');
+        mParticle._setWrapperSDKInfo('none', '2.0.5');
 
         mParticle.getInstance()._Store.wrapperSDKInfo.name.should.equal('flutter');
         mParticle.getInstance()._Store.wrapperSDKInfo.version.should.equal('1.0.3');

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -1157,7 +1157,7 @@ describe('core SDK', function() {
         done();
     });
 
-    it('should not set the wrapper sdk info in store after it has been set', function(done) {
+    it('should not set the wrapper sdk info in Store after it has previously been set', function(done) {
         mParticle._resetForTests(MPConfig);
 
         mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -1118,4 +1118,58 @@ describe('core SDK', function() {
 
         done();
     });
+
+    it('should not set the wrapper sdk info in store when mParticle._setWrapperSDKInfo() method is called if init not called', function(done) {
+        mParticle._resetForTests(MPConfig);
+
+        mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');
+
+        mParticle.getInstance()._Store.wrapperSDKInfo.name.should.equal('none');
+        (mParticle.getInstance()._Store.wrapperSDKInfo.version === null).should.equal(true);
+        mParticle.getInstance()._Store.wrapperSDKInfo.isInfoSet.should.equal(false);
+        
+        done();
+    });
+
+    it('should have the correct wrapper sdk info default values when init is called', function(done) {
+        mParticle._resetForTests(MPConfig);
+        
+        mParticle.init(apiKey, window.mParticle.config);
+
+        mParticle.getInstance()._Store.wrapperSDKInfo.name.should.equal('none');
+        (mParticle.getInstance()._Store.wrapperSDKInfo.version === null).should.equal(true);
+        mParticle.getInstance()._Store.wrapperSDKInfo.isInfoSet.should.equal(false);
+
+        done();
+    });
+
+    it('should set the wrapper sdk info in store when mParticle._setWrapperSDKInfo() method is called and init is called', function(done) {
+        mParticle._resetForTests(MPConfig);
+
+        mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');
+
+        mParticle.init(apiKey, window.mParticle.config);
+
+        mParticle.getInstance()._Store.wrapperSDKInfo.name.should.equal('flutter');
+        mParticle.getInstance()._Store.wrapperSDKInfo.version.should.equal('1.0.3');
+        mParticle.getInstance()._Store.wrapperSDKInfo.isInfoSet.should.equal(true);
+        
+        done();
+    });
+
+    it('should not set the wrapper sdk info in store after it has been set', function(done) {
+        mParticle._resetForTests(MPConfig);
+
+        mParticle.getInstance()._setWrapperSDKInfo('flutter', '1.0.3');
+
+        mParticle.init(apiKey, window.mParticle.config);
+
+        mParticle.getInstance()._setWrapperSDKInfo('none', '2.0.5');
+
+        mParticle.getInstance()._Store.wrapperSDKInfo.name.should.equal('flutter');
+        mParticle.getInstance()._Store.wrapperSDKInfo.version.should.equal('1.0.3');
+        mParticle.getInstance()._Store.wrapperSDKInfo.isInfoSet.should.equal(true);
+
+        done();
+    });
 });


### PR DESCRIPTION
## Summary
Add ability for wrapper SDKs to set their name and version on the core SDK.

## Testing Plan
Added unit tests and confirmed locally

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4758


[SQDSDKS-4758]: https://mparticle-eng.atlassian.net/browse/SQDSDKS-4758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ