### PR TITLE
ci: Manually build at each job instead of downloading the archive

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,9 +27,6 @@ jobs:
             - name: Lint with Prettier
               run: npm run prettier
 
-            - name: Build Files
-              run: npm run build
-
             - name: Archive Bundle
               uses: actions/upload-artifact@v3
               with:
@@ -61,10 +58,8 @@ jobs:
             - name: Run NPM CI
               run: npm ci
 
-            - name: Download Local Bundle
-              uses: actions/download-artifact@v3
-              with:
-                  name: bundle-local
+            - name: Build Files
+              run: npm run build:iife
 
             - name: Install Firefox Latest
               uses: browser-actions/setup-firefox@latest
@@ -163,7 +158,7 @@ jobs:
               run: npm ci
 
             - name: Build Files
-              run: npm run build
+              run: npm run build:npm
 
             - name: Build Test Bundle
               run: npm run build:test-bundle
@@ -201,7 +196,7 @@ jobs:
               run: npm ci
 
             - name: Build Files
-              run: npm run build
+              run: npm run build:esm
 
             - name: Build Test Bundle
               run: npm run build:test-bundle

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -162,10 +162,8 @@ jobs:
             - name: Run NPM CI
               run: npm ci
 
-            - name: Download Local Bundle
-              uses: actions/download-artifact@v3
-              with:
-                  name: bundle-local
+            - name: Build Files
+              run: npm run build
 
             - name: Build Test Bundle
               run: npm run build:test-bundle
@@ -202,10 +200,8 @@ jobs:
             - name: Run NPM CI
               run: npm ci
 
-            - name: Download Local Bundle
-              uses: actions/download-artifact@v3
-              with:
-                  name: bundle-local
+            - name: Build Files
+              run: npm run build
 
             - name: Build Test Bundle
               run: npm run build:test-bundle


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
I noticed that with the new CI steps merged from this [PR](https://go.mparticle.com/work/SQDSDKS-5163) that tests for commonjs and modulejs were failing in GHA, even though they were passing locally. 

https://github.com/mParticle/mparticle-web-sdk/actions/runs/4416514762/jobs/7741341885 

https://github.com/mParticle/mparticle-web-sdk/actions/runs/4416514762/jobs/7741341109 

Upon additional testing, it seems that there is an issue with downloading from the archive in each of these individual jobs. When we manually build the dist/ file, the tests pass, as shown in this build https://github.com/mParticle/mparticle-web-sdk/actions/runs/4417052866/jobs/7742205773

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5205