### PR TITLE
refactor: Migrate Config API Client to TypeScript

### DIFF
--- a/src/configAPIClient.ts
+++ b/src/configAPIClient.ts
@@ -1,5 +1,11 @@
 import { DataPlanConfig } from '@mparticle/web-sdk';
-import { KitConfigs, MParticleWebSDK, SDKInitConfig } from './sdkRuntimeModels';
+import {
+    BooleanStringLowerCase,
+    MParticleWebSDK,
+    SDKEventCustomFlags,
+    SDKInitConfig,
+} from './sdkRuntimeModels';
+import { Dictionary } from './utils';
 
 export type SDKInitFunction = (
     apiKey: string,
@@ -7,9 +13,52 @@ export type SDKInitFunction = (
     mpInstance: MParticleWebSDK
 ) => void;
 
+export interface IKitConfigs {
+    name: string;
+    moduleId: number;
+    isDebug: boolean;
+    isVisible: boolean;
+    isDebugString: BooleanStringLowerCase;
+    hasDebugString: BooleanStringLowerCase;
+    settings: Dictionary;
+    screenNameFilters: number[];
+    screenAttributeFilters: number[];
+    userIdentityFilters: number[];
+    userAttributeFilters: number[];
+    eventNameFilters: number[];
+    eventTypeFilters: number[];
+    attributeFilters: number[];
+    filteringEventAttributeValue: Dictionary;
+    filteringConsentRuleValues: Dictionary;
+    consentRegulationFilters: number[];
+    consentRegulationPurposeFilters: number[];
+    messageTypeFilters: number[];
+    messageTypeStateFilters: number[];
+    eventSubscriptionId: number;
+    excludeAnonymousUser: boolean;
+}
+
+export interface IPixelConfig {
+    name: string;
+    moduleId: number;
+    esId: number;
+    isDebug: boolean;
+    isProduction: boolean;
+    settings: Dictionary;
+    frequencyCap: number;
+    pixelUrl: string;
+    redirectUrl: string;
+}
+
 export interface IConfigResponse {
     appName: string;
-    kitConfigs: KitConfigs[];
+    kitConfigs: IKitConfigs[];
+    serviceUrl: string;
+    secureServiceUrl: string;
+    minWebviewBridgeVersion: number;
+    workspaceToken: string;
+    pixelConfigs: IPixelConfig[];
+    flags: SDKEventCustomFlags;
 }
 
 export interface IConfigAPIClient {

--- a/src/configAPIClient.ts
+++ b/src/configAPIClient.ts
@@ -28,7 +28,6 @@ export default function ConfigAPIClient(this: IConfigAPIClient) {
         completeSDKInitialization,
         mpInstance
     ): void => {
-        // debugger;
         let url: string;
         try {
             const xhrCallback = function() {

--- a/src/configAPIClient.ts
+++ b/src/configAPIClient.ts
@@ -1,13 +1,14 @@
 import { DataPlanConfig } from '@mparticle/web-sdk';
 import {
     BooleanStringLowerCase,
+    DataPlanResult,
     MParticleWebSDK,
     SDKEventCustomFlags,
     SDKInitConfig,
 } from './sdkRuntimeModels';
 import { Dictionary } from './utils';
 
-export type SDKInitFunction = (
+export type SDKCompleteInitCallback = (
     apiKey: string,
     config: SDKInitConfig,
     mpInstance: MParticleWebSDK
@@ -52,6 +53,7 @@ export interface IPixelConfig {
 
 export interface IConfigResponse {
     appName: string;
+    dataPlanResult: DataPlanResult;
     kitConfigs: IKitConfigs[];
     serviceUrl: string;
     secureServiceUrl: string;
@@ -65,7 +67,7 @@ export interface IConfigAPIClient {
     getSDKConfiguration: (
         apiKey: string,
         config: SDKInitConfig,
-        completeSDKInitialization: SDKInitFunction,
+        completeSDKInitialization: SDKCompleteInitCallback,
         mpInstance: MParticleWebSDK
     ) => void;
 }

--- a/src/configAPIClient.ts
+++ b/src/configAPIClient.ts
@@ -1,13 +1,37 @@
-export default function ConfigAPIClient() {
-    this.getSDKConfiguration = function(
+import { DataPlanConfig } from '@mparticle/web-sdk';
+import { KitConfigs, MParticleWebSDK, SDKInitConfig } from './sdkRuntimeModels';
+
+export type SDKInitFunction = (
+    apiKey: string,
+    config: SDKInitConfig,
+    mpInstance: MParticleWebSDK
+) => void;
+
+export interface IConfigResponse {
+    appName: string;
+    kitConfigs: KitConfigs[];
+}
+
+export interface IConfigAPIClient {
+    getSDKConfiguration: (
+        apiKey: string,
+        config: SDKInitConfig,
+        completeSDKInitialization: SDKInitFunction,
+        mpInstance: MParticleWebSDK
+    ) => void;
+}
+
+export default function ConfigAPIClient(this: IConfigAPIClient) {
+    this.getSDKConfiguration = (
         apiKey,
         config,
         completeSDKInitialization,
         mpInstance
-    ) {
-        var url;
+    ): void => {
+        // debugger;
+        let url: string;
         try {
-            var xhrCallback = function() {
+            const xhrCallback = function() {
                 if (xhr.readyState === 4) {
                     // when a 200 returns, merge current config with what comes back from config, prioritizing user inputted config
                     if (xhr.status === 200) {
@@ -31,7 +55,7 @@ export default function ConfigAPIClient() {
                 }
             };
 
-            var xhr = mpInstance._Helpers.createXHR(xhrCallback);
+            const xhr = mpInstance._Helpers.createXHR(xhrCallback);
             url =
                 'https://' +
                 mpInstance._Store.SDKConfig.configUrl +
@@ -43,7 +67,7 @@ export default function ConfigAPIClient() {
                 url = url + '0';
             }
 
-            var dataPlan = config.dataPlan;
+            const dataPlan = config.dataPlan as DataPlanConfig;
             if (dataPlan) {
                 if (dataPlan.planId) {
                     url = url + '&plan_id=' + dataPlan.planId || '';

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -6,7 +6,7 @@ import { IStore, SDKConfig } from './store';
 import Validators from './validators';
 import { Dictionary } from './utils';
 import { IServerModel } from './serverModel';
-
+import { IKitConfigs } from './configAPIClient';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;
@@ -158,10 +158,13 @@ export interface MParticleWebSDK {
     isIOS?: boolean;
 }
 
+// Used in cases where server requires booleans as strings
+export type BooleanStringLowerCase = 'false' | 'true';
+export type BooleanStringUpperCase = 'False' | 'True';
+
 export type LogLevelType = 'none' | 'verbose' | 'warning' | 'error';
 
 // TODO: Create true types for Kits and Kit Configs
-export type KitConfigs = Dictionary;
 export type Kit = Dictionary;
 export type MPForwarder = Dictionary;
 
@@ -172,11 +175,11 @@ export type MPForwarder = Dictionary;
 // Currently, this extends MPConfiguration in @types/mparticle__web-sdk
 // and the two will be merged in once the Store module is refactored
 export interface SDKInitConfig
-extends Omit<MPConfiguration, 'dataPlan' | 'logLevel'> {
+    extends Omit<MPConfiguration, 'dataPlan' | 'logLevel'> {
     dataPlan?: DataPlanConfig | KitBlockerDataPlan; // TODO: These should be eventually split into two different attributes
     logLevel?: LogLevelType;
 
-    kitConfigs?: KitConfigs[];
+    kitConfigs?: IKitConfigs[];
     kits?: Dictionary<Kit>;
     dataPlanOptions?: KitBlockerOptions;
     flags?: Dictionary;
@@ -222,7 +225,10 @@ export interface SDKHelpersApi {
     generateUniqueId();
     isObject(item: any);
     returnConvertedBoolean(data: string | boolean | number): boolean;
-    sanitizeAttributes(attrs: Dictionary<string>, name: string): Dictionary<string> | null;
+    sanitizeAttributes(
+        attrs: Dictionary<string>,
+        name: string
+    ): Dictionary<string> | null;
     Validators: typeof Validators;
 }
 

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -160,7 +160,7 @@ export interface MParticleWebSDK {
 
 // Used in cases where server requires booleans as strings
 export type BooleanStringLowerCase = 'false' | 'true';
-export type BooleanStringUpperCase = 'False' | 'True';
+export type BooleanStringTitleCase = 'False' | 'True';
 
 export type LogLevelType = 'none' | 'verbose' | 'warning' | 'error';
 

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -216,6 +216,7 @@ export interface SDKIdentityApi {
 
 export interface SDKHelpersApi {
     createServiceUrl(arg0: string, arg1: string): void;
+    createXHR?(cb: () => void): XMLHttpRequest;
     extend(...args: any[]);
     parseNumber(value: string | number): number;
     generateUniqueId();

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,12 +7,12 @@ import {
     IdentityCallback,
     SDKEventCustomFlags,
 } from '@mparticle/web-sdk';
+import { IKitConfigs } from './configAPIClient';
 import Constants from './constants';
 import {
     DataPlanResult,
     Kit,
     KitBlockerOptions,
-    KitConfigs,
     LogLevelType,
     MParticleWebSDK,
     MPForwarder,
@@ -45,7 +45,7 @@ export interface SDKConfig {
     appVersion?: string;
     package?: string;
     flags?: { [key: string]: string | number | boolean };
-    kitConfigs: KitConfigs[];
+    kitConfigs: IKitConfigs[];
     kits: Dictionary<Kit>;
     logLevel?: LogLevelType;
     cookieDomain?: string;
@@ -108,7 +108,6 @@ interface WrapperSDKInfo {
     version: string | null;
     isInfoSet: boolean;
 }
-
 
 // Temporary Interface until Store can be refactored as a class
 export interface IStore {

--- a/test/src/tests-config-api-client.ts
+++ b/test/src/tests-config-api-client.ts
@@ -1,0 +1,182 @@
+import sinon from 'sinon';
+import { urls } from './config';
+import { apiKey, MPConfig, testMPID } from './config';
+import { expect } from 'chai';
+import Constants from '../../src/constants';
+import ConfigAPIClient, { IConfigResponse } from '../../src/configAPIClient';
+import { MParticleWebSDK, SDKInitConfig } from '../../src/sdkRuntimeModels';
+
+declare global {
+    interface Window {
+        mParticle: MParticleWebSDK;
+        // fetchMock: any;
+    }
+}
+
+describe.only('ConfigAPIClient', () => {
+    let mockServer;
+    let sdkInitCompleteCallback;
+    let configUrl;
+    let dataPlan;
+
+    beforeEach(() => {
+        mockServer = sinon.createFakeServer();
+        mockServer.respondImmediately = true;
+        sdkInitCompleteCallback = sinon.spy();
+        window.mParticle._resetForTests(MPConfig);
+    });
+
+    afterEach(() => {
+        mockServer.reset();
+        sinon.restore();
+    });
+
+    describe('#getSDKConfiguration', () => {
+        describe('with defaults', () => {
+            beforeEach(() => {});
+            it('should fetch a config from the server', () => {
+                const config = { requestConfig: true } as SDKInitConfig;
+
+                mockServer.respondWith(urls.config, [
+                    200,
+                    {},
+                    JSON.stringify({ appName: 'Test App', kitConfigs: [] }),
+                ]);
+
+                window.mParticle.init(apiKey, config);
+
+                const configAPIClient = new ConfigAPIClient();
+                configAPIClient.getSDKConfiguration(
+                    apiKey,
+                    config,
+                    sdkInitCompleteCallback,
+                    window.mParticle.getInstance()
+                );
+
+                expect(sdkInitCompleteCallback.getCalls().length).to.equal(1);
+                expect(
+                    sdkInitCompleteCallback.calledWithMatch(
+                        apiKey,
+                        MPConfig,
+                        window.mParticle.getInstance()
+                    )
+                );
+                expect(mockServer.lastRequest).to.haveOwnProperty('response');
+
+                // TODO: Check mockServer
+                expect(mockServer.lastRequest.url).to.equal(urls.config);
+
+                const configResponse: IConfigResponse = JSON.parse(
+                    mockServer.lastRequest.response
+                );
+
+                expect(configResponse).to.be.ok;
+                expect(configResponse.appName).to.equal('Test App');
+                expect(configResponse.kitConfigs).to.be.ok;
+            });
+
+            it('should continue sdk init if fetch fails', () => {
+                const config = { requestConfig: true };
+
+                mockServer.respondWith(urls.config, [400, {}, '']);
+
+                window.mParticle.init(apiKey, window.mParticle.config);
+
+                const configAPIClient = new ConfigAPIClient();
+                configAPIClient.getSDKConfiguration(
+                    apiKey,
+                    config,
+                    sdkInitCompleteCallback,
+                    window.mParticle.getInstance()
+                );
+
+                expect(sdkInitCompleteCallback.getCalls().length).to.equal(1);
+                expect(
+                    sdkInitCompleteCallback.calledWithMatch(
+                        apiKey,
+                        MPConfig,
+                        window.mParticle.getInstance()
+                    )
+                );
+                expect(mockServer.lastRequest).to.haveOwnProperty('response');
+                expect(mockServer.lastRequest.url).to.equal(urls.config);
+            });
+        });
+
+        describe('with Data Plan', () => {
+            beforeEach(() => {
+                configUrl = `${urls.config}&plan_id=test_data_plan&plan_version=42`;
+
+                dataPlan = {
+                    planId: 'test_data_plan',
+                    planVersion: 42,
+                };
+
+                mockServer.respondWith(configUrl, [
+                    200,
+                    {},
+                    JSON.stringify({
+                        appName: 'Test App',
+                        kitConfigs: [],
+                        dataPlan,
+                    }),
+                ]);
+            });
+
+            it('appends data plan information to url', () => {
+                const config = { requestConfig: true, dataPlan: dataPlan };
+
+                window.mParticle.init(apiKey, window.mParticle.config);
+
+                const configAPIClient = new ConfigAPIClient();
+                configAPIClient.getSDKConfiguration(
+                    apiKey,
+                    config,
+                    sdkInitCompleteCallback,
+                    window.mParticle.getInstance()
+                );
+
+                expect(sdkInitCompleteCallback.getCalls().length).to.equal(1);
+                expect(
+                    sdkInitCompleteCallback.calledWithMatch(
+                        apiKey,
+                        MPConfig,
+                        window.mParticle.getInstance()
+                    )
+                );
+
+                expect(mockServer.lastRequest).to.haveOwnProperty('url');
+                expect(mockServer.lastRequest.url).to.equal(configUrl);
+            });
+
+            it('returns data plan information within the HTTP Response', () => {
+                const configUrl = `${urls.config}&plan_id=test_data_plan&plan_version=42`;
+                const config = { requestConfig: true, dataPlan: dataPlan };
+
+                window.mParticle.init(apiKey, window.mParticle.config);
+
+                const configAPIClient = new ConfigAPIClient();
+                configAPIClient.getSDKConfiguration(
+                    apiKey,
+                    config,
+                    sdkInitCompleteCallback,
+                    window.mParticle.getInstance()
+                );
+
+                expect(mockServer.lastRequest).to.haveOwnProperty('method');
+                expect(mockServer.lastRequest).to.haveOwnProperty('response');
+
+                expect(mockServer.lastRequest.method).to.equal('get');
+                expect(mockServer.lastRequest.url).to.equal(configUrl);
+
+                const configResponse: IConfigResponse = JSON.parse(
+                    mockServer.lastRequest.response
+                );
+
+                expect(configResponse).to.be.ok;
+                expect(configResponse.appName).to.equal('Test App');
+                expect(configResponse.kitConfigs).to.be.ok;
+            });
+        });
+    });
+});

--- a/test/src/tests-config-api-client.ts
+++ b/test/src/tests-config-api-client.ts
@@ -9,11 +9,10 @@ import { MParticleWebSDK, SDKInitConfig } from '../../src/sdkRuntimeModels';
 declare global {
     interface Window {
         mParticle: MParticleWebSDK;
-        // fetchMock: any;
     }
 }
 
-describe.only('ConfigAPIClient', () => {
+describe('ConfigAPIClient', () => {
     let mockServer;
     let sdkInitCompleteCallback;
     let configUrl;
@@ -33,7 +32,6 @@ describe.only('ConfigAPIClient', () => {
 
     describe('#getSDKConfiguration', () => {
         describe('with defaults', () => {
-            beforeEach(() => {});
             it('should fetch a config from the server', () => {
                 const config = { requestConfig: true } as SDKInitConfig;
 

--- a/test/src/tests-main.js
+++ b/test/src/tests-main.js
@@ -1,4 +1,4 @@
-import { MPConfig, workspaceToken} from './config';
+import { MPConfig, workspaceToken } from './config';
 
 var userApi = null;
 
@@ -7,8 +7,7 @@ beforeEach(function() {
     //mocha can't clean up after itself, so this lets
     //tests mock the current user and restores in between runs.
     if (!userApi) {
-        userApi = window.mParticle.getInstance().Identity
-            .getCurrentUser;
+        userApi = window.mParticle.getInstance().Identity.getCurrentUser;
     } else {
         window.mParticle.getInstance().Identity.getCurrentUser = userApi;
     }
@@ -20,7 +19,7 @@ beforeEach(function() {
         requestConfig: false,
         isDevelopmentMode: false,
     };
-    
+
     mParticle._resetForTests(MPConfig);
     delete mParticle._instances['default_instance'];
 });
@@ -55,3 +54,4 @@ import './tests-queue-public-methods';
 import './tests-validators';
 import './tests-utils';
 import './tests-store';
+import './tests-config-api-client';


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Migrate ConfigAPIClient to TypeScript
 - Add Unit Tests

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Run automated tests
 - Test manually via Sample App

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5010
