### PR TITLE
ci: Update workflows to ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
   create-release-branch:
       name: Create release branch
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-latest
       needs:
         - build-and-test
         - confirm-public-repo-master-branch
@@ -77,7 +77,7 @@ jobs:
 
   release:
       name: Perform Release
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-latest
       needs: 
         - build-and-test
         - create-release-branch
@@ -142,7 +142,7 @@ jobs:
   sync-repository:
       name: Sync repositories
       needs: release
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-latest
       steps:
         - name: Checkout master branch
           uses: actions/checkout@v3


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
We should update all web sdk workflows to use `ubuntu-latest` because ubuntu-18.04 is deprecated and preventing releases from happening.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5295