### PR TITLE
feat: Support sideloaded kits

### DIFF
--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -59,7 +59,6 @@ export default function Forwarders(mpInstance, kitBlocker) {
                         user ? user.getAllUserAttributes() : {},
                         forwarder.userAttributeFilters
                     );
-
                     if (!forwarder.initialized) {
                         forwarder.logger = mpInstance.Logger;
                         forwarder.init(
@@ -552,44 +551,60 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     config.isSandbox ===
                         mpInstance._Store.SDKConfig.isDevelopmentMode
                 ) {
-                    newForwarder = new forwarders[name].constructor();
-
-                    newForwarder.id = config.moduleId;
-                    newForwarder.isSandbox = config.isDebug || config.isSandbox;
-                    newForwarder.hasSandbox = config.hasDebugString === 'true';
-                    newForwarder.isVisible = config.isVisible;
-                    newForwarder.settings = config.settings;
-
-                    newForwarder.eventNameFilters = config.eventNameFilters;
-                    newForwarder.eventTypeFilters = config.eventTypeFilters;
-                    newForwarder.attributeFilters = config.attributeFilters;
-
-                    newForwarder.screenNameFilters = config.screenNameFilters;
-                    newForwarder.screenNameFilters = config.screenNameFilters;
-                    newForwarder.screenAttributeFilters =
-                        config.screenAttributeFilters;
-
-                    newForwarder.userIdentityFilters =
-                        config.userIdentityFilters;
-                    newForwarder.userAttributeFilters =
-                        config.userAttributeFilters;
-
-                    newForwarder.filteringEventAttributeValue =
-                        config.filteringEventAttributeValue;
-                    newForwarder.filteringUserAttributeValue =
-                        config.filteringUserAttributeValue;
-                    newForwarder.eventSubscriptionId =
-                        config.eventSubscriptionId;
-                    newForwarder.filteringConsentRuleValues =
-                        config.filteringConsentRuleValues;
-                    newForwarder.excludeAnonymousUser =
-                        config.excludeAnonymousUser;
+                    newForwarder = this.returnConfiguredKit(
+                        forwarders[name],
+                        config
+                    );
 
                     mpInstance._Store.configuredForwarders.push(newForwarder);
                     break;
                 }
             }
         }
