### PR TITLE
feat: Add Offline Storage for Events and Batches via Feature Flag

### DIFF
--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -8,7 +8,7 @@ import {
 } from './sdkRuntimeModels';
 import { convertEvents } from './sdkToEventsApiConverter';
 import Types from './types';
-import { isEmpty } from './utils';
+import { getRampNumber, isEmpty } from './utils';
 import { SessionStorageVault, LocalStorageVault } from './vault';
 
 /**
@@ -104,7 +104,7 @@ export class BatchUploader {
 
     private isOfflineStorageAvailable(): boolean {
         const {
-            _Helpers: { getRampNumber, getFeatureFlag },
+            _Helpers: { getFeatureFlag },
             _Store: { deviceId },
         } = this.mpInstance;
 
@@ -117,8 +117,6 @@ export class BatchUploader {
             10
         );
 
-        // TODO: Break out getRampNumber to be a utility method
-        //       https://go.mparticle.com/work/SQDSDKS-5074
         const rampNumber = getRampNumber(deviceId);
 
         // TODO: Handle cases where Local Storage is unavailable

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -335,7 +335,12 @@ export class BatchUploader {
         }
 
         // Update Offline Storage with current state of batch queue
-        if (this.offlineStorageEnabled && this.batchVault) {
+        if (!useBeacon && this.offlineStorageEnabled && this.batchVault) {
+            // Note: since beacon is "Fire and forget" it will empty `batchesThatDidNotUplod`
+            // regardless of whether the batches were successfully uploaded or not. We should
+            // therefore not update Offline Storage when beacon returns, so that we can retry
+            // uploading saved batches at a later time. Batches shoudl only be remove them once
+            // they have been confirmed to have been successfully uploaded.
             this.batchVault.store(this.batchesQueuedForProcessing);
 
             // Clear batch queue since everything should be in Offline Storage

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -338,9 +338,9 @@ export class BatchUploader {
         if (!useBeacon && this.offlineStorageEnabled && this.batchVault) {
             // Note: since beacon is "Fire and forget" it will empty `batchesThatDidNotUplod`
             // regardless of whether the batches were successfully uploaded or not. We should
-            // therefore not update Offline Storage when beacon returns, so that we can retry
-            // uploading saved batches at a later time. Batches shoudl only be remove them once
-            // they have been confirmed to have been successfully uploaded.
+            // therefore NOT overwrite Offline Storage when beacon returns, so that we can retry
+            // uploading saved batches at a later time. Batches should only be removed from
+            // Local Storage once we can confirm they are successfully uploaded.
             this.batchVault.store(this.batchesQueuedForProcessing);
 
             // Clear batch queue since everything should be in Offline Storage

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -161,6 +161,7 @@ const Constants = {
         ReportBatching: 'reportBatching',
         EventsV3: 'eventsV3',
         EventBatchingIntervalMillis: 'eventBatchingIntervalMillis',
+        OfflineStorage: 'offlineStorage',
     },
     DefaultInstance: 'default_instance',
 } as const;

--- a/src/mockBatchCreator.ts
+++ b/src/mockBatchCreator.ts
@@ -4,6 +4,7 @@ import ServerModel from './serverModel';
 import { SDKEvent, BaseEvent, MParticleWebSDK } from './sdkRuntimeModels';
 import { convertEvents } from './sdkToEventsApiConverter';
 import * as EventsApi from '@mparticle/event-models';
+import { Batch } from '@mparticle/event-models';
 
 const mockFunction = function () {
     return null;
@@ -119,16 +120,19 @@ export default class _BatchValidator {
         } as MParticleWebSDK;
     }
 
-    returnBatch(event: BaseEvent) {
+    private createSDKEventFunction(event): SDKEvent {
+        return new ServerModel(this.getMPInstance()).createEventObject(event);
+    }
+
+    public returnBatch(events: BaseEvent | BaseEvent[]): Batch | null {
         const mpInstance = this.getMPInstance();
-        const sdkEvent: SDKEvent = new ServerModel(
-            mpInstance
-        ).createEventObject(event);
-        const batch: EventsApi.Batch | null = convertEvents(
-            '0',
-            [sdkEvent],
-            mpInstance as any
-        );
+
+        const sdkEvents: SDKEvent[] = Array.isArray(events)
+            ? events.map((event) => this.createSDKEventFunction(event))
+            : [this.createSDKEventFunction(events)];
+
+        const batch: Batch = convertEvents('0', sdkEvents, mpInstance as any);
+
         return batch;
     }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -444,5 +444,12 @@ export default function Store(
         ) {
             this.SDKConfig.flags[Constants.FeatureFlags.ReportBatching] = false;
         }
+        if (
+            !this.SDKConfig.flags.hasOwnProperty(
+                Constants.FeatureFlags.OfflineStorage
+            )
+        ) {
+            this.SDKConfig.flags[Constants.FeatureFlags.OfflineStorage] = 0;
+        }
     }
 }

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -1,25 +1,32 @@
 import { Logger } from '@mparticle/web-sdk';
-import { Dictionary, isEmpty } from './utils';
+import { isEmpty } from './utils';
 
-interface IVaultOptions {
+export interface IVaultOptions {
     logger?: Logger;
     offlineStorageEnabled?: boolean;
 }
 
-export default class Vault<StorableItem> {
+export abstract class BaseVault<StorableItem> {
     public contents: StorableItem;
-    private readonly _storageKey: string;
-    private logger?: Logger;
+    protected readonly _storageKey: string;
+    protected logger?: Logger;
+    protected storageObject: Storage;
 
     /**
      *
      * @param {string} storageKey the local storage key string
-     * @param {string} itemKey an element within your StorableItem to use as a key
+     * @param {Storage} Web API Storage object that is being used
      * @param {IVaultOptions} options A Dictionary of IVaultOptions
      */
