### PR TITLE
ci: add in missing inherit in rebase job

### DIFF
--- a/.github/workflows/dependabot-branch-rebase.yml
+++ b/.github/workflows/dependabot-branch-rebase.yml
@@ -10,3 +10,4 @@ jobs:
   rebase-branch:
     name: "Rebase Development onto Dependabot Branch"
     uses: mParticle/mparticle-workflows/.github/workflows/dependabot-rebase-development.yml@stable
+    secrets: inherit


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Set up job to inherit token

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - N/A - Github Actions cannot be tested locally

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5203
