### PR TITLE
feat: Add Feature Flag Support for Offline Batching

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -161,6 +161,7 @@ const Constants = {
         ReportBatching: 'reportBatching',
         EventsV3: 'eventsV3',
         EventBatchingIntervalMillis: 'eventBatchingIntervalMillis',
+        OfflineBatching: 'offlineBatching',
     },
     DefaultInstance: 'default_instance',
 } as const;

--- a/src/store.ts
+++ b/src/store.ts
@@ -437,5 +437,12 @@ export default function Store(
         ) {
             this.SDKConfig.flags[Constants.FeatureFlags.ReportBatching] = false;
         }
+        if (
+            !this.SDKConfig.flags.hasOwnProperty(
+                Constants.FeatureFlags.OfflineBatching
+            )
+        ) {
+            this.SDKConfig.flags.offlineBatching = 0;
+        }
     }
 }

--- a/test/src/tests-beaconUpload.ts
+++ b/test/src/tests-beaconUpload.ts
@@ -13,6 +13,69 @@ declare global {
 
 describe('Beacon Upload', () => {
     let mockServer;
+    let mockLS;
+    let mockEventFromLS = {
+        EventName: 10,
+        EventAttributes: null,
+        SourceMessageId: 'b56a0cdf-91b8-4d86-96a8-57d8886d3b7a',
+        EventDataType: 10,
+        CustomFlags: {},
+        IsFirstRun: true,
+        LaunchReferral: 'http://localhost:9876/debug.html',
+        CurrencyCode: null,
+        MPID: 'testMPID',
+        ConsentState: null,
+        UserAttributes: {},
+        UserIdentities: [],
+        Store: {},
+        SDKVersion: '2.18.0',
+        SessionId: '0D63646B-EA93-4AD1-8378-FAD7A71A333B',
+        SessionStartDate: 1671576752819,
+        Debug: false,
+        Location: null,
+        OptOut: null,
+        ExpandedEventCount: 0,
+        ClientGeneratedId: '95a0d3e4-f16c-4bd4-a86a-60bfd1ed353f',
+        DeviceId: '062e7536-cf85-4430-a177-282dd0bbb31f',
+        IntegrationAttributes: {},
+        DataPlan: {},
+        Timestamp: 1671576752827,
+    };
+
+    let mockBatchFromLS = {
+        application_info: {},
+        consent_state: null,
+        device_info: {
+            platform: 'web',
+            screen_width: 3440,
+            screen_height: 1440,
+        },
+        platform: 'web',
+        screen_height: 1440,
+        screen_width: 3440,
+        environment: 'production',
+        events: [
+            {
+                event_type: 'session_start',
+                data: {
+                    custom_attributes: null,
+                    location: null,
+                    session_start_unixtime_ms: 1672254481735,
+                    session_uuid: 'AF7F14A6-5966-4A47-B90E-341731D1E53E',
+                    source_message_id: '57b21559-8188-47b3-a462-ff4f369b3bc5',
+                    timestamp_unixtime_ms: 1672254481751,
+                },
+            },
+        ],
+        integration_attributes: {},
+        mp_deviceid: '281cb431-5e27-4ae2-bfe9-6229f28bad29',
+        mpid: 'testMPID',
+        sdk_version: '2.18.0',
+        source_request_id: '74009286-5241-4581-a5b8-8c9444214250',
+        timestamp_unixtime_ms: 1672254531776,
+        user_attributes: {},
+        user_identities: null,
+    };
 
     beforeEach(function() {
         mockServer = sinon.createFakeServer();
@@ -24,6 +87,23 @@ describe('Beacon Upload', () => {
             JSON.stringify({ mpid: testMPID, is_logged_in: false }),
         ]);
 
+        // Stub Local Storage response because it causes beacon to not fire in
+        // repeated tests
+        // Note: Firefox won't let you mock local storage directly, so
+        //       you need to mock Storage.prototype
+        // https://github.com/jasmine/jasmine/issues/299#issuecomment-312599271
+        mockLS = sinon.stub(Storage.prototype, 'getItem');
+        mockLS.withArgs('mprtcl-v4_abcdef-events').returns(
+            JSON.stringify({
+                'b56a0cdf-91b8-4d86-96a8-57d8886d3b7a': mockEventFromLS,
+            })
+        );
+        mockLS.withArgs('mprtcl-v4_abcdef-batches').returns(
+            JSON.stringify({
+                '74009286-5241-4581-a5b8-8c9444214250': mockBatchFromLS,
+            })
+        );
+
         window.mParticle.config.flags = {
             eventsV3: '100',
             eventBatchingIntervalMillis: 1000,
@@ -33,9 +113,10 @@ describe('Beacon Upload', () => {
     afterEach(() => {
         sinon.restore();
         mockServer.reset();
+        window.localStorage.clear();
     });
 
-    it('should trigger beacon on page visibilitychange events', function(done) {
+    it('should trigger beacon on page visibilitychange events', done => {
         window.mParticle._resetForTests(MPConfig);
 
         var bond = sinon.spy(navigator, 'sendBeacon');
@@ -52,7 +133,7 @@ describe('Beacon Upload', () => {
         done();
     });
 
-    it('should trigger beacon on page beforeunload events', function(done) {
+    it('should trigger beacon on page beforeunload events', done => {
         window.mParticle._resetForTests(MPConfig);
 
         var bond = sinon.spy(navigator, 'sendBeacon');
@@ -70,7 +151,7 @@ describe('Beacon Upload', () => {
         done();
     });
 
-    it('should trigger beacon on pagehide events', function(done) {
+    it('should trigger beacon on pagehide events', done => {
         window.mParticle._resetForTests(MPConfig);
 
         var bond = sinon.spy(navigator, 'sendBeacon');


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- Implements two instances of the Vault Local Storage Wrapper, one for Events, and a second for Batches
- As events are queued, they are placed into local storage for later processing. Once the prepareAndUpload method is triggered, events are removed from local storage and converted to Batches, then placed into the batch vault.
- Once batches are ready to upload, they are removed from local storage to prevent accidental retransmissions, and an upload to our servers is attempted.
- If the transmission is successful, no further action is taken.
- If the transmission is unsuccessful, the batches are added back to local storage and are retransmitted during the next interval.
 - Implements a Feature Flag so we can control offline batching release to users via a server config

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5049
 - Reintroduces approved code from #373