### PR TITLE
test: Fix flakey session date test

### DIFF
--- a/test/src/tests-serverModel.ts
+++ b/test/src/tests-serverModel.ts
@@ -625,8 +625,8 @@ describe('ServerModel', () => {
                 'currentSessionMPIDs'
             ).to.eql(['testMPID']);
 
-            // A SessionEnd event appends sessionLength
-            expect(actualEventObject).to.have.property('sessionLength');
+            // A SessionEnd event appends SessionLength
+            expect(actualEventObject).to.have.property('SessionLength');
 
             // A SessionEnd event should ignore Event Attributes and use Session Attributes instead
             expect(actualEventObject.EventAttributes, 'EventAttributes').to.eql(

--- a/test/src/tests-serverModel.ts
+++ b/test/src/tests-serverModel.ts
@@ -598,12 +598,12 @@ describe('ServerModel', () => {
             ]);
         });
 
-        it('should set necessary attributes if MessageType is SessionEnd', () => {
+        it.only('should set necessary attributes if MessageType is SessionEnd', () => {
             const mPStore = mParticle.getInstance()._Store;
 
             mPStore.sessionAttributes = {
-                foo: 'session-foo',
-                bar: 'session-bar',
+                fooSessionAttr: 'session-foo',
+                barSessionAttr: 'session-bar',
             };
 
             const event: BaseEvent = {
@@ -611,8 +611,8 @@ describe('ServerModel', () => {
                 messageType: Types.MessageType.SessionEnd,
                 eventType: Types.EventType.Other,
                 data: {
-                    foo: 'bar',
-                    bizz: 'bazz',
+                    fooEventAttr: 'bar',
+                    barEventAttr: 'bazz',
                 },
             };
 
@@ -625,22 +625,19 @@ describe('ServerModel', () => {
                 'currentSessionMPIDs'
             ).to.eql(['testMPID']);
 
-            // CreateEventObject nullifies the store's sessionStartDate, so to verify we have a
-            // valid session length, we can check to make sure that the length is shorter than the last
-            // time seen but not zero
-            expect(
-                actualEventObject.SessionStartDate,
-                'sessionStartDate'
-            ).to.be.lessThan(mPStore.dateLastEventSent.getTime());
-            expect(
-                actualEventObject.SessionStartDate,
-                'sessionStartDate'
-            ).to.be.greaterThan(0);
+            // A SessionEnd event appends sessionLength
+            expect(actualEventObject).to.have.property('sessionLength');
 
-            // Session Events should ignore data/Event Attributes and use Session Attributes instead
+            // A SessionEnd event should ignore Event Attributes and use Session Attributes instead
             expect(actualEventObject.EventAttributes, 'EventAttributes').to.eql(
-                { foo: 'session-foo', bar: 'session-bar' }
+                { fooSessionAttr: 'session-foo', barSessionAttr: 'session-bar' }
             );
+            expect(actualEventObject.EventAttributes, 'EventAttributes').to.not.have.property('fooEventAttr');
+            expect(actualEventObject.EventAttributes, 'EventAttributes').to.not.have.property('barEventAttr');
+
+            // A SessionEnd event resets currentSessionMPIDs and sessionStartDate.  When a new session starts, these are filled again
+            expect(mPStore.currentSessionMPIDs).to.eql([]);
+            expect(mPStore.sessionStartDate).to.eql(null);
         });
 
         it('should set necessary attributes if MessageType is AppStateTransition', () => {

--- a/test/src/tests-serverModel.ts
+++ b/test/src/tests-serverModel.ts
@@ -598,7 +598,7 @@ describe('ServerModel', () => {
             ]);
         });
 
-        it.only('should set necessary attributes if MessageType is SessionEnd', () => {
+        it('should set necessary attributes if MessageType is SessionEnd', () => {
             const mPStore = mParticle.getInstance()._Store;
 
             mPStore.sessionAttributes = {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
The previous test format would fail because it was looking for the difference in 2 unix timestamps and this comparison can be flakey depending on how quickly the test is running (if it runs fast and there is no difference in timestamp then it fails, and if it runs slowly there is a difference in timestamp and so the test passes).  After reviewing the test, it was not testing the proper things.  It should instead check to see what properties exists on the `actualEventObject` when it is a Session End. It also mutates the store, which we should test.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - Ran unit tests over and over and it passed every time

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5031