### PR TITLE
fix: use currentUser consent state as backup if missing in last event

### DIFF
--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -49,8 +49,7 @@ export function convertEvents(
 
     let currentConsentState: SDKConsentState = null;
 
-    // If the event is missing consent state for some reason,
-    // get consent state from last event or user
+    // Add the consent state from either the Last Event or the user
     if (!isEmpty(lastEvent.ConsentState)) {
         currentConsentState = lastEvent.ConsentState;
     } else if (!isEmpty(user)) {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - In cases where the event is missing a consent state, we should use the current user's consent state

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5047
 - Broken out of #383 to split out unrelated functionality in that feature branch