+    };
+
+    // kits can be included via mParticle UI, or vi
+    this.configureSideloadedKit = function(sideloadedKit) {
+        mpInstance._Store.configuredForwarders.push(
+            this.returnConfiguredKit(sideloadedKit)
+        );
+    };
+
+    this.returnConfiguredKit = function(forwarder, config = {}) {
+        const newForwarder = new forwarder.constructor();
+        newForwarder.id = config.moduleId;
+
+        // TODO: isSandbox, hasSandbox is never used in any kit or in core SDK.
+        // isVisibleInvestigate is only used in 1 place. It is always true if
+        // it is sent to JS. Investigate further to determine if these can be removed.
+        // https://go.mparticle.com/work/SQDSDKS-5156
+        newForwarder.isSandbox = config.isDebug || config.isSandbox;
+        newForwarder.hasSandbox = config.hasDebugString === 'true';
+        newForwarder.isVisible = config.isVisible || true;
+        newForwarder.settings = config.settings || {};
+
+        newForwarder.eventNameFilters = config.eventNameFilters || [];
+        newForwarder.eventTypeFilters = config.eventTypeFilters || [];
+        newForwarder.attributeFilters = config.attributeFilters || [];
+
+        newForwarder.screenNameFilters = config.screenNameFilters || [];
+        newForwarder.screenAttributeFilters =
+            config.screenAttributeFilters || [];
+
+        newForwarder.userIdentityFilters = config.userIdentityFilters || [];
+        newForwarder.userAttributeFilters = config.userAttributeFilters || [];
+
+        newForwarder.filteringEventAttributeValue =
+            config.filteringEventAttributeValue || {};
+        newForwarder.filteringUserAttributeValue =
+            config.filteringUserAttributeValue || {};
+        newForwarder.eventSubscriptionId = config.eventSubscriptionId || null;
+        newForwarder.filteringConsentRuleValues =
+            config.filteringConsentRuleValues || {};
+        newForwarder.excludeAnonymousUser =
+            config.excludeAnonymousUser || false;
+
+        return newForwarder;
     };
 
     this.configurePixel = function(settings) {
@@ -610,6 +625,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
             );
         } else {
             try {
+                // Process MP configured Kits
                 if (
                     Array.isArray(config.kitConfigs) &&
                     config.kitConfigs.length
@@ -617,6 +633,30 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     config.kitConfigs.forEach(function(kitConfig) {
                         self.configureForwarder(kitConfig);
                     });
+                }
+
+                // Process sideloaded kits
+                // TODO: Sideloading kits currently requires the use of a register method
+                // which requires an object on which to be registered.
+                // In the future, when all kits are moved to the config rather than
+                // there being a separate process for MP configured kits and
+                // sideloaded kits, this will need to be refactored.
+                if (Array.isArray(config.sideloadedKits)) {
+                    var registeredSideloadedKits = { kits: {} };
+
+                    // First register each kit's constructor onto registeredSideloadedKits,
+                    // which is typed { kits: Dictionary<constructor> }.
+                    // The constructors are keyed by the name of the kit.
+                    config.sideloadedKits.forEach(function(sideloadedKit) {
+                        sideloadedKit.register(registeredSideloadedKits);
+                    });
+
+                    // Then configure each kit
+                    for (var registeredKit in registeredSideloadedKits.kits) {
+                        var kitConstructor =
+                            registeredSideloadedKits.kits[registeredKit];
+                        self.configureSideloadedKit(kitConstructor);
+                    }
                 }
 
                 if (

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -564,9 +564,9 @@ export default function Forwarders(mpInstance, kitBlocker) {
     };
 
     // kits can be included via mParticle UI, or vi
-    this.configureSideloadedKit = function(sideloadedKit) {
+    this.configureSideloadedKit = function(kitConstructor) {
         mpInstance._Store.configuredForwarders.push(
-            this.returnConfiguredKit(sideloadedKit)
+            this.returnConfiguredKit(kitConstructor)
         );
     };
 
@@ -652,9 +652,9 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     });
 
                     // Then configure each kit
-                    for (const registeredKit in registeredSideloadedKits.kits) {
+                    for (const registeredKitKey in registeredSideloadedKits.kits) {
                         const kitConstructor =
-                            registeredSideloadedKits.kits[registeredKit];
+                            registeredSideloadedKits.kits[registeredKitKey];
                         self.configureSideloadedKit(kitConstructor);
                     }
                 }

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -642,7 +642,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
                 // there being a separate process for MP configured kits and
                 // sideloaded kits, this will need to be refactored.
                 if (Array.isArray(config.sideloadedKits)) {
-                    var registeredSideloadedKits = { kits: {} };
+                    const registeredSideloadedKits = { kits: {} };
 
                     // First register each kit's constructor onto registeredSideloadedKits,
                     // which is typed { kits: Dictionary<constructor> }.
@@ -652,8 +652,8 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     });
 
                     // Then configure each kit
-                    for (var registeredKit in registeredSideloadedKits.kits) {
-                        var kitConstructor =
+                    for (const registeredKit in registeredSideloadedKits.kits) {
+                        const kitConstructor =
                             registeredSideloadedKits.kits[registeredKit];
                         self.configureSideloadedKit(kitConstructor);
                     }

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -695,10 +695,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
 
     this.processPixelConfigs = function(config) {
         try {
-            if (
-                Array.isArray(config.pixelConfigs) &&
-                config.pixelConfigs.length
-            ) {
+            if (!isEmpty(config.pixelConfigs)) {
                 config.pixelConfigs.forEach(function(pixelConfig) {
                     self.configurePixel(pixelConfig);
                 });

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -1,5 +1,6 @@
 import Types from './types';
 import filteredMparticleUser from './filteredMparticleUser';
+import { isEmpty } from './utils';
 
 export default function Forwarders(mpInstance, kitBlocker) {
     var self = this;
@@ -523,19 +524,59 @@ export default function Forwarders(mpInstance, kitBlocker) {
         mpInstance._Persistence.forwardingStatsBatches.forwardingStatsEventQueue = queue;
     };
 
-    this.configureForwarder = function(configuration) {
+    // Processing forwarders is a 2 step process:
+    //   1. Configure the kit
+    //   2. Initialize the kit
+    // There are 2 types of kits:
+    //   1. UI-enabled kits
+    //   2. Sideloaded kits.
+    this.processForwarders = function(config, forwardingStatsCallback) {
+        if (!config) {
+            mpInstance.Logger.warning(
+                'No config was passed. Cannot process forwarders'
+            );
+        } else {
+            this.processUIEnabledKits(config);
+            this.processSideloadedKits(config);
+
+            self.initForwarders(
+                mpInstance._Store.SDKConfig.identifyRequest.userIdentities,
+                forwardingStatsCallback
+            );
+        }
+    };
+
+    // These are kits that are enabled via the mParticle UI.
+    // A kit that is UI-enabled will have a kit configuration that returns from
+    // the server, or in rare cases, is passed in by the developer.
+    // The kit configuration will be compared with the kit constructors to determine
+    // if there is a match before being initialized.
+    // Only kits that are configured properly can be active and used for kit forwarding.
+    this.processUIEnabledKits = function(config) {
+        try {
+            if (Array.isArray(config.kitConfigs) && config.kitConfigs.length) {
+                config.kitConfigs.forEach(function(kitConfig) {
+                    self.configureUIEnabledKit(kitConfig);
+                });
+            }
+        } catch (e) {
+            mpInstance.Logger.error(
+                'MP Kits not configured propertly. Kits may not be initialized. ' +
+                    e
+            );
+        }
+    };
+
+    this.configureUIEnabledKit = function(configuration) {
         var newForwarder = null,
             config = configuration,
             forwarders = {};
 
-        // if there are kits inside of mpInstance._Store.SDKConfig.kits, then mParticle is self hosted
-        if (
-            mpInstance._Helpers.isObject(mpInstance._Store.SDKConfig.kits) &&
-            Object.keys(mpInstance._Store.SDKConfig.kits).length > 0
-        ) {
+        // If there are kits inside of mpInstance._Store.SDKConfig.kits, then mParticle is self hosted
+        if (!isEmpty(mpInstance._Store.SDKConfig.kits)) {
             forwarders = mpInstance._Store.SDKConfig.kits;
             // otherwise mParticle is loaded via script tag
-        } else if (mpInstance._preInit.forwarderConstructors.length > 0) {
+        } else if (!isEmpty(mpInstance._preInit.forwarderConstructors)) {
             mpInstance._preInit.forwarderConstructors.forEach(function(
                 forwarder
             ) {
@@ -560,6 +601,40 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     break;
                 }
             }
+        }
+    };
+
+    // Sideloaded kits are not configured in the UI and do not have kit configurations
+    // They are automatically added to active forwarders.
+
+    // TODO: Sideloading kits currently requires the use of a register method
+    // which requires an object on which to be registered.
+    // In the future, when all kits are moved to the config rather than
+    // there being a separate process for MP configured kits and
+    // sideloaded kits, this will need to be refactored.
+    this.processSideloadedKits = function(config) {
+        try {
+            if (Array.isArray(config.sideloadedKits)) {
+                const sideloadedKits = { kits: {} };
+                // First register each kit's constructor onto sideloadedKits,
+                // which is typed { kits: Dictionary<constructor> }.
+                // The constructors are keyed by the name of the kit.
+                config.sideloadedKits.forEach(function(sideloadedKit) {
+                    sideloadedKit.register(sideloadedKits);
+                });
+
+                // Then configure each kit
+                for (const registeredKitKey in sideloadedKits.kits) {
+                    const kitConstructor =
+                        sideloadedKits.kits[registeredKitKey];
+                    self.configureSideloadedKit(kitConstructor);
+                }
+            }
+        } catch (e) {
+            mpInstance.Logger.error(
+                'Sideloaded Kits not configured propertly. Kits may not be initialized. ' +
+                    e
+            );
         }
     };
 
@@ -615,69 +690,6 @@ export default function Forwarders(mpInstance, kitBlocker) {
                 mpInstance._Store.SDKConfig.isDevelopmentMode
         ) {
             mpInstance._Store.pixelConfigurations.push(settings);
-        }
-    };
-
-    this.processForwarders = function(config, forwardingStatsCallback) {
-        if (!config) {
-            mpInstance.Logger.warning(
-                'No config was passed. Cannot process forwarders'
-            );
-        } else {
-            this.processMpConfiguredKits(config);
-            this.processSideloadedKits(config);
-            this.processPixelConfigs(config);
-
-            self.initForwarders(
-                mpInstance._Store.SDKConfig.identifyRequest.userIdentities,
-                forwardingStatsCallback
-            );
-        }
-    };
-
-    this.processMpConfiguredKits = function(config) {
-        try {
-            if (Array.isArray(config.kitConfigs) && config.kitConfigs.length) {
-                config.kitConfigs.forEach(function(kitConfig) {
-                    self.configureForwarder(kitConfig);
-                });
-            }
-        } catch (e) {
-            mpInstance.Logger.error(
-                'MP Kits not configured propertly. Kits may not be initialized. ' +
-                    e
-            );
-        }
-    };
-
-    // TODO: Sideloading kits currently requires the use of a register method
-    // which requires an object on which to be registered.
-    // In the future, when all kits are moved to the config rather than
-    // there being a separate process for MP configured kits and
-    // sideloaded kits, this will need to be refactored.
-    this.processSideloadedKits = function(config) {
-        try {
-            if (Array.isArray(config.sideloadedKits)) {
-                const sideloadedKits = { kits: {} };
-                // First register each kit's constructor onto sideloadedKits,
-                // which is typed { kits: Dictionary<constructor> }.
-                // The constructors are keyed by the name of the kit.
-                config.sideloadedKits.forEach(function(sideloadedKit) {
-                    sideloadedKit.register(sideloadedKits);
-                });
-
-                // Then configure each kit
-                for (const registeredKitKey in sideloadedKits.kits) {
-                    const kitConstructor =
-                        sideloadedKits.kits[registeredKitKey];
-                    self.configureSideloadedKit(kitConstructor);
-                }
-            }
-        } catch (e) {
-            mpInstance.Logger.error(
-                'Sideloaded Kits not configured propertly. Kits may not be initialized. ' +
-                    e
-            );
         }
     };
 

--- a/src/mockBatchCreator.ts
+++ b/src/mockBatchCreator.ts
@@ -40,6 +40,7 @@ export default class _BatchValidator {
             _SessionManager: null,
             _Store: {
                 sessionId: 'mockSessionId',
+                sideloadedKits: [],
                 devToken: 'test_dev_token',
                 isFirstRun: true,
                 isEnabled: true,

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1421,6 +1421,8 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             mpInstance._APIClient.prepareForwardingStats
         );
 
+        mpInstance._Forwarders.processPixelConfigs(config);
+
         mpInstance._SessionManager.initialize();
         mpInstance._Events.logAST();
 

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -186,6 +186,7 @@ export interface SDKInitConfig
 
     kitConfigs?: IKitConfigs[];
     kits?: Dictionary<Kit>;
+    sideloadedKits?: MPForwarder[];
     dataPlanOptions?: KitBlockerOptions;
     flags?: Dictionary;
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -54,7 +54,7 @@ export interface SDKConfig {
     identifyRequest: IdentifyRequest;
     identityCallback: IdentityCallback;
     integrationDelayTimeout: number;
-
+    sideloadedKits: MPForwarder[];
     aliasMaxWindow: number;
     deviceId?: string;
     forceHttps?: boolean;
@@ -147,6 +147,7 @@ export interface IStore {
     prodStorageName: string | null;
     activeForwarders: MPForwarder[];
     kits: Dictionary<MPForwarder>;
+    sideloadedKits: MPForwarder[];
     configuredForwarders: MPForwarder[];
     pixelConfigurations: PixelConfiguration[];
     integrationDelayTimeoutStart: number; // UNIX Timestamp
@@ -197,6 +198,7 @@ export default function Store(
         prodStorageName: null,
         activeForwarders: [],
         kits: {},
+        sideloadedKits: [],
         configuredForwarders: [],
         pixelConfigurations: [],
         wrapperSDKInfo: {
@@ -258,6 +260,8 @@ export default function Store(
         this.SDKConfig.useNativeSdk = !!config.useNativeSdk;
 
         this.SDKConfig.kits = config.kits || {};
+
+        this.SDKConfig.sideloadedKits = config.sideloadedKits || [];
 
         if (config.hasOwnProperty('isIOS')) {
             this.SDKConfig.isIOS = config.isIOS;

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2658,7 +2658,7 @@ describe('forwarders', function() {
                 sideloadedKit2Event.should.have.property('EventName', 'foo');
             });
 
-            it('should invoke side loaded identify call', function() {
+            it('should invoke sideloaded identify call', function() {
                 const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
                 const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
@@ -2679,7 +2679,7 @@ describe('forwarders', function() {
                 window.SideloadedKit22.instance.should.have.property('onUserIdentifiedCalled', true);
             });
 
-            it('should invoke side loaded set/removeUserAttribute call', function() {
+            it('should invoke sideloaded set/removeUserAttribute call', function() {
                 const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
                 const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
@@ -2697,7 +2697,7 @@ describe('forwarders', function() {
                 window.SideloadedKit22.instance.should.have.property('removeUserAttributeCalled', true);
             });
 
-            it('should invoke side loaded logout call', function() {
+            it('should invoke sideloaded logout call', function() {
                 const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
                 const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
@@ -2711,7 +2711,7 @@ describe('forwarders', function() {
                 window.SideloadedKit22.instance.should.have.property('onLogoutCompleteCalled', true);
             });
 
-            it('should invoke side loaded login call', function() {
+            it('should invoke sideloaded login call', function() {
                 const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
                 const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
@@ -2725,7 +2725,7 @@ describe('forwarders', function() {
                 window.SideloadedKit22.instance.should.have.property('onLoginCompleteCalled', true);
             });
 
-            it('should invoke side loaded modify call', function() {
+            it('should invoke sideloaded modify call', function() {
                 const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
                 const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
@@ -2739,7 +2739,7 @@ describe('forwarders', function() {
                 window.SideloadedKit22.instance.should.have.property('onModifyCompleteCalled', true);
             });
 
-            it('should invoke side loaded modify call', function() {
+            it('should invoke sideloaded modify call', function() {
                 const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
                 const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -10,7 +10,7 @@ var getEvent = Utils.getEvent,
     setLocalStorage = Utils.setLocalStorage,
     forwarderDefaultConfiguration = Utils.forwarderDefaultConfiguration,
     MockForwarder = Utils.MockForwarder,
-    SideloadedKit = Utils.sideloadedKit,
+    MockSideloadedKit = Utils.MockSideloadedKit,
     mockServer;
 
 describe('forwarders', function() {
@@ -2595,8 +2595,8 @@ describe('forwarders', function() {
             });
 
             it('should add sideloaded kits to the active forwarders', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
                 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
@@ -2609,11 +2609,12 @@ describe('forwarders', function() {
             });
 
             it('should add sideloaded kits along with configured forwarders from server to the active forwarders', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
                 window.mParticle.config.sideloadedKits = sideloadedKits;
 
+                // This mockForwarder simulates a server configured forwarder
                 const mockForwarder = new MockForwarder('fooForwarder', 1);
                 mParticle.addForwarder(mockForwarder);
 
@@ -2643,8 +2644,8 @@ describe('forwarders', function() {
             });
 
             it('should send event to sideloaded kits', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
                 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
@@ -2659,8 +2660,8 @@ describe('forwarders', function() {
             });
 
             it('should invoke sideloaded identify call', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
                 
                 window.mParticle.config.identifyRequest = {
@@ -2680,8 +2681,8 @@ describe('forwarders', function() {
             });
 
             it('should invoke sideloaded set/removeUserAttribute call', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
@@ -2698,8 +2699,8 @@ describe('forwarders', function() {
             });
 
             it('should invoke sideloaded logout call', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
@@ -2712,8 +2713,8 @@ describe('forwarders', function() {
             });
 
             it('should invoke sideloaded login call', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
@@ -2726,8 +2727,8 @@ describe('forwarders', function() {
             });
 
             it('should invoke sideloaded modify call', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
@@ -2740,8 +2741,8 @@ describe('forwarders', function() {
             });
 
             it('should invoke sideloaded modify call', function() {
-                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKit1 = new MockSideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new MockSideloadedKit('SideloadedKit2', 2);
                 const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2595,9 +2595,9 @@ describe('forwarders', function() {
             });
 
             it('should add sideloaded kits to the active forwarders', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
                 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
 
@@ -2609,12 +2609,12 @@ describe('forwarders', function() {
             });
 
             it('should add sideloaded kits along with configured forwarders from server to the active forwarders', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
                 window.mParticle.config.sideloadedKits = sideloadedKits;
 
-                var mockForwarder = new MockForwarder('fooForwarder', 1);
+                const mockForwarder = new MockForwarder('fooForwarder', 1);
                 mParticle.addForwarder(mockForwarder);
 
                 window.mParticle.config.kitConfigs.push(
@@ -2643,25 +2643,25 @@ describe('forwarders', function() {
             });
 
             it('should send event to sideloaded kits', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
                 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
                 mParticle.init(apiKey, window.mParticle.config);
 
                 mParticle.logEvent('foo', mParticle.EventType.Navigation);
-                var sideloadedKit1Event = window.SideloadedKit11.instance.receivedEvent;
-                var sideloadedKit2Event = window.SideloadedKit22.instance.receivedEvent;
+                const sideloadedKit1Event = window.SideloadedKit11.instance.receivedEvent;
+                const sideloadedKit2Event = window.SideloadedKit22.instance.receivedEvent;
 
                 sideloadedKit1Event.should.have.property('EventName', 'foo');
                 sideloadedKit2Event.should.have.property('EventName', 'foo');
             });
 
             it('should invoke side loaded identify call', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
                 
                 window.mParticle.config.identifyRequest = {
                     userIdentities: {
@@ -2680,9 +2680,9 @@ describe('forwarders', function() {
             });
 
             it('should invoke side loaded set/removeUserAttribute call', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
 
@@ -2698,9 +2698,9 @@ describe('forwarders', function() {
             });
 
             it('should invoke side loaded logout call', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
 
@@ -2712,9 +2712,9 @@ describe('forwarders', function() {
             });
 
             it('should invoke side loaded login call', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
 
@@ -2726,9 +2726,9 @@ describe('forwarders', function() {
             });
 
             it('should invoke side loaded modify call', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
 
@@ -2740,9 +2740,9 @@ describe('forwarders', function() {
             });
 
             it('should invoke side loaded modify call', function() {
-                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
-                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
-                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                const sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                const sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                const sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
                 window.mParticle.config.sideloadedKits = sideloadedKits;
 

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2,12 +2,15 @@ import Utils from './utils';
 import sinon from 'sinon';
 import { urls } from './config';
 import { apiKey, MPConfig, testMPID, MessageType } from './config';
+import { expect } from 'chai';
+
 
 var getEvent = Utils.getEvent,
     getForwarderEvent = Utils.getForwarderEvent,
     setLocalStorage = Utils.setLocalStorage,
     forwarderDefaultConfiguration = Utils.forwarderDefaultConfiguration,
     MockForwarder = Utils.MockForwarder,
+    SideloadedKit = Utils.sideloadedKit,
     mockServer;
 
 describe('forwarders', function() {
@@ -24,6 +27,24 @@ describe('forwarders', function() {
         ]);
 
         mockServer.respondWith(urls.identify, [
+            200,
+            {},
+            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
+        ]);
+
+        mockServer.respondWith(urls.login, [
+            200,
+            {},
+            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
+        ]);
+
+        mockServer.respondWith(urls.logout, [
+            200,
+            {},
+            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
+        ]);
+
+        mockServer.respondWith(urls.modify, [
             200,
             {},
             JSON.stringify({ mpid: testMPID, is_logged_in: false }),
@@ -1122,12 +1143,6 @@ describe('forwarders', function() {
         config1.userIdentityFilters = [mParticle.IdentityType.Google];
         window.mParticle.config.kitConfigs.push(config1);
 
-        mockServer.respondWith(urls.modify, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
-        ]);
-
         mParticle.Identity.modify({
             userIdentities: {
                 google: 'test@google.com',
@@ -1162,12 +1177,6 @@ describe('forwarders', function() {
         window.mParticle.config.kitConfigs.push(config1);
 
         mParticle.init(apiKey, window.mParticle.config);
-
-        mockServer.respondWith(urls.modify, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
-        ]);
 
         mParticle.Identity.modify({
             userIdentities: {
@@ -1409,6 +1418,11 @@ describe('forwarders', function() {
 
         window.MockForwarder1.instance.should.have.property(
             'logOutCalled',
+            true
+        );
+
+        window.MockForwarder1.instance.should.have.property(
+            'onLogoutCompleteCalled',
             true
         );
 
@@ -2566,5 +2580,179 @@ describe('forwarders', function() {
         infoMessage.should.equal('Test Event sent');
 
         done();
+    });
+
+    describe('side loaded kits', function() {
+        describe('initialization', function() {
+            beforeEach(function() {
+                mParticle._resetForTests(MPConfig);
+                delete mParticle._instances['default_instance'];
+            });
+
+            afterEach(function() {
+                delete window.MockForwarder1;
+                mockServer.restore();
+            });
+
+            it('should add sideloaded kits to the active forwarders', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+
+                mParticle.init(apiKey, window.mParticle.config);
+                const activeForwarders = mParticle.getInstance()._getActiveForwarders();
+                expect(activeForwarders.length, 'active forwarders length').to.equal(sideloadedKits.length);
+                expect(activeForwarders[0].name, '1st active forwarder ').to.deep.equal(sideloadedKit1.name);
+                expect(activeForwarders[1].name, '2nd active forwarder').to.deep.equal(sideloadedKit2.name);
+            });
+
+            it('should add sideloaded kits along with configured forwarders from server to the active forwarders', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+
+                var mockForwarder = new MockForwarder('fooForwarder', 1);
+                mParticle.addForwarder(mockForwarder);
+
+                window.mParticle.config.kitConfigs.push(
+                    forwarderDefaultConfiguration('fooForwarder', 1)
+                );
+                
+                mParticle.init(apiKey, window.mParticle.config);
+                const activeForwarders = mParticle.getInstance()._getActiveForwarders();
+
+                expect(activeForwarders.length, 'active forwarders length').to.equal(sideloadedKits.length +1);
+                expect(activeForwarders[0].name, '1st active forwarder name').to.equal('fooForwarder');
+                expect(activeForwarders[1].name, '2nd active forwarder ').to.deep.equal(sideloadedKit1.name);
+                expect(activeForwarders[2].name, '3rd active forwarder').to.deep.equal(sideloadedKit2.name);
+            });
+        });
+
+        describe('forwarding', function() {
+            beforeEach(function() {
+                mParticle._resetForTests(MPConfig);
+                delete mParticle._instances['default_instance'];
+            });
+
+            afterEach(function() {
+                delete window.MockForwarder1;
+                mockServer.restore();
+            });
+
+            it('should send event to sideloaded kits', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+                mParticle.init(apiKey, window.mParticle.config);
+
+                mParticle.logEvent('foo', mParticle.EventType.Navigation);
+                var sideloadedKit1Event = window.SideloadedKit11.instance.receivedEvent;
+                var sideloadedKit2Event = window.SideloadedKit22.instance.receivedEvent;
+
+                sideloadedKit1Event.should.have.property('EventName', 'foo');
+                sideloadedKit2Event.should.have.property('EventName', 'foo');
+            });
+
+            it('should invoke side loaded identify call', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+                
+                window.mParticle.config.identifyRequest = {
+                    userIdentities: {
+                        google: 'google123',
+                    },
+                };
+
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+
+                mParticle.init(apiKey, window.mParticle.config);
+                window.SideloadedKit11.instance.should.have.property('setUserIdentityCalled', true);
+                window.SideloadedKit22.instance.should.have.property('setUserIdentityCalled', true);
+
+                window.SideloadedKit11.instance.should.have.property('onUserIdentifiedCalled', true);
+                window.SideloadedKit22.instance.should.have.property('onUserIdentifiedCalled', true);
+            });
+
+            it('should invoke side loaded set/removeUserAttribute call', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+
+                mParticle.init(apiKey, window.mParticle.config);
+                mParticle.Identity.getCurrentUser().setUserAttribute('gender', 'male');
+                mParticle.Identity.getCurrentUser().removeUserAttribute('gender');
+
+                window.SideloadedKit11.instance.should.have.property('setUserAttributeCalled', true);
+                window.SideloadedKit22.instance.should.have.property('setUserAttributeCalled', true);
+
+                window.SideloadedKit11.instance.should.have.property('removeUserAttributeCalled', true);
+                window.SideloadedKit22.instance.should.have.property('removeUserAttributeCalled', true);
+            });
+
+            it('should invoke side loaded logout call', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+
+                mParticle.init(apiKey, window.mParticle.config);
+                mParticle.Identity.logout();
+
+                window.SideloadedKit11.instance.should.have.property('onLogoutCompleteCalled', true);
+                window.SideloadedKit22.instance.should.have.property('onLogoutCompleteCalled', true);
+            });
+
+            it('should invoke side loaded login call', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+
+                mParticle.init(apiKey, window.mParticle.config);
+                mParticle.Identity.login({userIdentities: {customerid: 'abc'}});
+
+                window.SideloadedKit11.instance.should.have.property('onLoginCompleteCalled', true);
+                window.SideloadedKit22.instance.should.have.property('onLoginCompleteCalled', true);
+            });
+
+            it('should invoke side loaded modify call', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+
+                mParticle.init(apiKey, window.mParticle.config);
+                mParticle.Identity.modify({userIdentities: {customerid: 'abc'}});
+
+                window.SideloadedKit11.instance.should.have.property('onModifyCompleteCalled', true);
+                window.SideloadedKit22.instance.should.have.property('onModifyCompleteCalled', true);
+            });
+
+            it('should invoke side loaded modify call', function() {
+                var sideloadedKit1 = new SideloadedKit('SideloadedKit1', 1);
+                var sideloadedKit2 = new SideloadedKit('SideloadedKit2', 2);
+                var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+
+                window.mParticle.config.sideloadedKits = sideloadedKits;
+
+                mParticle.init(apiKey, window.mParticle.config);
+                        mParticle.setOptOut(true);
+
+
+                window.SideloadedKit11.instance.should.have.property('setOptOutCalled', true);
+                window.SideloadedKit22.instance.should.have.property('setOptOutCalled', true);
+            });
+        });
     });
 });

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -3,6 +3,8 @@ import sinon from 'sinon';
 import { SDKInitConfig } from '../../src/sdkRuntimeModels';
 import Store, { IStore } from '../../src/store';
 import { MPConfig, apiKey } from './config';
+import Utils from './utils';
+const SideloadedKit = Utils.sideloadedKit;
 
 describe('Store', () => {
     const now = new Date();
@@ -73,6 +75,7 @@ describe('Store', () => {
         expect(store.prodStorageName, 'prodStorageName').to.eq(null);
         expect(store.activeForwarders.length, 'activeForwarders').to.eq(0);
         expect(store.kits, 'kits').to.be.ok;
+        expect(store.sideloadedKits, 'sideloaded kits').to.be.ok;
         expect(store.configuredForwarders, 'configuredForwarders').to.be.ok;
         expect(store.pixelConfigurations.length, 'pixelConfigurations').to.eq(
             0
@@ -133,6 +136,7 @@ describe('Store', () => {
         expect(store.SDKConfig.isIOS, 'isIOS').to.eq(false);
 
         expect(store.SDKConfig.kits, 'kits').to.deep.equal({});
+        expect(store.SDKConfig.sideloadedKits, 'kits').to.deep.equal([]);
         expect(store.SDKConfig.logLevel, 'logLevel').to.eq(null);
 
         expect(store.SDKConfig.maxCookieSize, 'maxCookieSize').to.eq(3000);
@@ -176,5 +180,21 @@ describe('Store', () => {
             PlanId: 'test-data-plan',
             PlanVersion: 3,
         });
+    });
+
+    it('should assign expected values to side loaded kits', () => {
+        var sideloadedKit1 = new SideloadedKit();
+        var sideloadedKit2 = new SideloadedKit();
+        var sideloadedKits = [sideloadedKit1, sideloadedKit2];
+
+        const config = {
+            ...sampleConfig,
+            sideloadedKits,
+        };
+        const store: IStore = new Store(config, window.mParticle);
+
+        expect(store.SDKConfig.sideloadedKits.length, 'side loaded kits').to.equal(sideloadedKits.length);
+        expect(store.SDKConfig.sideloadedKits[0], 'side loaded kits').to.deep.equal(sideloadedKit1);
+        expect(store.SDKConfig.sideloadedKits[1], 'side loaded kits').to.deep.equal(sideloadedKit2);
     });
 });

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -4,7 +4,7 @@ import { SDKInitConfig } from '../../src/sdkRuntimeModels';
 import Store, { IStore } from '../../src/store';
 import { MPConfig, apiKey } from './config';
 import Utils from './utils';
-const SideloadedKit = Utils.sideloadedKit;
+const MockSideloadedKit = Utils.MockSideloadedKit;
 
 describe('Store', () => {
     const now = new Date();
@@ -183,8 +183,8 @@ describe('Store', () => {
     });
 
     it('should assign expected values to side loaded kits', () => {
-        var sideloadedKit1 = new SideloadedKit();
-        var sideloadedKit2 = new SideloadedKit();
+        var sideloadedKit1 = new MockSideloadedKit();
+        var sideloadedKit2 = new MockSideloadedKit();
         var sideloadedKits = [sideloadedKit1, sideloadedKit2];
 
         const config = {

--- a/test/src/tests-temp-session-bug-fix.js
+++ b/test/src/tests-temp-session-bug-fix.js
@@ -115,7 +115,6 @@ describe('session bug fix test', function() {
         clock.tick(70000);
 
         mParticle.logEvent('Test Event2');
-        // debugger;s
         var testEvent2 = findEventFromRequestTemp(window.fetchMock._calls, 'Test Event2');
         testEvent.data.session_uuid.should.not.equal(testEvent2.data.session_uuid);
         mParticle.getInstance()._SessionManager.clearSessionTimeout(); clock.restore();

--- a/test/src/utils.js
+++ b/test/src/utils.js
@@ -416,6 +416,7 @@ var pluses = /\+/g,
             name: this.name,
         };
     },
+    sideloadedKit = MockForwarder,
     mParticleAndroid = function() {
         var self = this;
 
@@ -537,6 +538,7 @@ var TestsCore = {
     findRequest: findRequest,
     getIdentityEvent: getIdentityEvent,
     MockForwarder: MockForwarder,
+    sideloadedKit: sideloadedKit,
     mParticleAndroid: mParticleAndroid,
     mParticleIOS: mParticleIOS,
     v4CookieKey: v4CookieKey,

--- a/test/src/utils.js
+++ b/test/src/utils.js
@@ -416,7 +416,7 @@ var pluses = /\+/g,
             name: this.name,
         };
     },
-    sideloadedKit = MockForwarder,
+    MockSideloadedKit = MockForwarder,
     mParticleAndroid = function() {
         var self = this;
 
@@ -538,7 +538,7 @@ var TestsCore = {
     findRequest: findRequest,
     getIdentityEvent: getIdentityEvent,
     MockForwarder: MockForwarder,
-    sideloadedKit: sideloadedKit,
+    MockSideloadedKit: MockSideloadedKit,
     mParticleAndroid: mParticleAndroid,
     mParticleIOS: mParticleIOS,
     v4CookieKey: v4CookieKey,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
This PR introduces an API change in order to support sideloaded kits.  This is supported on both NPM and CDN.  When the customer imports a custom kit and uses the following CDN:

```
mParticle.config.sideloadedKits = [SideloadedKit];
```
The sideloaded kit is processed and added to activeForwarders array so that all mParticle methods (ie. logPageView, logEvent, login, etc) will map to it. 

Note that as this is the first milestone, there is no filtering logic, so I added defaults to [each forwarder setting here.](https://github.com/mParticle/mparticle-web-sdk/pull/395/files#diff-5f6c74306b4617bc6153000c0fc1fec37efa885c93f4cd1806f867b56bda5984R561-R585).


 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
* Unit tests written
* [Simple integration written](https://github.com/mparticle-integrations/mparticle-javascript-integration-example/tree/feat/side-loaded-kit) and new API tested incorporating this via both CDN and NPM.  Loads successfully with proper callbacks firing
![image](https://user-images.githubusercontent.com/5377436/222800424-3930f32d-6f08-4dec-88e3-17a75baa866d.png)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/ SQDSDKS-5113