-    constructor(storageKey: string, options?: IVaultOptions) {
+    constructor(
+        storageKey: string,
+        storageObject: Storage,
+        options?: IVaultOptions
+    ) {
         this._storageKey = storageKey;
-        this.contents = this.getFromLocalStorage();
+        this.storageObject = storageObject;
+
+        this.contents = this.retrieve();
 
         // Add a fake logger in case one is not provided or needed
         this.logger = options?.logger || {
@@ -30,59 +37,58 @@ export default class Vault<StorableItem> {
     }
 
     /**
-     * Stores a StorableItem to Local Storage
-     * @method storeItem
+     * Stores a StorableItem to Storage
+     * @method store
      * @param item {StorableItem}
      */
     public store(item: StorableItem): void {
         this.contents = item;
 
-        this.logger.verbose(`Saved to local storage: ${item}`);
-
-        this.saveToLocalStorage(this.contents);
+        try {
+            this.storageObject.setItem(
+                this._storageKey,
+                !isEmpty(item) ? JSON.stringify(item) : ''
+            );
+        } catch (error) {
+            this.logger.error(`Cannot Save items to Storage: ${item}`);
+            this.logger.error(error as string);
+        }
     }
 
     /**
-     * Retrieves all StorableItems from local storage as an array
-     * @method retrieveItems
-     * @returns {StorableItem[]} an array of Items
+     * Retrieve StorableItem from Storage
+     * @method retrieve
+     * @returns {StorableItem}
      */
-    public retrieve(): StorableItem {
-        this.contents = this.getFromLocalStorage();
+    public retrieve(): StorableItem | null {
+        // TODO: Handle cases where Local Storage is unavailable
+        // https://go.mparticle.com/work/SQDSDKS-5022
+        const item: string = this.storageObject.getItem(this._storageKey);
+
+        this.contents = item ? JSON.parse(item) : null;
 
         return this.contents;
     }
 
     /**
-     * Removes all persisted data from local storage based on this vault's `key`
+     * Removes all persisted data from Storage based on this vault's `key`
+     * Will remove storage key from Storage as well
      * @method purge
      */
     public purge(): void {
         this.contents = null;
-        this.removeFromLocalStorage();
+        this.storageObject.removeItem(this._storageKey);
     }
+}
 
-    private saveToLocalStorage(items: StorableItem): void {
-        try {
-            window.localStorage.setItem(
-                this._storageKey,
-                !isEmpty(items) ? JSON.stringify(items) : ''
-            );
-        } catch (error) {
-            this.logger.error(`Cannot Save items to Local Storage: ${items}`);
-            this.logger.error(error as string);
-        }
+export class LocalStorageVault<StorableItem> extends BaseVault<StorableItem> {
+    constructor(storageKey: string, options?: IVaultOptions) {
+        super(storageKey, window.localStorage, options);
     }
+}
 
-    private getFromLocalStorage(): StorableItem | null {
-        // TODO: Handle cases where Local Storage is unavailable
-        // https://go.mparticle.com/work/SQDSDKS-5022
-        const item: string = window.localStorage.getItem(this._storageKey);
-
-        return item ? JSON.parse(item) : null;
-    }
-
-    private removeFromLocalStorage(): void {
-        window.localStorage.removeItem(this._storageKey);
+export class SessionStorageVault<StorableItem> extends BaseVault<StorableItem> {
+    constructor(storageKey: string, options?: IVaultOptions) {
+        super(storageKey, window.sessionStorage, options);
     }
 }

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -18,6 +18,22 @@ if (DEBUG === 'true') {
     singleRun = false;
 }
 
+let browserConsoleLogOptions = {
+    terminal: false,
+};
+
+let captureConsole = false;
+
+// Allows console logs to appear when doing npm run test:debug
+if (DEBUG === 'true') {
+    browserConsoleLogOptions = {
+        level: 'log',
+        format: '%b %T: %m',
+        terminal: true,
+    };
+    captureConsole = true;
+}
+
 module.exports = function(config) {
     config.set({
         frameworks: ['mocha', 'should'],
@@ -29,11 +45,9 @@ module.exports = function(config) {
         singleRun,
         debug: true,
         logLevel: config.LOG_INFO,
-        browserConsoleLogOptions: {
-            terminal: false,
-        },
+        browserConsoleLogOptions,
         client: {
-            captureConsole: false,
+            captureConsole,
         },
         customLaunchers: {
             FirefoxHeadless: {

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -20,6 +20,95 @@ declare global {
     }
 }
 
+const event0: SDKEvent = {
+    EventName: 'Test Event 0',
+    EventAttributes: null,
+    SourceMessageId: 'test-smid',
+    EventDataType: 4,
+    EventCategory: 1,
+    CustomFlags: {},
+    IsFirstRun: false,
+    CurrencyCode: null,
+    MPID: 'testMPID',
+    ConsentState: null,
+    UserAttributes: {},
+    UserIdentities: [],
+    SDKVersion: 'X.XX.XX',
+    SessionId: 'test-session-id',
+    SessionStartDate: 0,
+    Debug: false,
+    DeviceId: 'test-device',
+    Timestamp: 0,
+};
+
+const event1: SDKEvent = {
+    EventName: 'Test Event 1',
+    EventAttributes: null,
+    SourceMessageId: 'test-smid',
+    EventDataType: 4,
+    EventCategory: 1,
+    CustomFlags: {},
+    IsFirstRun: false,
+    CurrencyCode: null,
+    MPID: 'testMPID',
+    ConsentState: null,
+    UserAttributes: {},
+    UserIdentities: [],
+    SDKVersion: 'X.XX.XX',
+    SessionId: 'test-session-id',
+    SessionStartDate: 0,
+    Debug: false,
+    DeviceId: 'test-device',
+    Timestamp: 0,
+};
+
+const event2: SDKEvent = {
+    EventName: 'Test Event 2',
+    EventAttributes: null,
+    SourceMessageId: 'test-smid',
+    EventDataType: 4,
+    EventCategory: 1,
+    CustomFlags: {},
+    IsFirstRun: false,
+    CurrencyCode: null,
+    MPID: 'testMPID',
+    ConsentState: null,
+    UserAttributes: {},
+    UserIdentities: [],
+    SDKVersion: 'X.XX.XX',
+    SessionId: 'test-session-id',
+    SessionStartDate: 0,
+    Debug: false,
+    DeviceId: 'test-device',
+    Timestamp: 0,
+};
+
+const event3: SDKEvent = {
+    EventName: 'Test Event 3',
+    EventAttributes: null,
+    SourceMessageId: 'test-smid',
+    EventDataType: 4,
+    EventCategory: 1,
+    CustomFlags: {},
+    IsFirstRun: false,
+    CurrencyCode: null,
+    MPID: 'testMPID',
+    ConsentState: null,
+    UserAttributes: {},
+    UserIdentities: [],
+    SDKVersion: 'X.XX.XX',
+    SessionId: 'test-session-id',
+    SessionStartDate: 0,
+    Debug: false,
+    DeviceId: 'test-device',
+    Timestamp: 0,
+};
+
+const enableBatchingConfigFlags = {
+    eventsV3: '100',
+    eventBatchingIntervalMillis: 1000,
+};
+
 describe('batch uploader', () => {
     let mockServer;
     let clock;
@@ -37,6 +126,7 @@ describe('batch uploader', () => {
 
     afterEach(() => {
         mockServer.reset();
+        window.localStorage.clear();
     });
 
     describe('Unit Tests', () => {
@@ -97,69 +187,6 @@ describe('batch uploader', () => {
                 const mpInstance = window.mParticle.getInstance();
 
                 const uploader = new BatchUploader(mpInstance, 1000);
-
-                const event1: SDKEvent = {
-                    EventName: 'Test Event 1',
-                    EventAttributes: null,
-                    SourceMessageId: 'test-smid-abc',
-                    EventDataType: 4,
-                    EventCategory: 1,
-                    CustomFlags: {},
-                    IsFirstRun: false,
-                    CurrencyCode: null,
-                    MPID: 'testMPID',
-                    ConsentState: null,
-                    UserAttributes: {},
-                    UserIdentities: [],
-                    SDKVersion: 'X.XX.XX',
-                    SessionId: 'test-session-id',
-                    SessionStartDate: 0,
-                    Debug: false,
-                    DeviceId: 'test-device',
-                    Timestamp: 0,
-                };
-
-                const event2: SDKEvent = {
-                    EventName: 'Test Event 2',
-                    EventAttributes: null,
-                    SourceMessageId: 'test-smid-132',
-                    EventDataType: 4,
-                    EventCategory: 1,
-                    CustomFlags: {},
-                    IsFirstRun: false,
-                    CurrencyCode: null,
-                    MPID: 'testMPID',
-                    ConsentState: null,
-                    UserAttributes: {},
-                    UserIdentities: [],
-                    SDKVersion: 'X.XX.XX',
-                    SessionId: 'test-session-id',
-                    SessionStartDate: 0,
-                    Debug: false,
-                    DeviceId: 'test-device',
-                    Timestamp: 0,
-                };
-
-                const event3: SDKEvent = {
-                    EventName: 'Test Event 3',
-                    EventAttributes: null,
-                    SourceMessageId: 'test-smid-ABCDEFG',
-                    EventDataType: 4,
-                    EventCategory: 1,
-                    CustomFlags: {},
-                    IsFirstRun: false,
-                    CurrencyCode: null,
-                    MPID: 'testMPID',
-                    ConsentState: null,
-                    UserAttributes: {},
-                    UserIdentities: [],
-                    SDKVersion: 'X.XX.XX',
-                    SessionId: 'test-session-id',
-                    SessionStartDate: 0,
-                    Debug: false,
-                    DeviceId: 'test-device',
-                    Timestamp: 0,
-                };
 
                 uploader.queueEvent(event1);
                 uploader.queueEvent(event2);
@@ -415,6 +442,709 @@ describe('batch uploader', () => {
         });
     });
 
+    describe('Offline Storage Feature Flag', () => {
+        afterEach(() => {
+            sinon.restore();
+            mockServer.reset();
+            window.localStorage.clear();
+            window.sessionStorage.clear();
+        });
+
+        it('should use local storage when enabled', (done) => {
+            window.mParticle.config.flags = {
+                offlineStorage: '100',
+            };
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const getItemSpy = sinon.spy(Storage.prototype, 'getItem');
+            const setItemSpy = sinon.spy(Storage.prototype, 'setItem');
+
+            const mpInstance = window.mParticle.getInstance();
+
+            const uploader = new BatchUploader(mpInstance, 1000);
+
+            const event: SDKEvent = {
+                EventName: 'Test Event',
+                EventAttributes: null,
+                SourceMessageId: 'test-smid',
+                EventDataType: 4,
+                EventCategory: 1,
+                CustomFlags: {},
+                IsFirstRun: false,
+                CurrencyCode: null,
+                MPID: 'testMPID',
+                ConsentState: null,
+                UserAttributes: {},
+                UserIdentities: [],
+                SDKVersion: 'X.XX.XX',
+                SessionId: 'test-session-id',
+                SessionStartDate: 0,
+                Debug: false,
+                DeviceId: 'test-device',
+                Timestamp: 0,
+            };
+
+            const expectedEvent = [event];
+
+            uploader.queueEvent(event);
+
+            expect(uploader.eventsQueuedForProcessing.length).to.eql(1);
+
+            expect(setItemSpy.called).to.eq(true);
+            expect(setItemSpy.getCall(0).lastArg).to.equal(
+                JSON.stringify(expectedEvent)
+            );
+
+            expect(getItemSpy.called).to.eq(true);
+            expect(getItemSpy.getCall(0).lastArg).to.equal(
+                'mprtcl-v4_abcdef-events'
+            );
+
+            done();
+        });
+
+        it('should not use local storage when disabled', () => {
+            window.mParticle.config.flags = {
+                // offlineStorage: '0', // Defaults to 0, but test if not included, just in case
+            };
+
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const getItemSpy = sinon.spy(Storage.prototype, 'getItem');
+            const setItemSpy = sinon.spy(Storage.prototype, 'setItem');
+
+            const mpInstance = window.mParticle.getInstance();
+
+            const uploader = new BatchUploader(mpInstance, 1000);
+
+            const event: SDKEvent = {
+                EventName: 'Test Event',
+                EventAttributes: null,
+                SourceMessageId: 'test-smid',
+                EventDataType: 4,
+                EventCategory: 1,
+                CustomFlags: {},
+                IsFirstRun: false,
+                CurrencyCode: null,
+                MPID: 'testMPID',
+                ConsentState: null,
+                UserAttributes: {},
+                UserIdentities: [],
+                SDKVersion: 'X.XX.XX',
+                SessionId: 'test-session-id',
+                SessionStartDate: 0,
+                Debug: false,
+                DeviceId: 'test-device',
+                Timestamp: 0,
+            };
+
+            uploader.queueEvent(event);
+
+            expect(uploader.eventsQueuedForProcessing.length).to.eql(1);
+            expect(uploader.eventsQueuedForProcessing[0]).to.eql(event);
+
+            expect(setItemSpy.called).to.eq(false);
+            expect(getItemSpy.called).to.eq(false);
+
+            expect(
+                window.localStorage.getItem('mprtcl-v4_abcdef-events')
+            ).to.equal(null);
+        });
+    });
+
+    describe('Offline Storage Disabled', () => {
+        beforeEach(() => {
+            window.mParticle.config.flags = {
+                offlineStorage: '0',
+                ...enableBatchingConfigFlags,
+            };
+
+            clock = sinon.useFakeTimers({
+                now: new Date().getTime(),
+            });
+
+            window.localStorage.clear();
+        });
+
+        afterEach(() => {
+            sinon.restore();
+            window.localStorage.clear();
+            window.fetchMock.restore();
+            clock.restore();
+        });
+
+        it('should not save events or batches in local storage', done => {
+            const eventStorageKey = 'mprtcl-v4_abcdef-events';
+            const batchStorageKey = 'mprtcl-v4_abcdef-batches';
+
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            // Init will fire a Session Start and AST. We are adding event0
+            // to show that manually queued events will also be grouped
+            // into a batch
+            uploader.queueEvent(event0);
+
+            const eventQueue: SDKEvent[] = uploader.eventsQueuedForProcessing;
+
+            expect(eventQueue.length).to.equal(3);
+
+            expect(
+                window.localStorage.getItem(eventStorageKey),
+                'Local Storage Events should be empty'
+            ).to.equal(null);
+
+            const batchQueue: Batch[] = uploader.batchesQueuedForProcessing;
+
+            // Manually initiate the upload process - turn event into batches and upload the batch
+            window.mParticle.upload();
+
+            expect(batchQueue.length).to.equal(2);
+
+            expect(
+                window.localStorage.getItem(batchStorageKey),
+                'Local Storage Batches should be empty'
+            ).to.equal(null);
+
+            done();
+        });
+    });
+
+    describe('Offline Storage Enabled', () => {
+        beforeEach(() => {
+            window.mParticle.config.flags = {
+                offlineStorage: '100',
+                ...enableBatchingConfigFlags,
+            };
+
+            clock = sinon.useFakeTimers({
+                now: new Date().getTime(),
+            });
+
+            window.sessionStorage.clear();
+            window.localStorage.clear();
+        });
+
+        afterEach(() => {
+            sinon.restore();
+            window.fetchMock.restore();
+            clock.restore();
+        });
+
+        it('should store events in Session Storage in order of creation', (done) => {
+            const eventStorageKey = 'mprtcl-v4_abcdef-events';
+
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            // Init will fire a Session Start and AST. We are adding event0
+            // to show that manually queued events will also be grouped
+            // into a batch
+            uploader.queueEvent(event0);
+
+            const eventQueue: SDKEvent[] = uploader.eventsQueuedForProcessing;
+
+            expect(eventQueue.length).to.equal(3);
+
+            const storedEvents: SDKEvent[] = JSON.parse(
+                window.sessionStorage.getItem(eventStorageKey)
+            );
+
+            expect(storedEvents.length, 'Local Storage Events').to.equal(3);
+
+            expect(storedEvents[0], 'Local Storage: Session Start').to.eql(
+                eventQueue[0]
+            );
+            expect(storedEvents[1], 'Local Storage: AST').to.eql(eventQueue[1]);
+            expect(storedEvents[2], 'Local Storage: Test Event 0').to.eql(
+                eventQueue[2]
+            );
+
+            done();
+        });
+
+        it('should purge events from Session Storage upon Batch Creation', (done) => {
+            const eventStorageKey = 'mprtcl-v4_abcdef-events';
+
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            // Init will fire a Session Start and AST. We are adding event0
+            // to show that manually queued events will also be grouped
+            // into a batch
+            uploader.queueEvent(event0);
+
+            expect(uploader.eventsQueuedForProcessing.length).to.equal(3);
+            expect(uploader.batchesQueuedForProcessing.length).to.equal(0);
+
+            expect(
+                window.sessionStorage.getItem(eventStorageKey),
+                'Queued Events should appear in Session Storage'
+            ).to.be.ok;
+            expect(
+                JSON.parse(window.sessionStorage.getItem(eventStorageKey))
+                    .length
+            ).to.equal(3);
+
+            // Manually initiate the upload process - turn event into batches and upload the batch
+            window.mParticle.upload();
+
+            // If Session Storage is purged, it should return an empty string
+            expect(window.sessionStorage.getItem(eventStorageKey)).to.equal('');
+            expect(uploader.eventsQueuedForProcessing.length).to.equal(0);
+
+            // Batch Queue should be empty because batch successfully uploaded
+            expect(uploader.batchesQueuedForProcessing.length).to.equal(0);
+
+            done();
+        });
+
+        it('should save batches in sequence to Local Storage when an HTTP 500 error is encountered', (done) => {
+            const batchStorageKey = 'mprtcl-v4_abcdef-batches';
+
+            window.fetchMock.post(urls.eventsV3, 500);
+
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            // Init will fire a Session Start and AST. We are adding event0
+            // to show that manually queued events will also be grouped
+            // into a batch
+            uploader.queueEvent(event0);
+
+            // Manually initiate the upload process - turn event into batches and upload the batch
+            window.mParticle.upload();
+
+            clock.restore();
+
+            setTimeout(() => {
+                expect(window.localStorage.getItem(batchStorageKey)).to.be.ok;
+
+                const storedBatches: Batch[] = JSON.parse(
+                    window.localStorage.getItem(batchStorageKey)
+                );
+
+                // Note: Events are usually are groupd together into a single batch
+                // However, in this case, since we are mocking a custom event (event0)
+                // our batching logic is grouping event0 into a separate batch from
+                // the Session Start + AST event from init as they have a different
+                // SessionID
+                expect(storedBatches.length).to.equal(2);
+                expect(
+                    storedBatches[0].events[0].event_type,
+                    'Batch 1: Session Start'
+                ).to.equal('session_start');
+                expect(
+                    storedBatches[0].events[1].event_type,
+                    'Batch 1: AST'
+                ).to.equal('application_state_transition');
+
+                expect(
+                    storedBatches[1].events[0].event_type,
+                    'Batch 2: Custom Event Type'
+                ).to.equal('custom_event');
+                expect(
+                    (storedBatches[1].events[0].data as CustomEventData)
+                        .event_name,
+                    'Batch 2: Custom Event Name'
+                ).to.equal('Test Event 0');
+
+                done();
+            }, 0);
+        });
+
+        it('should save batches in sequence to Local Storage when an HTTP 429 error is encountered', (done) => {
+            const batchStorageKey = 'mprtcl-v4_abcdef-batches';
+
+            window.fetchMock.post(urls.eventsV3, 429);
+
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            // Init will fire a Session Start and AST. We are adding event0
+            // to show that manually queued events will also be grouped
+            // into a batch
+            uploader.queueEvent(event0);
+
+            // Manually initiate the upload process - turn event into batches and upload the batch
+            window.mParticle.upload();
+
+            clock.restore();
+
+            setTimeout(() => {
+                expect(window.localStorage.getItem(batchStorageKey)).to.be.ok;
+
+                const storedBatches: Batch[] = JSON.parse(
+                    window.localStorage.getItem(batchStorageKey)
+                );
+
+                expect(storedBatches.length).to.equal(2);
+                expect(
+                    storedBatches[0].events[0].event_type,
+                    'Batch 1: Session Start'
+                ).to.equal('session_start');
+                expect(
+                    storedBatches[0].events[1].event_type,
+                    'Batch 1: AST'
+                ).to.equal('application_state_transition');
+
+                expect(
+                    storedBatches[1].events[0].event_type,
+                    'Batch 2: Custom Event Type'
+                ).to.equal('custom_event');
+                expect(
+                    (storedBatches[1].events[0].data as CustomEventData)
+                        .event_name,
+                    'Batch 2: Custom Event Name'
+                ).to.equal('Test Event 0');
+
+                done();
+            }, 0);
+        });
+
+        it('should NOT save any batches to Local Storage when an HTTP 401 error is encountered', (done) => {
+            // When a 401 is encountered, we assume that the batch is bad so we clear those
+            // batches from the Upload Queue. Therefore, there should not be anything in
+            // Offline Storage afterwards
+            const batchStorageKey = 'mprtcl-v4_abcdef-batches';
+
+            window.fetchMock.post(urls.eventsV3, 401);
+
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            // Init will fire a Session Start and AST. We are adding event0
+            // to show that manually queued events will also be grouped
+            // into a batch
+            uploader.queueEvent(event0);
+
+            // Manually initiate the upload process - turn event into batches and upload the batch
+            window.mParticle.upload();
+
+            clock.restore();
+
+            setTimeout(() => {
+                expect(window.localStorage.getItem(batchStorageKey)).to.equal(
+                    ''
+                );
+
+                done();
+            }, 0);
+        });
+
+        it('should save batches in sequence to Local Storage when upload is interrupted', (done) => {
+            // Interruption in this context means that the first upload is successful, but
+            // the next upload in sequence is not. For example, on a mobile device on the
+            // subway or if a connection is rate limited. In this case, we should save
+            // batches in the order they were created for a future upload attempt
+
+            const batchStorageKey = 'mprtcl-v4_abcdef-batches';
+
+            // First upload is successful
+            window.fetchMock.post(urls.eventsV3, 200, {
+                overwriteRoutes: false,
+                repeat: 1,
+            });
+
+            // Second upload is rate limited
+            window.fetchMock.post(urls.eventsV3, 429, {
+                overwriteRoutes: false,
+            });
+
+            // Set up SDK and Uploader
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            const batchValidator = new _BatchValidator();
+
+            // Create sample batches for testing
+            const batch1 = batchValidator.returnBatch([
+                {
+                    messageType: 4,
+                    name: 'Test Event 1',
+                },
+                {
+                    messageType: 4,
+                    name: 'Test Event 2',
+                },
+            ]);
+
+            const batch2 = batchValidator.returnBatch([
+                {
+                    messageType: 4,
+                    name: 'Test Event 3',
+                },
+                {
+                    messageType: 4,
+                    name: 'Test Event 4',
+                },
+            ]);
+
+            const batch3 = batchValidator.returnBatch([
+                {
+                    messageType: 4,
+                    name: 'Test Event 5',
+                },
+                {
+                    messageType: 4,
+                    name: 'Test Event 6',
+                },
+            ]);
+
+            // Init will generate a batch with Session Start and AST which normally comes first
+            // but for testing purposes the Session Start + AST batches will be the last batches
+            // as we are manually queueing additional batches to verify sequence
+            uploader.batchesQueuedForProcessing.push(batch1);
+            uploader.batchesQueuedForProcessing.push(batch2);
+            uploader.batchesQueuedForProcessing.push(batch3);
+
+            // Manually initiate the upload process
+            // This will also turn the SessionStart + AST events into a batch and add it to the end of the queue
+            window.mParticle.upload();
+
+            clock.restore();
+
+            setTimeout(() => {
+                expect(window.localStorage.getItem(batchStorageKey)).to.be.ok;
+
+                const storedBatches: Batch[] = JSON.parse(
+                    window.localStorage.getItem(batchStorageKey)
+                );
+
+                // We tried to upload 4 batches (3 unique batches + Session Start/AST from init)
+                expect(storedBatches.length).to.equal(3);
+
+                // The following assertions should verify the sequence presented below
+                // - Batch 1: Test Event 1 and 2 - Should have been uploaded - No Longer in Offline Storage
+                // - Batch 2: Test Event 3 and 4 - Failed Upload - Saved to Offline Storage
+                // - Batch 3: Test Event 5 and 6 - Upload suspended - Saved to Offline Storage
+                // - Batch 4: Session Start and AST - Upload suspended - Saved to Offline Storage
+                // Because Batch 2 failed to upload, subsequent Batches should be suspended until Batch 2 succeeds
+                expect(
+                    storedBatches[0].events[0].event_type,
+                    'Batch 2: Test Event 3 Event Type'
+                ).to.equal('custom_event');
+                expect(
+                    (storedBatches[0].events[0].data as CustomEventData)
+                        .event_name,
+                    'Batch 2: Test Event 3 Event Name'
+                ).to.equal('Test Event 3');
+
+                expect(
+                    storedBatches[0].events[1].event_type,
+                    'Batch 2: Test Event 4 Event Type'
+                ).to.equal('custom_event');
+                expect(
+                    (storedBatches[0].events[1].data as CustomEventData)
+                        .event_name,
+                    'Batch 2: Test Event 4 Event Name'
+                ).to.equal('Test Event 4');
+
+                expect(
+                    storedBatches[1].events[0].event_type,
+                    'Batch 3: Test Event 5 Event Type'
+                ).to.equal('custom_event');
+                expect(
+                    (storedBatches[1].events[0].data as CustomEventData)
+                        .event_name,
+                    'Batch 3: Test Event 5 Event Name'
+                ).to.equal('Test Event 5');
+
+                expect(
+                    storedBatches[1].events[1].event_type,
+                    'Batch 3: Test Event 6 Event Type'
+                ).to.equal('custom_event');
+                expect(
+                    (storedBatches[1].events[1].data as CustomEventData)
+                        .event_name,
+                    'Batch 3: Test Event 6 Event Name'
+                ).to.equal('Test Event 6');
+
+                // These are the events that are generated by mParticle.init. Usually they
+                // come before any queued events, but we manually queued the previous
+                // batches increase the number of attempted uploads to verify that batches
+                // are retained in Offline Storage in order of creation
+                expect(
+                    storedBatches[2].events[0].event_type,
+                    'Batch 4: Session Start'
+                ).to.equal('session_start');
+                expect(
+                    storedBatches[2].events[1].event_type,
+                    'Batch 4: AST'
+                ).to.equal('application_state_transition');
+
+                done();
+            }, 0);
+        });
+
+        it('should attempt to upload batches from Offline Storage before new batches', (done) => {
+            // This test should verify that batches read from Offline Storage are prepended
+            // to the upload queue before newly created batches.
+
+            const batchStorageKey = 'mprtcl-v4_abcdef-batches';
+
+            window.fetchMock.post(urls.eventsV3, 200);
+
+            // Set up SDK and Uploader
+            window.mParticle._resetForTests(MPConfig);
+            window.mParticle.init(apiKey, window.mParticle.config);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            const batchValidator = new _BatchValidator();
+
+            // Create sample batches for testing
+            const batch1 = batchValidator.returnBatch([
+                {
+                    messageType: 4,
+                    name: 'Test Event 1',
+                },
+                {
+                    messageType: 4,
+                    name: 'Test Event 2',
+                },
+            ]);
+
+            const batch2 = batchValidator.returnBatch([
+                {
+                    messageType: 4,
+                    name: 'Test Event 3',
+                },
+                {
+                    messageType: 4,
+                    name: 'Test Event 4',
+                },
+            ]);
+
+            const batch3 = batchValidator.returnBatch([
+                {
+                    messageType: 4,
+                    name: 'Test Event 5',
+                },
+                {
+                    messageType: 4,
+                    name: 'Test Event 6',
+                },
+            ]);
+
+            // Write batches to Offline Storage before queuing new events or batches
+            window.localStorage.setItem(
+                batchStorageKey,
+                JSON.stringify([batch1, batch2, batch3])
+            );
+
+            // Batch Queue should be empty before we upload
+            expect(uploader.batchesQueuedForProcessing.length).to.equal(0);
+
+            // Manually initiate the upload process - turn event into batches and upload the batch
+            window.mParticle.upload();
+
+            clock.restore();
+
+            setTimeout(() => {
+                expect(
+                    window.localStorage.getItem(batchStorageKey),
+                    'Offline Batch Storage should be empty'
+                ).to.equal('');
+
+                // To verify the sequence, we should look at what has been uploaded
+                // as the upload queue and Offline Storage should be empty
+                expect(window.fetchMock.calls().length).to.equal(4);
+
+                const uploadedBatch1: Batch = JSON.parse(
+                    window.fetchMock.calls()[0][1].body
+                );
+                const uploadedBatch2: Batch = JSON.parse(
+                    window.fetchMock.calls()[1][1].body
+                );
+                const uploadedBatch3: Batch = JSON.parse(
+                    window.fetchMock.calls()[2][1].body
+                );
+                const uploadedBatch4: Batch = JSON.parse(
+                    window.fetchMock.calls()[3][1].body
+                );
+
+                // The following assertions should verify the sequence presented below
+                // - Batch 1: Test Event 1 and 2 - Read from Offline Storage
+                // - Batch 2: Test Event 3 and 4 - Read from Offline Storage
+                // - Batch 3: Test Event 5 and 6 - Read from Offline Storage
+                // - Batch 4: Session Start and AST - (new) Created by Init
+
+                expect(
+                    (uploadedBatch1.events[0].data as CustomEventData)
+                        .event_name,
+                    'Batch 1: Test Event 1 '
+                ).to.equal('Test Event 1');
+                expect(
+                    (uploadedBatch1.events[1].data as CustomEventData)
+                        .event_name,
+                    'Batch 1: Test Event 2'
+                ).to.equal('Test Event 2');
+
+                expect(
+                    (uploadedBatch2.events[0].data as CustomEventData)
+                        .event_name,
+                    'Batch 2: Test Event 3 Event Name'
+                ).to.equal('Test Event 3');
+                expect(
+                    (uploadedBatch2.events[1].data as CustomEventData)
+                        .event_name,
+                    'Batch 2: Test Event 4 Event Name'
+                ).to.equal('Test Event 4');
+
+                expect(
+                    (uploadedBatch3.events[0].data as CustomEventData)
+                        .event_name,
+                    'Batch 2: Test Event 5 Event Name'
+                ).to.equal('Test Event 5');
+                expect(
+                    (uploadedBatch3.events[1].data as CustomEventData)
+                        .event_name,
+                    'Batch 2: Test Event 6 Event Name'
+                ).to.equal('Test Event 6');
+
+                // These are the events that are generated by mParticle.init. Usually they
+                // come before any queued events, but we manually queued the previous
+                // batches increase the number of attempted uploads to verify that batches
+                // are retained in Offline Storage in order of creation
+                expect(
+                    uploadedBatch4.events[0].event_type,
+                    'Batch 4: Session Start'
+                ).to.equal('session_start');
+                expect(
+                    uploadedBatch4.events[1].event_type,
+                    'Batch 4: AST'
+                ).to.equal('application_state_transition');
+
+                done();
+            }, 0);
+        });
+    });
+
     describe('Upload Workflow', () => {
         beforeEach(() => {
             clock = sinon.useFakeTimers({
@@ -435,8 +1165,7 @@ describe('batch uploader', () => {
             window.fetchMock.config.overwriteRoutes = true;
 
             window.mParticle.config.flags = {
-                eventsV3: '100',
-                eventBatchingIntervalMillis: 1000,
+                ...enableBatchingConfigFlags,
             };
 
             window.mParticle._resetForTests(MPConfig);
@@ -444,7 +1173,7 @@ describe('batch uploader', () => {
 
             window.mParticle.logEvent('Test Event 0');
 
-            // Manually initiate the upload process - turn event into batches and upload the batch 
+            // Manually initiate the upload process - turn event into batches and upload the batch
             window.mParticle.upload();
 
             expect(
@@ -505,8 +1234,7 @@ describe('batch uploader', () => {
             window.fetchMock.post(urls.eventsV3, 500);
 
             window.mParticle.config.flags = {
-                eventsV3: '100',
-                eventBatchingIntervalMillis: 1000,
+                ...enableBatchingConfigFlags,
             };
 
             window.mParticle._resetForTests(MPConfig);
@@ -607,8 +1335,7 @@ describe('batch uploader', () => {
             });
 
             window.mParticle.config.flags = {
-                eventsV3: '100',
-                eventBatchingIntervalMillis: 1000,
+                ...enableBatchingConfigFlags,
             };
 
             window.mParticle._resetForTests(MPConfig);
@@ -683,9 +1410,8 @@ describe('batch uploader', () => {
             clock = sinon.useFakeTimers({now: new Date().getTime()});
 
             window.mParticle.config.flags = {
-                eventsV3: '100',
-                eventBatchingIntervalMillis: 1000,
-            }
+                ...enableBatchingConfigFlags,
+            };
         });
 
         afterEach(() => {

--- a/test/src/tests-vault.ts
+++ b/test/src/tests-vault.ts
@@ -1,51 +1,261 @@
 import { Batch } from '@mparticle/event-models';
 import { expect } from 'chai';
 import { Dictionary } from '../../src/utils';
-import Vault from '../../src/vault';
+import { SessionStorageVault, LocalStorageVault } from '../../src/vault';
+
+const testObject: Dictionary<Dictionary<string>> = {
+    foo: { foo: 'bar', buzz: 'bazz' },
+    pinky: { narf: 'poit' },
+};
+
+const testArray: Dictionary<string>[] = [
+    { foo: 'bar', buzz: 'bazz' },
+    { narf: 'poit' },
+];
 
 describe('Vault', () => {
-    afterEach(() => {
-        window.localStorage.clear();
+    describe('SessionStorageVault', () => {
+        afterEach(() => {
+            window.sessionStorage.clear();
+        });
+
+        describe('#store', () => {
+            it('should store an object', () => {
+                const storageKey = 'test-key-store-object';
+
+                const vault = new SessionStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+
+                vault.store(testObject);
+
+                expect(vault.contents).to.equal(testObject);
+                expect(window.sessionStorage.getItem(storageKey)).to.equal(
+                    JSON.stringify(testObject)
+                );
+            });
+
+            it('should store an array', () => {
+                const storageKey = 'test-key-store-array';
+
+                const vault = new SessionStorageVault<Dictionary<string>[]>(
+                    storageKey
+                );
+
+                vault.store(testArray);
+
+                expect(vault.contents).to.equal(testArray);
+                expect(window.sessionStorage.getItem(storageKey)).to.equal(
+                    JSON.stringify(testArray)
+                );
+            });
+        });
+
+        describe('#retrieve', () => {
+            it('should retrieve an object', () => {
+                const storageKey = 'test-key-retrieve-object';
+
+                window.sessionStorage.setItem(
+                    storageKey,
+                    JSON.stringify(testObject)
+                );
+
+                const vault = new SessionStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+
+                const retrievedItem = vault.retrieve();
+
+                // We are storing a simple object, so we are not doing a
+                // deep equals, merely making sure the two objects
+                // match
+                expect(retrievedItem).to.eql(testObject);
+            });
+
+            it('should retrieve an array', () => {
+                const storageKey = 'test-key-retrieve-array';
+
+                window.sessionStorage.setItem(
+                    storageKey,
+                    JSON.stringify(testArray)
+                );
+
+                const vault = new SessionStorageVault<Dictionary<string>[]>(
+                    storageKey
+                );
+
+                const retrievedItem = vault.retrieve();
+
+                expect(retrievedItem).to.eql(testArray);
+            });
+        });
+
+        describe('#purge', () => {
+            it('should purge an object', () => {
+                const storageKey = 'test-key-purge-object';
+
+                window.sessionStorage.setItem(
+                    storageKey,
+                    JSON.stringify(testObject)
+                );
+
+                const vault = new SessionStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+
+                vault.purge();
+
+                expect(vault.contents).to.equal(null);
+                expect(window.sessionStorage.getItem(storageKey)).to.equal(
+                    null
+                );
+            });
+
+            it('should purge an array', () => {
+                const storageKey = 'test-key-retrieve-array';
+
+                window.sessionStorage.setItem(
+                    storageKey,
+                    JSON.stringify(testArray)
+                );
+
+                const vault = new SessionStorageVault<Dictionary<string>[]>(
+                    storageKey
+                );
+
+                vault.purge();
+
+                expect(vault.contents).to.equal(null);
+                expect(window.sessionStorage.getItem(storageKey)).to.equal(
+                    null
+                );
+            });
+        });
     });
 
-    describe('#store', () => {
-        it('should store an object', () => {
-            const storageKey = 'test-key-store-object';
-
-            const dict: Dictionary<Dictionary<string>> = {
-                foo: { foo: 'bar', buzz: 'bazz' },
-                pinky: { narf: 'poit' },
-            };
-
-            const vault = new Vault<Dictionary<Dictionary<string>>>(storageKey);
-
-            vault.store(dict);
-
-            expect(vault.contents).to.equal(dict);
-            expect(window.localStorage.getItem(storageKey)).to.equal(
-                JSON.stringify(dict)
-            );
+    describe('LocalStorageVault', () => {
+        afterEach(() => {
+            window.localStorage.clear();
         });
 
-        it('should store an array', () => {
-            const storageKey = 'test-key-store-array';
+        describe('#store', () => {
+            it('should store an object', () => {
+                const storageKey = 'test-key-store-object';
 
-            const array: Dictionary<string>[] = [
-                { foo: 'bar', buzz: 'bazz' },
-                { narf: 'poit' },
-            ];
+                const vault = new LocalStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
 
-            const vault = new Vault<Dictionary<string>[]>(storageKey);
+                vault.store(testObject);
 
-            vault.store(array);
+                expect(vault.contents).to.equal(testObject);
+                expect(window.localStorage.getItem(storageKey)).to.equal(
+                    JSON.stringify(testObject)
+                );
+            });
 
-            expect(vault.contents).to.equal(array);
-            expect(window.localStorage.getItem(storageKey)).to.equal(
-                JSON.stringify(array)
-            );
+            it('should store an array', () => {
+                const storageKey = 'test-key-store-array';
+
+                const vault = new LocalStorageVault<Dictionary<string>[]>(
+                    storageKey
+                );
+
+                vault.store(testArray);
+
+                expect(vault.contents).to.equal(testArray);
+                expect(window.localStorage.getItem(storageKey)).to.equal(
+                    JSON.stringify(testArray)
+                );
+            });
         });
 
-        it('should store batches in the order they were added', () => {
+        describe('#retrieve', () => {
+            it('should retrieve an object', () => {
+                const storageKey = 'test-key-retrieve-object';
+
+                window.localStorage.setItem(
+                    storageKey,
+                    JSON.stringify(testObject)
+                );
+
+                const vault = new LocalStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+
+                const retrievedItem = vault.retrieve();
+
+                // We are storing a simple object, so we are not doing a
+                // deep equals, merely making sure the two objects
+                // match
+                expect(retrievedItem).to.eql(testObject);
+            });
+
+            it('should retrieve an array', () => {
+                const storageKey = 'test-key-retrieve-array';
+
+                window.localStorage.setItem(
+                    storageKey,
+                    JSON.stringify(testArray)
+                );
+
+                const vault = new LocalStorageVault<Dictionary<string>[]>(
+                    storageKey
+                );
+
+                const retrievedItem = vault.retrieve();
+
+                expect(retrievedItem).to.eql(testArray);
+            });
+        });
+
+        describe('#purge', () => {
+            it('should purge an object', () => {
+                const storageKey = 'test-key-purge-object';
+
+                window.localStorage.setItem(
+                    storageKey,
+                    JSON.stringify(testObject)
+                );
+
+                const vault = new LocalStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+
+                vault.purge();
+
+                expect(vault.contents).to.equal(null);
+                expect(window.localStorage.getItem(storageKey)).to.equal(null);
+            });
+
+            it('should purge an array', () => {
+                const storageKey = 'test-key-retrieve-array';
+
+                window.localStorage.setItem(
+                    storageKey,
+                    JSON.stringify(testArray)
+                );
+
+                const vault = new LocalStorageVault<Dictionary<string>[]>(
+                    storageKey
+                );
+
+                vault.purge();
+
+                expect(vault.contents).to.equal(null);
+                expect(window.localStorage.getItem(storageKey)).to.equal(null);
+            });
+        });
+    });
+
+    // This is an example of how to use Vault for Batch Persistence so that we can verify
+    // sequencing and use cases specific to batches
+    describe('Batch Vault', () => {
+        afterEach(() => {
+            window.localStorage.clear();
+        });
+
+        it('should store and retrieve batches in the order they were added', () => {
             const storageKey = 'test-batch-save-order';
 
             const batch1: Partial<Batch> = {
@@ -73,7 +283,7 @@ describe('Vault', () => {
                 source_request_id: 'source-request-id-5',
             };
 
-            const vault = new Vault<Partial<Batch>[]>(storageKey);
+            const vault = new LocalStorageVault<Partial<Batch>[]>(storageKey);
 
             vault.store([batch1, batch2, batch3, batch4, batch5]);
 
@@ -83,86 +293,15 @@ describe('Vault', () => {
             expect(vault.contents[3]).to.eql(batch4);
             expect(vault.contents[4]).to.eql(batch5);
 
+            expect(vault.retrieve()[0]).to.eql(batch1);
+            expect(vault.retrieve()[1]).to.eql(batch2);
+            expect(vault.retrieve()[2]).to.eql(batch3);
+            expect(vault.retrieve()[3]).to.eql(batch4);
+            expect(vault.retrieve()[4]).to.eql(batch5);
+
             expect(window.localStorage.getItem(storageKey)).to.equal(
                 JSON.stringify([batch1, batch2, batch3, batch4, batch5])
             );
-        });
-    });
-
-    describe('#retrieve', () => {
-        it('should retrieve an object', () => {
-            const storageKey = 'test-key-retrieve-object';
-
-            const dict: Dictionary<Dictionary<string>> = {
-                foo: { foo: 'bar', buzz: 'bazz' },
-                pinky: { narf: 'poit' },
-            };
-
-            window.localStorage.setItem(storageKey, JSON.stringify(dict));
-
-            const vault = new Vault<Dictionary<Dictionary<string>>>(storageKey);
-
-            const retrievedItem = vault.retrieve();
-
-            // We are storing a simple object, so we are not doing a
-            // deep equals, merely making sure the two objects
-            // match
-            expect(retrievedItem).to.eql(dict);
-        });
-
-        it('should retrieve an array', () => {
-            const storageKey = 'test-key-retrieve-array';
-
-            const array: Dictionary<string>[] = [
-                { foo: 'bar', buzz: 'bazz' },
-                { narf: 'poit' },
-            ];
-
-            window.localStorage.setItem(storageKey, JSON.stringify(array));
-
-            const vault = new Vault<Dictionary<string>[]>(storageKey);
-
-            const retrievedItem = vault.retrieve();
-
-            expect(retrievedItem).to.eql(array);
-        });
-    });
-
-    describe('#purge', () => {
-        it('should purge an object', () => {
-            const storageKey = 'test-key-purge-object';
-
-            const dict: Dictionary<Dictionary<string>> = {
-                foo: { foo: 'bar', buzz: 'bazz' },
-                pinky: { narf: 'poit' },
-            };
-
-            window.localStorage.setItem(storageKey, JSON.stringify(dict));
-
-            const vault = new Vault<Dictionary<Dictionary<string>>>(storageKey);
-
-            vault.purge();
-
-            expect(vault.contents).to.equal(null);
-            expect(window.localStorage.getItem(storageKey)).to.equal(null);
-        });
-
-        it('should purge an array', () => {
-            const storageKey = 'test-key-retrieve-array';
-
-            const array: Dictionary<string>[] = [
-                { foo: 'bar', buzz: 'bazz' },
-                { narf: 'poit' },
-            ];
-
-            window.localStorage.setItem(storageKey, JSON.stringify(array));
-
-            const vault = new Vault<Dictionary<string>[]>(storageKey);
-
-            vault.purge();
-
-            expect(vault.contents).to.equal(null);
-            expect(window.localStorage.getItem(storageKey)).to.equal(null);
         });
     });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
* Introduces a refactor of our Web API Storage Wrapper (Vault) to support SessionStorage and LocalStorage
* Implements two instances of Vaults; one for Events (Session Storage), and a second for Batches (Local Storage)
* As events are queued, they are placed into Session Storage for later processing. Once the `prepareAndUpload` method is triggered, events are removed from Session Storage and converted to Batches for upload.
* If any Batches exist in Local Storage, they are prepended to the in-memory Batch Queue, then purged from Local Storage to prevent accidental retransmissions.
  * Note: In cases where a Beacon Upload is requested, Batches are stored in Local Storage before transmission, as it is a "fire-and-forget" upload.
* If the transmission is successful, nothing is stored in Local Storage and the in-memory Batch Queue is purged.
* If the transmission is unsuccessful, the batches are saved to Local Storage and are retransmitted during the next interval, in the order they were created.
* This new logic is wrapped in a Feature Flag so we can control the release of Offline Storage via a config flag.
* Also includes a small refactor of MockBatchCreator for testing and allows console logs to appear in `npm run test:debug`

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Run automated tests
 - Verify manually using a sample app
   - Events should be stored in Session Storage before conversion to batches
   - Events should be cleared from Session Storage once converted to batches
   - Batches should not be stored in Local Storage before upload, unless `useBeacon` is true
   - Restarting the browser before events are converted to batches should retain events within Session Storage
   - Batches that do not upload should be put back into local storage, in the order they were created
   - Reloading the sample app should reload batches and events from Local Storage and Session Storage, respectively
   - Events and Batches should maintain sequence at all points during the batch upload process
   - Inspect Live Stream for any potential duplicate events or batches

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5171
