### PR TITLE
refactor: Modify BatchUploader to use promises for individual uploads

### DIFF
--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -9,17 +9,35 @@ import { convertEvents } from './sdkToEventsApiConverter';
 import Types from './types';
 import { isEmpty } from './utils';
 
+/**
+ * BatchUploader contains all the logic to upload batches to mParticle.
+ * It queues events as they come in and at set intervals turns them into batches.
+ * It then attempts to upload them to mParticle.
+ *
+ * These uploads happen on an interval basis using window.fetch or XHR
+ * requests, depending on what is available in the browser.
+ *
+ * Uploads can also triggered on browser visibility/focus changes via an
+ * event listener, which then uploads to mPartice via the browser's Beacon API.
+ */
+
 export class BatchUploader {
-    //we upload JSON, but this content type is required to avoid a CORS preflight request
+    // We upload JSON, but this content type is required to avoid a CORS preflight request
     static readonly CONTENT_TYPE: string = 'text/plain;charset=UTF-8';
     static readonly MINIMUM_INTERVAL_MILLIS: number = 500;
     uploadIntervalMillis: number;
-    pendingEvents: SDKEvent[];
-    pendingUploads: Batch[];
+    eventsQueuedForProcessing: SDKEvent[];
+    batchesQueuedForProcessing: Batch[];
     mpInstance: MParticleWebSDK;
     uploadUrl: string;
     batchingEnabled: boolean;
+    private uploader: AsyncUploader;
 
+    /**
+     * Creates an instance of a BatchUploader
+     * @param {MParticleWebSDK} mpInstance - the mParticle SDK instance
+     * @param {number} uploadInterval - the desired upload interval in milliseconds
+     */
     constructor(mpInstance: MParticleWebSDK, uploadInterval: number) {
         this.mpInstance = mpInstance;
         this.uploadIntervalMillis = uploadInterval;
@@ -28,8 +46,8 @@ export class BatchUploader {
         if (this.uploadIntervalMillis < BatchUploader.MINIMUM_INTERVAL_MILLIS) {
             this.uploadIntervalMillis = BatchUploader.MINIMUM_INTERVAL_MILLIS;
         }
-        this.pendingEvents = [];
-        this.pendingUploads = [];
+        this.eventsQueuedForProcessing = [];
+        this.batchesQueuedForProcessing = [];
 
         const { SDKConfig, devToken } = this.mpInstance._Store;
         const baseUrl = this.mpInstance._Helpers.createServiceUrl(
@@ -38,15 +56,20 @@ export class BatchUploader {
         );
         this.uploadUrl = `${baseUrl}/events`;
 
-        setTimeout(() => {
-            this.prepareAndUpload(true, false);
-        }, this.uploadIntervalMillis);
+        this.uploader = window.fetch
+            ? new FetchUploader(this.uploadUrl)
+            : new XHRUploader(this.uploadUrl);
+
+        this.triggerUploadInterval(true, false);
         this.addEventListeners();
     }
 
+    // Adds listeners to be used trigger Navigator.sendBeacon if the browser
+    // loses focus for any reason, such as closing browser tab or minimizing window
     private addEventListeners() {
         const _this = this;
 
+        // visibility change is a document property, not window
         document.addEventListener('visibilitychange', () => {
             _this.prepareAndUpload(false, _this.isBeaconAvailable());
         });
@@ -65,16 +88,32 @@ export class BatchUploader {
         return false;
     }
 
+    // Triggers a setTimeout for prepareAndUpload
+    private triggerUploadInterval(
+        triggerFuture: boolean = false,
+        useBeacon: boolean = false
+    ): void {
+        setTimeout(() => {
+            this.prepareAndUpload(triggerFuture, useBeacon);
+        }, this.uploadIntervalMillis);
+    }
+
+    /**
+     * This method will queue a single Event which will eventually be processed into a Batch
+     * @param event event that should be queued
+     */
     queueEvent(event: SDKEvent): void {
         if (!isEmpty(event)) {
-            this.pendingEvents.push(event);
+            this.eventsQueuedForProcessing.push(event);
             this.mpInstance.Logger.verbose(
                 `Queuing event: ${JSON.stringify(event)}`
             );
             this.mpInstance.Logger.verbose(
-                `Queued event count: ${this.pendingEvents.length}`
+                `Queued event count: ${this.eventsQueuedForProcessing.length}`
             );
 
+            // TODO: Remove this check once the v2 code path is removed
+            //       https://go.mparticle.com/work/SQDSDKS-3720
             if (
                 !this.batchingEnabled ||
                 Types.TriggerUploadType[event.EventDataType]
@@ -93,7 +132,7 @@ export class BatchUploader {
      * @param sdkEvents current pending events
      * @param defaultUser the user to reference for events that are missing data
      */
-    private static createNewUploads(
+    private static createNewBatches(
         sdkEvents: SDKEvent[],
         defaultUser: MParticleUser,
         mpInstance: MParticleWebSDK
@@ -141,9 +180,8 @@ export class BatchUploader {
                     mpInstance._Store.SDKConfig.onCreateBatch;
 
                 if (onCreateBatchCallback) {
-                    uploadBatchObject = onCreateBatchCallback(
-                        uploadBatchObject
-                    );
+                    uploadBatchObject =
+                        onCreateBatchCallback(uploadBatchObject);
                     if (uploadBatchObject) {
                         uploadBatchObject.modified = true;
                     } else {
@@ -169,112 +207,122 @@ export class BatchUploader {
      * @param triggerFuture whether to trigger the loop again - for manual/forced uploads this should be false
      * @param useBeacon whether to use the beacon API - used when the page is being unloaded
      */
-    private async prepareAndUpload(triggerFuture: boolean, useBeacon: boolean) {
+    private async prepareAndUpload(
+        triggerFuture: boolean,
+        useBeacon: boolean
+    ): Promise<void> {
         const currentUser = this.mpInstance.Identity.getCurrentUser();
 
-        const currentEvents = this.pendingEvents;
-        this.pendingEvents = [];
-        const newUploads = BatchUploader.createNewUploads(
+        const currentEvents = this.eventsQueuedForProcessing;
+        this.eventsQueuedForProcessing = [];
+
+        const newBatches = BatchUploader.createNewBatches(
             currentEvents,
             currentUser,
             this.mpInstance
         );
-        if (newUploads && newUploads.length) {
-            this.pendingUploads.push(...newUploads);
+        if (!isEmpty(newBatches)) {
+            this.batchesQueuedForProcessing.push(...newBatches);
         }
 
-        const currentUploads = this.pendingUploads;
-        this.pendingUploads = [];
-        const remainingUploads: Batch[] = await this.upload(
-            this.mpInstance.Logger,
-            currentUploads,
-            useBeacon
-        );
-        if (remainingUploads && remainingUploads.length) {
-            this.pendingUploads.unshift(...remainingUploads);
+        const batchesToUpload = this.batchesQueuedForProcessing;
+        const batchesThatDidNotUpload: Batch[] = [];
+        this.batchesQueuedForProcessing = [];
+
+        // Create an array of promises as we try to upload each batch indvidually
+        const promises: Promise<Batch>[] = batchesToUpload.map((upload) => {
+            return this.upload(this.mpInstance.Logger, upload, useBeacon);
+        });
+
+        // Iterate through fulfilled promises and store any remaining batches
+        // for future re-transmission attempts
+        if (!isEmpty(promises)) {
+            Promise.all(promises)
+                .then((batchResponses) => {
+                    batchResponses.forEach((batch) =>
+                        !isEmpty(batch)
+                            ? batchesThatDidNotUpload.push(batch)
+                            : null
+                    );
+                })
+                .catch((error) => {
+                    this.mpInstance.Logger.error(
+                        `Error processing batches during upload attempt: ${error}`
+                    );
+                })
+                .finally(() => {
+                    // Any batches that did not upload should be put back into the queue for processing
+                    if (!isEmpty(batchesThatDidNotUpload)) {
+                        this.batchesQueuedForProcessing.unshift(
+                            ...batchesThatDidNotUpload
+                        );
+                    }
+                });
         }
 
         if (triggerFuture) {
-            setTimeout(() => {
-                this.prepareAndUpload(true, false);
-            }, this.uploadIntervalMillis);
+            this.triggerUploadInterval(triggerFuture, false);
         }
     }
 
     private async upload(
         logger: SDKLoggerApi,
-        _uploads: Batch[],
+        batch: Batch,
         useBeacon: boolean
-    ): Promise<Batch[]> {
-        let uploader;
-
-        // Filter out any batches that don't have events
-        const uploads = _uploads.filter(upload => !isEmpty(upload.events));
-
-        if (isEmpty(uploads)) {
+    ): Promise<Batch | null> {
+        if (isEmpty(batch) || isEmpty(batch.events)) {
             return null;
         }
 
-        logger.verbose(`Uploading batches: ${JSON.stringify(uploads)}`);
-        logger.verbose(`Batch count: ${uploads.length}`);
+        logger.verbose(`Uploading batches: ${JSON.stringify(batch)}`);
 
-        for (let i = 0; i < uploads.length; i++) {
-            const fetchPayload: fetchPayload = {
-                method: 'POST',
-                headers: {
-                    Accept: BatchUploader.CONTENT_TYPE,
-                    'Content-Type': 'text/plain;charset=UTF-8',
-                },
-                body: JSON.stringify(uploads[i]),
-            };
+        const fetchPayload: fetchPayload = {
+            method: 'POST',
+            headers: {
+                Accept: BatchUploader.CONTENT_TYPE,
+                'Content-Type': 'text/plain;charset=UTF-8',
+            },
+            body: JSON.stringify(batch),
+        };
 
-            // beacon is only used on onbeforeunload onpagehide events
-            if (useBeacon && this.isBeaconAvailable()) {
-                let blob = new Blob([fetchPayload.body], {
-                    type: 'text/plain;charset=UTF-8',
-                });
-                navigator.sendBeacon(this.uploadUrl, blob);
-            } else {
-                if (!uploader) {
-                    if (window.fetch) {
-                        uploader = new FetchUploader(this.uploadUrl, logger);
-                    } else {
-                        uploader = new XHRUploader(this.uploadUrl, logger);
-                    }
-                }
-                try {
-                    const response = await uploader.upload(
-                        fetchPayload,
-                        uploads,
-                        i
+        // TODO: Make beacon its own function
+        // beacon is only used on onbeforeunload onpagehide events
+        if (useBeacon && this.isBeaconAvailable()) {
+            let blob = new Blob([fetchPayload.body], {
+                type: 'text/plain;charset=UTF-8',
+            });
+            navigator.sendBeacon(this.uploadUrl, blob);
+        } else {
+            try {
+                const response = await this.uploader.upload(fetchPayload);
+
+                // TODO: Should we make this a switch statement instead?
+                if (response.status >= 200 && response.status < 300) {
+                    logger.verbose(
+                        `Upload success for request ID: ${batch.source_request_id}`
                     );
 
-                    if (response.status >= 200 && response.status < 300) {
-                        logger.verbose(
-                            `Upload success for request ID: ${uploads[i].source_request_id}`
-                        );
-                    } else if (
-                        response.status >= 500 ||
-                        response.status === 429
-                    ) {
-                        logger.error(
-                            `HTTP error status ${response.status} received`
-                        );
-                        //server error, add back current events and try again later
-                        return uploads.slice(i, uploads.length);
-                    } else if (response.status >= 401) {
-                        logger.error(
-                            `HTTP error status ${response.status} while uploading - please verify your API key.`
-                        );
-                        //if we're getting a 401, assume we'll keep getting a 401 and clear the uploads.
-                        return null;
-                    }
-                } catch (e) {
+                    return null;
+                } else if (response.status >= 500 || response.status === 429) {
                     logger.error(
-                        `Error sending event to mParticle servers. ${e}`
+                        `HTTP error status ${response.status} received`
                     );
-                    return uploads.slice(i, uploads.length);
+
+                    // Server error, return current batch and try again later
+                    return batch;
+                } else if (response.status >= 401) {
+                    logger.error(
+                        `HTTP error status ${response.status} while uploading - please verify your API key.`
+                    );
+                    // if we're getting a 401, assume we'll keep getting a 401
+                    // so return the upload so it can be stored for later use
+                    return batch;
                 }
+            } catch (error) {
+                logger.error(
+                    `Error sending event to mParticle servers. ${error}`
+                );
+                return batch;
             }
         }
         return null;
@@ -283,34 +331,24 @@ export class BatchUploader {
 
 abstract class AsyncUploader {
     url: string;
-    logger: SDKLoggerApi;
+    public abstract upload(fetchPayload: fetchPayload): Promise<XHRResponse>;
 
-    constructor(url: string, logger: SDKLoggerApi) {
+    constructor(url: string) {
         this.url = url;
-        this.logger = logger;
     }
 }
 
 class FetchUploader extends AsyncUploader {
-    private async upload(
-        fetchPayload: fetchPayload,
-        uploads: Batch[],
-        i: number
-    ) {
+    public async upload(fetchPayload: fetchPayload): Promise<XHRResponse> {
         const response: XHRResponse = await fetch(this.url, fetchPayload);
         return response;
     }
 }
 
 class XHRUploader extends AsyncUploader {
-    private async upload(
-        fetchPayload: fetchPayload,
-        uploads: Batch[],
-        i: number
-    ) {
+    public async upload(fetchPayload: fetchPayload): Promise<XHRResponse> {
         const response: XHRResponse = await this.makeRequest(
             this.url,
-            this.logger,
             fetchPayload.body
         );
         return response;
@@ -318,7 +356,6 @@ class XHRUploader extends AsyncUploader {
 
     private async makeRequest(
         url: string,
-        logger: SDKLoggerApi,
         data: string
     ): Promise<XMLHttpRequest> {
         const xhr: XMLHttpRequest = new XMLHttpRequest();

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -17,7 +17,7 @@ import { isEmpty } from './utils';
  * These uploads happen on an interval basis using window.fetch or XHR
  * requests, depending on what is available in the browser.
  *
- * Uploads can also triggered on browser visibility/focus changes via an
+ * Uploads can also be triggered on browser visibility/focus changes via an
  * event listener, which then uploads to mPartice via the browser's Beacon API.
  */
 

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -16,14 +16,13 @@ import Logger from '../../src/logger.js';
 declare global {
     interface Window {
         mParticle: MParticleWebSDK;
-        // beforeunload: any;
         fetchMock: any;
     }
 }
 
 describe('batch uploader', () => {
-    var mockServer,
-        clock
+    let mockServer;
+    let clock;
 
     beforeEach(function() {
         mockServer = sinon.createFakeServer();
@@ -73,7 +72,7 @@ describe('batch uploader', () => {
 
                 uploader.queueEvent(event);
 
-                expect(uploader.pendingEvents.length).to.eql(1);
+                expect(uploader.eventsQueuedForProcessing.length).to.eql(1);
             });
 
             it('should reject batches without events', () => {
@@ -87,8 +86,8 @@ describe('batch uploader', () => {
                 uploader.queueEvent(null);
                 uploader.queueEvent(({} as unknown) as SDKEvent);
 
-                expect(uploader.pendingEvents).to.eql([]);
-                expect(uploader.pendingUploads).to.eql([]);
+                expect(uploader.eventsQueuedForProcessing).to.eql([]);
+                expect(uploader.batchesQueuedForProcessing).to.eql([]);
             });
         });
     });
@@ -221,7 +220,9 @@ describe('batch uploader', () => {
             window.mParticle.init(apiKey, window.mParticle.config);
             window.mParticle.logEvent('Test Event');
 
-            let pendingEvents = window.mParticle.getInstance()._APIClient.uploader.pendingEvents
+            debugger;
+
+            let pendingEvents = window.mParticle.getInstance()._APIClient.uploader.eventsQueuedForProcessing;
 
             pendingEvents.length.should.equal(3)
             pendingEvents[0].EventName.should.equal(1);
@@ -233,7 +234,7 @@ describe('batch uploader', () => {
             (window.fetchMock.lastCall() === undefined).should.equal(true);
             clock.tick(1000);
 
-            let nowPendingEvents = window.mParticle.getInstance()._APIClient.uploader.pendingEvents
+            let nowPendingEvents = window.mParticle.getInstance()._APIClient.uploader.eventsQueuedForProcessing;
             nowPendingEvents.length.should.equal(0);
 
             var batch = JSON.parse(window.fetchMock.lastCall()[1].body);
@@ -339,103 +340,167 @@ describe('batch uploader', () => {
             // Force an upload of events
             window.mParticle.upload();
             
-            // We have to restore the clock in order to use setTimeout below
-            clock.restore();
+            var batch1 = JSON.parse(window.fetchMock._calls[0][1].body);
+            var batch2 = JSON.parse(window.fetchMock._calls[1][1].body);
+            var batch3 = JSON.parse(window.fetchMock._calls[2][1].body);
+            var batch4 = JSON.parse(window.fetchMock._calls[3][1].body);
+            var batch5 = JSON.parse(window.fetchMock._calls[4][1].body);
 
-            // This timeout is required for all batches to be sent due to there being
-            // an async/await inside of a for loop in the batch uploader
-            setTimeout(function() {
-                var batch1 = JSON.parse(window.fetchMock._calls[0][1].body);
-                var batch2 = JSON.parse(window.fetchMock._calls[1][1].body);
-                var batch3 = JSON.parse(window.fetchMock._calls[2][1].body);
-                var batch4 = JSON.parse(window.fetchMock._calls[3][1].body);
-                var batch5 = JSON.parse(window.fetchMock._calls[4][1].body);
+            // UAC event
+            expect(batch1.events.length, 'Batch 1: UAC event').to.equal(1);
 
-                // UAC event
-                batch1.events.length.should.equal(1);
+            // session start, AST
+            expect(
+                batch2.events.length,
+                'Batch 2: Session Start, AST'
+            ).to.equal(2);
 
-                // session start, AST
-                batch2.events.length.should.equal(2);
+            // session end
+            expect(batch3.events.length, 'Batch 3: Session End').to.equal(1);
 
-                // session end
-                batch3.events.length.should.equal(1);
+            // UAC event
+            expect(batch4.events.length, 'Batch 4: UAC event').to.equal(1);
 
-                // session start, AST
-                batch4.events.length.should.equal(2);
+            // session start, AST
+            expect(
+                batch5.events.length,
+                'Batch 5: Session Start, AST'
+            ).to.equal(2);
 
-                // UAC event
-                batch5.events.length.should.equal(1);
+            var batch1UAC = Utils.findEventFromBatch(
+                batch1,
+                'user_attribute_change'
+            );
+            batch1UAC.should.be.ok();
 
-                var batch1UAC = Utils.findEventFromBatch(batch1, 'user_attribute_change');
-                batch1UAC.should.be.ok();
+            var batch2SessionStart = Utils.findEventFromBatch(
+                batch2,
+                'session_start'
+            );
+            var batch2AST = Utils.findEventFromBatch(
+                batch2,
+                'application_state_transition'
+            );
 
-                var batch2SessionStart = Utils.findEventFromBatch(batch2, 'session_start');
-                var batch2AST = Utils.findEventFromBatch(batch2, 'application_state_transition');
+            batch2SessionStart.should.be.ok();
+            batch2AST.should.be.ok();
 
-                batch2SessionStart.should.be.ok();
-                batch2AST.should.be.ok();
+            var batch3SessionEnd = Utils.findEventFromBatch(
+                batch3,
+                'session_end'
+            );
+            batch3SessionEnd.should.be.ok();
 
-                var batch3SessionEnd = Utils.findEventFromBatch(batch3, 'session_end');
-                batch3SessionEnd.should.be.ok();
+            var batch4UAC = Utils.findEventFromBatch(
+                batch4,
+                'user_attribute_change'
+            );
+            batch4UAC.should.be.ok();
 
-                var batch4SessionStart = Utils.findEventFromBatch(batch4, 'session_start');
-                var batch4AST = Utils.findEventFromBatch(batch4, 'application_state_transition');
+            var batch5SessionStart = Utils.findEventFromBatch(
+                batch5,
+                'session_start'
+            );
+            var batch5AST = Utils.findEventFromBatch(
+                batch5,
+                'application_state_transition'
+            );
 
-                batch4SessionStart.should.be.ok();
-                batch4AST.should.be.ok();
-                
-                var batch5UAC = Utils.findEventFromBatch(batch5, 'user_attribute_change');
-                batch5UAC.should.be.ok();
+            batch5SessionStart.should.be.ok();
+            batch5AST.should.be.ok();
 
-                (typeof batch1.source_request_id).should.equal('string');
-                (typeof batch2.source_request_id).should.equal('string');
-                (typeof batch3.source_request_id).should.equal('string');
-                (typeof batch4.source_request_id).should.equal('string');
-                (typeof batch5.source_request_id).should.equal('string');
+            (typeof batch1.source_request_id).should.equal('string');
+            (typeof batch2.source_request_id).should.equal('string');
+            (typeof batch3.source_request_id).should.equal('string');
+            (typeof batch4.source_request_id).should.equal('string');
+            (typeof batch5.source_request_id).should.equal('string');
 
-                batch1.source_request_id.should.not.equal(batch2.source_request_id);
-                batch1.source_request_id.should.not.equal(batch3.source_request_id);
-                batch1.source_request_id.should.not.equal(batch4.source_request_id);
-                batch1.source_request_id.should.not.equal(batch5.source_request_id);
-                batch2.source_request_id.should.not.equal(batch3.source_request_id);
-                batch2.source_request_id.should.not.equal(batch4.source_request_id);
-                batch2.source_request_id.should.not.equal(batch5.source_request_id);
+            batch1.source_request_id.should.not.equal(batch2.source_request_id);
+            batch1.source_request_id.should.not.equal(batch3.source_request_id);
+            batch1.source_request_id.should.not.equal(batch4.source_request_id);
+            batch1.source_request_id.should.not.equal(batch5.source_request_id);
 
-                batch3.source_request_id.should.not.equal(batch4.source_request_id);
-                batch3.source_request_id.should.not.equal(batch5.source_request_id);
-                batch4.source_request_id.should.not.equal(batch5.source_request_id);
+            batch2.source_request_id.should.not.equal(batch3.source_request_id);
+            batch2.source_request_id.should.not.equal(batch4.source_request_id);
+            batch2.source_request_id.should.not.equal(batch5.source_request_id);
 
-                batch1UAC.data.session_uuid.should.equal(batch2AST.data.session_uuid);
-                batch1UAC.data.session_uuid.should.equal(batch2SessionStart.data.session_uuid);
-                batch1UAC.data.session_uuid.should.not.equal(batch4SessionStart.data.session_uuid);
-                batch1UAC.data.session_uuid.should.not.equal(batch4AST.data.session_uuid);
-                batch1UAC.data.session_uuid.should.not.equal(batch5UAC.data.session_uuid);
-                
-                batch1UAC.data.session_start_unixtime_ms.should.equal(batch2AST.data.session_start_unixtime_ms);
-                batch1UAC.data.session_start_unixtime_ms.should.equal(batch2SessionStart.data.session_start_unixtime_ms);
-                batch1UAC.data.session_start_unixtime_ms.should.not.equal(batch4SessionStart.data.session_start_unixtime_ms);
-                batch1UAC.data.session_start_unixtime_ms.should.not.equal(batch4AST.data.session_start_unixtime_ms);
-                batch1UAC.data.session_start_unixtime_ms.should.not.equal(batch5UAC.data.session_start_unixtime_ms);
+            batch3.source_request_id.should.not.equal(batch4.source_request_id);
+            batch3.source_request_id.should.not.equal(batch5.source_request_id);
+            batch4.source_request_id.should.not.equal(batch5.source_request_id);
 
-                batch2SessionStart.data.session_uuid.should.equal(batch2AST.data.session_uuid);
-                batch2SessionStart.data.session_uuid.should.equal(batch3SessionEnd.data.session_uuid);
-                batch2AST.data.session_uuid.should.equal(batch3SessionEnd.data.session_uuid);
+            batch1UAC.data.session_uuid.should.equal(
+                batch2AST.data.session_uuid
+            );
+            batch1UAC.data.session_uuid.should.equal(
+                batch2SessionStart.data.session_uuid
+            );
+            batch1UAC.data.session_uuid.should.not.equal(
+                batch4UAC.data.session_uuid
+            );
+            batch1UAC.data.session_uuid.should.not.equal(
+                batch5SessionStart.data.session_uuid
+            );
+            batch1UAC.data.session_uuid.should.not.equal(
+                batch5AST.data.session_uuid
+            );
 
-                batch2SessionStart.data.session_start_unixtime_ms.should.equal(batch2AST.data.session_start_unixtime_ms);
-                batch2SessionStart.data.session_start_unixtime_ms.should.equal(batch3SessionEnd.data.session_start_unixtime_ms);
-                batch2AST.data.session_start_unixtime_ms.should.equal(batch3SessionEnd.data.session_start_unixtime_ms);
+            batch1UAC.data.session_start_unixtime_ms.should.equal(
+                batch2AST.data.session_start_unixtime_ms
+            );
+            batch1UAC.data.session_start_unixtime_ms.should.equal(
+                batch2SessionStart.data.session_start_unixtime_ms
+            );
+            batch1UAC.data.session_start_unixtime_ms.should.not.equal(
+                batch4UAC.data.session_start_unixtime_ms
+            );
+            batch1UAC.data.session_start_unixtime_ms.should.not.equal(
+                batch5SessionStart.data.session_start_unixtime_ms
+            );
+            batch1UAC.data.session_start_unixtime_ms.should.not.equal(
+                batch5AST.data.session_start_unixtime_ms
+            );
 
-                batch4SessionStart.data.session_uuid.should.equal(batch4AST.data.session_uuid);
-                batch4SessionStart.data.session_uuid.should.equal(batch5UAC.data.session_uuid);
-                batch4AST.data.session_uuid.should.equal(batch5UAC.data.session_uuid);
+            batch2SessionStart.data.session_uuid.should.equal(
+                batch2AST.data.session_uuid
+            );
+            batch2SessionStart.data.session_uuid.should.equal(
+                batch3SessionEnd.data.session_uuid
+            );
+            batch2AST.data.session_uuid.should.equal(
+                batch3SessionEnd.data.session_uuid
+            );
 
-                batch4SessionStart.data.session_start_unixtime_ms.should.equal(batch4AST.data.session_start_unixtime_ms);
-                batch4SessionStart.data.session_start_unixtime_ms.should.equal(batch5UAC.data.session_start_unixtime_ms);
-                batch4AST.data.session_start_unixtime_ms.should.equal(batch5UAC.data.session_start_unixtime_ms);
-                
-                done();
-                // wait for more than 1000 milliseconds to force the final upload
-            }, 1200);
+            batch2SessionStart.data.session_start_unixtime_ms.should.equal(
+                batch2AST.data.session_start_unixtime_ms
+            );
+            batch2SessionStart.data.session_start_unixtime_ms.should.equal(
+                batch3SessionEnd.data.session_start_unixtime_ms
+            );
+            batch2AST.data.session_start_unixtime_ms.should.equal(
+                batch3SessionEnd.data.session_start_unixtime_ms
+            );
+
+            batch5AST.data.session_uuid.should.equal(
+                batch4UAC.data.session_uuid
+            );
+            batch5SessionStart.data.session_uuid.should.equal(
+                batch4UAC.data.session_uuid
+            );
+            batch5SessionStart.data.session_uuid.should.equal(
+                batch5AST.data.session_uuid
+            );
+
+            batch5AST.data.session_start_unixtime_ms.should.equal(
+                batch4UAC.data.session_start_unixtime_ms
+            );
+            batch5SessionStart.data.session_start_unixtime_ms.should.equal(
+                batch4UAC.data.session_start_unixtime_ms
+            );
+            batch5SessionStart.data.session_start_unixtime_ms.should.equal(
+                batch5AST.data.session_start_unixtime_ms
+            );
+            
+            done();
         });
     })
 
@@ -602,7 +667,7 @@ describe('batch uploader', () => {
             window.mParticle.init(apiKey, window.mParticle.config);
             window.mParticle.logEvent('Test Event');
 
-            let pendingEvents = window.mParticle.getInstance()._APIClient.uploader.pendingEvents
+            const pendingEvents = window.mParticle.getInstance()._APIClient.uploader.eventsQueuedForProcessing;
 
             pendingEvents.length.should.equal(3)
             pendingEvents[0].EventName.should.equal(1);
@@ -611,7 +676,7 @@ describe('batch uploader', () => {
 
             clock.tick(1000);
 
-            let nowPendingEvents = window.mParticle.getInstance()._APIClient.uploader.pendingEvents
+            const nowPendingEvents = window.mParticle.getInstance()._APIClient.uploader.eventsQueuedForProcessing;
             nowPendingEvents.length.should.equal(0);
 
             var batch = JSON.parse(mockServer.secondRequest.requestBody);
@@ -685,69 +750,6 @@ describe('batch uploader', () => {
         });
     })
 
-    describe('upload beacon', ()=> {
-        beforeEach(() => {
-            window.mParticle.config.flags = {
-                eventsV3: '100',
-                eventBatchingIntervalMillis: 1000,
-            }
-        })
-        afterEach(() => {
-            sinon.restore();
-        });
-
-        it('should trigger beacon on page visibilitychange events', function(done) {
-            window.mParticle._resetForTests(MPConfig);
-
-            var bond = sinon.spy(navigator, 'sendBeacon');
-            window.mParticle.init(apiKey, window.mParticle.config);
-            document.dispatchEvent(new Event('visibilitychange'))
-
-            bond.called.should.eql(true);
-            bond.getCalls()[0].args[0].should.eql(
-                'https://jssdks.mparticle.com/v3/JS/test_key/events'
-            );
-
-            done();
-        });
-
-        it('should trigger beacon on page beforeunload events', function(done) {
-            window.mParticle._resetForTests(MPConfig);
-
-            var bond = sinon.spy(navigator, 'sendBeacon');
-            window.mParticle.init(apiKey, window.mParticle.config);
-
-            // karma fails if onbeforeunload is not set to null
-            window.onbeforeunload = null
-            window.dispatchEvent(new Event('beforeunload'))
-            
-            bond.called.should.eql(true);
-            bond.getCalls()[0].args[0].should.eql(
-                'https://jssdks.mparticle.com/v3/JS/test_key/events'
-            );
-                
-            done();
-        });
-
-        it('should trigger beacon on pagehide events', function(done) {
-            window.mParticle._resetForTests(MPConfig);
-            
-            var bond = sinon.spy(navigator, 'sendBeacon');
-            
-            window.mParticle.init(apiKey, window.mParticle.config);
-            window.dispatchEvent(new Event('pagehide'))
-
-            bond.called.should.eql(true);
-            bond.getCalls()[0].args[0].should.eql(
-                'https://jssdks.mparticle.com/v3/JS/test_key/events'
-            );
-
-            (typeof(bond.getCalls()[0].args[1])).should.eql('object');
-
-            done();
-        });
-    });
-
     describe('handling eventless batches', () => {
         it('should reject batches without events', async () => {
             window.mParticle.config.flags = {
@@ -787,10 +789,10 @@ describe('batch uploader', () => {
             const eventlessBatch = batchValidator.returnBatch(
                 ({} as unknown) as BaseEvent
             );
-            const testBatches = [actualBatch, eventlessBatch];
 
             // HACK: Directly access uploader to Force an upload
-            await (<any>uploader).upload(newLogger, testBatches, false);
+            await (<any>uploader).upload(newLogger, actualBatch, false);
+            await (<any>uploader).upload(newLogger, eventlessBatch, false);
 
             expect(window.fetchMock.calls().length).to.equal(1);
 

--- a/test/src/tests-beaconUpload.ts
+++ b/test/src/tests-beaconUpload.ts
@@ -1,0 +1,90 @@
+import sinon from 'sinon';
+import { urls } from './config';
+import { apiKey, MPConfig, testMPID } from './config';
+import { MParticleWebSDK } from '../../src/sdkRuntimeModels';
+import _BatchValidator from '../../src/mockBatchCreator';
+
+declare global {
+    interface Window {
+        mParticle: MParticleWebSDK;
+        fetchMock: any;
+    }
+}
+
+describe('Beacon Upload', () => {
+    let mockServer;
+
+    beforeEach(function() {
+        mockServer = sinon.createFakeServer();
+        mockServer.respondImmediately = true;
+
+        mockServer.respondWith(urls.identify, [
+            200,
+            {},
+            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
+        ]);
+
+        window.mParticle.config.flags = {
+            eventsV3: '100',
+            eventBatchingIntervalMillis: 1000,
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        mockServer.reset();
+    });
+
+    it('should trigger beacon on page visibilitychange events', function(done) {
+        window.mParticle._resetForTests(MPConfig);
+
+        var bond = sinon.spy(navigator, 'sendBeacon');
+        window.mParticle.init(apiKey, window.mParticle.config);
+
+        // visibility change is a document property, not window
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        bond.called.should.eql(true);
+        bond.getCalls()[0].args[0].should.eql(
+            'https://jssdks.mparticle.com/v3/JS/test_key/events'
+        );
+
+        done();
+    });
+
+    it('should trigger beacon on page beforeunload events', function(done) {
+        window.mParticle._resetForTests(MPConfig);
+
+        var bond = sinon.spy(navigator, 'sendBeacon');
+        window.mParticle.init(apiKey, window.mParticle.config);
+
+        // karma fails if onbeforeunload is not set to null
+        window.onbeforeunload = null;
+        window.dispatchEvent(new Event('beforeunload'));
+
+        bond.called.should.eql(true);
+        bond.getCalls()[0].args[0].should.eql(
+            'https://jssdks.mparticle.com/v3/JS/test_key/events'
+        );
+
+        done();
+    });
+
+    it('should trigger beacon on pagehide events', function(done) {
+        window.mParticle._resetForTests(MPConfig);
+
+        var bond = sinon.spy(navigator, 'sendBeacon');
+        window.mParticle.init(apiKey, window.mParticle.config);
+
+        window.dispatchEvent(new Event('pagehide'));
+
+        bond.called.should.eql(true);
+        bond.getCalls()[0].args[0].should.eql(
+            'https://jssdks.mparticle.com/v3/JS/test_key/events'
+        );
+
+        (typeof bond.getCalls()[0].args[1]).should.eql('object');
+
+        done();
+    });
+});

--- a/test/src/tests-main.js
+++ b/test/src/tests-main.js
@@ -28,6 +28,9 @@ afterEach(function() {
     window.fetchMock.restore();
 });
 
+// NOTE: Beacon upload must come before core sdk tests beause of race condition
+import './tests-beaconUpload';
+
 import './tests-core-sdk';
 import './tests-temp-session-bug-fix';
 import './tests-batchUploader';


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
This pull request refactors parts of the BatchUploader to better handle asynchronous uploads. Currently, a single asynchronous request is made that iterates through a list of batches, yet each batch is individually uploaded to the server. Loops inside of promises are not recommended in JavaScript as they could lead a longer turnaround time to process the response or other unexpected results. By breaking up the single upload promise into individual promises, each upload is a single process that returns quicker requires less processing.

Also, Beacon Uploader tests are moved out of the Batch Uploader test suite as there was an issue with race condition in the test runner.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5048
 - Breaks out non-persistence related functionality from #383
