### PR TITLE
fix: removeUserAttribute and forwarder filters fix

### DIFF
--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -404,8 +404,8 @@ export default function Forwarders(mpInstance, kitBlocker) {
         mpInstance._Store.activeForwarders.forEach(function(forwarder) {
             const forwarderFunction = forwarder[functionNameKey];
             if (
-                forwarderFunction &&
-                mpInstance._Helpers.isFilteredUserAttribute(
+                !forwarderFunction ||
+                !mpInstance._Helpers.isFilteredUserAttribute(
                     key,
                     forwarder.userAttributeFilters
                 )

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -3,6 +3,12 @@ import filteredMparticleUser from './filteredMparticleUser';
 
 export default function Forwarders(mpInstance, kitBlocker) {
     var self = this;
+
+    const UserAttributeActionTypes = {
+        setUserAttribute: 'setUserAttribute',
+        removeUserAttribute: 'removeUserAttribute'
+    }
+
     this.initForwarders = function(userIdentities, forwardingStatsCallback) {
         var user = mpInstance.Identity.getCurrentUser();
         if (
@@ -387,14 +393,14 @@ export default function Forwarders(mpInstance, kitBlocker) {
         }
     };
 
-    this.onHandleForwarderUserAttributes = function(key, value, functionName) {
+    this.onHandleForwarderUserAttributes = function(key, value, functionNameKey) {
         if (kitBlocker && kitBlocker.isAttributeKeyBlocked(key)) {
             return;
         }
 
         if (mpInstance._Store.activeForwarders.length) {
             mpInstance._Store.activeForwarders.forEach(function(forwarder) {
-                var forwarderFunction = forwarder[functionName];
+                var forwarderFunction = forwarder[functionNameKey];
                 if (
                     forwarderFunction &&
                     forwarder.userAttributeFilters &&
@@ -406,9 +412,9 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     try {
                         var result;
 
-                        if (functionName === 'setUserAttribute') {
+                        if (functionNameKey === UserAttributeActionTypes.setUserAttribute) {
                             result = forwarder.setUserAttribute(key, value);
-                        } else if (functionName === 'removeUserAttribute') {
+                        } else if (functionNameKey === UserAttributeActionTypes.removeUserAttribute) {
                             result = forwarder.removeUserAttribute(key);
                         }
 

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -6,8 +6,8 @@ export default function Forwarders(mpInstance, kitBlocker) {
 
     const UserAttributeActionTypes = {
         setUserAttribute: 'setUserAttribute',
-        removeUserAttribute: 'removeUserAttribute'
-    }
+        removeUserAttribute: 'removeUserAttribute',
+    };
 
     this.initForwarders = function(userIdentities, forwardingStatsCallback) {
         var user = mpInstance.Identity.getCurrentUser();
@@ -393,14 +393,18 @@ export default function Forwarders(mpInstance, kitBlocker) {
         }
     };
 
-    this.onHandleForwarderUserAttributes = function(key, value, functionNameKey) {
+    this.onHandleForwarderUserAttributes = function(
+        key,
+        value,
+        functionNameKey
+    ) {
         if (kitBlocker && kitBlocker.isAttributeKeyBlocked(key)) {
             return;
         }
 
         if (mpInstance._Store.activeForwarders.length) {
             mpInstance._Store.activeForwarders.forEach(function(forwarder) {
-                var forwarderFunction = forwarder[functionNameKey];
+                const forwarderFunction = forwarder[functionNameKey];
                 if (
                     forwarderFunction &&
                     forwarder.userAttributeFilters &&
@@ -412,9 +416,15 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     try {
                         var result;
 
-                        if (functionNameKey === UserAttributeActionTypes.setUserAttribute) {
+                        if (
+                            functionNameKey ===
+                            UserAttributeActionTypes.setUserAttribute
+                        ) {
                             result = forwarder.setUserAttribute(key, value);
-                        } else if (functionNameKey === UserAttributeActionTypes.removeUserAttribute) {
+                        } else if (
+                            functionNameKey ===
+                            UserAttributeActionTypes.removeUserAttribute
+                        ) {
                             result = forwarder.removeUserAttribute(key);
                         }
 

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -387,15 +387,16 @@ export default function Forwarders(mpInstance, kitBlocker) {
         }
     };
 
-    this.callSetUserAttributeOnForwarders = function(key, value) {
+    this.onHandleForwarderUserAttributes = function(key, value, functionName) {
         if (kitBlocker && kitBlocker.isAttributeKeyBlocked(key)) {
             return;
         }
 
         if (mpInstance._Store.activeForwarders.length) {
             mpInstance._Store.activeForwarders.forEach(function(forwarder) {
+                var forwarderFunction = forwarder[functionName];
                 if (
-                    forwarder.setUserAttribute &&
+                    forwarderFunction &&
                     forwarder.userAttributeFilters &&
                     !mpInstance._Helpers.inArray(
                         forwarder.userAttributeFilters,
@@ -403,7 +404,13 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     )
                 ) {
                     try {
-                        var result = forwarder.setUserAttribute(key, value);
+                        var result;
+
+                        if (functionName === 'setUserAttribute') {
+                            result = forwarder.setUserAttribute(key, value);
+                        } else if (functionName === 'removeUserAttribute') {
+                            result = forwarder.removeUserAttribute(key);
+                        }
 
                         if (result) {
                             mpInstance.Logger.verbose(result);

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -410,27 +410,28 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     forwarder.userAttributeFilters
                 )
             ) {
-                try {
-                    var result;
+                return;
+            }
+            try {
+                let result;
 
-                    if (
-                        functionNameKey ===
-                        UserAttributeActionTypes.setUserAttribute
-                    ) {
-                        result = forwarder.setUserAttribute(key, value);
-                    } else if (
-                        functionNameKey ===
-                        UserAttributeActionTypes.removeUserAttribute
-                    ) {
-                        result = forwarder.removeUserAttribute(key);
-                    }
-
-                    if (result) {
-                        mpInstance.Logger.verbose(result);
-                    }
-                } catch (e) {
-                    mpInstance.Logger.error(e);
+                if (
+                    functionNameKey ===
+                    UserAttributeActionTypes.setUserAttribute
+                ) {
+                    result = forwarder.setUserAttribute(key, value);
+                } else if (
+                    functionNameKey ===
+                    UserAttributeActionTypes.removeUserAttribute
+                ) {
+                    result = forwarder.removeUserAttribute(key);
                 }
+
+                if (result) {
+                    mpInstance.Logger.verbose(result);
+                }
+            } catch (e) {
+                mpInstance.Logger.error(e);
             }
         });
     };

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -393,7 +393,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
         }
     };
 
-    this.handleForwarderUserAttributes = function(key, value, functionNameKey) {
+    this.handleForwarderUserAttributes = function(functionNameKey, key, value) {
         if (
             (kitBlocker && kitBlocker.isAttributeKeyBlocked(key)) ||
             !mpInstance._Store.activeForwarders.length
@@ -405,7 +405,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
             const forwarderFunction = forwarder[functionNameKey];
             if (
                 !forwarderFunction ||
-                !mpInstance._Helpers.isFilteredUserAttribute(
+                mpInstance._Helpers.isFilteredUserAttribute(
                     key,
                     forwarder.userAttributeFilters
                 )

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -393,50 +393,46 @@ export default function Forwarders(mpInstance, kitBlocker) {
         }
     };
 
-    this.onHandleForwarderUserAttributes = function(
-        key,
-        value,
-        functionNameKey
-    ) {
-        if (kitBlocker && kitBlocker.isAttributeKeyBlocked(key)) {
+    this.handleForwarderUserAttributes = function(key, value, functionNameKey) {
+        if (
+            (kitBlocker && kitBlocker.isAttributeKeyBlocked(key)) ||
+            !mpInstance._Store.activeForwarders.length
+        ) {
             return;
         }
 
-        if (mpInstance._Store.activeForwarders.length) {
-            mpInstance._Store.activeForwarders.forEach(function(forwarder) {
-                const forwarderFunction = forwarder[functionNameKey];
-                if (
-                    forwarderFunction &&
-                    forwarder.userAttributeFilters &&
-                    !mpInstance._Helpers.inArray(
-                        forwarder.userAttributeFilters,
-                        mpInstance._Helpers.generateHash(key)
-                    )
-                ) {
-                    try {
-                        var result;
+        mpInstance._Store.activeForwarders.forEach(function(forwarder) {
+            const forwarderFunction = forwarder[functionNameKey];
+            if (
+                forwarderFunction &&
+                mpInstance._Helpers.isFilteredUserAttribute(
+                    key,
+                    forwarder.userAttributeFilters
+                )
+            ) {
+                try {
+                    var result;
 
-                        if (
-                            functionNameKey ===
-                            UserAttributeActionTypes.setUserAttribute
-                        ) {
-                            result = forwarder.setUserAttribute(key, value);
-                        } else if (
-                            functionNameKey ===
-                            UserAttributeActionTypes.removeUserAttribute
-                        ) {
-                            result = forwarder.removeUserAttribute(key);
-                        }
-
-                        if (result) {
-                            mpInstance.Logger.verbose(result);
-                        }
-                    } catch (e) {
-                        mpInstance.Logger.error(e);
+                    if (
+                        functionNameKey ===
+                        UserAttributeActionTypes.setUserAttribute
+                    ) {
+                        result = forwarder.setUserAttribute(key, value);
+                    } else if (
+                        functionNameKey ===
+                        UserAttributeActionTypes.removeUserAttribute
+                    ) {
+                        result = forwarder.removeUserAttribute(key);
                     }
+
+                    if (result) {
+                        mpInstance.Logger.verbose(result);
+                    }
+                } catch (e) {
+                    mpInstance.Logger.error(e);
                 }
-            });
-        }
+            }
+        });
     };
 
     this.setForwarderUserIdentities = function(userIdentities) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -387,6 +387,14 @@ export default function Helpers(mpInstance) {
         return filteredUserAttributes;
     };
 
+    this.isFilteredUserAttribute = function(userAttributeKey, filterList) {
+        var hashedUserAttribute = self.generateHash(userAttributeKey);
+        if (filterList && !self.inArray(filterList, hashedUserAttribute)) {
+            return true;
+        }
+        return false;
+    };
+
     this.isEventType = function(type) {
         for (var prop in Types.EventType) {
             if (Types.EventType.hasOwnProperty(prop)) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -389,7 +389,7 @@ export default function Helpers(mpInstance) {
 
     this.isFilteredUserAttribute = function(userAttributeKey, filterList) {
         const hashedUserAttribute = self.generateHash(userAttributeKey);
-        return filterList && !self.inArray(filterList, hashedUserAttribute);
+        return filterList && self.inArray(filterList, hashedUserAttribute);
     };
 
     this.isEventType = function(type) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -389,10 +389,7 @@ export default function Helpers(mpInstance) {
 
     this.isFilteredUserAttribute = function(userAttributeKey, filterList) {
         const hashedUserAttribute = self.generateHash(userAttributeKey);
-        if (filterList && !self.inArray(filterList, hashedUserAttribute)) {
-            return true;
-        }
-        return false;
+        return filterList && !self.inArray(filterList, hashedUserAttribute);
     };
 
     this.isEventType = function(type) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -388,7 +388,7 @@ export default function Helpers(mpInstance) {
     };
 
     this.isFilteredUserAttribute = function(userAttributeKey, filterList) {
-        var hashedUserAttribute = self.generateHash(userAttributeKey);
+        const hashedUserAttribute = self.generateHash(userAttributeKey);
         if (filterList && !self.inArray(filterList, hashedUserAttribute)) {
             return true;
         }

--- a/src/identity.js
+++ b/src/identity.js
@@ -905,9 +905,9 @@ export default function Identity(mpInstance) {
                             mpInstance._APIClient.prepareForwardingStats
                         );
                         mpInstance._Forwarders.handleForwarderUserAttributes(
+                            'setUserAttribute',
                             key,
-                            newValue,
-                            'setUserAttribute'
+                            newValue
                         );
                     }
                 }
@@ -992,9 +992,9 @@ export default function Identity(mpInstance) {
                         mpInstance._APIClient.prepareForwardingStats
                     );
                     mpInstance._Forwarders.handleForwarderUserAttributes(
+                        'removeUserAttribute',
                         key,
-                        null,
-                        'removeUserAttribute'
+                        null
                     );
                 }
             },
@@ -1101,9 +1101,9 @@ export default function Identity(mpInstance) {
                         mpInstance._APIClient.prepareForwardingStats
                     );
                     mpInstance._Forwarders.handleForwarderUserAttributes(
+                        'setUserAttribute',
                         key,
-                        arrayCopy,
-                        'setUserAttribute'
+                        arrayCopy
                     );
                 }
             },
@@ -1131,9 +1131,9 @@ export default function Identity(mpInstance) {
                         for (var prop in userAttributes) {
                             if (userAttributes.hasOwnProperty(prop)) {
                                 mpInstance._Forwarders.handleForwarderUserAttributes(
+                                    'removeUserAttribute',
                                     prop,
-                                    null,
-                                    'removeUserAttribute'
+                                    null
                                 );
                             }
                             this.removeUserAttribute(prop);

--- a/src/identity.js
+++ b/src/identity.js
@@ -904,9 +904,10 @@ export default function Identity(mpInstance) {
                             self.IdentityAPI.getCurrentUser().getUserIdentities(),
                             mpInstance._APIClient.prepareForwardingStats
                         );
-                        mpInstance._Forwarders.callSetUserAttributeOnForwarders(
+                        mpInstance._Forwarders.onHandleForwarderUserAttributes(
                             key,
-                            newValue
+                            newValue,
+                            'setUserAttribute'
                         );
                     }
                 }
@@ -990,9 +991,10 @@ export default function Identity(mpInstance) {
                         self.IdentityAPI.getCurrentUser().getUserIdentities(),
                         mpInstance._APIClient.prepareForwardingStats
                     );
-                    mpInstance._Forwarders.applyToForwarders(
-                        'removeUserAttribute',
-                        key
+                    mpInstance._Forwarders.onHandleForwarderUserAttributes(
+                        key,
+                        null,
+                        'removeUserAttribute'
                     );
                 }
             },
@@ -1098,9 +1100,10 @@ export default function Identity(mpInstance) {
                         self.IdentityAPI.getCurrentUser().getUserIdentities(),
                         mpInstance._APIClient.prepareForwardingStats
                     );
-                    mpInstance._Forwarders.callSetUserAttributeOnForwarders(
+                    mpInstance._Forwarders.onHandleForwarderUserAttributes(
                         key,
-                        arrayCopy
+                        arrayCopy,
+                        'setUserAttribute'
                     );
                 }
             },
@@ -1127,9 +1130,10 @@ export default function Identity(mpInstance) {
                     if (userAttributes) {
                         for (var prop in userAttributes) {
                             if (userAttributes.hasOwnProperty(prop)) {
-                                mpInstance._Forwarders.applyToForwarders(
-                                    'removeUserAttribute',
-                                    prop
+                                mpInstance._Forwarders.onHandleForwarderUserAttributes(
+                                    prop,
+                                    null,
+                                    'removeUserAttribute'
                                 );
                             }
                             this.removeUserAttribute(prop);

--- a/src/identity.js
+++ b/src/identity.js
@@ -904,7 +904,7 @@ export default function Identity(mpInstance) {
                             self.IdentityAPI.getCurrentUser().getUserIdentities(),
                             mpInstance._APIClient.prepareForwardingStats
                         );
-                        mpInstance._Forwarders.onHandleForwarderUserAttributes(
+                        mpInstance._Forwarders.handleForwarderUserAttributes(
                             key,
                             newValue,
                             'setUserAttribute'
@@ -991,7 +991,7 @@ export default function Identity(mpInstance) {
                         self.IdentityAPI.getCurrentUser().getUserIdentities(),
                         mpInstance._APIClient.prepareForwardingStats
                     );
-                    mpInstance._Forwarders.onHandleForwarderUserAttributes(
+                    mpInstance._Forwarders.handleForwarderUserAttributes(
                         key,
                         null,
                         'removeUserAttribute'
@@ -1100,7 +1100,7 @@ export default function Identity(mpInstance) {
                         self.IdentityAPI.getCurrentUser().getUserIdentities(),
                         mpInstance._APIClient.prepareForwardingStats
                     );
-                    mpInstance._Forwarders.onHandleForwarderUserAttributes(
+                    mpInstance._Forwarders.handleForwarderUserAttributes(
                         key,
                         arrayCopy,
                         'setUserAttribute'
@@ -1130,7 +1130,7 @@ export default function Identity(mpInstance) {
                     if (userAttributes) {
                         for (var prop in userAttributes) {
                             if (userAttributes.hasOwnProperty(prop)) {
-                                mpInstance._Forwarders.onHandleForwarderUserAttributes(
+                                mpInstance._Forwarders.handleForwarderUserAttributes(
                                     prop,
                                     null,
                                     'removeUserAttribute'

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -1233,7 +1233,6 @@ describe('forwarders', function() {
         mParticle._resetForTests(MPConfig);
         const mockForwarder = new MockForwarder();
         mockForwarder.register(window.mParticle.config);
-        mParticle.init(apiKey, window.mParticle.config);
 
         const config1 = forwarderDefaultConfiguration('MockForwarder', 1);
 
@@ -1249,6 +1248,7 @@ describe('forwarders', function() {
         // force filtered UA in mock forwarder (due to filtering affecting setUserAttribute) and test init
         window.MockForwarder1.instance.userAttributes['weight'] = 150
         mParticle.Identity.getCurrentUser().removeUserAttribute('weight');
+        window.MockForwarder1.instance.removeUserAttributeCalled.should.equal(false);
         mParticle.userAttributesFilterOnInitTest.should.have.property(
             'weight'
         );
@@ -1267,10 +1267,7 @@ describe('forwarders', function() {
 
         // "age" is filtered and should not call removeUserAttribute on forwarder
         mParticle.Identity.getCurrentUser().removeUserAttribute('age');
-        window.MockForwarder1.instance.should.not.have.property(
-            'removeUserAttributeCalled',
-            true
-        );
+        window.MockForwarder1.instance.removeUserAttributeCalled.should.equal(false);
         window.MockForwarder1.instance.userAttributes.should.have.property(
             'age',
             20
@@ -1278,10 +1275,7 @@ describe('forwarders', function() {
 
         // "gender" is not filtered and should call removeUserAttribute on forwarder
         mParticle.Identity.getCurrentUser().removeUserAttribute('gender');
-        window.MockForwarder1.instance.should.have.property(
-            'removeUserAttributeCalled',
-            true
-        );
+        window.MockForwarder1.instance.removeUserAttributeCalled.should.equal(true);
         window.MockForwarder1.instance.userAttributes.should.not.have.property(
             'gender'
         );

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -1231,11 +1231,11 @@ describe('forwarders', function() {
 
     it('should filter user attributes from forwarder on init, and on subsequent remove attribute calls', function(done) {
         mParticle._resetForTests(MPConfig);
-        var mockForwarder = new MockForwarder();
+        const mockForwarder = new MockForwarder();
         mockForwarder.register(window.mParticle.config);
         mParticle.init(apiKey, window.mParticle.config);
 
-        var config1 = forwarderDefaultConfiguration('MockForwarder', 1);
+        const config1 = forwarderDefaultConfiguration('MockForwarder', 1);
 
         // filtered User Attributes that should should not call removeUserAttribute
         config1.userAttributeFilters = [
@@ -1255,7 +1255,7 @@ describe('forwarders', function() {
 
         mParticle.init(apiKey, window.mParticle.config);
 
-        let dummyUserAttributes = {
+        const dummyUserAttributes = {
             'gender': 'male',
             'age': 20,
         }

--- a/test/src/utils.js
+++ b/test/src/utils.js
@@ -383,8 +383,9 @@ var pluses = /\+/g,
                 this.userAttributes[key] = value;
             };
 
-            this.removeUserAttribute = function() {
+            this.removeUserAttribute = function(key) {
                 this.removeUserAttributeCalled = true;
+                delete this.userAttributes[key]
             };
 
             window[this.name + this.id] = {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - User attributes when removes are not respecting the filters set which leads some forwarder to set them as null even though they're filtered. The fix here is to not fire removeUserAttribute for a filtered UA.

 ## Testing Plan
- Was tested locally via local overrides and passed unit testing

## References
- Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-5414
