### PR TITLE
ci: Fix security lint checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,12 @@ name: Web SDK Build & Test
 on: pull_request
 
 jobs:
+    security-lint-checks:
+      name: Security Lint Checks
+      uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
+      with:
+        base_branch: "development"
+
     build-and-test:
         name: Build and Test
         runs-on: ubuntu-latest
@@ -27,10 +33,6 @@ jobs:
             - name: Lint with Prettier
               run: npm run prettier
 
-            - name: Security Lint Checks
-              uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
-              with:
-                base_branch: "development"
 
             - name: Build Files
               run: npm run build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,12 +6,6 @@ name: Web SDK Build & Test
 on: pull_request
 
 jobs:
-    security-lint-checks:
-      name: Security Lint Checks
-      uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
-      with:
-        base_branch: "development"
-
     build-and-test:
         name: Build and Test
         runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,7 +27,6 @@ jobs:
             - name: Lint with Prettier
               run: npm run prettier
 
-
             - name: Build Files
               run: npm run build
 

--- a/.github/workflows/reusable-workflows.yml
+++ b/.github/workflows/reusable-workflows.yml
@@ -15,6 +15,6 @@ jobs:
     uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@stable
   security-lint-checks:
     name: Security Lint Checks
-    uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
+    uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@stable
     with:
       base_branch: "development"

--- a/.github/workflows/reusable-workflows.yml
+++ b/.github/workflows/reusable-workflows.yml
@@ -13,3 +13,8 @@ jobs:
   pr-branch-target-gitflow:
     name: Check PR for semantic target branch
     uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@stable
+  security-lint-checks:
+    name: Security Lint Checks
+    uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
+    with:
+      base_branch: "development"


### PR DESCRIPTION
## Summary
Ever since the security check was added to the Github action, it prevented the build and test from running.  This should fix that.  Example failure here - https://github.com/mParticle/mparticle-web-sdk/actions/runs/3789930377

## Testing Plan
NA