### PR TITLE
ci: Move Security Checks for PR Actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,12 @@ name: Web SDK Build & Test
 on: pull_request
 
 jobs:
+    security-check:
+        name: Security Lint Checks
+        uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
+        with:
+            base_branch: "development"
+
     build-and-test:
         name: Build and Test
         runs-on: ubuntu-latest
@@ -27,10 +33,6 @@ jobs:
             - name: Lint with Prettier
               run: npm run prettier
 
-            - name: Security Lint Checks
-              uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
-              with:
-                base_branch: "development"
 
             - name: Build Files
               run: npm run build
@@ -183,7 +185,9 @@ jobs:
     dependabot-automerge:
         name: Rebase dependabot PRs
         runs-on: [ubuntu-latest]
-        needs: build-and-test
+        needs:
+            - build-and-test
+            - security-check
         if: contains(github.repository, 'internal') && github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' && github.ref == 'refs/heads/development'
         steps:
             - name: Rebase Dependabot PR


### PR DESCRIPTION
## Summary
- Current position of Security Checks are breaking PR checks. Moving them to the top of the jobs list as per Github Action requirements

## Testing Plan
- Github Actions should detect and run tests

## Master Issue
Closes https://go.mparticle.com/work/REPLACE
