### PR TITLE
ci: Allow dependabot to only update direct dependencies; add new dependencies label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,9 @@ updates:
       schedule:
           interval: daily
       target-branch: 'chore/dependabot'
-      labels: ['dependabot']
+      labels: ['dependabot', 'dependencies']
       open-pull-requests-limit: 10
       commit-message:
           prefix: "chore"
-      ignore:
-          - dependency-name: 'rollup'
-          - dependency-name: 'browserify'
-          - dependency-name: '@babel/runtime'
+      allow:
+        dependency-type: "direct"


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Allow dependabot to only update direct dependencies
 - - Add new dependencies label

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
