### PR TITLE
refactor: Move getRampNumber and random number generators into utils

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -8,7 +8,7 @@ import {
     SDKEvent,
 } from './sdkRuntimeModels';
 import KitBlocker from './kitBlocking';
-import { Dictionary } from './utils';
+import { Dictionary, getRampNumber } from './utils';
 import { IUploadObject } from './serverModel';
 
 const Messages = Constants.Messages;
@@ -67,9 +67,7 @@ export default function APIClient(
             return false;
         }
 
-        const rampNumber = mpInstance._Helpers.getRampNumber(
-            mpInstance._Store.deviceId
-        );
+        const rampNumber = getRampNumber(mpInstance._Store.deviceId);
         return eventsV3Percentage >= rampNumber;
     };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -426,6 +426,8 @@ export default function Helpers(mpInstance) {
         }
     };
 
+    // TODO: Refactor SDK to directly use these methods
+    // https://go.mparticle.com/work/SQDSDKS-5239
     // Utility Functions
     this.converted = utils.converted;
     this.findKeyInObject = utils.findKeyInObject;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -26,18 +26,7 @@ export default function Helpers(mpInstance) {
         return null;
     };
 
-    /**
-     * Returns a value between 1-100 inclusive.
-     */
-    this.getRampNumber = function(deviceId) {
-        if (!deviceId) {
-            return 100;
-        }
-        var hash = self.generateHash(deviceId);
-        return Math.abs(hash % 100) + 1;
-    };
-
-    this.invokeCallback = function(
+    this.invokeCallback = function (
         callback,
         code,
         body,
@@ -284,40 +273,7 @@ export default function Helpers(mpInstance) {
         return xhr;
     };
 
-    function generateRandomValue(a) {
-        var randomValue;
-        if (window.crypto && window.crypto.getRandomValues) {
-            randomValue = window.crypto.getRandomValues(new Uint8Array(1)); // eslint-disable-line no-undef
-        }
-        if (randomValue) {
-            return (a ^ (randomValue[0] % 16 >> (a / 4))).toString(16);
-        }
-
-        return (a ^ ((Math.random() * 16) >> (a / 4))).toString(16);
-    }
-
-    this.generateUniqueId = function(a) {
-        // https://gist.github.com/jed/982883
-        // Added support for crypto for better random
-
-        return a // if the placeholder was passed, return
-            ? generateRandomValue(a) // a random number
-            : // or otherwise a concatenated string:
-              (
-                  [1e7] + // 10000000 +
-                  -1e3 + // -1000 +
-                  -4e3 + // -4000 +
-                  -8e3 + // -80000000 +
-                  -1e11
-              ) // -100000000000,
-                  .replace(
-                      // replacing
-                      /[018]/g, // zeroes, ones, and eights with
-                      self.generateUniqueId // random hex digits
-                  );
-    };
-
-    this.filterUserIdentities = function(userIdentitiesObject, filterList) {
+    this.filterUserIdentities = function (userIdentitiesObject, filterList) {
         var filteredUserIdentities = [];
 
         if (userIdentitiesObject && Object.keys(userIdentitiesObject).length) {
@@ -403,38 +359,7 @@ export default function Helpers(mpInstance) {
         return false;
     };
 
-    this.generateHash = function(name) {
-        var hash = 0,
-            i = 0,
-            character;
-
-        if (name === undefined || name === null) {
-            return 0;
-        }
-
-        name = name.toString().toLowerCase();
-
-        if (Array.prototype.reduce) {
-            return name.split('').reduce(function(a, b) {
-                a = (a << 5) - a + b.charCodeAt(0);
-                return a & a;
-            }, 0);
-        }
-
-        if (name.length === 0) {
-            return hash;
-        }
-
-        for (i = 0; i < name.length; i++) {
-            character = name.charCodeAt(i);
-            hash = (hash << 5) - hash + character;
-            hash = hash & hash;
-        }
-
-        return hash;
-    };
-
-    this.sanitizeAttributes = function(attrs, name) {
+    this.sanitizeAttributes = function (attrs, name) {
         if (!attrs || !self.isObject(attrs)) {
             return null;
         }
@@ -510,6 +435,8 @@ export default function Helpers(mpInstance) {
     this.decoded = utils.decoded;
     this.returnConvertedBoolean = utils.returnConvertedBoolean;
     this.parseStringOrNumber = utils.parseStringOrNumber;
+    this.generateHash = utils.generateHash;
+    this.generateUniqueId = utils.generateUniqueId;
 
     // Imported Validators
     this.Validators = Validators;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -26,7 +26,7 @@ export default function Helpers(mpInstance) {
         return null;
     };
 
-    this.invokeCallback = function (
+    this.invokeCallback = function(
         callback,
         code,
         body,
@@ -273,7 +273,7 @@ export default function Helpers(mpInstance) {
         return xhr;
     };
 
-    this.filterUserIdentities = function (userIdentitiesObject, filterList) {
+    this.filterUserIdentities = function(userIdentitiesObject, filterList) {
         var filteredUserIdentities = [];
 
         if (userIdentitiesObject && Object.keys(userIdentitiesObject).length) {
@@ -359,7 +359,7 @@ export default function Helpers(mpInstance) {
         return false;
     };
 
-    this.sanitizeAttributes = function (attrs, name) {
+    this.sanitizeAttributes = function(attrs, name) {
         if (!attrs || !self.isObject(attrs)) {
             return null;
         }

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -230,7 +230,6 @@ export interface SDKHelpersApi {
     generateUniqueId();
     generateHash?(value: string): string;
     getFeatureFlag?(feature: string); // TODO: Feature Constants should be converted to enum
-    getRampNumber?(deviceId: string): number;
     isDelayedByIntegration?(
         delayedIntegrations: Dictionary<boolean>,
         timeoutStart: number,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,12 +101,12 @@ const generateUniqueId = (a: string = ''): string =>
 /**
  * Returns a value between 1-100 inclusive.
  */
-const getRampNumber = (idString?: string): number => {
-    if (!idString) {
+const getRampNumber = (value?: string): number => {
+    if (!value) {
         return 100;
     }
 
-    const hash = generateHash(idString);
+    const hash = generateHash(value);
 
     return Math.abs(hash % 100) + 1;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,20 +36,37 @@ const findKeyInObject = (obj: any, key: string): string => {
     return null;
 };
 
-const generateHash = (value: any): number => {
-    if (value === undefined || value === null) {
+function generateHash(name: string): number {
+    let hash: number = 0;
+    let character: number;
+
+    if (name === undefined || name === null) {
         return 0;
     }
 
-    value = value.toString().toLowerCase();
+    name = name.toString().toLowerCase();
 
-    return value.split('').reduce((a, b) => {
-        a = (a << 5) - a + b.charCodeAt(0);
-        return a & a;
-    }, 0);
-};
+    if (Array.prototype.reduce) {
+        return name.split('').reduce(function (a: number, b: string) {
+            a = (a << 5) - a + b.charCodeAt(0);
+            return a & a;
+        }, 0);
+    }
 
-const generateRandomValue = (value?: number | string): string => {
+    if (name.length === 0) {
+        return hash;
+    }
+
+    for (let i = 0; i < name.length; i++) {
+        character = name.charCodeAt(i);
+        hash = (hash << 5) - hash + character;
+        hash = hash & hash;
+    }
+
+    return hash;
+}
+
+const generateRandomValue = (value?: string): string => {
     let randomValue: string;
     let a: number;
 
@@ -65,23 +82,19 @@ const generateRandomValue = (value?: number | string): string => {
     return (a ^ ((Math.random() * 16) >> (a / 4))).toString(16);
 };
 
-// TODO: What is the value actually for?
-const generateUniqueId = (value?: any): string => {
+const generateUniqueId = (a: string = ''): string =>
     // https://gist.github.com/jed/982883
     // Added support for crypto for better random
-
-    return value // if the placeholder was passed, return
-        ? generateRandomValue(value) // a random number
-        : // or otherwise a concatenated string:
-
-          `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`.replace(
-              // replacing
-              /[018]/g, // zeroes, ones, and eights with
-              generateUniqueId // random hex digits
+    a
+        ? generateRandomValue(a)
+        : `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`.replace(
+              /[018]/g,
+              generateUniqueId
           );
-};
 
-// Returns a value between 1-100 inclusive.
+/**
+ * Returns a value between 1-100 inclusive.
+ */
 const getRampNumber = (idString?: string): number => {
     if (!idString) {
         return 100;
@@ -158,7 +171,6 @@ export {
     decoded,
     findKeyInObject,
     generateHash,
-    generateRandomValue,
     generateUniqueId,
     getRampNumber,
     inArray,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,11 +85,17 @@ const generateRandomValue = (value?: string): string => {
 const generateUniqueId = (a: string = ''): string =>
     // https://gist.github.com/jed/982883
     // Added support for crypto for better random
-    a
-        ? generateRandomValue(a)
-        : `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`.replace(
-              /[018]/g,
-              generateUniqueId
+
+    a // if the placeholder was passed, return
+        ? generateRandomValue(a) // if the placeholder was passed, return
+        : // [1e7] -> // 10000000 +
+          // -1e3  -> // -1000 +
+          // -4e3  -> // -4000 +
+          // -8e3  -> // -80000000 +
+          // -1e11 -> //-100000000000,
+          `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`.replace(
+              /[018]/g, // zeroes, ones, and eights with
+              generateUniqueId // random hex digits
           );
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,62 @@ const findKeyInObject = (obj: any, key: string): string => {
     return null;
 };
 
+const generateHash = (value: any): number => {
+    if (value === undefined || value === null) {
+        return 0;
+    }
+
+    value = value.toString().toLowerCase();
+
+    return value.split('').reduce((a, b) => {
+        a = (a << 5) - a + b.charCodeAt(0);
+        return a & a;
+    }, 0);
+};
+
+const generateRandomValue = (value?: number | string): string => {
+    let randomValue: string;
+    let a: number;
+
+    if (window.crypto && window.crypto.getRandomValues) {
+        // @ts-ignore
+        randomValue = window.crypto.getRandomValues(new Uint8Array(1)); // eslint-disable-line no-undef
+    }
+    if (randomValue) {
+        // @ts-ignore
+        return (a ^ (randomValue[0] % 16 >> (a / 4))).toString(16);
+    }
+
+    return (a ^ ((Math.random() * 16) >> (a / 4))).toString(16);
+};
+
+// TODO: What is the value actually for?
+const generateUniqueId = (value?: any): string => {
+    // https://gist.github.com/jed/982883
+    // Added support for crypto for better random
+
+    return value // if the placeholder was passed, return
+        ? generateRandomValue(value) // a random number
+        : // or otherwise a concatenated string:
+
+          `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`.replace(
+              // replacing
+              /[018]/g, // zeroes, ones, and eights with
+              generateUniqueId // random hex digits
+          );
+};
+
+// Returns a value between 1-100 inclusive.
+const getRampNumber = (idString?: string): number => {
+    if (!idString) {
+        return 100;
+    }
+
+    const hash = generateHash(idString);
+
+    return Math.abs(hash % 100) + 1;
+};
+
 const isObject = (value: any): boolean => {
     var objType = Object.prototype.toString.call(value);
     return objType === '[object Object]' || objType === '[object Error]';
@@ -76,10 +132,7 @@ const decoded = (s: string): string =>
 
 const converted = (s: string): string => {
     if (s.indexOf('"') === 0) {
-        s = s
-            .slice(1, -1)
-            .replace(/\\"/g, '"')
-            .replace(/\\\\/g, '\\');
+        s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
     }
 
     return s;
@@ -104,6 +157,10 @@ export {
     converted,
     decoded,
     findKeyInObject,
+    generateHash,
+    generateRandomValue,
+    generateUniqueId,
+    getRampNumber,
     inArray,
     isObject,
     isStringOrNumber,

--- a/test/src/tests-helpers.js
+++ b/test/src/tests-helpers.js
@@ -93,28 +93,6 @@ describe('helpers', function() {
         done();
     });
 
-    it('should generate ramp number correctly', function(done) {
-        var result = mParticle.getInstance()._Helpers.getRampNumber();
-        result.should.equal(100);
-
-        result = mParticle.getInstance()._Helpers.getRampNumber(null);
-        result.should.equal(100);
-
-        var uniqueId = mParticle.getInstance()._Helpers.generateUniqueId();
-        var result1 = mParticle.getInstance()._Helpers.getRampNumber(uniqueId);
-        result1.should.be.below(101);
-        result1.should.be.above(0);
-
-        var result2 = mParticle.getInstance()._Helpers.getRampNumber(uniqueId);
-        result2.should.equal(result1);
-
-        result = mParticle
-            .getInstance()
-            ._Helpers.getRampNumber('2b907d8b-cefe-4530-a6fe-60a381f2e066');
-        result.should.equal(60);
-        done();
-    });
-
     it('should correctly validate an identity request with copyUserAttribute as a key using any identify method', function(done) {
         var identityApiData = {
             userIdentities: {

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -2,6 +2,10 @@ import {
     converted,
     decoded,
     findKeyInObject,
+    generateHash,
+    generateRandomValue,
+    generateUniqueId,
+    getRampNumber,
     inArray,
     isDataPlanSlug,
     isEmpty,
@@ -14,6 +18,52 @@ import {
 import { expect } from 'chai';
 
 describe('Utils', () => {
+    describe('#generateHash', () => {
+        it('should return a valid hash', () => {
+            expect(generateHash('A'), 'A').to.equal(97);
+            expect(generateHash(false)).to.equal(97196323);
+            expect(generateHash('3569038')).to.equal(-412991536);
+            expect(generateHash(3569038)).to.equal(-412991536);
+            expect(generateHash('TestHash')).to.equal(-1146196832);
+            expect(generateHash('mParticle'), 'mParticle String').to.equal(1744810483);
+        });
+
+        it('returns 0 when hashing undefined or null', () => {
+            expect(generateHash(null)).to.equal(0);
+            expect(generateHash(undefined)).to.equal(0);
+            expect(typeof generateHash(false)).to.equal('number');
+            expect(generateHash(false)).to.not.equal(0);
+        });
+    });
+
+    describe.only('#generateRandomValue', () => {
+        it('should generate random values', () => {
+            // @ts-ignore
+            expect(generateRandomValue().length).to.equal(1);
+            expect(generateRandomValue()).to.equal('1234567');
+        });
+    });
+
+    describe('#generateUniqueId', () => {
+        it('returns a unique ID', () => {
+            expect(generateUniqueId()).to.be.ok;
+            expect(generateUniqueId().length).to.equal(36);
+            expect(typeof generateUniqueId()).to.equal('string');
+
+            // Tests format to be broken up by 5 hypens
+            expect(generateUniqueId().split('-').length).to.equal(5);
+        });
+    });
+
+    describe('#getRampNumber', () => {
+        it('returns a ramp number', () =>{
+            expect(getRampNumber()).to.equal(100);
+            expect(getRampNumber(null)).to.equal(100);
+
+            expect(getRampNumber('2b907d8b-cefe-4530-a6fe-60a381f2e066')).to.equal(100);
+        });
+    });
+
     describe('#isObject', () => {
         it('returns true if object is an object', () => {
             const validObject = {

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -49,7 +49,7 @@ describe('Utils', () => {
             expect(generateUniqueId().length).to.equal(36);
             expect(typeof generateUniqueId()).to.equal('string');
 
-            // Tests format to be broken up by 5 hypens
+            // Tests format to be broken up by 4 hyphens
             expect(generateUniqueId().split('-').length).to.equal(5);
 
             window.crypto.getRandomValues = undefined;

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -3,7 +3,6 @@ import {
     decoded,
     findKeyInObject,
     generateHash,
-    generateRandomValue,
     generateUniqueId,
     getRampNumber,
     inArray,
@@ -13,54 +12,73 @@ import {
     isStringOrNumber,
     parseNumber,
     parseStringOrNumber,
-    returnConvertedBoolean
+    returnConvertedBoolean,
 } from '../../src/utils';
 import { expect } from 'chai';
 
 describe('Utils', () => {
     describe('#generateHash', () => {
-        it('should return a valid hash', () => {
+        it('should a hash number with a valid input', () => {
             expect(generateHash('A'), 'A').to.equal(97);
-            expect(generateHash(false)).to.equal(97196323);
+            expect(generateHash('false')).to.equal(97196323);
             expect(generateHash('3569038')).to.equal(-412991536);
-            expect(generateHash(3569038)).to.equal(-412991536);
             expect(generateHash('TestHash')).to.equal(-1146196832);
-            expect(generateHash('mParticle'), 'mParticle String').to.equal(1744810483);
+            expect(generateHash('mParticle'), 'mParticle String').to.equal(
+                1744810483
+            );
+            expect(
+                generateHash('d71b49a6-4248-4581-afff-abb28dada53d')
+            ).to.equal(635757846);
         });
 
         it('returns 0 when hashing undefined or null', () => {
             expect(generateHash(null)).to.equal(0);
             expect(generateHash(undefined)).to.equal(0);
-            expect(typeof generateHash(false)).to.equal('number');
-            expect(generateHash(false)).to.not.equal(0);
-        });
-    });
 
-    describe.only('#generateRandomValue', () => {
-        it('should generate random values', () => {
-            // @ts-ignore
-            expect(generateRandomValue().length).to.equal(1);
-            expect(generateRandomValue()).to.equal('1234567');
+            // Use bad values to verify expected fail cases
+            expect(typeof generateHash(false as unknown as string)).to.equal(
+                'number'
+            );
+            expect(generateHash(false as unknown as string)).to.not.equal(0);
         });
     });
 
     describe('#generateUniqueId', () => {
-        it('returns a unique ID', () => {
+        it('generate a random value', () => {
             expect(generateUniqueId()).to.be.ok;
             expect(generateUniqueId().length).to.equal(36);
             expect(typeof generateUniqueId()).to.equal('string');
 
             // Tests format to be broken up by 5 hypens
             expect(generateUniqueId().split('-').length).to.equal(5);
+
+            window.crypto.getRandomValues = undefined;
+            expect(generateUniqueId()).to.be.ok;
+            // old browsers may return undefined despite
+            // defining the getRandomValues API.
+            window.crypto.getRandomValues = function (a) {
+                a = undefined;
+                return a;
+            };
+            expect(generateUniqueId()).to.be.ok;
         });
     });
 
     describe('#getRampNumber', () => {
-        it('returns a ramp number', () =>{
+        it('returns a ramp number', () => {
             expect(getRampNumber()).to.equal(100);
             expect(getRampNumber(null)).to.equal(100);
+            expect(
+                getRampNumber('2b907d8b-cefe-4530-a6fe-60a381f2e066')
+            ).to.equal(60);
+            expect(
+                getRampNumber('d71b49a6-4248-4581-afff-abb28dada53d')
+            ).to.equal(47);
 
-            expect(getRampNumber('2b907d8b-cefe-4530-a6fe-60a381f2e066')).to.equal(100);
+            const uniqueId = generateUniqueId();
+            const result = getRampNumber(uniqueId);
+            expect(result).to.be.lessThan(101);
+            expect(result).to.be.greaterThan(0);
         });
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Moved out `getRampNumber` along with associated methods, `generateHash`, `generateRandomValue`, and `generateUniqueId`, into Utils modules so that we can decouple utility functions from Helper. Helper has a hard dependency on the full SDK instance and these are simple utility functions that do not require such tight coupling.
 - Add tests where necessary for added coverage.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Verify that ramp number is generated
 - Verify that randomized guids are generated

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5074
