### PR TITLE
refactor: Remove non-batching event code path (v2 events endpoint)

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -8,17 +8,14 @@ import {
     SDKEvent,
 } from './sdkRuntimeModels';
 import KitBlocker from './kitBlocking';
-import { Dictionary, getRampNumber } from './utils';
+import { Dictionary, getRampNumber, isEmpty } from './utils';
 import { IUploadObject } from './serverModel';
-
-const Messages = Constants.Messages;
 
 export type ForwardingStatsData = Dictionary<any>;
 
 export interface IAPIClient {
     uploader: BatchUploader | null;
     queueEventForBatchUpload: (event: SDKEvent) => void;
-    shouldEnableBatching: () => boolean;
     processQueuedEvents: () => void;
     appendUserInfoToEvents: (user: MParticleUser, events: SDKEvent[]) => void;
     sendEventToServer: (event: SDKEvent, _options?: Dictionary<any>) => void;
@@ -53,22 +50,6 @@ export default function APIClient(
         this.uploader.queueEvent(event);
 
         mpInstance._Persistence.update();
-    };
-
-    this.shouldEnableBatching = function() {
-        // Returns a string of a number that must be parsed
-        // Invalid strings will be parsed to NaN which is falsey
-        const eventsV3Percentage = parseInt(
-            mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.EventsV3),
-            10
-        );
-
-        if (!eventsV3Percentage) {
-            return false;
-        }
-
-        const rampNumber = getRampNumber(mpInstance._Store.deviceId);
-        return eventsV3Percentage >= rampNumber;
     };
 
     this.processQueuedEvents = function() {
@@ -135,15 +116,15 @@ export default function APIClient(
 
         this.processQueuedEvents();
 
-        if (event && options.shouldUploadEvent) {
-            if (this.shouldEnableBatching()) {
-                this.queueEventForBatchUpload(event);
-            } else {
-                this.sendSingleEventToServer(event);
-            }
+        if (isEmpty(event)) {
+            return;
         }
 
-        if (event && event.EventName !== Types.MessageType.AppStateTransition) {
+        if (options.shouldUploadEvent) {
+            this.queueEventForBatchUpload(event);
+        }
+
+        if (event.EventName !== Types.MessageType.AppStateTransition) {
             if (kitBlocker && kitBlocker.kitBlockingEnabled) {
                 event = kitBlocker.createBlockedEvent(event);
             }
@@ -152,50 +133,6 @@ export default function APIClient(
             // can nullify the event
             if (event) {
                 mpInstance._Forwarders.sendEventToForwarders(event);
-            }
-        }
-    };
-
-    this.sendSingleEventToServer = function(event) {
-        if (event.EventDataType === Types.MessageType.Media) {
-            return;
-        }
-        let xhr,
-            xhrCallback = function() {
-                if (xhr.readyState === 4) {
-                    mpInstance.Logger.verbose(
-                        'Received ' + xhr.statusText + ' from server'
-                    );
-                    mpInstance._Persistence.update();
-                }
-            };
-
-        if (!event) {
-            mpInstance.Logger.error(Messages.ErrorMessages.EventEmpty);
-            return;
-        }
-        mpInstance.Logger.verbose(Messages.InformationMessages.SendHttp);
-        xhr = mpInstance._Helpers.createXHR(xhrCallback);
-        if (xhr) {
-            try {
-                xhr.open(
-                    'post',
-                    mpInstance._Helpers.createServiceUrl(
-                        mpInstance._Store.SDKConfig.v2SecureServiceUrl,
-                        mpInstance._Store.devToken
-                    ) + '/Events'
-                );
-                xhr.send(
-                    JSON.stringify(
-                        mpInstance._ServerModel.convertEventToV2DTO(
-                            event as IUploadObject
-                        )
-                    )
-                );
-            } catch (e) {
-                mpInstance.Logger.error(
-                    'Error sending event to mParticle servers. ' + e
-                );
             }
         }
     };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -159,7 +159,6 @@ const Constants = {
     },
     FeatureFlags: {
         ReportBatching: 'reportBatching',
-        EventsV3: 'eventsV3',
         EventBatchingIntervalMillis: 'eventBatchingIntervalMillis',
         OfflineStorage: 'offlineStorage',
     },

--- a/src/identity.js
+++ b/src/identity.js
@@ -1058,42 +1058,36 @@ export default function Identity(mpInstance) {
                         mpInstance._Persistence.savePersistence(cookies, mpid);
                     }
 
-                    if (mpInstance._APIClient.shouldEnableBatching()) {
-                        // If the new attributeList length is different previous, then there is a change event.
-                        // Loop through new attributes list, see if they are all in the same index as previous user attributes list
-                        // If there are any changes, break, and immediately send a userAttributeChangeEvent with full array as a value
-                        if (
-                            !previousUserAttributeValue ||
-                            !Array.isArray(previousUserAttributeValue)
-                        ) {
-                            userAttributeChange = true;
-                        } else if (
-                            newValue.length !==
-                            previousUserAttributeValue.length
-                        ) {
-                            userAttributeChange = true;
-                        } else {
-                            for (var i = 0; i < newValue.length; i++) {
-                                if (
-                                    previousUserAttributeValue[i] !==
-                                    newValue[i]
-                                ) {
-                                    userAttributeChange = true;
-                                    break;
-                                }
+                    // If the new attributeList length is different previous, then there is a change event.
+                    // Loop through new attributes list, see if they are all in the same index as previous user attributes list
+                    // If there are any changes, break, and immediately send a userAttributeChangeEvent with full array as a value
+                    if (
+                        !previousUserAttributeValue ||
+                        !Array.isArray(previousUserAttributeValue)
+                    ) {
+                        userAttributeChange = true;
+                    } else if (
+                        newValue.length !== previousUserAttributeValue.length
+                    ) {
+                        userAttributeChange = true;
+                    } else {
+                        for (var i = 0; i < newValue.length; i++) {
+                            if (previousUserAttributeValue[i] !== newValue[i]) {
+                                userAttributeChange = true;
+                                break;
                             }
                         }
+                    }
 
-                        if (userAttributeChange) {
-                            self.sendUserAttributeChangeEvent(
-                                key,
-                                newValue,
-                                previousUserAttributeValue,
-                                isNewAttribute,
-                                false,
-                                this
-                            );
-                        }
+                    if (userAttributeChange) {
+                        self.sendUserAttributeChangeEvent(
+                            key,
+                            newValue,
+                            previousUserAttributeValue,
+                            isNewAttribute,
+                            false,
+                            this
+                        );
                     }
 
                     mpInstance._Forwarders.initForwarders(
@@ -1730,10 +1724,6 @@ export default function Identity(mpInstance) {
     ) {
         var currentUserInMemory, userIdentityChangeEvent;
 
-        if (!mpInstance._APIClient.shouldEnableBatching()) {
-            return;
-        }
-
         if (!mpid) {
             if (method !== 'modify') {
                 return;
@@ -1799,9 +1789,6 @@ export default function Identity(mpInstance) {
         deleted,
         user
     ) {
-        if (!mpInstance._APIClient.shouldEnableBatching()) {
-            return;
-        }
         var userAttributeChangeEvent = self.createUserAttributeChange(
             attributeKey,
             newUserAttributeValue,

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1290,18 +1290,6 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
     mpInstance._APIClient = new APIClient(mpInstance, kitBlocker);
     mpInstance._Forwarders = new Forwarders(mpInstance, kitBlocker);
     if (config.flags) {
-        if (config.flags.hasOwnProperty(Constants.FeatureFlags.EventsV3)) {
-            // TODO: Remove this after 8/12/2022
-            if (config.flags[Constants.FeatureFlags.EventsV3] !== '100') {
-                var message =
-                    'mParticle will be enabling Event Batching for all customers on July 12, 2022. ' +
-                    'For more details, please see our docs: https://docs.mparticle.com/developers/sdk/web/getting-started/';
-                mpInstance.Logger.warning(message);
-            }
-
-            mpInstance._Store.SDKConfig.flags[Constants.FeatureFlags.EventsV3] =
-                config.flags[Constants.FeatureFlags.EventsV3];
-        }
         if (
             config.flags.hasOwnProperty(
                 Constants.FeatureFlags.EventBatchingIntervalMillis

--- a/src/store.ts
+++ b/src/store.ts
@@ -423,13 +423,6 @@ export default function Store(
         }
         if (
             !this.SDKConfig.flags.hasOwnProperty(
-                Constants.FeatureFlags.EventsV3
-            )
-        ) {
-            this.SDKConfig.flags[Constants.FeatureFlags.EventsV3] = 0;
-        }
-        if (
-            !this.SDKConfig.flags.hasOwnProperty(
                 Constants.FeatureFlags.EventBatchingIntervalMillis
             )
         ) {

--- a/test/integrations/requirejs/karma.requirejs.config.js
+++ b/test/integrations/requirejs/karma.requirejs.config.js
@@ -5,6 +5,7 @@ switch (FILE_ORDER) {
     case 'before_mp':
         files = [
             '../../lib/mockhttprequest.js',
+            '../../../node_modules/fetch-mock/dist/es5/client-bundle.js',
             '../../lib/require.2.3.6.min.js',
             '../../../dist/mparticle.js',
             'test-requirejs.js',
@@ -13,6 +14,7 @@ switch (FILE_ORDER) {
     case 'after_mp':
         files = [
             '../../lib/mockhttprequest.js',
+            '../../../node_modules/fetch-mock/dist/es5/client-bundle.js',
             '../../../dist/mparticle.js',
             '../../lib/require.2.3.6.min.js',
             'test-requirejs.js',

--- a/test/integrations/requirejs/test-requirejs.js
+++ b/test/integrations/requirejs/test-requirejs.js
@@ -2,6 +2,18 @@ describe('Require.JS Pages', function() {
     it('loads mParticle properly', function() {
         var server = new MockHttpServer();
         server.start();
+        window.fetchMock.post('https://jssdks.mparticle.com/v3/JS/test_key/events', 200);
+        window.mParticle = window.mParticle || {};
+        window.mParticle.config = {
+            workspaceToken: 'fooToken',
+            logLevel: 'none',
+            requestConfig: false,
+            isDevelopmentMode: false,
+            flags: {
+                eventsV3: '100',
+                eventBatchingIntervalMillis: 0,
+            }
+        };
 
         server.handle = function(request) {
             request.setResponseHeader('Content-Type', 'application/json');
@@ -14,13 +26,15 @@ describe('Require.JS Pages', function() {
             );
         };
 
-        mParticle.init('fakeapikey', { requestConfig: false });
-        server.requests = [];
-        mParticle.logEvent('test event');
-        assert.isDefined(mParticle, 'mParticle should be defined');
-        assert(
-            JSON.parse(server.requests[0].requestText).n === 'test event',
-            'Request has the proper test event'
-        );
+        mParticle.init('test_key', window.mParticle.config);
+
+        window.fetchMock._calls = [];
+
+        mParticle.logEvent('Test Event1');
+
+        const testEvent = window.fetchMock._calls[0];
+        const testEventName = JSON.parse(testEvent[1].body).events[0].data.event_name;
+
+        testEventName.should.equal('Test Event1');
     });
 });

--- a/test/src/config.ts
+++ b/test/src/config.ts
@@ -1,8 +1,7 @@
 import { SDKInitConfig } from "../../src/sdkRuntimeModels";
 
 export const urls = {
-    eventsV2: 'https://jssdks.mparticle.com/v2/JS/test_key/Events',
-    eventsV3: 'https://jssdks.mparticle.com/v3/JS/test_key/events',
+    events: 'https://jssdks.mparticle.com/v3/JS/test_key/events',
     identify: 'https://identity.mparticle.com/v1/identify',
     login: 'https://identity.mparticle.com/v1/login',
     logout: 'https://identity.mparticle.com/v1/logout',

--- a/test/src/tests-apiClient.ts
+++ b/test/src/tests-apiClient.ts
@@ -22,45 +22,6 @@ describe('Api Client', () => {
         mParticle._resetForTests(MPConfig);
     });
 
-    it('should enable batching for ramp percentages', done => {
-        mParticle.getInstance()._Store.SDKConfig.flags[
-            Constants.FeatureFlags.EventsV3
-        ] = 0;
-        let result1 = mParticle.getInstance()._APIClient.shouldEnableBatching();
-        expect(result1).to.be.not.ok;
-
-        mParticle.getInstance()._Store.SDKConfig.flags[
-            Constants.FeatureFlags.EventsV3
-        ] = null;
-        let nullResult = mParticle
-            .getInstance()
-            ._APIClient.shouldEnableBatching();
-        expect(nullResult).to.be.not.ok;
-
-        mParticle.getInstance()._Store.SDKConfig.flags[
-            Constants.FeatureFlags.EventsV3
-        ] = '100';
-        let result2 = mParticle.getInstance()._APIClient.shouldEnableBatching();
-        expect(result2).to.be.ok;
-
-        const fakeDeviceId = '946cdc15-3179-41fe-b777-4f3bf1ac0ddc';
-        mParticle.getInstance()._Store.deviceId = fakeDeviceId; //this will hash/ramp to 28
-        mParticle.getInstance()._Store.SDKConfig.flags[
-            Constants.FeatureFlags.EventsV3
-        ] = '28';
-
-        let result3 = mParticle.getInstance()._APIClient.shouldEnableBatching();
-        expect(result3).to.be.ok;
-
-        mParticle.getInstance()._Store.SDKConfig.flags[
-            Constants.FeatureFlags.EventsV3
-        ] = '27';
-        let result4 = mParticle.getInstance()._APIClient.shouldEnableBatching();
-        expect(result4).to.not.be.ok;
-
-        done();
-    });
-
     it('should update queued events with latest user info', done => {
         const event = {
             messageType: Types.MessageType.PageEvent,
@@ -152,20 +113,6 @@ describe('Api Client', () => {
         expect(Object.keys(sdkEvent2.UserAttributes).length).to.equal(2);
         expect(sdkEvent2.MPID).to.equal('98765');
         expect(sdkEvent2.ConsentState).to.not.equal(null);
-
-        done();
-    });
-
-    it('should return true when events v3 endpoint is "100"', done => {
-        mParticle.getInstance()._Store.SDKConfig.flags = {
-            eventBatchingIntervalMillis: '0',
-            eventsV3: '100',
-        };
-        const batchingEnabled = mParticle
-            .getInstance()
-            ._APIClient.shouldEnableBatching();
-
-        expect(batchingEnabled).to.equal(true);
 
         done();
     });

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -114,6 +114,7 @@ describe('batch uploader', () => {
     let clock;
 
     beforeEach(() => {
+        window.fetchMock.restore();
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
@@ -126,6 +127,7 @@ describe('batch uploader', () => {
 
     afterEach(() => {
         mockServer.reset();
+        window.fetchMock.restore();
         window.localStorage.clear();
     });
 
@@ -211,12 +213,12 @@ describe('batch uploader', () => {
                 window.mParticle._resetForTests(MPConfig);
                 window.mParticle.init(apiKey, window.mParticle.config);
             });
+            afterEach(() => {
+                window.fetchMock.restore();
+            });
 
             it('should reject batches without events', async () => {
-                window.fetchMock.post(
-                    'https://jssdks.mparticle.com/v3/JS/test_key/events',
-                    200
-                );
+                window.fetchMock.post(urls.events, 200);
 
                 const newLogger = new Logger(window.mParticle.config);
                 const mpInstance = window.mParticle.getInstance();
@@ -252,10 +254,7 @@ describe('batch uploader', () => {
             });
 
             it('should return batches that fail to upload with 500 errors', async () => {
-                window.fetchMock.post(
-                    'https://jssdks.mparticle.com/v3/JS/test_key/events',
-                    500
-                );
+                window.fetchMock.post(urls.events, 500);
 
                 const newLogger = new Logger(window.mParticle.config);
                 const mpInstance = window.mParticle.getInstance();
@@ -302,10 +301,7 @@ describe('batch uploader', () => {
             });
 
             it('should return batches that fail to upload with 429 errors', async () => {
-                window.fetchMock.post(
-                    'https://jssdks.mparticle.com/v3/JS/test_key/events',
-                    429
-                );
+                window.fetchMock.post(urls.events,  429);
 
                 const newLogger = new Logger(window.mParticle.config);
                 const mpInstance = window.mParticle.getInstance();
@@ -352,10 +348,7 @@ describe('batch uploader', () => {
             });
 
             it('should return null if batches fail to upload with 401 errors', async () => {
-                window.fetchMock.post(
-                    'https://jssdks.mparticle.com/v3/JS/test_key/events',
-                    401
-                );
+                window.fetchMock.post(urls.events, 401);
 
                 const newLogger = new Logger(window.mParticle.config);
                 const mpInstance = window.mParticle.getInstance();
@@ -389,10 +382,7 @@ describe('batch uploader', () => {
             });
 
             it('should return batches that fail to unknown HTTP errors', async () => {
-                window.fetchMock.post(
-                    'https://jssdks.mparticle.com/v3/JS/test_key/events',
-                    400
-                );
+                window.fetchMock.post(urls.events, 400);
 
                 const newLogger = new Logger(window.mParticle.config);
                 const mpInstance = window.mParticle.getInstance();
@@ -443,8 +433,18 @@ describe('batch uploader', () => {
     });
 
     describe('Offline Storage Feature Flag', () => {
+        beforeEach(() => {
+            sinon.restore();
+            window.fetchMock.restore();
+
+            mockServer.reset();
+            window.localStorage.clear();
+            window.sessionStorage.clear();
+        });
         afterEach(() => {
             sinon.restore();
+            window.fetchMock.restore();
+
             mockServer.reset();
             window.localStorage.clear();
             window.sessionStorage.clear();
@@ -625,6 +625,7 @@ describe('batch uploader', () => {
             clock = sinon.useFakeTimers({
                 now: new Date().getTime(),
             });
+            window.fetchMock.restore();
 
             window.sessionStorage.clear();
             window.localStorage.clear();
@@ -671,7 +672,7 @@ describe('batch uploader', () => {
             done();
         });
 
-        it('should purge events from Session Storage upon Batch Creation', (done) => {
+         it('should purge events from Session Storage upon Batch Creation', (done) => {
             const eventStorageKey = 'mprtcl-v4_abcdef-events';
 
             window.mParticle._resetForTests(MPConfig);
@@ -713,7 +714,7 @@ describe('batch uploader', () => {
         it('should save batches in sequence to Local Storage when an HTTP 500 error is encountered', (done) => {
             const batchStorageKey = 'mprtcl-v4_abcdef-batches';
 
-            window.fetchMock.post(urls.eventsV3, 500);
+            window.fetchMock.post(urls.events, 500);
 
             window.mParticle._resetForTests(MPConfig);
             window.mParticle.init(apiKey, window.mParticle.config);
@@ -770,7 +771,7 @@ describe('batch uploader', () => {
         it('should save batches in sequence to Local Storage when an HTTP 429 error is encountered', (done) => {
             const batchStorageKey = 'mprtcl-v4_abcdef-batches';
 
-            window.fetchMock.post(urls.eventsV3, 429);
+            window.fetchMock.post(urls.events, 429);
 
             window.mParticle._resetForTests(MPConfig);
             window.mParticle.init(apiKey, window.mParticle.config);
@@ -825,7 +826,7 @@ describe('batch uploader', () => {
             // Offline Storage afterwards
             const batchStorageKey = 'mprtcl-v4_abcdef-batches';
 
-            window.fetchMock.post(urls.eventsV3, 401);
+            window.fetchMock.post(urls.events, 401);
 
             window.mParticle._resetForTests(MPConfig);
             window.mParticle.init(apiKey, window.mParticle.config);
@@ -861,13 +862,13 @@ describe('batch uploader', () => {
             const batchStorageKey = 'mprtcl-v4_abcdef-batches';
 
             // First upload is successful
-            window.fetchMock.post(urls.eventsV3, 200, {
-                overwriteRoutes: false,
+            window.fetchMock.post(urls.events, 200, {
+                overwriteRoutes: true,
                 repeat: 1,
             });
 
             // Second upload is rate limited
-            window.fetchMock.post(urls.eventsV3, 429, {
+            window.fetchMock.post(urls.events, 429, {
                 overwriteRoutes: false,
             });
 
@@ -1006,7 +1007,7 @@ describe('batch uploader', () => {
 
             const batchStorageKey = 'mprtcl-v4_abcdef-batches';
 
-            window.fetchMock.post(urls.eventsV3, 200);
+            window.fetchMock.post(urls.events, 200);
 
             // Set up SDK and Uploader
             window.mParticle._resetForTests(MPConfig);

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -1161,7 +1161,7 @@ describe('batch uploader', () => {
             // Batches should be uploaded in the order they were created to prevent
             // any potential corruption.
 
-            window.fetchMock.post(urls.eventsV3, 200);
+            window.fetchMock.post(urls.events, 200);
             window.fetchMock.config.overwriteRoutes = true;
 
             window.mParticle.config.flags = {
@@ -1231,7 +1231,7 @@ describe('batch uploader', () => {
             // If batches cannot upload, they should be added back to the Batch Queue
             // in the order they were created so they can be retransmitted.
 
-            window.fetchMock.post(urls.eventsV3, 500);
+            window.fetchMock.post(urls.events, 500);
 
             window.mParticle.config.flags = {
                 ...enableBatchingConfigFlags,
@@ -1325,12 +1325,12 @@ describe('batch uploader', () => {
         // https://go.mparticle.com/work/SQDSDKS-5165
         it.skip('should keep and retry batches in sequence if the transmission fails midway', (done) => {
             // First request is successful, subsequent requests fail
-            window.fetchMock.post(urls.eventsV3, 200, {
+            window.fetchMock.post(urls.events, 200, {
                 overwriteRoutes: false,
                 repeat: 1,
             });
 
-            window.fetchMock.post(urls.eventsV3, 429, {
+            window.fetchMock.post(urls.events, 429, {
                 overwriteRoutes: false,
             });
 
@@ -1405,7 +1405,7 @@ describe('batch uploader', () => {
 
     describe('batching via window.fetch', () => {
         beforeEach(() => {
-            window.fetchMock.post(urls.eventsV3, 200);
+            window.fetchMock.post(urls.events, 200);
             window.fetchMock.config.overwriteRoutes = true;
             clock = sinon.useFakeTimers({now: new Date().getTime()});
 
@@ -1437,7 +1437,7 @@ describe('batch uploader', () => {
             const endpoint = lastCall[0];
             var batch = JSON.parse(window.fetchMock.lastCall()[1].body);
 
-            endpoint.should.equal(urls.eventsV3);
+            endpoint.should.equal(urls.events);
             batch.events[0].event_type.should.equal('session_start');
             batch.events[1].event_type.should.equal('application_state_transition');
             batch.events[2].event_type.should.equal('custom_event');
@@ -1458,7 +1458,7 @@ describe('batch uploader', () => {
             const lastCall = window.fetchMock.lastCall();
             const endpoint = lastCall[0];
             var batch = JSON.parse(window.fetchMock.lastCall()[1].body);
-            endpoint.should.equal(urls.eventsV3);
+            endpoint.should.equal(urls.events);
             batch.events[2].data.location.should.have.property('latitude', 100)
             batch.events[2].data.location.should.have.property('longitude', 100)
     
@@ -1485,7 +1485,7 @@ describe('batch uploader', () => {
             const endpoint = lastCall[0];
             var batch = JSON.parse(window.fetchMock.lastCall()[1].body);
 
-            endpoint.should.equal(urls.eventsV3);
+            endpoint.should.equal(urls.events);
             batch.events[0].event_type.should.equal('session_start');
             batch.events[1].event_type.should.equal('application_state_transition');
             batch.events[2].event_type.should.equal('custom_event');
@@ -1510,7 +1510,7 @@ describe('batch uploader', () => {
             const endpoint = lastCall[0];
             var batch = JSON.parse(window.fetchMock.lastCall()[1].body);
 
-            endpoint.should.equal(urls.eventsV3);
+            endpoint.should.equal(urls.events);
             batch.events[0].event_type.should.equal('session_start');
             batch.events[1].event_type.should.equal('application_state_transition');
             batch.events[2].event_type.should.equal('custom_event');
@@ -1525,7 +1525,7 @@ describe('batch uploader', () => {
             window.mParticle._resetForTests(MPConfig);
             var clock = sinon.useFakeTimers();
 
-            window.fetchMock.post(urls.eventsV3, 500);
+            window.fetchMock.post(urls.events, 500);
             
             window.mParticle.init(apiKey, window.mParticle.config);
             window.mParticle.logEvent('Test Event');
@@ -1537,7 +1537,7 @@ describe('batch uploader', () => {
             pendingEvents[1].EventName.should.equal(10);
             pendingEvents[2].EventName.should.equal('Test Event');
 
-            window.fetchMock.post(urls.eventsV3, 200);
+            window.fetchMock.post(urls.events, 200);
             
             (window.fetchMock.lastCall() === undefined).should.equal(true);
             clock.tick(1000);
@@ -1567,7 +1567,7 @@ describe('batch uploader', () => {
             const endpoint = lastCall[0];
             var batch = JSON.parse(window.fetchMock.lastCall()[1].body);
 
-            endpoint.should.equal(urls.eventsV3);
+            endpoint.should.equal(urls.events);
             batch.events[0].data.should.have.property('source_message_id')
 
             done();
@@ -1597,7 +1597,7 @@ describe('batch uploader', () => {
             const endpoint = lastCall[0];
             var batch = JSON.parse(window.fetchMock.lastCall()[1].body);
 
-            endpoint.should.equal(urls.eventsV3);
+            endpoint.should.equal(urls.events);
             // event batch includes session start, ast, then last event is Test Event
             batch.events[batch.events.length-1].data.should.have.property('source_message_id', 'abcdefg')
 
@@ -1850,7 +1850,7 @@ describe('batch uploader', () => {
                 eventsV3: '100',
                 eventBatchingIntervalMillis: 1000,
             }
-            mockServer.respondWith(urls.eventsV3, [
+            mockServer.respondWith(urls.events, [
                 200,
                 {},
                 JSON.stringify({ mpid: testMPID, Store: {}})
@@ -1995,7 +1995,7 @@ describe('batch uploader', () => {
             window.mParticle._resetForTests(MPConfig);
             var clock = sinon.useFakeTimers();
 
-            mockServer.respondWith(urls.eventsV3, [
+            mockServer.respondWith(urls.events, [
                 500,
                 {},
                 JSON.stringify({ mpid: testMPID, Store: {}})

--- a/test/src/tests-beaconUpload.ts
+++ b/test/src/tests-beaconUpload.ts
@@ -13,8 +13,13 @@ declare global {
 
 describe('Beacon Upload', () => {
     let mockServer;
+    before(function() {
+        window.fetchMock.restore();
+        sinon.restore();
+    });
 
     beforeEach(function() {
+        window.fetchMock.restore();
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
@@ -33,6 +38,7 @@ describe('Beacon Upload', () => {
     afterEach(() => {
         sinon.restore();
         mockServer.reset();
+        window.fetchMock.restore();
     });
 
     it('should trigger beacon on page visibilitychange events', function(done) {
@@ -45,9 +51,7 @@ describe('Beacon Upload', () => {
         document.dispatchEvent(new Event('visibilitychange'));
 
         bond.called.should.eql(true);
-        bond.getCalls()[0].args[0].should.eql(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events'
-        );
+        bond.lastCall.args[0].should.eql(urls.events);
 
         done();
     });
@@ -63,9 +67,7 @@ describe('Beacon Upload', () => {
         window.dispatchEvent(new Event('beforeunload'));
 
         bond.called.should.eql(true);
-        bond.getCalls()[0].args[0].should.eql(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events'
-        );
+        bond.getCalls()[0].args[0].should.eql(urls.events);
 
         done();
     });
@@ -79,9 +81,7 @@ describe('Beacon Upload', () => {
         window.dispatchEvent(new Event('pagehide'));
 
         bond.called.should.eql(true);
-        bond.getCalls()[0].args[0].should.eql(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events'
-        );
+        bond.getCalls()[0].args[0].should.eql(urls.events);
 
         (typeof bond.getCalls()[0].args[1]).should.eql('object');
 

--- a/test/src/tests-consent.ts
+++ b/test/src/tests-consent.ts
@@ -28,9 +28,9 @@ const mParticle = window.mParticle;
 
 describe('Consent', function() {
     beforeEach(function() {
+        window.fetchMock.post(urls.events, 200);
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
-
 
         mockServer.respondWith(urls.identify, [
             200,
@@ -42,6 +42,7 @@ describe('Consent', function() {
 
     afterEach(function() {
         mockServer.restore();
+        window.fetchMock.restore();
         mParticle._resetForTests(MPConfig);
     });
 

--- a/test/src/tests-cookie-syncing.js
+++ b/test/src/tests-cookie-syncing.js
@@ -16,11 +16,6 @@ describe('cookie syncing', function() {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}})
-        ])
         mockServer.respondWith(urls.identify, [
             200,
             {},

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -15,6 +15,7 @@ var DefaultConfig = Constants.DefaultConfig,
 
 describe('core SDK', function() {
     beforeEach(function() {
+        window.fetchMock.post(urls.events, 200);
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
@@ -29,6 +30,8 @@ describe('core SDK', function() {
     afterEach(function() {
         mockServer.reset();
         mParticle._resetForTests(MPConfig);
+        window.fetchMock.restore();
+        sinon.restore();
     });
 
     it('starts new session', function(done) {
@@ -800,9 +803,9 @@ describe('core SDK', function() {
 
     it('should have default urls if no custom urls are set in config object, but use custom urls when they are set', function(done) {
         window.mParticle.config.v3SecureServiceUrl =
-            'custom-v3secureserviceurl/v3/JS/';
+            'testtesttest-custom-v3secureserviceurl/v3/JS/';
         window.mParticle.config.configUrl =
-            'custom-configUrl/v2/JS/';
+            'foo-custom-configUrl/v2/JS/';
         window.mParticle.config.identityUrl = 'custom-identityUrl/';
         window.mParticle.config.aliasUrl = 'custom-aliasUrl/';
 
@@ -861,7 +864,7 @@ describe('core SDK', function() {
     });
 
     it('should use custom v3 endpoint when specified on config object', function(done) {
-        mParticle.config.v3SecureServiceUrl = 'custom-v3SecureServiceUrl/v3/JS/';
+        mParticle.config.v3SecureServiceUrl = 'def-v3SecureServiceUrl/v3/JS/';
 
         mParticle.config.flags = {
             eventsV3: '100',
@@ -869,7 +872,7 @@ describe('core SDK', function() {
         }
 
         window.fetchMock.post(
-            'https://custom-v3SecureServiceUrl/v3/JS/test_key/events',
+            'https://def-v3SecureServiceUrl/v3/JS/test_key/events',
             200
         );
 

--- a/test/src/tests-eCommerce.js
+++ b/test/src/tests-eCommerce.js
@@ -1,10 +1,10 @@
 import Utils from './utils';
 import sinon from 'sinon';
-import { urls, apiKey, CommerceEventType, workspaceToken, MPConfig, testMPID, ProductActionType, PromotionActionType } from './config';
+import { urls, apiKey, workspaceToken, MPConfig, testMPID, ProductActionType, PromotionActionType } from './config';
 
 var getLocalStorageProducts = Utils.getLocalStorageProducts,
     forwarderDefaultConfiguration = Utils.forwarderDefaultConfiguration,
-    getEvent = Utils.getEvent,
+    findEventFromRequest = Utils.findEventFromRequest,
     MockForwarder = Utils.MockForwarder,
     mockServer;
 
@@ -15,16 +15,12 @@ describe('eCommerce', function() {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}})
-        ])
         mockServer.respondWith(urls.identify, [
             200,
             {},
             JSON.stringify({ mpid: testMPID, is_logged_in: false }),
         ]);
+
         mParticle.init(apiKey, window.mParticle.config);
     });
 
@@ -95,36 +91,39 @@ describe('eCommerce', function() {
             );
 
         mParticle.eCommerce.logPurchase(transactionAttributes, product);
-        var data = getEvent(mockServer.requests, 'eCommerce - Purchase');
 
-        data.should.have.property('pd');
-        data.pd.should.have.property('an', ProductActionType.Purchase);
-        data.pd.should.have.property('ti', '12345');
-        data.pd.should.have.property('ta', 'test-affiliation');
-        data.pd.should.have.property('tcc', 'coupon-code');
-        data.pd.should.have.property('tr', 44334);
-        data.pd.should.have.property('ts', 600);
-        data.pd.should.have.property('tt', 200);
-        data.pd.should.have.property('pl').with.lengthOf(1);
+        var purchaseEvent = findEventFromRequest(window.fetchMock._calls, 'purchase');
 
-        data.pd.pl[0].should.have.property('id', '12345');
-        data.pd.pl[0].should.have.property('nm', 'iPhone');
-        data.pd.pl[0].should.have.property('pr', 400);
-        data.pd.pl[0].should.have.property('qt', 2);
-        data.pd.pl[0].should.have.property('br', 'Apple');
-        data.pd.pl[0].should.have.property('va', 'Plus');
-        data.pd.pl[0].should.have.property('ca', 'Phones');
-        data.pd.pl[0].should.have.property('ps', 1);
-        data.pd.pl[0].should.have.property('cc', 'my-coupon-code');
-        data.pd.pl[0].should.have.property('tpa', 800);
-        data.pd.pl[0].should.have.property('attrs');
+        purchaseEvent.data.should.have.property('product_action');
+        purchaseEvent.data.product_action.should.have.property('action', 'purchase');
+        purchaseEvent.data.product_action.should.have.property('transaction_id', '12345');
+        purchaseEvent.data.product_action.should.have.property('affiliation', 'test-affiliation');
+        purchaseEvent.data.product_action.should.have.property('coupon_code', 'coupon-code');
+        purchaseEvent.data.product_action.should.have.property('total_amount', 44334);
+        purchaseEvent.data.product_action.should.have.property('shipping_amount', 600);
+        purchaseEvent.data.product_action.should.have.property('tax_amount', 200);
+        purchaseEvent.data.product_action.should.have.property('products').with.lengthOf(1);
 
-        data.pd.pl[0].attrs.should.have.property('customkey', 'customvalue');
+        purchaseEvent.data.product_action.products[0].should.have.property('id', '12345');
+        purchaseEvent.data.product_action.products[0].should.have.property('name', 'iPhone');
+        purchaseEvent.data.product_action.products[0].should.have.property('price', 400);
+        purchaseEvent.data.product_action.products[0].should.have.property('quantity', 2);
+        purchaseEvent.data.product_action.products[0].should.have.property('brand', 'Apple');
+        purchaseEvent.data.product_action.products[0].should.have.property('variant', 'Plus');
+        purchaseEvent.data.product_action.products[0].should.have.property('category', 'Phones');
+        purchaseEvent.data.product_action.products[0].should.have.property('total_product_amount', 800);
+        purchaseEvent.data.product_action.products[0].should.have.property('position', 1);
+        purchaseEvent.data.product_action.products[0].should.have.property('coupon_code', 'my-coupon-code');
+        purchaseEvent.data.product_action.products[0].should.have.property('custom_attributes');
+
+        purchaseEvent.data.product_action.products[0].custom_attributes.should.have.property('customkey', 'customvalue');
 
         done();
     });
 
     it('should not log a ecommerce event if there is a typo in the product action type', function(done) {
+        // fetchMock calls will have session start and AST events, we want to reset so that we can prove the product action type does not go through (length remains 0 after logging)
+        window.fetchMock._calls = [];
         var product = mParticle.eCommerce.createProduct(
                 'iPhone',
                 '12345',
@@ -133,12 +132,11 @@ describe('eCommerce', function() {
         // At this point, mockServer.requests contains 3 requests - an identity,
         // session start, and AST event. 
         // We empty it in order to prove the following event does not send an event
-        mockServer.requests = [];
         mParticle.eCommerce.logProductAction(
             mParticle.ProductActionType.Typo, // <------ will result in a null when converting the product action type as this is not a real value
             [product]
         );
-        mockServer.requests.length.should.equal(0);
+        window.fetchMock._calls.length.should.equal(0);
 
         done();
     });
@@ -166,31 +164,32 @@ describe('eCommerce', function() {
             );
 
         mParticle.eCommerce.logPurchase(transactionAttributes, product);
-        var data = getEvent(mockServer.requests, 'eCommerce - Purchase');
 
-        data.should.have.property('pd');
-        data.pd.should.have.property('an', ProductActionType.Purchase);
-        data.pd.should.have.property('ti', '12345');
-        data.pd.should.have.property('ta', 'test-affiliation');
-        data.pd.should.have.property('tcc', 'coupon-code');
-        data.pd.should.have.property('tr', 0);
-        data.pd.should.have.property('ts', 0);
-        data.pd.should.have.property('tt', 0);
-        data.pd.should.have.property('pl').with.lengthOf(1);
+        var purchaseEvent = findEventFromRequest(window.fetchMock._calls, 'purchase');
+        
+        purchaseEvent.data.should.have.property('product_action');
+        purchaseEvent.data.product_action.should.have.property('action', 'purchase');
+        purchaseEvent.data.product_action.should.have.property('transaction_id', '12345');
+        purchaseEvent.data.product_action.should.have.property('affiliation', 'test-affiliation');
+        purchaseEvent.data.product_action.should.have.property('coupon_code', 'coupon-code');
+        purchaseEvent.data.product_action.should.have.property('total_amount', 0);
+        purchaseEvent.data.product_action.should.have.property('shipping_amount', 0);
+        purchaseEvent.data.product_action.should.have.property('tax_amount', 0);
+        purchaseEvent.data.product_action.should.have.property('products').with.lengthOf(1);
 
-        data.pd.pl[0].should.have.property('id', '12345');
-        data.pd.pl[0].should.have.property('nm', 'iPhone');
-        data.pd.pl[0].should.have.property('pr', 0);
-        data.pd.pl[0].should.have.property('qt', 0);
-        data.pd.pl[0].should.have.property('br', 'Apple');
-        data.pd.pl[0].should.have.property('va', 'Plus');
-        data.pd.pl[0].should.have.property('ca', 'Phones');
-        data.pd.pl[0].should.have.property('ps', 0);
-        data.pd.pl[0].should.have.property('cc', 'my-coupon-code');
-        data.pd.pl[0].should.have.property('tpa', 0);
-        data.pd.pl[0].should.have.property('attrs');
+        purchaseEvent.data.product_action.products[0].should.have.property('id', '12345');
+        purchaseEvent.data.product_action.products[0].should.have.property('name', 'iPhone');
+        purchaseEvent.data.product_action.products[0].should.have.property('price', 0);
+        purchaseEvent.data.product_action.products[0].should.have.property('quantity', 0);
+        purchaseEvent.data.product_action.products[0].should.have.property('brand', 'Apple');
+        purchaseEvent.data.product_action.products[0].should.have.property('variant', 'Plus');
+        purchaseEvent.data.product_action.products[0].should.have.property('category', 'Phones');
+        purchaseEvent.data.product_action.products[0].should.have.property('position', null);
+        purchaseEvent.data.product_action.products[0].should.have.property('coupon_code', 'my-coupon-code');
+        purchaseEvent.data.product_action.products[0].should.have.property('total_product_amount', 0);
+        purchaseEvent.data.product_action.products[0].should.have.property('custom_attributes');
 
-        data.pd.pl[0].attrs.should.have.property('customkey', 'customvalue');
+        purchaseEvent.data.product_action.products[0].custom_attributes.should.have.property('customkey', 'customvalue');
 
         done();
     });
@@ -218,35 +217,34 @@ describe('eCommerce', function() {
             );
 
         mParticle.eCommerce.logPurchase(transactionAttributes, product);
-        var data = getEvent(mockServer.requests, 'eCommerce - Purchase');
+        var purchaseEvent1 = findEventFromRequest(window.fetchMock._calls, 'purchase');
 
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
+
         mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Purchase, product, null, null, transactionAttributes)
-        var data2 = getEvent(mockServer.requests, 'eCommerce - Purchase');
+        var purchaseEvent2 = findEventFromRequest(window.fetchMock._calls, 'purchase');
 
-        data.should.have.property('pd');
+        purchaseEvent1.data.product_action.action.should.equal(purchaseEvent2.data.product_action.action);
+        purchaseEvent1.data.product_action.transaction_id.should.equal(purchaseEvent2.data.product_action.transaction_id);
+        purchaseEvent1.data.product_action.affiliation.should.equal(purchaseEvent2.data.product_action.affiliation);
+        purchaseEvent1.data.product_action.coupon_code.should.equal(purchaseEvent2.data.product_action.coupon_code);
+        purchaseEvent1.data.product_action.total_amount.should.equal(purchaseEvent2.data.product_action.total_amount);
+        purchaseEvent1.data.product_action.shipping_amount.should.equal(purchaseEvent2.data.product_action.shipping_amount);
+        purchaseEvent1.data.product_action.tax_amount.should.equal(purchaseEvent2.data.product_action.tax_amount);
+        purchaseEvent1.data.product_action.products.length.should.equal(purchaseEvent2.data.product_action.products.length);
 
-        data.pd.an.should.equal(data2.pd.an);
-        data.pd.ti.should.equal(data2.pd.ti);
-        data.pd.ta.should.equal(data2.pd.ta);
-        data.pd.tcc.should.equal(data2.pd.tcc);
-        data.pd.tr.should.equal(data2.pd.tr);
-        data.pd.ts.should.equal(data2.pd.ts);
-        data.pd.tt.should.equal(data2.pd.tt);
-        data.pd.pl.length.should.equal(data2.pd.pl.length)
-
-        data.pd.pl[0].id.should.equal(data2.pd.pl[0].id)
-        data.pd.pl[0].pr.should.equal(data2.pd.pl[0].pr)
-        data.pd.pl[0].qt.should.equal(data2.pd.pl[0].qt)
-        data.pd.pl[0].br.should.equal(data2.pd.pl[0].br)
-        data.pd.pl[0].va.should.equal(data2.pd.pl[0].va)
-        data.pd.pl[0].ca.should.equal(data2.pd.pl[0].ca)
-        data.pd.pl[0].ps.should.equal(data2.pd.pl[0].ps)
-        data.pd.pl[0].cc.should.equal(data2.pd.pl[0].cc)
-        data.pd.pl[0].tpa.should.equal(data2.pd.pl[0].tpa)
-        data.pd.pl[0].nm.should.equal(data2.pd.pl[0].nm)
+        purchaseEvent1.data.product_action.products[0].name.should.equal(purchaseEvent2.data.product_action.products[0].name);
+        purchaseEvent1.data.product_action.products[0].id.should.equal(purchaseEvent2.data.product_action.products[0].id);
+        purchaseEvent1.data.product_action.products[0].price.should.equal(purchaseEvent2.data.product_action.products[0].price);
+        purchaseEvent1.data.product_action.products[0].quantity.should.equal(purchaseEvent2.data.product_action.products[0].quantity);
+        purchaseEvent1.data.product_action.products[0].brand.should.equal(purchaseEvent2.data.product_action.products[0].brand);
+        purchaseEvent1.data.product_action.products[0].variant.should.equal(purchaseEvent2.data.product_action.products[0].variant);
+        purchaseEvent1.data.product_action.products[0].category.should.equal(purchaseEvent2.data.product_action.products[0].category);
+        purchaseEvent1.data.product_action.products[0].position.should.equal(purchaseEvent2.data.product_action.products[0].position);
         
-        data.pd.pl[0].attrs.customkey.should.equal(data2.pd.pl[0].attrs.customkey);
+        purchaseEvent1.data.product_action.products[0].coupon_code.should.equal(purchaseEvent2.data.product_action.products[0].coupon_code);
+        purchaseEvent1.data.product_action.products[0].total_product_amount.should.equal(purchaseEvent2.data.product_action.products[0].total_product_amount);
+        purchaseEvent1.data.product_action.products[0].custom_attributes.customkey.should.equal(purchaseEvent2.data.product_action.products[0].custom_attributes.customkey);
 
         done();
     });
@@ -262,12 +260,13 @@ describe('eCommerce', function() {
             product1,
             product2,
         ]);
-        var data = getEvent(mockServer.requests, 'eCommerce - Purchase');
 
-        data.should.have.property('pd');
-        data.pd.should.have.property('pl').with.lengthOf(2);
-        data.pd.pl[0].should.have.property('nm', 'iPhone');
-        data.pd.pl[1].should.have.property('nm', 'Android');
+        var purchaseEvent = findEventFromRequest(window.fetchMock._calls, 'purchase');
+
+        purchaseEvent.data.should.have.property('product_action');
+        purchaseEvent.data.product_action.should.have.property('products').with.lengthOf(2);
+        purchaseEvent.data.product_action.products[0].should.have.property('name', 'iPhone');
+        purchaseEvent.data.product_action.products[1].should.have.property('name', 'Android');
 
         done();
     });
@@ -283,13 +282,13 @@ describe('eCommerce', function() {
             product1,
             product2,
         ]);
-        var data = getEvent(mockServer.requests, 'eCommerce - Refund');
 
-        data.should.have.property('pd');
-        data.pd.should.have.property('an', ProductActionType.Refund);
-        data.pd.should.have.property('pl').with.lengthOf(2);
-        data.pd.pl[0].should.have.property('nm', 'iPhone');
-        data.pd.pl[1].should.have.property('nm', 'Android');
+        var refundEvent = findEventFromRequest(window.fetchMock._calls, 'refund');
+
+        refundEvent.data.should.have.property('product_action');
+        refundEvent.data.product_action.should.have.property('products').with.lengthOf(2);
+        refundEvent.data.product_action.products[0].should.have.property('name', 'iPhone');
+        refundEvent.data.product_action.products[1].should.have.property('name', 'Android');
 
         done();
     });
@@ -325,18 +324,16 @@ describe('eCommerce', function() {
             promotion
         );
 
-        var event = getEvent(mockServer.requests, 'eCommerce - PromotionClick');
+        var promotionEvent = findEventFromRequest(window.fetchMock._calls, 'click');
 
-        Should(event).be.ok();
+        Should(promotionEvent).be.ok();
 
-        event.should.have.property('et', CommerceEventType.PromotionClick);
-        event.should.have.property('pm');
-        event.pm.should.have.property('an', PromotionActionType.PromotionClick);
-        event.pm.should.have.property('pl');
-        event.pm.pl[0].should.have.property('id', '12345');
-        event.pm.pl[0].should.have.property('nm', 'creative-name');
-        event.pm.pl[0].should.have.property('cr', 'my-creative');
-        event.pm.pl[0].should.have.property('ps', 1);
+        promotionEvent.data.promotion_action.should.have.property('action', PromotionActionType.PromotionClick);
+        promotionEvent.data.promotion_action.should.have.property('promotions');
+        promotionEvent.data.promotion_action.promotions[0].should.have.property('id', '12345');
+        promotionEvent.data.promotion_action.promotions[0].should.have.property('name', 'creative-name');
+        promotionEvent.data.promotion_action.promotions[0].should.have.property('creative', 'my-creative');
+        promotionEvent.data.promotion_action.promotions[0].should.have.property('position', 1);
 
         done();
     });
@@ -361,22 +358,21 @@ describe('eCommerce', function() {
             [promotion1, promotion2]
         );
 
-        var event = getEvent(mockServer.requests, 'eCommerce - PromotionClick');
+        var promotionEvent = findEventFromRequest(window.fetchMock._calls, 'click');
 
-        Should(event).be.ok();
+        Should(promotionEvent).be.ok();
 
-        event.should.have.property('et', CommerceEventType.PromotionClick);
-        event.should.have.property('pm');
-        event.pm.should.have.property('an', PromotionActionType.PromotionClick);
-        event.pm.should.have.property('pl');
-        event.pm.pl[0].should.have.property('id', '12345');
-        event.pm.pl[0].should.have.property('nm', 'creative-name1');
-        event.pm.pl[0].should.have.property('cr', 'my-creative1');
-        event.pm.pl[0].should.have.property('ps', 1);
-        event.pm.pl[1].should.have.property('id', '67890');
-        event.pm.pl[1].should.have.property('nm', 'creative-name2');
-        event.pm.pl[1].should.have.property('cr', 'my-creative2');
-        event.pm.pl[1].should.have.property('ps', 2);
+        promotionEvent.data.promotion_action.should.have.property('action', PromotionActionType.PromotionClick);
+        promotionEvent.data.promotion_action.should.have.property('promotions');
+        promotionEvent.data.promotion_action.promotions.length.should.equal(2);
+        promotionEvent.data.promotion_action.promotions[0].should.have.property('id', '12345');
+        promotionEvent.data.promotion_action.promotions[0].should.have.property('name', 'creative-name1');
+        promotionEvent.data.promotion_action.promotions[0].should.have.property('creative', 'my-creative1');
+        promotionEvent.data.promotion_action.promotions[0].should.have.property('position', 1);
+        promotionEvent.data.promotion_action.promotions[1].should.have.property('id', '67890');
+        promotionEvent.data.promotion_action.promotions[1].should.have.property('name', 'creative-name2');
+        promotionEvent.data.promotion_action.promotions[1].should.have.property('creative', 'my-creative2');
+        promotionEvent.data.promotion_action.promotions[1].should.have.property('position', 2);
 
         done();
     });
@@ -396,9 +392,8 @@ describe('eCommerce', function() {
             { shouldUploadEvent: false }
         );
 
-        var event = getEvent(mockServer.requests, 'eCommerce - PromotionClick');
-
-        Should(event).not.be.ok();
+        var promotionEvent = findEventFromRequest(window.fetchMock._calls, 'click');
+        Should(promotionEvent).not.be.ok();
 
         done();
     });
@@ -425,15 +420,14 @@ describe('eCommerce', function() {
             );
 
         mParticle.eCommerce.logImpression(impression);
+        var impressionEvent = findEventFromRequest(window.fetchMock._calls, 'impression');
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Impression');
+        Should(impressionEvent).be.ok();
 
-        Should(event).be.ok();
-
-        event.should.have.property('pi').with.lengthOf(1);
-        event.pi[0].should.have.property('pil', 'impression-name');
-        event.pi[0].should.have.property('pl').with.lengthOf(1);
-        event.pi[0].pl[0].should.have.property('id', '12345');
+        impressionEvent.data.should.have.property('product_impressions').with.lengthOf(1);
+        impressionEvent.data.product_impressions[0].should.have.property('product_impression_list', 'impression-name');
+        impressionEvent.data.product_impressions[0].should.have.property('products').with.lengthOf(1);
+        impressionEvent.data.product_impressions[0].products[0].should.have.property('id', '12345');
 
         done();
     });
@@ -448,9 +442,9 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.logImpression(impression, null, null, { shouldUploadEvent: false });
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Impression');
+        var impressionEvent = findEventFromRequest(window.fetchMock._calls, 'impression');
 
-        Should(event).not.be.ok();
+        Should(impressionEvent).not.be.ok();
 
         done();
     });
@@ -473,16 +467,19 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.logImpression([impression, impression2]);
 
-        var event1 = getEvent(mockServer.requests, 'eCommerce - Impression');
+        var impressionEvent = findEventFromRequest(window.fetchMock._calls, 'impression');
 
-        event1.should.have.property('pi').with.lengthOf(2);
-        event1.pi[0].should.have.property('pil', 'impression-name1');
-        event1.pi[0].should.have.property('pl').with.lengthOf(1);
-        event1.pi[0].pl[0].should.have.property('id', '12345');
+        Should(impressionEvent).be.ok();
 
-        event1.pi[1].should.have.property('pil', 'impression-name2');
-        event1.pi[1].should.have.property('pl').with.lengthOf(1);
-        event1.pi[1].pl[0].should.have.property('id', '23456');
+        impressionEvent.data.should.have.property('product_impressions').with.lengthOf(2);
+
+        impressionEvent.data.product_impressions[0].should.have.property('product_impression_list', 'impression-name1');
+        impressionEvent.data.product_impressions[0].should.have.property('products').with.lengthOf(1);
+        impressionEvent.data.product_impressions[0].products[0].should.have.property('id', '12345');
+
+        impressionEvent.data.product_impressions[1].should.have.property('product_impression_list', 'impression-name2');
+        impressionEvent.data.product_impressions[1].should.have.property('products').with.lengthOf(1);
+        impressionEvent.data.product_impressions[1].products[0].should.have.property('id', '23456');
 
         done();
     });
@@ -508,27 +505,29 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.logRefund(transactionAttributes, product);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Refund');
-        Should(event).be.ok();
 
-        event.should.have.property('pd');
+        var refundEvent = findEventFromRequest(window.fetchMock._calls, 'refund');
 
-        event.pd.should.have.property('an', ProductActionType.Refund);
-        event.pd.should.have.property('ti', '12345');
-        event.pd.should.have.property('ta', 'test-affiliation');
-        event.pd.should.have.property('tcc', 'coupon-code');
-        event.pd.should.have.property('tr', 44334);
-        event.pd.should.have.property('ts', 600);
-        event.pd.should.have.property('tt', 200);
-        event.pd.pl.should.have.length(1);
-        event.pd.pl[0].should.have.property('id', '12345')
-        event.pd.pl[0].should.have.property('nm', 'iPhone')
-        event.pd.pl[0].should.have.property('pr', 400)
-        event.pd.pl[0].should.have.property('qt', 2)
-        event.pd.pl[0].should.have.property('br', 'Phones')
-        event.pd.pl[0].should.have.property('va', 'Apple')
-        event.pd.pl[0].should.have.property('ca', 'Plus')
-        event.pd.pl[0].should.have.property('tpa', 800)
+        Should(refundEvent).be.ok();
+
+        refundEvent.data.should.have.property('product_action');
+
+        refundEvent.data.product_action.should.have.property('action', 'refund');
+        refundEvent.data.product_action.should.have.property('transaction_id', '12345');
+        refundEvent.data.product_action.should.have.property('affiliation', 'test-affiliation');
+        refundEvent.data.product_action.should.have.property('coupon_code', 'coupon-code');
+        refundEvent.data.product_action.should.have.property('total_amount', 44334);
+        refundEvent.data.product_action.should.have.property('shipping_amount', 600);
+        refundEvent.data.product_action.should.have.property('tax_amount', 200);
+        refundEvent.data.product_action.products.should.have.length(1);
+        refundEvent.data.product_action.products[0].should.have.property('id', '12345')
+        refundEvent.data.product_action.products[0].should.have.property('name', 'iPhone')
+        refundEvent.data.product_action.products[0].should.have.property('price', 400)
+        refundEvent.data.product_action.products[0].should.have.property('quantity', 2)
+        refundEvent.data.product_action.products[0].should.have.property('brand', 'Phones')
+        refundEvent.data.product_action.products[0].should.have.property('variant', 'Apple')
+        refundEvent.data.product_action.products[0].should.have.property('category', 'Plus')
+        refundEvent.data.product_action.products[0].should.have.property('total_product_amount', 800)
 
         done();
     });
@@ -557,32 +556,33 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.logRefund(transactionAttributes, product);
         
-        var data = getEvent(mockServer.requests, 'eCommerce - Refund');
-        
-        mockServer.requests = [];
+        var refundEvent1 = findEventFromRequest(window.fetchMock._calls, 'refund');
+
+        window.fetchMock._calls = [];
         
         mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Refund, product, null, null, transactionAttributes)
 
-        var data2 = getEvent(mockServer.requests, 'eCommerce - Refund');
+        var refundEvent2 = findEventFromRequest(window.fetchMock._calls, 'refund');
 
-        Should(data2).be.ok();
+        Should(refundEvent1).be.ok();
+        Should(refundEvent2).be.ok();
 
-        data.pd.an.should.equal(data2.pd.an);
-        data.pd.ti.should.equal(data2.pd.ti);
-        data.pd.ta.should.equal(data2.pd.ta);
-        data.pd.tcc.should.equal(data2.pd.tcc);
-        data.pd.tr.should.equal(data2.pd.tr);
-        data.pd.ts.should.equal(data2.pd.ts);
-        data.pd.tt.should.equal(data2.pd.tt);
-        data.pd.pl.length.should.equal(data2.pd.pl.length)
+        refundEvent1.data.product_action.action.should.equal(refundEvent2.data.product_action.action);
+        refundEvent1.data.product_action.transaction_id.should.equal(refundEvent2.data.product_action.transaction_id);
+        refundEvent1.data.product_action.affiliation.should.equal(refundEvent2.data.product_action.affiliation);
+        refundEvent1.data.product_action.coupon_code.should.equal(refundEvent2.data.product_action.coupon_code);
+        refundEvent1.data.product_action.total_amount.should.equal(refundEvent2.data.product_action.total_amount);
+        refundEvent1.data.product_action.shipping_amount.should.equal(refundEvent2.data.product_action.shipping_amount);
+        refundEvent1.data.product_action.tax_amount.should.equal(refundEvent2.data.product_action.tax_amount);
+        refundEvent1.data.product_action.products.length.should.equal(refundEvent2.data.product_action.products.length)
 
-        data.pd.pl[0].id.should.equal(data2.pd.pl[0].id)
-        data.pd.pl[0].pr.should.equal(data2.pd.pl[0].pr)
-        data.pd.pl[0].qt.should.equal(data2.pd.pl[0].qt)
-        data.pd.pl[0].br.should.equal(data2.pd.pl[0].br)
-        data.pd.pl[0].va.should.equal(data2.pd.pl[0].va)
-        data.pd.pl[0].ca.should.equal(data2.pd.pl[0].ca)
-        data.pd.pl[0].ps.should.equal(data2.pd.pl[0].ps)
+        refundEvent1.data.product_action.products[0].id.should.equal(refundEvent2.data.product_action.products[0].id)
+        refundEvent1.data.product_action.products[0].price.should.equal(refundEvent2.data.product_action.products[0].price)
+        refundEvent1.data.product_action.products[0].quantity.should.equal(refundEvent2.data.product_action.products[0].quantity)
+        refundEvent1.data.product_action.products[0].brand.should.equal(refundEvent2.data.product_action.products[0].brand)
+        refundEvent1.data.product_action.products[0].variant.should.equal(refundEvent2.data.product_action.products[0].variant)
+        refundEvent1.data.product_action.products[0].category.should.equal(refundEvent2.data.product_action.products[0].category)
+        refundEvent1.data.product_action.products[0].position.should.equal(refundEvent2.data.product_action.products[0].position)
 
         done();
     });
@@ -618,7 +618,7 @@ describe('eCommerce', function() {
             { shouldUploadEvent: false}
         );
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Purchase');
+        var event = findEventFromRequest(window.fetchMock._calls, 'purchase');
 
         Should(event).not.be.ok();
         done();
@@ -629,12 +629,12 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.Cart.add(product, true);
 
-        var data = getEvent(mockServer.requests, 'eCommerce - AddToCart');
-
-        data.should.have.property('pd');
-        data.pd.should.have.property('an', ProductActionType.AddToCart);
-        data.pd.should.have.property('pl').with.lengthOf(1);
-        data.pd.pl[0].should.have.property('id', '12345');
+        var addToCartEvent = findEventFromRequest(window.fetchMock._calls, 'add_to_cart');
+        
+        addToCartEvent.data.should.have.property('product_action');
+        addToCartEvent.data.product_action.should.have.property('action', 'add_to_cart');
+        addToCartEvent.data.product_action.should.have.property('products').with.lengthOf(1);
+        addToCartEvent.data.product_action.products[0].should.have.property('id', '12345');
 
         done();
     });
@@ -645,12 +645,12 @@ describe('eCommerce', function() {
         mParticle.eCommerce.Cart.add(product);
         mParticle.eCommerce.Cart.remove({ Sku: '12345' }, true);
 
-        var data = getEvent(mockServer.requests, 'eCommerce - RemoveFromCart');
-
-        data.should.have.property('pd');
-        data.pd.should.have.property('an', ProductActionType.RemoveFromCart);
-        data.pd.should.have.property('pl').with.lengthOf(1);
-        data.pd.pl[0].should.have.property('id', '12345');
+        var removeFromCartEvent = findEventFromRequest(window.fetchMock._calls, 'remove_from_cart');
+        
+        removeFromCartEvent.data.should.have.property('product_action');
+        removeFromCartEvent.data.product_action.should.have.property('action', 'remove_from_cart');
+        removeFromCartEvent.data.product_action.should.have.property('products').with.lengthOf(1);
+        removeFromCartEvent.data.product_action.products[0].should.have.property('id', '12345');
 
         done();
     });
@@ -722,21 +722,21 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.logCheckout(1, 'Visa');
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
+        var checkoutEvent = findEventFromRequest(window.fetchMock._calls, 'checkout');
 
-        Should(event).be.ok();
+        Should(checkoutEvent).be.ok();
 
         bond.called.should.eql(true);
         bond.getCalls()[0].args[0].should.eql(
             'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead'
         );
 
-        event.should.have.property('et', CommerceEventType.ProductCheckout);
-        event.should.have.property('pd');
+        checkoutEvent.should.have.property('event_type', 'commerce_event');
+        checkoutEvent.data.should.have.property('product_action');
 
-        event.pd.should.have.property('an', ProductActionType.Checkout);
-        event.pd.should.have.property('cs', 1);
-        event.pd.should.have.property('co', 'Visa');
+        checkoutEvent.data.product_action.should.have.property('action', 'checkout');
+        checkoutEvent.data.product_action.should.have.property('checkout_step', 1);
+        checkoutEvent.data.product_action.should.have.property('checkout_options', 'Visa');
 
         done();
     });
@@ -747,17 +747,18 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Step: 4, Option: 'Visa'});
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
+        var checkoutEvent = findEventFromRequest(window.fetchMock._calls, 'checkout');
 
-        Should(event).be.ok();
+        Should(checkoutEvent).be.ok();
 
-        event.should.have.property('et', CommerceEventType.ProductCheckout);
-        event.should.have.property('pd');
-        event.pd.pl[0].id.should.equal('iphoneSKU')
-        event.pd.pl[1].id.should.equal('galaxySKU')
-        event.pd.should.have.property('an', ProductActionType.Checkout);
-        event.pd.should.have.property('cs', 4);
-        event.pd.should.have.property('co', 'Visa');
+        checkoutEvent.should.have.property('event_type', 'commerce_event');
+        checkoutEvent.data.should.have.property('product_action');
+
+        checkoutEvent.data.product_action.should.have.property('action', 'checkout');
+        checkoutEvent.data.product_action.should.have.property('checkout_step', 4);
+        checkoutEvent.data.product_action.should.have.property('checkout_options', 'Visa');
+        checkoutEvent.data.product_action.products[0].should.have.property('id', 'iphoneSKU');
+        checkoutEvent.data.product_action.products[1].should.have.property('id', 'galaxySKU');
 
         done();
     });
@@ -771,18 +772,19 @@ describe('eCommerce', function() {
             { color: 'blue' }
         );
 
-        var event = getEvent(mockServer.requests, 'eCommerce - CheckoutOption');
+        var checkoutOptionEvent = findEventFromRequest(window.fetchMock._calls, 'checkout_option');
 
-        Should(event).be.ok();
 
-        event.should.have.property(
-            'et',
-            CommerceEventType.ProductCheckoutOption
+        Should(checkoutOptionEvent).be.ok();
+
+        checkoutOptionEvent.should.have.property(
+            'event_type',
+            'commerce_event'
         );
-        event.should.have.property('pd');
+        checkoutOptionEvent.data.should.have.property('product_action');
 
-        event.pd.should.have.property('an', ProductActionType.CheckoutOption);
-        event.attrs.should.have.property('color', 'blue');
+        checkoutOptionEvent.data.product_action.should.have.property('action', 'checkout_option');
+        checkoutOptionEvent.data.custom_attributes.should.have.property('color', 'blue');
         done();
     });
 
@@ -794,15 +796,15 @@ describe('eCommerce', function() {
             product
         );
 
-        var event = getEvent(mockServer.requests, 'eCommerce - ViewDetail');
+        var viewDetailEvent = findEventFromRequest(window.fetchMock._calls, 'view_detail');
+        Should(viewDetailEvent).be.ok();
+    
+        viewDetailEvent.should.have.property('event_type', 'commerce_event');
+        viewDetailEvent.data.should.have.property('product_action');
+        viewDetailEvent.data.product_action.should.have.property('action', 'view_detail');
+        viewDetailEvent.data.product_action.should.have.property('products').with.lengthOf(1);
+        viewDetailEvent.data.product_action.products[0].should.have.property('id', '12345');
 
-        event.should.have.property('et', CommerceEventType.ProductViewDetail);
-        event.should.have.property('pd');
-        event.pd.should.have.property('an', ProductActionType.ViewDetail);
-        event.pd.should.have.property('pl').with.lengthOf(1);
-        event.pd.pl[0].should.have.property('id', '12345');
-
-        Should(event).be.ok();
 
         done();
     });
@@ -889,9 +891,10 @@ describe('eCommerce', function() {
             );
 
         mParticle.eCommerce.logPurchase(transactionAttributes, product);
-        var data = getEvent(mockServer.requests, 'eCommerce - Purchase');
+        var purchaseEvent = findEventFromRequest(window.fetchMock._calls, 'purchase');
 
-        data.pd.pl[0].should.have.property('ps', 0);
+        purchaseEvent.data.product_action.products[0].should.not.have.property('position');
+
 
         done();
     });
@@ -912,19 +915,19 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.Cart.add([product1, product2], true);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - AddToCart');
+        var addToCartEvent = findEventFromRequest(window.fetchMock._calls, 'add_to_cart');
 
-        Should(event).be.ok();
+        Should(addToCartEvent).be.ok();
 
-        event.should.have.property('pd');
-        event.pd.should.have.property('an', ProductActionType.AddToCart);
-        event.pd.should.have.property('pl').with.lengthOf(2);
+        addToCartEvent.data.should.have.property('product_action');
+        addToCartEvent.data.product_action.should.have.property('action', 'add_to_cart');
+        addToCartEvent.data.product_action.should.have.property('products').with.lengthOf(2);
 
-        event.pd.pl[0].should.have.property('id', '12345');
-        event.pd.pl[0].should.have.property('nm', 'iPhone');
+        addToCartEvent.data.product_action.products[0].should.have.property('id', '12345');
+        addToCartEvent.data.product_action.products[0].should.have.property('name', 'iPhone');
 
-        event.pd.pl[1].should.have.property('id', '67890');
-        event.pd.pl[1].should.have.property('nm', 'Nexus');
+        addToCartEvent.data.product_action.products[1].should.have.property('id', '67890');
+        addToCartEvent.data.product_action.products[1].should.have.property('name', 'Nexus');
 
         done();
     });
@@ -939,16 +942,16 @@ describe('eCommerce', function() {
 
         mParticle.eCommerce.Cart.add(product1, true);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - AddToCart');
+        var addToCartEvent = findEventFromRequest(window.fetchMock._calls, 'add_to_cart');
 
-        Should(event).be.ok();
+        Should(addToCartEvent).be.ok();
 
-        event.should.have.property('pd');
-        event.pd.should.have.property('an', ProductActionType.AddToCart);
-        event.pd.should.have.property('pl').with.lengthOf(1);
+        addToCartEvent.data.should.have.property('product_action');
+        addToCartEvent.data.product_action.should.have.property('action', 'add_to_cart');
+        addToCartEvent.data.product_action.should.have.property('products').with.lengthOf(1);
 
-        event.pd.pl[0].should.have.property('id', '12345');
-        event.pd.pl[0].should.have.property('nm', 'iPhone');
+        addToCartEvent.data.product_action.products[0].should.have.property('id', '12345');
+        addToCartEvent.data.product_action.products[0].should.have.property('name', 'iPhone');
 
         done();
     });
@@ -1412,9 +1415,9 @@ describe('eCommerce', function() {
 
     it('should add customFlags to logCheckout events', function(done) {
         mParticle.eCommerce.logCheckout(1, {}, {}, { interactionEvent: true });
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        Array.isArray(event.flags.interactionEvent).should.equal(true);
-        event.flags.interactionEvent[0].should.equal('true');
+
+        var checkoutEvent = findEventFromRequest(window.fetchMock._calls, 'checkout');
+        checkoutEvent.data.custom_flags.interactionEvent.should.equal(true);
 
         done();
     });
@@ -1427,10 +1430,9 @@ describe('eCommerce', function() {
             { price: 5 },
             { interactionEvent: true }
         );
+        var unknownEvent = findEventFromRequest(window.fetchMock._calls, 'unknown');
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Unknown');
-        Array.isArray(event.flags.interactionEvent).should.equal(true);
-        event.flags.interactionEvent[0].should.equal('true');
+        unknownEvent.data.custom_flags.interactionEvent.should.equal(true);
 
         done();
     });
@@ -1449,9 +1451,10 @@ describe('eCommerce', function() {
             { shipping: 5 },
             { interactionEvent: true }
         );
-        var event = getEvent(mockServer.requests, 'eCommerce - Purchase');
-        Array.isArray(event.flags.interactionEvent).should.equal(true);
-        event.flags.interactionEvent[0].should.equal('true');
+
+        var purchaseEvent = findEventFromRequest(window.fetchMock._calls, 'purchase');
+
+        purchaseEvent.data.custom_flags.interactionEvent.should.equal(true);
 
         done();
     });
@@ -1470,9 +1473,10 @@ describe('eCommerce', function() {
             { interactionEvent: true }
         );
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Unknown');
-        Array.isArray(event.flags.interactionEvent).should.equal(true);
-        event.flags.interactionEvent[0].should.equal('true');
+
+        var promotionEvent = findEventFromRequest(window.fetchMock._calls, 'click');
+
+        promotionEvent.data.custom_flags.interactionEvent.should.equal(true);
 
         done();
     });
@@ -1488,9 +1492,9 @@ describe('eCommerce', function() {
             { shipping: 5 },
             { interactionEvent: true }
         );
-        var event = getEvent(mockServer.requests, 'eCommerce - Impression');
-        Array.isArray(event.flags.interactionEvent).should.equal(true);
-        event.flags.interactionEvent[0].should.equal('true');
+
+        var impressionEvent = findEventFromRequest(window.fetchMock._calls, 'impression');
+        impressionEvent.data.custom_flags.interactionEvent.should.equal(true);
 
         done();
     });
@@ -1509,9 +1513,9 @@ describe('eCommerce', function() {
             { shipping: 5 },
             { interactionEvent: true }
         );
-        var event = getEvent(mockServer.requests, 'eCommerce - Refund');
-        Array.isArray(event.flags.interactionEvent).should.equal(true);
-        event.flags.interactionEvent[0].should.equal('true');
+        var refundEvent = findEventFromRequest(window.fetchMock._calls, 'refund');
+
+        refundEvent.data.custom_flags.interactionEvent.should.equal(true);
 
         done();
     });

--- a/test/src/tests-eCommerce.js
+++ b/test/src/tests-eCommerce.js
@@ -14,6 +14,7 @@ describe('eCommerce', function() {
         delete mParticle._instances['default_instance'];
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
+        window.fetchMock.post(urls.events, 200);
 
         mockServer.respondWith(urls.identify, [
             200,
@@ -26,6 +27,7 @@ describe('eCommerce', function() {
 
     afterEach(function() {
         mockServer.restore();
+        window.fetchMock.restore();
         mParticle._resetForTests(MPConfig);
     });
 

--- a/test/src/tests-event-logging.js
+++ b/test/src/tests-event-logging.js
@@ -13,6 +13,7 @@ var getIdentityEvent = Utils.getIdentityEvent,
 describe('event logging', function() {
     beforeEach(function() {
         mParticle._resetForTests(MPConfig);
+        window.fetchMock.post(urls.events, 200);
         delete mParticle._instances['default_instance'];
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
@@ -28,6 +29,7 @@ describe('event logging', function() {
 
     afterEach(function() {
         mockServer.restore();
+        window.fetchMock.restore();
         mParticle._resetForTests(MPConfig);
     });
 

--- a/test/src/tests-event-logging.js
+++ b/test/src/tests-event-logging.js
@@ -5,8 +5,9 @@ import { urls, apiKey,
     MPConfig,
     MessageType } from './config';
 
-var getEvent = Utils.getEvent,
-    getIdentityEvent = Utils.getIdentityEvent,
+var getIdentityEvent = Utils.getIdentityEvent,
+    findEventFromRequest = Utils.findEventFromRequest,
+    findBatch = Utils.findBatch,
     mockServer;
 
 describe('event logging', function() {
@@ -16,11 +17,6 @@ describe('event logging', function() {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}})
-        ]);
 
         mockServer.respondWith(urls.identify, [
             200,
@@ -41,13 +37,15 @@ describe('event logging', function() {
             mParticle.EventType.Navigation,
             { mykey: 'myvalue' }
         );
-        var data = getEvent(mockServer.requests, 'Test Event');
+        var testEvent = findEventFromRequest(window.fetchMock._calls, 'Test Event');
+        var testEventBatch = findBatch(window.fetchMock._calls, 'Test Event');
 
-        data.should.have.property('n', 'Test Event');
-        data.should.have.property('et', mParticle.EventType.Navigation);
-        data.should.have.property('attrs');
-        data.should.have.property('mpid', testMPID);
-        data.attrs.should.have.property('mykey', 'myvalue');
+        testEvent.data.should.have.property('event_name', 'Test Event');
+        testEvent.data.should.have.property('custom_event_type', 'navigation');
+        testEvent.data.should.have.property('custom_attributes');
+        testEvent.data.custom_attributes.should.have.property('mykey', 'myvalue');
+
+        testEventBatch.should.have.property('mpid', testMPID);
 
         done();
     });
@@ -58,16 +56,18 @@ describe('event logging', function() {
             mParticle.EventType.Navigation,
             { mykey: 'myvalue' }
         );
-        var data = getEvent(mockServer.requests, 'Test Event');
+
+        var testEventBatch = findBatch(window.fetchMock._calls, 'Test Event');
         // this das should be the SDK auto generated one, which is 36 characters long
-        data.das.should.have.length(36)
+        testEventBatch.mp_deviceid.should.have.length(36)
 
         mParticle.setDeviceId('foo-guid');
-        
+
         window.mParticle.logEvent('Test Event2',);
-        var data2 = getEvent(mockServer.requests, 'Test Event2');
+        var testEvent2Batch = findBatch(window.fetchMock._calls, 'Test Event2');
+
         // das should be the one passed to setDeviceId()
-        data2.should.have.property('das', 'foo-guid');
+        testEvent2Batch.should.have.property('mp_deviceid', 'foo-guid');
 
         done();
     });
@@ -79,9 +79,10 @@ describe('event logging', function() {
         mParticle.init(apiKey, window.mParticle.config);
 
         window.mParticle.logEvent('Test Event',);
-        var data = getEvent(mockServer.requests, 'Test Event');
+        var testEventBatch = findBatch(window.fetchMock._calls, 'Test Event');
+
         // this das should be the SDK auto generated one
-        data.should.have.property('das', 'foo-guid');
+        testEventBatch.should.have.property('mp_deviceid', 'foo-guid');
 
         done();
     });
@@ -107,17 +108,19 @@ describe('event logging', function() {
             }
         );
         
-        var uploadedData = getEvent(mockServer.requests, 'Test Standard Upload');
-        var bypassData = getEvent(mockServer.requests, 'Test Upload Bypass');
+        var uploadEvent = findEventFromRequest(window.fetchMock._calls, 'Test Standard Upload');
+        var uploadEventBatch = findBatch(window.fetchMock._calls, 'Test Standard Upload');
 
-        uploadedData.should.be.ok;
-        uploadedData.should.have.property('n', 'Test Standard Upload');
-        uploadedData.should.have.property('et', mParticle.EventType.Navigation);
-        uploadedData.should.have.property('attrs');
-        uploadedData.should.have.property('mpid', testMPID);
-        uploadedData.attrs.should.have.property('mykey', 'myvalue');
+        var bypassedEvent = findEventFromRequest(window.fetchMock._calls, 'Test Upload Bypass');
 
-        Should(bypassData).not.be.ok()
+        uploadEvent.should.be.ok();
+        uploadEvent.data.should.have.property('event_name', 'Test Standard Upload');
+        uploadEvent.data.should.have.property('custom_event_type', 'navigation');
+        uploadEvent.data.should.have.property('custom_attributes');
+        uploadEvent.data.custom_attributes.should.have.property('mykey', 'myvalue');
+        uploadEventBatch.should.have.property('mpid', testMPID);
+
+        Should(bypassedEvent).not.be.ok()
 
         done();
     });
@@ -143,17 +146,20 @@ describe('event logging', function() {
             shouldUploadEvent: false,
         });
 
-        var uploadedData = getEvent(mockServer.requests, 'Test Standard Upload');
-        var bypassData = getEvent(mockServer.requests, 'Test Upload Bypass');
+        var uploadEvent = findEventFromRequest(window.fetchMock._calls, 'Test Standard Upload');
+        var uploadEventBatch = findBatch(window.fetchMock._calls, 'Test Standard Upload');
 
-        uploadedData.should.be.ok;
-        uploadedData.should.have.property('n', 'Test Standard Upload');
-        uploadedData.should.have.property('et', mParticle.EventType.Navigation);
-        uploadedData.should.have.property('attrs');
-        uploadedData.should.have.property('mpid', testMPID);
-        uploadedData.attrs.should.have.property('mykey', 'myvalue');
+        var bypassedEvent = findEventFromRequest(window.fetchMock._calls, 'Test Upload Bypass');
 
-        Should(bypassData).not.be.ok()
+        uploadEvent.should.be.ok();
+
+        uploadEvent.data.should.have.property('event_name', 'Test Standard Upload');
+        uploadEvent.data.should.have.property('custom_event_type', 'navigation');
+        uploadEvent.data.should.have.property('custom_attributes');
+        uploadEvent.data.custom_attributes.should.have.property('mykey', 'myvalue');
+        uploadEventBatch.should.have.property('mpid', testMPID);
+
+        Should(bypassedEvent).not.be.ok()
 
         done();
     });
@@ -161,13 +167,13 @@ describe('event logging', function() {
     it('should log an error', function(done) {
         mParticle.logError('my error');
 
-        var data = getEvent(mockServer.requests, 'Error');
+        var errorEvent = findEventFromRequest(window.fetchMock._calls, 'my error');
 
-        Should(data).be.ok();
+        Should(errorEvent).be.ok();
 
-        data.should.have.property('n', 'Error');
-        data.should.have.property('attrs');
-        data.attrs.should.have.property('m', 'my error');
+        errorEvent.data.should.have.property('message', 'Error');
+        errorEvent.data.should.have.property('custom_attributes');
+        errorEvent.data.custom_attributes.should.have.property('m', 'my error');
 
         done();
     });
@@ -178,15 +184,15 @@ describe('event logging', function() {
 
         mParticle.logError(error);
 
-        var data = getEvent(mockServer.requests, 'Error');
+        var errorEvent = findEventFromRequest(window.fetchMock._calls, 'my error');
 
-        Should(data).be.ok();
+        Should(errorEvent).be.ok();
 
-        data.should.have.property('n', 'Error');
-        data.should.have.property('attrs');
-        data.attrs.should.have.property('m', 'my error');
-        data.attrs.should.have.property('s', 'Error');
-        data.attrs.should.have.property('t', 'my stacktrace');
+        errorEvent.data.should.have.property('message', 'Error');
+        errorEvent.data.should.have.property('custom_attributes');
+        errorEvent.data.custom_attributes.should.have.property('m', 'my error');
+        errorEvent.data.custom_attributes.should.have.property('s', 'Error');
+        errorEvent.data.custom_attributes.should.have.property('t', 'my stacktrace');
 
         done();
     });
@@ -197,32 +203,31 @@ describe('event logging', function() {
 
         mParticle.logError(error, { location: 'my path', myData: 'my data' });
 
-        var data = getEvent(mockServer.requests, 'Error');
+        var errorEvent = findEventFromRequest(window.fetchMock._calls, 'my error');
 
-        Should(data).be.ok();
-        data.should.have.property('n', 'Error');
-        data.should.have.property('attrs');
-        data.attrs.should.have.property('location', 'my path');
-        data.attrs.should.have.property('myData', 'my data');
+        Should(errorEvent).be.ok();
+        errorEvent.data.should.have.property('message', 'Error');
+        errorEvent.data.should.have.property('custom_attributes');
+        errorEvent.data.custom_attributes.should.have.property('location', 'my path');
+        errorEvent.data.custom_attributes.should.have.property('myData', 'my data');
 
         done();
     });
 
     it('should sanitize error custom attrs', function(done) {
         var bond = sinon.spy(mParticle.getInstance().Logger, 'warning');
-
         mParticle.logError('my error', {
             invalid: ['my invalid attr'],
             valid: 10,
         });
 
-        var data = getEvent(mockServer.requests, 'Error');
+        var errorEvent = findEventFromRequest(window.fetchMock._calls, 'my error');
 
-        Should(data).be.ok();
-        data.should.have.property('n', 'Error');
-        data.should.have.property('attrs');
-        data.attrs.should.have.property('valid', 10);
-        data.attrs.should.not.have.property('invalid');
+        Should(errorEvent).be.ok();
+        errorEvent.data.should.have.property('message', 'Error');
+        errorEvent.data.should.have.property('custom_attributes');
+        errorEvent.data.custom_attributes.should.have.property('valid', 10);
+        errorEvent.data.custom_attributes.should.not.have.property('invalid');
 
         bond.called.should.eql(true);
         bond.callCount.should.equal(1);
@@ -235,32 +240,34 @@ describe('event logging', function() {
     });
 
     it('should log an AST with firstRun = true when first visiting a page, and firstRun = false when reloading the page', function(done) {
-        var data = getEvent(mockServer.requests, MessageType.AppStateTransition);
-        data.should.have.property('at', 1);
-        data.should.have.property('fr', true);
-        data.should.have.property('iu', false);
+        var astEvent = findEventFromRequest(window.fetchMock._calls, 'application_state_transition');
+
+        astEvent.data.should.have.property('application_transition_type', 'application_initialized');
+        astEvent.data.should.have.property('is_first_run', true);
+        astEvent.data.should.have.property('is_upgrade', false);
+
         if (document.referrer && document.referrer.length > 0) {
-            data.should.have.property('lr', window.location.href);
+            astEvent.data.should.have.property('launch_referral', window.location.href);
         }
 
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
 
         mParticle.init(apiKey, window.mParticle.config)
-        var data2 = getEvent(mockServer.requests, MessageType.AppStateTransition);
-        data2.should.have.property('fr', false);
+        var astEvent2 = findEventFromRequest(window.fetchMock._calls, 'application_state_transition');
+
+        astEvent2.data.should.have.property('is_first_run', false);
 
         done();
     });
 
     it('should log an AST on init with firstRun = false when cookies already exist', function(done) {
         // cookies currently exist, mParticle.init called from beforeEach
-
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         // log second AST
         mParticle.init(apiKey, window.mParticle.config);
 
-        var data2 = getEvent(mockServer.requests, MessageType.AppStateTransition);
-        data2.should.have.property('fr', false);
+        var astEvent = findEventFromRequest(window.fetchMock._calls, 'application_state_transition');
+        astEvent.data.should.have.property('is_first_run', false);
 
         done();
     });
@@ -268,13 +275,13 @@ describe('event logging', function() {
     it('should log a page view', function(done) {
         mParticle.logPageView();
 
-        var event = getEvent(mockServer.requests, 'PageView');
+        var pageViewEvent = findEventFromRequest(window.fetchMock._calls, 'screen_view');
 
-        Should(event).be.ok();
+        Should(pageViewEvent).be.ok();
 
-        event.should.have.property('attrs');
-        event.attrs.should.have.property('hostname', window.location.hostname);
-        event.attrs.should.have.property('title', window.document.title);
+        pageViewEvent.data.should.have.property('custom_attributes');
+        pageViewEvent.data.custom_attributes.should.have.property('hostname', window.location.hostname);
+        pageViewEvent.data.custom_attributes.should.have.property('title', window.document.title);
 
         done();
     });
@@ -288,13 +295,14 @@ describe('event logging', function() {
             }
         );
 
-        var event = getEvent(mockServer.requests, 'My Page View');
+        var pageViewEvent = findEventFromRequest(window.fetchMock._calls, 'screen_view');
 
-        event.should.have.property('attrs');
-        event.attrs.should.have.property('testattr', 1);
+        Should(pageViewEvent).be.ok();
 
-        event.should.have.property('flags');
-        event.flags.should.have.property('MyCustom.Flag', ['Test']);
+        pageViewEvent.data.should.have.property('custom_attributes');
+        pageViewEvent.data.should.have.property('screen_name', 'My Page View');
+        pageViewEvent.data.custom_attributes.should.have.property('testattr', 1);
+        pageViewEvent.data.custom_flags.should.have.property('MyCustom.Flag', 'Test');
 
         done();
     });
@@ -304,12 +312,12 @@ describe('event logging', function() {
             'MyCustom.Flag': 'Test',
         });
 
-        var event = getEvent(mockServer.requests, 'test');
+        var pageViewEvent = findEventFromRequest(window.fetchMock._calls, 'screen_view');
 
-        Should(event).be.ok();
+        Should(pageViewEvent).be.ok();
 
-        event.should.have.property('flags');
-        event.flags.should.have.property('MyCustom.Flag', ['Test']);
+        pageViewEvent.data.should.have.property('custom_flags');
+        pageViewEvent.data.custom_flags.should.have.property('MyCustom.Flag', 'Test');
 
         done();
     });
@@ -322,70 +330,49 @@ describe('event logging', function() {
             { shouldUploadEvent: false }
         );
 
-        var event = getEvent(mockServer.requests, 'test bypass');
+        var pageViewEvent = findEventFromRequest(window.fetchMock._calls, 'screen_view');
 
-        Should(event).not.be.ok();
-        done();
-    });
-
-    it('should convert custom flag dictionary values to array', function(done) {
-        mParticle.logPageView('test', null, {
-            'MyCustom.String': 'Test',
-            'MyCustom.Number': 1,
-            'MyCustom.Boolean': true,
-            'MyCustom.Object': {},
-            'MyCustom.Array': ['Blah', 'Hello', {}],
-        });
-
-        var event = getEvent(mockServer.requests, 'test');
-
-        Should(event).be.ok();
-
-        event.should.have.property('flags');
-        event.flags.should.have.property('MyCustom.String', ['Test']);
-        event.flags.should.have.property('MyCustom.Number', ['1']);
-        event.flags.should.have.property('MyCustom.Boolean', ['true']);
-        event.flags.should.not.have.property('MyCustom.Object');
-        event.flags.should.have.property('MyCustom.Array', ['Blah', 'Hello']);
-
+        Should(pageViewEvent).not.be.ok();
         done();
     });
 
     it('should not log a PageView event if there are invalid attrs', function(done) {
         mParticle.logPageView('test1', 'invalid', null);
-        var event2 = getEvent(mockServer.requests, 'test1');
+        var pageViewEvent = findEventFromRequest(window.fetchMock._calls, 'screen_view');
 
-        Should(event2).not.be.ok();
+        Should(pageViewEvent).not.be.ok();
 
         done();
     });
 
     it('should not log an event that has an invalid customFlags', function(done) {
         mParticle.logPageView('test', null, 'invalid');
-        var event1 = getEvent(mockServer.requests, 'test');
-        Should(event1).not.be.ok();
+
+        var pageViewEvent = findEventFromRequest(window.fetchMock._calls, 'screen_view');
+        Should(pageViewEvent).not.be.ok();
 
         done();
     });
 
     it('should log event with name PageView when an invalid event name is passed', function(done) {
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
+
         mParticle.logPageView(null);
-        mockServer.requests.length.should.equal(1);
-        var event1 = getEvent(mockServer.requests, 'PageView');
-        event1.n.should.equal('PageView');
+        window.fetchMock._calls.length.should.equal(1);
+        var pageViewEvent = findEventFromRequest(window.fetchMock._calls, 'screen_view');
+        pageViewEvent.data.screen_name.should.equal('PageView');
 
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.logPageView({ test: 'test' });
-        mockServer.requests.length.should.equal(1);
-        var event2 = getEvent(mockServer.requests, 'PageView');
-        event2.n.should.equal('PageView');
+        window.fetchMock._calls.length.should.equal(1);
+        var pageViewEvent2 = findEventFromRequest(window.fetchMock._calls, 'screen_view');
+        pageViewEvent2.data.screen_name.should.equal('PageView');
 
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.logPageView([1, 2, 3]);
-        mockServer.requests.length.should.equal(1);
-        var event3 = getEvent(mockServer.requests, 'PageView');
-        event3.n.should.equal('PageView');
+        window.fetchMock._calls.length.should.equal(1);
+        var pageViewEvent3 = findEventFromRequest(window.fetchMock._calls, 'screen_view');
+        pageViewEvent3.data.screen_name.should.equal('PageView');
 
         done();
     });
@@ -393,70 +380,75 @@ describe('event logging', function() {
     it('should log opt out', function(done) {
         mParticle.setOptOut(true);
 
-        var event = getEvent(mockServer.requests, MessageType.OptOut);
+        var optOutEvent = findEventFromRequest(window.fetchMock._calls, 'opt_out');
 
-        event.should.have.property('dt', MessageType.OptOut);
-        event.should.have.property('o', true);
+        optOutEvent.event_type.should.equal('opt_out');
+        optOutEvent.data.should.have.property('is_opted_out', true);
 
         done();
     });
 
     it('log event requires name', function(done) {
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.logEvent();
 
-        Should(mockServer.requests).have.lengthOf(0);
+        window.fetchMock._calls.should.have.lengthOf(0);
 
         done();
     });
 
     it('log event requires valid event type', function(done) {
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
+
         mParticle.logEvent('test', 100);
 
-        Should(mockServer.requests).have.lengthOf(0);
+        window.fetchMock._calls.should.have.lengthOf(0);
 
         done();
     });
 
     it('event attributes must be object', function(done) {
-        mParticle.logEvent('test', null, 1);
+        mParticle.logEvent('Test Event', null, 1);
 
-        var data = getEvent(mockServer.requests, 'test');
+        var testEvent = findEventFromRequest(window.fetchMock._calls, 'Test Event');
 
-        data.should.have.property('attrs', null);
+        testEvent.data.should.have.property('custom_attributes', null);
 
         done();
     });
 
     it('opting out should prevent events being sent', function(done) {
         mParticle.setOptOut(true);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
+
 
         mParticle.logEvent('test');
-        mockServer.requests.should.have.lengthOf(0);
+        window.fetchMock._calls.should.have.lengthOf(0);
 
         done();
     });
 
     it('after logging optout, and reloading, events still should not be sent until opt out is enabled when using local storage', function(done) {
         mParticle.setOptOut(true);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
 
         mParticle.logEvent('test');
-        mockServer.requests.should.have.lengthOf(0);
+        window.fetchMock._calls.should.have.lengthOf(0);
+
         mParticle.setOptOut(false);
 
         mParticle.init(apiKey, window.mParticle.config);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
+
         mParticle.logEvent('test');
-        mockServer.requests.should.have.lengthOf(1);
+        window.fetchMock._calls.should.have.lengthOf(1);
 
         mParticle.setOptOut(true);
         mParticle.init(apiKey, window.mParticle.config);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
+
         mParticle.logEvent('test');
-        mockServer.requests.should.have.lengthOf(0);
+        window.fetchMock._calls.should.have.lengthOf(0);
 
         done();
     });
@@ -465,22 +457,23 @@ describe('event logging', function() {
         mParticle.config.useCookieStorage = true;
         mParticle.init(apiKey, window.mParticle.config);
         mParticle.setOptOut(true);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
 
         mParticle.logEvent('test');
-        mockServer.requests.should.have.lengthOf(0);
+        window.fetchMock._calls.should.have.lengthOf(0);
+
         mParticle.setOptOut(false);
 
         mParticle.init(apiKey, window.mParticle.config);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.logEvent('test');
-        mockServer.requests.should.have.lengthOf(1);
+        window.fetchMock._calls.should.have.lengthOf(1);
 
         mParticle.setOptOut(true);
         mParticle.init(apiKey, window.mParticle.config);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.logEvent('test');
-        mockServer.requests.should.have.lengthOf(0);
+        window.fetchMock._calls.should.have.lengthOf(0);
 
         done();
     });
@@ -548,10 +541,10 @@ describe('event logging', function() {
 
     it('should send das with each event logged', function(done) {
         window.mParticle.logEvent('Test Event');
-        var data = getEvent(mockServer.requests, 'Test Event');
+        var testEventBatch = findBatch(window.fetchMock._calls, 'Test Event');
 
-        data.should.have.property('das');
-        data.das.length.should.equal(36);
+        testEventBatch.should.have.property('mp_deviceid');
+        testEventBatch.mp_deviceid.length.should.equal(36);
         done();
     });
 
@@ -570,22 +563,24 @@ describe('event logging', function() {
         mParticle.Identity.getCurrentUser().setConsentState(consentState);
 
         window.mParticle.logEvent('Test Event');
-        var data = getEvent(mockServer.requests, 'Test Event');
+        var testEvent = findBatch(window.fetchMock._calls, 'Test Event');
 
-        data.should.have.property('con');
-        data.con.should.have.property('gdpr');
-        data.con.gdpr.should.have.property('foo purpose');
-        var purpose = data.con.gdpr['foo purpose'];
-        purpose.should.have.property('ts', 10);
-        purpose.should.have.property('d', 'foo document');
-        purpose.should.have.property('l', 'foo location');
-        purpose.should.have.property('h', 'foo hardwareId');
+        testEvent.should.have.property('consent_state');
+        testEvent.consent_state.should.have.property('gdpr');
+        testEvent.consent_state.gdpr.should.have.property('foo purpose');
+
+        var purpose = testEvent.consent_state.gdpr['foo purpose'];
+        purpose.should.have.property('timestamp_unixtime_ms', 10);
+        purpose.should.have.property('document', 'foo document');
+        purpose.should.have.property('location', 'foo location');
+        purpose.should.have.property('hardware_id', 'foo hardwareId');
 
         mParticle.Identity.getCurrentUser().setConsentState(null);
 
         window.mParticle.logEvent('Test Event2');
-        data = getEvent(mockServer.requests, 'Test Event2');
-        data.should.have.not.property('con');
+        var testEvent2 = findBatch(window.fetchMock._calls, 'Test Event2');
+
+        testEvent2.should.have.property('consent_state', null);
 
         done();
     });
@@ -593,11 +588,11 @@ describe('event logging', function() {
     it('should log integration attributes with each event', function(done) {
         mParticle.setIntegrationAttribute(128, { MCID: 'abcdefg' });
         mParticle.logEvent('Test Event');
-        var data = getEvent(mockServer.requests, 'Test Event');
+        var testEvent = findBatch(window.fetchMock._calls, 'Test Event');
 
-        data.should.have.property('ia');
-        data.ia.should.have.property('128');
-        data.ia['128'].should.have.property('MCID', 'abcdefg');
+        testEvent.should.have.property('integration_attributes');
+        testEvent.integration_attributes.should.have.property('128');
+        testEvent.integration_attributes['128'].should.have.property('MCID', 'abcdefg');
 
         done();
     });
@@ -613,21 +608,25 @@ describe('event logging', function() {
         mParticle.startTrackingLocation(function() {
             numberTimesCalled += 1;
             successCallbackCalled = true;
-            mParticle.logEvent('test event');
+            mParticle.logEvent('Test Event');
         });
 
         // mock geo will successfully run after 1 second (geomock.js // navigator.geolocation.delay)
         clock.tick(1000);
         successCallbackCalled.should.equal(true);
-        var event = getEvent(mockServer.requests, 'test event');
-        event.lc.lat.should.equal(52.5168);
-        event.lc.lng.should.equal(13.3889);
-        mockServer.requests = [];
+        var testEvent = findEventFromRequest(window.fetchMock._calls, 'Test Event');
+
+        testEvent.data.location.latitude.should.equal(52.5168);
+        testEvent.data.location.longitude.should.equal(13.3889);
+        window.fetchMock._calls = [];
+
         //this will hit the watch position again, but won't call the callback again
         clock.tick(1000);
         numberTimesCalled.should.equal(1);
-        event = getEvent(mockServer.requests, 'test event');
-        Should(event).not.be.ok();
+
+        testEvent = findEventFromRequest(window.fetchMock._calls, 'Test Event');
+
+        Should(testEvent).not.be.ok();
 
         clock.restore();
 
@@ -647,21 +646,24 @@ describe('event logging', function() {
         mParticle.startTrackingLocation(function() {
             numberTimesCalled += 1;
             successCallbackCalled = true;
-            mParticle.logEvent('test event');
+            mParticle.logEvent('Test Event');
         });
 
         // mock geo will successfully run after 1 second (geomock.js // navigator.geolocation.delay)
         clock.tick(1000);
         successCallbackCalled.should.equal(true);
-        var event = getEvent(mockServer.requests, 'test event');
-        event.should.have.property('lc', null);
-        mockServer.requests = [];
+
+        var testEvent = findEventFromRequest(window.fetchMock._calls, 'Test Event');
+
+        testEvent.data.should.have.property('location', null);
+                window.fetchMock._calls = [];
+
 
         //this will hit the watch position again, but won't call the callback again
         clock.tick(1000);
         numberTimesCalled.should.equal(1);
-        event = getEvent(mockServer.requests, 'test event');
-        Should(event).not.be.ok();
+        testEvent = findEventFromRequest(window.fetchMock._calls, 'Test Event');
+        Should(testEvent).not.be.ok();
 
         navigator.geolocation.shouldFail = false;
 
@@ -707,7 +709,7 @@ describe('event logging', function() {
 
         function callback() {
             successCallbackCalled = true;
-            mParticle.logEvent('test event');
+            mParticle.logEvent('Test Event');
         }
 
         mParticle.startTrackingLocation(callback);
@@ -715,11 +717,12 @@ describe('event logging', function() {
         // mock geo will successfully run after 1 second (geomock.js // navigator.geolocation.delay)
         clock.tick(1000);
         successCallbackCalled.should.equal(true);
-        var event = getEvent(mockServer.requests, 'test event');
+        var testEvent = findEventFromRequest(window.fetchMock._calls, 'Test Event');
+
         var latitudeResult = 52.5168;
         var longitudeResult = 13.3889;
-        event.lc.lat.should.equal(latitudeResult);
-        event.lc.lng.should.equal(longitudeResult);
+        testEvent.data.location.latitude.should.equal(latitudeResult);
+        testEvent.data.location.longitude.should.equal(longitudeResult);
 
         clock.restore();
 
@@ -735,11 +738,6 @@ describe('event logging', function() {
 
         mParticle.init(apiKey, mParticle.config);
 
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
         window.mParticle.logEvent('Test Event');
 
         var batch = JSON.parse(window.fetchMock.lastOptions().body);
@@ -753,15 +751,6 @@ describe('event logging', function() {
 
     it('should log AST first_run as true on new page loads, and false for when a page has previously been loaded', function (done) {
         mParticle._resetForTests(MPConfig);
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
-        mParticle.config.flags = {
-            eventsV3: '100',
-            eventBatchingIntervalMillis: 0,
-        }
 
         mParticle.init(apiKey, mParticle.config);
 
@@ -779,10 +768,6 @@ describe('event logging', function() {
 
     it('should log AST with launch_referral with a url', function (done) {
         mParticle._resetForTests(MPConfig);
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
 
         mParticle.config.flags = {
             eventsV3: '100',
@@ -809,11 +794,6 @@ describe('event logging', function() {
         mParticle.init(apiKey, mParticle.config);
         mParticle.setAppName('another name');
 
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
         window.mParticle.logEvent('Test Event');
 
         var batch = JSON.parse(window.fetchMock.lastOptions().body);
@@ -836,11 +816,6 @@ describe('event logging', function() {
         };
 
         mParticle.init(apiKey, mParticle.config);
-
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
 
         window.mParticle.logEvent('Test Event');
 
@@ -867,12 +842,6 @@ describe('event logging', function() {
 
         mParticle.init(apiKey, mParticle.config);
 
-
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
         window.mParticle.logEvent('Test Event');
 
         var batch = JSON.parse(window.fetchMock.lastOptions().body);
@@ -895,11 +864,6 @@ describe('event logging', function() {
         mParticle.config.dataPlan = {
             planVersion: 10
         };
-
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
 
         mParticle.init(apiKey, mParticle.config);
 
@@ -934,11 +898,7 @@ describe('event logging', function() {
             planVersion: 10,
         };
         
-        mParticle.init(apiKey, mParticle.config);
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
+        mParticle.init(apiKey, mParticle.config)
             
         window.mParticle.logEvent('Test Event');
 
@@ -958,11 +918,6 @@ describe('event logging', function() {
         mParticle.config.dataPlan = {
             planVersion: 10
         };
-
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
 
         mParticle.init(apiKey, mParticle.config);
 
@@ -1023,11 +978,6 @@ describe('event logging', function() {
 
         mParticle.init(apiKey, mParticle.config);
 
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
         var product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
         var product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
 
@@ -1066,11 +1016,6 @@ describe('event logging', function() {
         }
 
         mParticle.init(apiKey, mParticle.config);
-
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
 
         var product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 'string', 'string', 'variant', 'category', 'brand', 'string', 'coupon');
         var product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 'string', 'string', 'variant', 'category', 'brand', 'string', 'coupon');

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -4,8 +4,7 @@ import { urls } from './config';
 import { apiKey, MPConfig, testMPID, MessageType } from './config';
 import { expect } from 'chai';
 
-
-var getEvent = Utils.getEvent,
+var findEventFromRequest = Utils.findEventFromRequest,
     getForwarderEvent = Utils.getForwarderEvent,
     setLocalStorage = Utils.setLocalStorage,
     forwarderDefaultConfiguration = Utils.forwarderDefaultConfiguration,
@@ -19,12 +18,6 @@ describe('forwarders', function() {
         delete mParticle._instances['default_instance'];
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
-
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}})
-        ]);
 
         mockServer.respondWith(urls.identify, [
             200,
@@ -1027,7 +1020,7 @@ describe('forwarders', function() {
             { 'my-key': 'my-value' }
         );
 
-        var event = getEvent(mockServer.requests, 'send this event to forwarder', true);
+        var event = findEventFromRequest(window.fetchMock._calls, 'send this event to forwarder', true);
 
         Should(event).should.not.have.property('n');
 
@@ -2042,12 +2035,6 @@ describe('forwarders', function() {
             JSON.stringify({ mpid: 'MPID1', is_logged_in: false }),
         ]);
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: 'MPID1', is_logged_in: false }),
-        ]);
-
         mParticle.init(apiKey, window.mParticle.config);
 
         var activeForwarders = mParticle.getInstance()._getActiveForwarders();
@@ -2227,23 +2214,24 @@ describe('forwarders', function() {
         mParticle._setIntegrationDelay(10, true);
 
         mParticle.init(apiKey, window.mParticle.config);
-        mockServer.requests = [];
-        mParticle.logEvent('test1');
-        mockServer.requests.length.should.equal(0);
+        window.fetchMock._calls = [];
+        mParticle.logEvent('Test Event1');
+        window.fetchMock._calls.length.should.equal(0);
 
         mParticle._setIntegrationDelay(10, false);
         mParticle._setIntegrationDelay(128, false);
-        mParticle.logEvent('test2');
-        mockServer.requests.length.should.equal(4);
-        var sessionStartEvent = getEvent(mockServer.requests, 1);
-        var astEvent = getEvent(mockServer.requests, 10);
-        var test1 = getEvent(mockServer.requests, 'test1');
-        var test2 = getEvent(mockServer.requests, 'test2');
+        mParticle.logEvent('Test Event2');
+        window.fetchMock._calls.length.should.equal(4);
 
-        (typeof sessionStartEvent === 'object').should.equal(true);
-        (typeof astEvent === 'object').should.equal(true);
-        (typeof test1 === 'object').should.equal(true);
-        (typeof test2 === 'object').should.equal(true);
+        var sessionStartEvent = findEventFromRequest(window.fetchMock._calls, 'session_start');
+        var ASTEvent = findEventFromRequest(window.fetchMock._calls, 'application_state_transition');
+        var testEvent1 = findEventFromRequest(window.fetchMock._calls, 'Test Event1');
+        var testEvent2 = findEventFromRequest(window.fetchMock._calls, 'Test Event2');
+
+        sessionStartEvent.should.be.ok();
+        ASTEvent.should.be.ok();
+        testEvent1.should.be.ok();
+        testEvent2.should.be.ok();
 
         done();
     });
@@ -2269,23 +2257,24 @@ describe('forwarders', function() {
                 .length
         ).equal(3);
         mParticle.init(apiKey, window.mParticle.config);
-        mockServer.requests = [];
-        mParticle.logEvent('test1');
-        mockServer.requests.length.should.equal(0);
+        window.fetchMock._calls = [];
+        mParticle.logEvent('Test Event1');
+        window.fetchMock._calls.length.should.equal(0);
 
         clock.tick(5001);
 
-        mParticle.logEvent('test2');
-        mockServer.requests.length.should.equal(4);
-        var sessionStartEvent = getEvent(mockServer.requests, 1);
-        var astEvent = getEvent(mockServer.requests, 10);
-        var test1 = getEvent(mockServer.requests, 'test1');
-        var test2 = getEvent(mockServer.requests, 'test2');
+        mParticle.logEvent('Test Event2');
+        window.fetchMock._calls.length.should.equal(4);
 
-        (typeof sessionStartEvent === 'object').should.equal(true);
-        (typeof astEvent === 'object').should.equal(true);
-        (typeof test1 === 'object').should.equal(true);
-        (typeof test2 === 'object').should.equal(true);
+        var sessionStartEvent = findEventFromRequest(window.fetchMock._calls, 'session_start');
+        var ASTEvent = findEventFromRequest(window.fetchMock._calls, 'application_state_transition');
+        var testEvent1 = findEventFromRequest(window.fetchMock._calls, 'Test Event1');
+        var testEvent2 = findEventFromRequest(window.fetchMock._calls, 'Test Event2');
+
+        sessionStartEvent.should.be.ok();
+        ASTEvent.should.be.ok();
+        testEvent1.should.be.ok();
+        testEvent2.should.be.ok();
         clock.restore();
 
         // testing user-configured integrationDelayTimeout
@@ -2296,23 +2285,24 @@ describe('forwarders', function() {
         mParticle._setIntegrationDelay(24, false);
         mParticle._setIntegrationDelay(10, true);
         mParticle.init(apiKey, window.mParticle.config);
-        mockServer.requests = [];
-        mParticle.logEvent('test1');
-        mockServer.requests.length.should.equal(0);
+        window.fetchMock._calls = [];
+        mParticle.logEvent('Test Event3');
+        window.fetchMock._calls.length.should.equal(0);
 
         clock.tick(1001);
 
-        mParticle.logEvent('test2');
-        mockServer.requests.length.should.equal(4);
-        sessionStartEvent = getEvent(mockServer.requests, 1);
-        astEvent = getEvent(mockServer.requests, 10);
-        test1 = getEvent(mockServer.requests, 'test1');
-        test2 = getEvent(mockServer.requests, 'test2');
+        mParticle.logEvent('Test Event4');
+        window.fetchMock._calls.length.should.equal(4);
 
-        (typeof sessionStartEvent === 'object').should.equal(true);
-        (typeof astEvent === 'object').should.equal(true);
-        (typeof test1 === 'object').should.equal(true);
-        (typeof test2 === 'object').should.equal(true);
+        var sessionStartEvent2 = findEventFromRequest(window.fetchMock._calls, 'session_start');
+        var ASTEvent2 = findEventFromRequest(window.fetchMock._calls, 'application_state_transition');
+        var testEvent3 = findEventFromRequest(window.fetchMock._calls, 'Test Event3');
+        var testEvent4 = findEventFromRequest(window.fetchMock._calls, 'Test Event4');
+
+        sessionStartEvent2.should.be.ok();
+        ASTEvent2.should.be.ok();
+        testEvent3.should.be.ok();
+        testEvent4.should.be.ok();
         clock.restore();
 
         done();
@@ -2325,16 +2315,15 @@ describe('forwarders', function() {
         mParticle._setIntegrationDelay(128, true);
         mParticle._setIntegrationDelay(24, false);
         mParticle.init(apiKey, window.mParticle.config);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.logEvent('test1');
-        mockServer.requests.length.should.equal(0);
-
+        window.fetchMock._calls.length.should.equal(0);
         // now that we set all integrations to false, the SDK should process queued events
         mParticle._setIntegrationDelay(128, false);
 
         clock.tick(5001);
 
-        mockServer.requests.length.should.equal(3);
+        window.fetchMock._calls.length.should.equal(3);
         clock.restore();
 
         done();

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -16,6 +16,7 @@ describe('forwarders', function() {
     beforeEach(function() {
         mParticle._resetForTests(MPConfig);
         delete mParticle._instances['default_instance'];
+        window.fetchMock.post(urls.events, 200);
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
@@ -52,6 +53,7 @@ describe('forwarders', function() {
     });
 
     afterEach(function() {
+        window.fetchMock.restore();
         delete window.MockForwarder1;
         mockServer.restore();
     });

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -15,6 +15,7 @@ describe('identities and attributes', function() {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
+        window.fetchMock.post(urls.events, 200);
         mockServer.respondWith(urls.identify, [
             200,
             {},
@@ -25,6 +26,7 @@ describe('identities and attributes', function() {
 
     afterEach(function() {
         mockServer.restore();
+        window.fetchMock.restore();
     });
 
     it('should set user attribute', function(done) {

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -4,7 +4,8 @@ import { urls, apiKey,
     testMPID,
     MPConfig } from './config';
 
-var getEvent = Utils.getEvent,
+var findEventFromRequest = Utils.findEventFromRequest,
+    findBatch = Utils.findBatch,
     getLocalStorage = Utils.getLocalStorage, 
     MockForwarder = Utils.MockForwarder,
     mockServer;
@@ -14,11 +15,6 @@ describe('identities and attributes', function() {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}})
-        ])
         mockServer.respondWith(urls.identify, [
             200,
             {},
@@ -41,10 +37,10 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
 
-        event.should.have.property('ua');
-        event.ua.should.have.property('gender', 'male');
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.have.property('gender', 'male');
 
         var cookies = getLocalStorage();
         cookies[testMPID].ua.should.have.property('gender', 'male');
@@ -66,21 +62,21 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
 
         var cookies = getLocalStorage();
         cookies[testMPID].ua.should.have.property('gender', 'female');
 
-        event.should.have.property('ua');
-        event.ua.should.have.property('gender', 'female');
-        event.ua.should.not.have.property('Gender');
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.have.property('gender', 'female');
+        event.user_attributes.should.not.have.property('Gender');
 
         mParticle.Identity.getCurrentUser().setUserAttribute('Gender', 'male');
 
         mParticle.logEvent('test user attributes2');
-        var event2 = getEvent(mockServer.requests, 'test user attributes2');
-        event2.ua.should.have.property('Gender', 'male');
-        event2.ua.should.not.have.property('gender');
+        var event2 = findBatch(window.fetchMock._calls, 'test user attributes2');
+        event2.user_attributes.should.have.property('Gender', 'male');
+        event2.user_attributes.should.not.have.property('gender');
 
         cookies = getLocalStorage();
         cookies[testMPID].ua.should.have.property('Gender', 'male');
@@ -101,15 +97,15 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
 
         var cookies = getLocalStorage();
         cookies[testMPID].ua.should.have.property('gender', 'male');
         cookies[testMPID].ua.should.have.property('age', 21);
 
-        event.should.have.property('ua');
-        event.ua.should.have.property('gender', 'male');
-        event.ua.should.have.property('age', 21);
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.have.property('gender', 'male');
+        event.user_attributes.should.have.property('age', 21);
 
         done();
     });
@@ -125,8 +121,8 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
-        event.should.not.have.property('gender');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
+        event.user_attributes.should.not.have.property('gender');
 
         var cookies = getLocalStorage();
         Should(cookies[testMPID].ua).not.be.ok();
@@ -145,8 +141,8 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
-        event.should.not.have.property('Gender');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
+        event.user_attributes.should.not.have.property('Gender');
 
         var cookies = getLocalStorage();
         Should(cookies[testMPID].ua).not.be.ok();
@@ -159,14 +155,14 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test event');
 
-        var event = getEvent(mockServer.requests, 'test event');
+        var event = findEventFromRequest(window.fetchMock._calls, 'test event');
 
-        event.should.not.have.property('sa');
+        Should(event.data.custom_attributes).equal(null);
 
         mParticle.endSession();
-        var sessionEndEvent = getEvent(mockServer.requests, 2);
+        var sessionEndEvent = findEventFromRequest(window.fetchMock._calls, 'session_end');
 
-        sessionEndEvent.attrs.should.have.property('name', 'test');
+        sessionEndEvent.data.custom_attributes.should.have.property('name', 'test');
 
         done();
     });
@@ -177,10 +173,10 @@ describe('identities and attributes', function() {
 
         mParticle.endSession();
 
-        var sessionEndEvent = getEvent(mockServer.requests, 2);
+        var sessionEndEvent = findEventFromRequest(window.fetchMock._calls, 'session_end');
 
-        sessionEndEvent.attrs.should.have.property('name', 'test1');
-        sessionEndEvent.attrs.should.not.have.property('Name');
+        sessionEndEvent.data.custom_attributes.should.have.property('name', 'test1');
+        sessionEndEvent.data.custom_attributes.should.not.have.property('Name');
 
         done();
     });
@@ -188,16 +184,16 @@ describe('identities and attributes', function() {
     it("should not set a session attribute's key as an object or array)", function(done) {
         mParticle.setSessionAttribute({ key: 'value' }, 'test');
         mParticle.endSession();
-        var sessionEndEvent1 = getEvent(mockServer.requests, 2);
+        var sessionEndEvent1 = findEventFromRequest(window.fetchMock._calls, 'session_end');
 
         mParticle.startNewSession();
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.setSessionAttribute(['test'], 'test');
         mParticle.endSession();
-        var sessionEndEvent2 = getEvent(mockServer.requests, 2);
+        var sessionEndEvent2 = findEventFromRequest(window.fetchMock._calls, 'session_end');
 
-        Object.keys(sessionEndEvent1.attrs).length.should.equal(0);
-        Object.keys(sessionEndEvent2.attrs).length.should.equal(0);
+        Object.keys(sessionEndEvent1.data.custom_attributes).length.should.equal(0);
+        Object.keys(sessionEndEvent2.data.custom_attributes).length.should.equal(0);
 
         done();
     });
@@ -207,26 +203,26 @@ describe('identities and attributes', function() {
         mParticle.setSessionAttribute('name', 'test');
         mParticle.endSession();
 
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.startNewSession();
         mParticle.endSession();
 
-        var sessionEndEvent = getEvent(mockServer.requests, 2);
+        var sessionEndEvent = findEventFromRequest(window.fetchMock._calls, 'session_end');
 
-        sessionEndEvent.attrs.should.not.have.property('name');
+        sessionEndEvent.data.custom_attributes.should.not.have.property('name');
 
         done();
     });
 
     it('should set and log position', function(done) {
         mParticle.setPosition(34.134103, -118.321694);
-        mParticle.logEvent('test event');
+        mParticle.logEvent('Test Event');
 
-        var event = getEvent(mockServer.requests, 'test event');
+        var event = findEventFromRequest(window.fetchMock._calls, 'Test Event');
 
-        event.should.have.property('lc');
-        event.lc.should.have.property('lat', 34.134103);
-        event.lc.should.have.property('lng', -118.321694);
+        event.data.should.have.property('location');
+        event.data.location.should.have.property('latitude', 34.134103);
+        event.data.location.should.have.property('longitude', -118.321694);
 
         done();
     });
@@ -234,12 +230,12 @@ describe('identities and attributes', function() {
     it('should set user tag', function(done) {
         mParticle.Identity.getCurrentUser().setUserTag('test');
 
-        mParticle.logEvent('test event');
+        mParticle.logEvent('Test Event');
 
-        var event = getEvent(mockServer.requests, 'test event');
+        var event = findBatch(window.fetchMock._calls, 'Test Event');
 
-        event.should.have.property('ua');
-        event.ua.should.have.property('test', null);
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.have.property('test', null);
 
         var cookies = getLocalStorage();
         cookies[testMPID].ua.should.have.property('test');
@@ -251,13 +247,13 @@ describe('identities and attributes', function() {
         mParticle.Identity.getCurrentUser().setUserTag('Test');
         mParticle.Identity.getCurrentUser().setUserTag('test');
 
-        mParticle.logEvent('test event');
+        mParticle.logEvent('Test Event');
 
-        var event = getEvent(mockServer.requests, 'test event');
+        var event = findBatch(window.fetchMock._calls, 'Test Event');
 
-        event.should.have.property('ua');
-        event.ua.should.not.have.property('Test');
-        event.ua.should.have.property('test');
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.not.have.property('Test');
+        event.user_attributes.should.have.property('test');
 
         var cookies = getLocalStorage();
         cookies[testMPID].ua.should.have.property('test');
@@ -271,10 +267,10 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test event');
 
-        var event = getEvent(mockServer.requests, 'test event');
+        var event = findBatch(window.fetchMock._calls, 'test event');
 
-        event.should.have.property('ua');
-        event.ua.should.not.have.property('test');
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.not.have.property('test');
 
         var cookies = getLocalStorage();
         Should(cookies[testMPID].ua).not.be.ok();
@@ -288,10 +284,10 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test event');
 
-        var event = getEvent(mockServer.requests, 'test event');
+        var event = findBatch(window.fetchMock._calls, 'test event');
 
-        event.should.have.property('ua');
-        event.ua.should.not.have.property('Test');
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.not.have.property('Test');
 
         var cookies = getLocalStorage();
         Should(cookies[testMPID].ua).not.be.ok();
@@ -313,10 +309,10 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
 
-        event.should.have.property('ua');
-        event.ua.should.have.property('numbers', [1, 2, 3, 4, 5]);
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.have.property('numbers', [1, 2, 3, 4, 5]);
 
         var cookies = getLocalStorage();
         cookies[testMPID].ua.numbers.length.should.equal(5);
@@ -346,12 +342,12 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
         var cookies = getLocalStorage();
 
-        event.should.have.property('ua');
-        event.ua.should.have.property('Numbers', [1, 2, 3, 4, 5, 6]);
-        event.ua.should.not.have.property('numbers');
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.have.property('Numbers', [1, 2, 3, 4, 5, 6]);
+        event.user_attributes.should.not.have.property('numbers');
         cookies[testMPID].ua.Numbers.length.should.equal(6);
 
         mParticle.Identity.getCurrentUser().setUserAttributeList('numbers', [
@@ -363,11 +359,11 @@ describe('identities and attributes', function() {
         ]);
 
         mParticle.logEvent('test user attributes2');
-        var event2 = getEvent(mockServer.requests, 'test user attributes2');
+        var event2 = findBatch(window.fetchMock._calls, 'test user attributes2');
         var cookies3 = getLocalStorage();
 
-        event2.ua.should.have.property('numbers', [1, 2, 3, 4, 5]);
-        event2.ua.should.not.have.property('Numbers');
+        event2.user_attributes.should.have.property('numbers', [1, 2, 3, 4, 5]);
+        event2.user_attributes.should.not.have.property('Numbers');
         cookies3[testMPID].ua.numbers.length.should.equal(5);
 
         done();
@@ -389,14 +385,14 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
 
         var cookies = getLocalStorage();
 
         cookies[testMPID].ua.numbers.length.should.equal(5);
 
-        event.should.have.property('ua');
-        event.ua.should.have.property('numbers').with.lengthOf(5);
+        event.should.have.property('user_attributes');
+        event.user_attributes.should.have.property('numbers').with.lengthOf(5);
 
         done();
     });
@@ -416,10 +412,10 @@ describe('identities and attributes', function() {
 
         mParticle.logEvent('test user attributes');
 
-        var event = getEvent(mockServer.requests, 'test user attributes');
+        var event = findBatch(window.fetchMock._calls, 'test user attributes');
         var cookies = getLocalStorage();
 
-        event.should.have.property('ua', {});
+        event.should.have.property('user_attributes', {});
         Should(cookies[testMPID].ua).not.be.ok();
 
         done();
@@ -533,9 +529,9 @@ describe('identities and attributes', function() {
 
         mParticle.endSession();
 
-        var sessionEndEvent = getEvent(mockServer.requests, 2);
+        var sessionEndEvent = findEventFromRequest(window.fetchMock._calls, 'session_end');
 
-        sessionEndEvent.attrs.should.not.have.property('name');
+        sessionEndEvent.data.custom_attributes.should.not.have.property('name');
 
         done();
     });
@@ -545,7 +541,7 @@ describe('identities and attributes', function() {
             bad: 'bad',
         });
         mParticle.logEvent('test bad user attributes1');
-        var event1 = getEvent(mockServer.requests, 'test bad user attributes1');
+        var event1 = findBatch(window.fetchMock._calls, 'test bad user attributes1');
 
         mParticle.Identity.getCurrentUser().setUserAttribute('gender', [
             'bad',
@@ -553,50 +549,50 @@ describe('identities and attributes', function() {
             'bad',
         ]);
         mParticle.logEvent('test bad user attributes2');
-        var event2 = getEvent(mockServer.requests, 'test bad user attributes2');
+        var event2 = findBatch(window.fetchMock._calls, 'test bad user attributes2');
 
         mParticle.Identity.getCurrentUser().setUserAttribute(
             { bad: 'bad' },
             'male'
         );
         mParticle.logEvent('test bad user attributes3');
-        var event3 = getEvent(mockServer.requests, 'test bad user attributes3');
+        var event3 = findBatch(window.fetchMock._calls, 'test bad user attributes3');
 
         mParticle.Identity.getCurrentUser().setUserAttribute(
             ['bad', 'bad', 'bad'],
             'female'
         );
         mParticle.logEvent('test bad user attributes4');
-        var event4 = getEvent(mockServer.requests, 'test bad user attributes4');
+        var event4 = findBatch(window.fetchMock._calls, 'test bad user attributes4');
 
         mParticle.Identity.getCurrentUser().setUserAttribute(null, 'female');
         mParticle.logEvent('test bad user attributes5');
-        var event5 = getEvent(mockServer.requests, 'test bad user attributes5');
+        var event5 = findBatch(window.fetchMock._calls, 'test bad user attributes5');
 
         mParticle.Identity.getCurrentUser().setUserAttribute(
             undefined,
             'female'
         );
         mParticle.logEvent('test bad user attributes6');
-        var event6 = getEvent(mockServer.requests, 'test bad user attributes6');
+        var event6 = findBatch(window.fetchMock._calls, 'test bad user attributes6');
 
-        event1.should.have.property('ua');
-        event1.ua.should.not.have.property('gender');
+        event1.should.have.property('user_attributes');
+        event1.user_attributes.should.not.have.property('gender');
 
-        event2.should.have.property('ua');
-        event2.ua.should.not.have.property('gender');
+        event2.should.have.property('user_attributes');
+        event2.user_attributes.should.not.have.property('gender');
 
-        event3.should.have.property('ua');
-        event3.ua.should.not.have.property('gender');
+        event3.should.have.property('user_attributes');
+        event3.user_attributes.should.not.have.property('gender');
 
-        event4.should.have.property('ua');
-        event4.ua.should.not.have.property('gender');
+        event4.should.have.property('user_attributes');
+        event4.user_attributes.should.not.have.property('gender');
 
-        event5.should.have.property('ua');
-        event5.ua.should.not.have.property('gender');
+        event5.should.have.property('user_attributes');
+        event5.user_attributes.should.not.have.property('gender');
 
-        event6.should.have.property('ua');
-        event6.ua.should.not.have.property('gender');
+        event6.should.have.property('user_attributes');
+        event6.user_attributes.should.not.have.property('gender');
 
         done();
     });
@@ -620,15 +616,6 @@ describe('identities and attributes', function() {
 
     it('should send user attribute change requests when setting new attributes', function(done) {
         mParticle._resetForTests(MPConfig);
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
-        window.mParticle.config.flags = {
-            eventsV3: 100,
-            EventBatchingIntervalMillis: 0,
-        };
 
         mParticle.init(apiKey, window.mParticle.config);
 
@@ -731,15 +718,6 @@ describe('identities and attributes', function() {
 
     it('should send user attribute change requests for the MPID it is being set on', function(done) {
         mParticle._resetForTests(MPConfig);
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
-        window.mParticle.config.flags = {
-            eventsV3: 100,
-            EventBatchingIntervalMillis: 0,
-        };
 
         mParticle.init(apiKey, window.mParticle.config);
 
@@ -834,20 +812,12 @@ describe('identities and attributes', function() {
     it('should send user identity change requests when setting new identities on new users', function(done) {
         mParticle._resetForTests(MPConfig);
 
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
+        window.fetchMock._calls = [];
 
         window.mParticle.config.identifyRequest = {
             userIdentities: {
                 email: 'initial@gmail.com'
             }
-        };
-
-        window.mParticle.config.flags = {
-            eventsV3: 100,
-            EventBatchingIntervalMillis: 0,
         };
 
         mParticle.init(apiKey, window.mParticle.config);
@@ -1010,11 +980,6 @@ describe('identities and attributes', function() {
     it('should send historical UIs on batches when MPID changes', function(done) {
         mParticle._resetForTests(MPConfig);
 
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
         window.mParticle.config.identifyRequest = {
             userIdentities: {
                 email: 'initial@gmail.com'
@@ -1089,88 +1054,9 @@ describe('identities and attributes', function() {
 
         done();
     });
-    
-    it('should not send user identity change requests when not batching', function(done) {
-        // mock v3 events endpoint
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
-        // set eventsv3 endpoint to 0 to disable batching and send all events to v2 endpoint
-        window.mParticle.config.flags = {
-            eventsV3: 0,
-        };
-        mParticle.init(apiKey, window.mParticle.config);
-
-        // anonymous user is in storage, new user logs in
-        var loginUser = {
-            userIdentities: {
-                customerid: 'customerid1',
-            },
-        };
-
-        mockServer.respondWith(urls.identify, [
-            200,
-            {},
-            JSON.stringify({ mpid: 'mpid1', is_logged_in: false }),
-        ]);
-
-        window.fetchMock._calls = [];
-        mockServer.requests = [];
-        mParticle.Identity.login(loginUser);
-        // when a login request is performed and batching is enabled, it sends 2 requests, 1 to /login and 1 to /events
-        // when batching is not enabled, it only sends 1 request (to /login)
-        (mockServer.requests.length === 1).should.equal(true);
-        (window.fetchMock.lastOptions() === undefined).should.equal(true);
-        done();
-    });
-
-    it('should not send user attribute change requests when not batching', function(done) {
-        // v3 events endpoint
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
-
-        // set eventsv3 endpoint to 0 to disable batching and send all events to v2 endpoint
-        window.mParticle.config.flags = {
-            eventsV3: 0,
-        };
-        mParticle.init(apiKey, window.mParticle.config);
-
-        // clear out fetchMock for v3 endpoint calls
-        window.fetchMock._calls = [];
-        // clear out mockServer.requests for v2 endpoint calls (xhr requests)
-        mockServer.requests = [];
-
-        mParticle.Identity.getCurrentUser().setUserAttribute('age', '25');
-        (window.fetchMock.lastOptions() === undefined).should.equal(true);
-
-        mParticle.Identity.getCurrentUser().setUserAttribute('age', '30');
-        (window.fetchMock.lastOptions() === undefined).should.equal(true);
-
-        mParticle.Identity.getCurrentUser().removeUserAttribute('age');
-        (window.fetchMock.lastOptions() === undefined).should.equal(true);
-
-        mParticle.Identity.getCurrentUser().setUserAttributeList('age', [
-            'test1',
-            'test2',
-        ]);
-
-        (window.fetchMock.lastOptions() === undefined).should.equal(true);
-        (mockServer.requests.length === 0).should.equal(true);
-
-        done();
-    });
 
     it('should not send user attribute change requests when user attribute already set with same value with false values', function(done) {
         mParticle._resetForTests(MPConfig);
-
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
 
         window.mParticle.config.flags = {
             eventsV3: 100,
@@ -1258,11 +1144,6 @@ describe('identities and attributes', function() {
 
     it('should send user attribute change event when setting different falsey values', function(done) {
         mParticle._resetForTests(MPConfig);
-
-        window.fetchMock.post(
-            'https://jssdks.mparticle.com/v3/JS/test_key/events',
-            200
-        );
 
         window.mParticle.config.flags = {
             eventsV3: 100,

--- a/test/src/tests-identity.js
+++ b/test/src/tests-identity.js
@@ -22,6 +22,7 @@ var getLocalStorage = Utils.getLocalStorage,
 describe('identity', function() {
     beforeEach(function() {
         delete mParticle.config.useCookieStorage;
+        window.fetchMock.post(urls.events, 200);
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
@@ -35,6 +36,7 @@ describe('identity', function() {
 
     afterEach(function() {
         mockServer.restore();
+        window.fetchMock.restore();
         mParticle._resetForTests(MPConfig);
     });
 

--- a/test/src/tests-identity.js
+++ b/test/src/tests-identity.js
@@ -11,7 +11,8 @@ var getLocalStorage = Utils.getLocalStorage,
     findCookie = Utils.findCookie,
     forwarderDefaultConfiguration = Utils.forwarderDefaultConfiguration,
     getLocalStorageProducts = Utils.getLocalStorageProducts,
-    getEvent = Utils.getEvent,
+    findEventFromRequest = Utils.findEventFromRequest,
+    findBatch = Utils.findBatch,
     getIdentityEvent = Utils.getIdentityEvent,
     setCookie = Utils.setCookie,
     MockForwarder = Utils.MockForwarder,
@@ -23,12 +24,6 @@ describe('identity', function() {
         delete mParticle.config.useCookieStorage;
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
-
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}})
-        ]);
 
         mockServer.respondWith(urls.identify, [
             200,
@@ -168,12 +163,6 @@ describe('identity', function() {
             ._Persistence.getLocalStorage();
 
         localStorageDataBeforeSessionEnd.gs.csm.length.should.equal(2);
-
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: 'otherMPID', Store: {}})
-        ]);
 
         mParticle.endSession();
         var localStorageDataAfterSessionEnd1 = mParticle
@@ -728,8 +717,6 @@ describe('identity', function() {
     });
 
     it('should not make a request when an invalid request is sent to login', function(done) {
-        mockServer.requests = [];
-
         var identityAPIRequest1 = {
             userIdentities: 'badUserIdentitiesString',
         };
@@ -766,7 +753,6 @@ describe('identity', function() {
     });
 
     it('should not make a request when an invalid request is sent to logout', function(done) {
-        mockServer.requests = [];
         var identityAPIRequest1 = {
             userIdentities: 'badUserIdentitiesString',
         };
@@ -803,7 +789,6 @@ describe('identity', function() {
     });
 
     it('should not make a request when an invalid request is sent to modify', function(done) {
-        mockServer.requests = [];
         var identityAPIRequest1 = {
             userIdentities: 'badUserIdentitiesString',
         };
@@ -1016,12 +1001,6 @@ describe('identity', function() {
     it('queue events when MPID is 0, and then flush events once MPID changes', function(done) {
         mParticle._resetForTests(MPConfig);
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({})
-        ]);
-
         mockServer.respondWith(urls.identify, [
             0,
             {},
@@ -1030,32 +1009,35 @@ describe('identity', function() {
 
         mParticle.init(apiKey, window.mParticle.config);
 
-        mockServer.requests = [];
-        mParticle.logEvent('Test1');
-        var event1 = getEvent(mockServer.requests, 'Test1');
-        Should(event1).not.be.ok();
+        window.fetchMock._calls = [];
+        mParticle.logEvent('Test Event1');
 
+        let testEvent1 = findEventFromRequest(window.fetchMock._calls, 'Test Event1');
+        
+        Should(testEvent1).not.be.ok();
+        
         mockServer.respondWith(urls.login, [
             200,
             {},
             JSON.stringify({ mpid: 'otherMPID', is_logged_in: false }),
         ]);
 
-        mParticle.logEvent('Test2');
+        mParticle.logEvent('Test Event2');
         mParticle.Identity.login();
-
         // server requests will have AST, sessionStart, Test1, Test2, and login
-        mockServer.requests.length.should.equal(5);
-        event1 = getEvent(mockServer.requests, 'Test1');
-        var event2 = getEvent(mockServer.requests, 'Test2');
-        var event3 = getEvent(mockServer.requests, 10);
-        var event4 = getEvent(mockServer.requests, 1);
-        var event5 = getIdentityEvent(mockServer.requests, 'login');
-        Should(event1).be.ok();
-        Should(event2).be.ok();
-        Should(event3).be.ok();
-        Should(event4).be.ok();
-        Should(event5).be.ok();
+        testEvent1 = findEventFromRequest(window.fetchMock._calls, 'Test Event1');
+        window.fetchMock._calls.length.should.equal(4);
+        
+        const testEvent2 = findEventFromRequest(window.fetchMock._calls, 'Test Event2');
+        const ASTEvent = findEventFromRequest(window.fetchMock._calls, 'application_state_transition');
+        const sessionStartEvent = findEventFromRequest(window.fetchMock._calls, 'session_start');
+        const loginEvent = getIdentityEvent(mockServer.requests, 'login');
+
+        Should(testEvent1).be.ok();
+        Should(testEvent2).be.ok();
+        Should(ASTEvent).be.ok();
+        Should(sessionStartEvent).be.ok();
+        Should(loginEvent).be.ok();
 
         done();
     });
@@ -1236,19 +1218,6 @@ describe('identity', function() {
         done();
     });
 
-    it('should convert user identities object to an array if no identityRequest is passed through', function(done) {
-        mParticle._resetForTests(MPConfig);
-        mockServer.requests = [];
-
-        mParticle.identifyRequest = null;
-        mParticle.init(apiKey, window.mParticle.config);
-
-        var data = getEvent(mockServer.requests, 1);
-
-        Array.isArray(data.ui).should.equal(true);
-        done();
-    });
-
     it('should reject a callback that is not a function', function(done) {
         var identityRequest = {
             userIdentities: {
@@ -1303,14 +1272,13 @@ describe('identity', function() {
         );
         mParticle.eCommerce.Cart.add(product1);
 
-        mParticle.logEvent('test event1');
-        var event1 = getEvent(mockServer.requests, 'test event1');
+        mParticle.logEvent('Test Event1');
 
-        event1.ua.should.have.property('foo1', 'bar1');
-        event1.ui[0].should.have.property('Type', 1);
-        event1.ui[0].should.have.property('Identity', 'customerid1');
-        event1.ui[1].should.have.property('Type', 7);
-        event1.ui[1].should.have.property('Identity', 'email2@test.com');
+        const testEvent1Batch = findBatch(window.fetchMock._calls, 'Test Event1');
+
+        testEvent1Batch.user_attributes.should.have.property('foo1', 'bar1');
+        testEvent1Batch.user_identities.should.have.property('customer_id', 'customerid1');
+        testEvent1Batch.user_identities.should.have.property('email', 'email2@test.com');
 
         var products = getLocalStorageProducts();
 
@@ -1337,12 +1305,12 @@ describe('identity', function() {
         ]);
 
         mParticle.Identity.logout(user2);
-        mParticle.logEvent('test event 2');
-        var event2 = getEvent(mockServer.requests, 'test event 2');
+        mParticle.logEvent('Test Event2');
 
-        Object.keys(event2.ua).length.should.equal(0);
-        event2.ui[0].should.have.property('Type', 1);
-        event2.ui[0].should.have.property('Identity', 'customerid2');
+        const testEvent2Batch = findBatch(window.fetchMock._calls, 'Test Event2');
+
+        Object.keys(testEvent2Batch.user_attributes).length.should.equal(0);
+        testEvent2Batch.user_identities.should.have.property('customer_id', 'customerid2');
 
         mockServer.respondWith(urls.login, [
             200,
@@ -1351,15 +1319,13 @@ describe('identity', function() {
         ]);
 
         mParticle.Identity.login(user1);
-        mParticle.logEvent('test event3');
-        var event3 = getEvent(mockServer.requests, 'test event3');
+        mParticle.logEvent('Test Event3');
+        const testEvent3Batch = findBatch(window.fetchMock._calls, 'Test Event3');
 
-        event3.ua.should.have.property('foo1', 'bar1');
-        event3.ui.length.should.equal(2);
-        event3.ui[0].should.have.property('Type', 1);
-        event3.ui[0].should.have.property('Identity', 'customerid1');
-        event3.ui[1].should.have.property('Type', 7);
-        event3.ui[1].should.have.property('Identity', 'email2@test.com');
+        testEvent3Batch.user_attributes.should.have.property('foo1', 'bar1');
+        Object.keys(testEvent3Batch.user_identities).length.should.equal(2);
+        testEvent3Batch.user_identities.should.have.property('customer_id', 'customerid1');
+        testEvent3Batch.user_identities.should.have.property('email', 'email2@test.com');
 
         var products2 = getLocalStorageProducts();
 
@@ -1719,8 +1685,10 @@ describe('identity', function() {
         cartProducts2[1].Name.should.equal('HTC');
 
         mParticle.eCommerce.logCheckout(1);
-        var commerceEventUser2 = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        commerceEventUser2.sc.pl.length.should.equal(0)
+
+        const checkoutEvent = findEventFromRequest(window.fetchMock._calls, 'checkout');
+
+        checkoutEvent.data.product_action.should.have.property('products', null)
 
         mockServer.respondWith(urls.login, [
             200,
@@ -1729,13 +1697,15 @@ describe('identity', function() {
         ]);
 
         mParticle.Identity.login(identityAPIRequest1);
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.eCommerce.logCheckout(1);
 
-        var commerceEventUser1 = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        commerceEventUser1.sc.pl.length.should.equal(0);
+        var checkoutEvent2 = findEventFromRequest(window.fetchMock._calls, 'checkout');
+
+        checkoutEvent2.data.product_action.should.have.property('products', null);
 
         done();
+    
     });
 
     it('should update cookies after modifying identities', function(done) {
@@ -2051,16 +2021,17 @@ describe('identity', function() {
             mParticle.Identity.getCurrentUser().setUserAttribute('foo', 'bar');
         };
 
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.init(apiKey, window.mParticle.config);
 
-        (mockServer.requests.length === 0).should.equal.true
+        (window.fetchMock._calls.length === 0).should.equal.true
         clock.tick(1000);
-        
-        var sessionStart = getEvent(mockServer.requests, 1);
-        var ASTEvent = getEvent(mockServer.requests, 10);
-        sessionStart.ua.should.have.property('foo', 'bar');
-        ASTEvent.ua.should.have.property('foo', 'bar');
+
+        const sessionStartEventBatch = findBatch(window.fetchMock._calls, 'session_start');
+        const ASTEventBatch = findBatch(window.fetchMock._calls, 'application_state_transition');
+
+        sessionStartEventBatch.user_attributes.should.have.property('foo', 'bar');
+        ASTEventBatch.user_attributes.should.have.property('foo', 'bar');
         clock.restore();
 
         done();
@@ -2091,10 +2062,10 @@ describe('identity', function() {
             JSON.stringify({ mpid: 'MPID1', is_logged_in: false }),
         ]);
 
-        mockServer.requests = [];
+        window.fetchMock._calls = [];
         mParticle.init(apiKey, window.mParticle.config);
         //the only server request is the AST, there is no request to Identity
-        mockServer.requests.length.should.equal(1);
+        window.fetchMock._calls.length.should.equal(1);
         result.should.have.properties('body', 'httpCode', 'getUser');
 
         result.httpCode.should.equal(-3);
@@ -2914,7 +2885,7 @@ describe('identity', function() {
         done();
     });
 
-    it('Should warn if legal aliasRequest cannot be created with MParticleUser', function(done) {
+    it('should warn if legal aliasRequest cannot be created with MParticleUser', function(done) {
         var millisPerDay = 24 * 60 * 60 * 1000;
 
         mParticle.config.logLevel = 'verbose';

--- a/test/src/tests-kit-blocking.ts
+++ b/test/src/tests-kit-blocking.ts
@@ -1298,7 +1298,7 @@ describe('kit blocking', () => {
                 );
 
                 let errorMessages = [];
-                console.log(errorMessages);
+
                 window.mParticle._resetForTests(MPConfig);
 
                 let mockForwarder = new MockForwarder();
@@ -1319,7 +1319,7 @@ describe('kit blocking', () => {
                         errorMessages.push(err)
                     }
                 }
-                console.log(errorMessages);
+
                 window.mParticle.init(apiKey, window.mParticle.config);
                 errorMessages[0].should.equal(errorMessage);
                 window.mParticle.config.requestConfig = false;

--- a/test/src/tests-mParticleUser.js
+++ b/test/src/tests-mParticleUser.js
@@ -8,38 +8,31 @@ var forwarderDefaultConfiguration = Utils.forwarderDefaultConfiguration,
 
 describe('mParticleUser', function() {
     beforeEach(function() {
-        // TODO - for some reason when these MPIDs are all testMPID, the following test breaks:
-        // onIdentifyComplete/onLoginComplete/onLogoutComplete/onModifyComplete 
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: 'testtest', Store: {}})
-        ]);
 
         mockServer.respondWith(urls.identify, [
             200,
             {},
-            JSON.stringify({ mpid: 'testtest', is_logged_in: false }),
+            JSON.stringify({ mpid: 'testMPID', is_logged_in: false }),
         ]);
 
         mockServer.respondWith(urls.login, [
             200,
             {},
-            JSON.stringify({ mpid: 'testtest', is_logged_in: false }),
+            JSON.stringify({ mpid: 'testMPID', is_logged_in: false }),
         ]);
 
         mockServer.respondWith(urls.logout, [
             200,
             {},
-            JSON.stringify({ mpid: 'testtest', is_logged_in: false }),
+            JSON.stringify({ mpid: 'testMPID', is_logged_in: false }),
         ]);
 
-        mockServer.respondWith('https://identity.mparticle.com/v1/testtest/modify', [
+        mockServer.respondWith('https://identity.mparticle.com/v1/testMPID/modify', [
             200,
             {},
-            JSON.stringify({ mpid: 'testtest', is_logged_in: false }),
+            JSON.stringify({ mpid: 'testMPID', is_logged_in: false }),
         ]);
     });
 

--- a/test/src/tests-main.js
+++ b/test/src/tests-main.js
@@ -1,4 +1,4 @@
-import { MPConfig, workspaceToken } from './config';
+import { MPConfig, workspaceToken, urls } from './config';
 
 var userApi = null;
 
@@ -18,7 +18,13 @@ beforeEach(function() {
         kitConfigs: [],
         requestConfig: false,
         isDevelopmentMode: false,
+        flags: {
+            eventBatchingIntervalMillis: 0,
+        }
     };
+
+    window.fetchMock.post(urls.events, 200);
+    window.fetchMock.config.overwriteRoutes = true;
 
     mParticle._resetForTests(MPConfig);
     delete mParticle._instances['default_instance'];
@@ -28,10 +34,10 @@ afterEach(function() {
     window.fetchMock.restore();
 });
 
+import './tests-beaconUpload';
+import './tests-batchUploader';
 import './tests-core-sdk';
 import './tests-temp-session-bug-fix';
-import './tests-batchUploader';
-import './tests-beaconUpload';
 import './tests-kit-blocking';
 import './tests-migrations';
 import './tests-persistence';

--- a/test/src/tests-main.js
+++ b/test/src/tests-main.js
@@ -1,4 +1,4 @@
-import { MPConfig, workspaceToken, urls } from './config';
+import { MPConfig, workspaceToken } from './config';
 
 var userApi = null;
 
@@ -23,9 +23,6 @@ beforeEach(function() {
         }
     };
 
-    window.fetchMock.post(urls.events, 200);
-    window.fetchMock.config.overwriteRoutes = true;
-
     mParticle._resetForTests(MPConfig);
     delete mParticle._instances['default_instance'];
 });
@@ -34,10 +31,10 @@ afterEach(function() {
     window.fetchMock.restore();
 });
 
-import './tests-beaconUpload';
-import './tests-batchUploader';
 import './tests-core-sdk';
 import './tests-temp-session-bug-fix';
+import './tests-batchUploader';
+import './tests-beaconUpload';
 import './tests-kit-blocking';
 import './tests-migrations';
 import './tests-persistence';

--- a/test/src/tests-migrations.js
+++ b/test/src/tests-migrations.js
@@ -20,6 +20,7 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
+        window.fetchMock.post(urls.events, 200);
         mockServer.respondWith(urls.identify, [
             200,
             {},
@@ -30,6 +31,7 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
     afterEach(function() {
         deleteAllCookies();
         mockServer.restore();
+        window.fetchMock.restore();
     });
 
     var mP = new _Persistence(mParticle.getInstance());

--- a/test/src/tests-migrations.js
+++ b/test/src/tests-migrations.js
@@ -8,7 +8,8 @@ import { urls, apiKey, testMPID, MPConfig, v3CookieKey, workspaceCookieName, v3L
 var getLocalStorageProducts = Utils.getLocalStorageProducts,
     setCookie = Utils.setCookie,
     setLocalStorage = Utils.setLocalStorage,
-    getEvent = Utils.getEvent,
+    findBatch = Utils.findBatch,
+    findEventFromRequest = Utils.findEventFromRequest,
     findCookie = Utils.findCookie,
     v4CookieKey = Utils.v4CookieKey,
     deleteAllCookies = Utils.deleteAllCookies,
@@ -19,11 +20,6 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}})
-        ]);
         mockServer.respondWith(urls.identify, [
             200,
             {},
@@ -126,14 +122,12 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
         localStorage.setItem(v3LSKey, lsProductsRaw);
         mParticle.init(apiKey, window.mParticle.config);
 
-        mockServer.requests = [];
         mParticle.eCommerce.logCheckout(1);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        event.ui[0].should.have.property('Identity', 'customerid1');
-        event.ui[0].should.have.property('Type', 1);
-        event.ui[1].should.have.property('Identity', 'test@email.com');
-        event.ui[1].should.have.property('Type', 7);
+        const checkoutEvent = findBatch(window.fetchMock._calls, 'checkout');
+
+        checkoutEvent.user_identities.should.have.property('customer_id', 'customerid1');
+        checkoutEvent.user_identities.should.have.property('email', 'test@email.com');
 
         done();
     });
@@ -148,9 +142,9 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
         mockServer.requests = [];
         mParticle.eCommerce.logCheckout(1);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        event.ui[0].should.have.property('Identity', 'test@email.com');
-        event.ui[0].should.have.property('Type', 7);
+        const checkoutEvent = findBatch(window.fetchMock._calls, 'checkout');
+
+        checkoutEvent.user_identities.should.have.property('email', 'test@email.com');
 
         done();
     });
@@ -207,11 +201,10 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
         mockServer.requests = [];
         mParticle.eCommerce.logCheckout(1);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        event.ui[0].should.have.property('Identity', 'customerid1');
-        event.ui[0].should.have.property('Type', 1);
-        event.ui[1].should.have.property('Identity', 'test@email.com');
-        event.ui[1].should.have.property('Type', 7);
+        const checkoutEventBatch = findBatch(window.fetchMock._calls, 'checkout');
+
+        checkoutEventBatch.user_identities.should.have.property('customer_id', 'customerid1');
+        checkoutEventBatch.user_identities.should.have.property('email', 'test@email.com');
 
         done();
     });
@@ -226,11 +219,10 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
         mockServer.requests = [];
         mParticle.eCommerce.logCheckout(1);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        event.ui[0].should.have.property('Identity', 'customerid1');
-        event.ui[0].should.have.property('Type', 1);
-        event.ui[1].should.have.property('Identity', 'test@email.com');
-        event.ui[1].should.have.property('Type', 7);
+        const checkoutEventBatch = findBatch(window.fetchMock._calls, 'checkout');
+
+        checkoutEventBatch.user_identities.should.have.property('customer_id', 'customerid1');
+        checkoutEventBatch.user_identities.should.have.property('email', 'test@email.com');
 
         done();
     });
@@ -333,8 +325,8 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
         );
         mParticle.eCommerce.logCheckout(1);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        event.sc.pl.length.should.equal(0);
+        const checkoutEvent = findEventFromRequest(window.fetchMock._calls, 'checkout');
+        checkoutEvent.data.product_action.should.have.property('products', null);
 
         done();
     });
@@ -378,8 +370,9 @@ describe('persistence migrations from SDKv1 to SDKv2', function() {
         );
         mParticle.eCommerce.logCheckout(1);
 
-        var event = getEvent(mockServer.requests, 'eCommerce - Checkout');
-        event.sc.pl.length.should.equal(0);
+        const checkoutEvent = findEventFromRequest(window.fetchMock._calls, 'checkout');
+
+        checkoutEvent.data.product_action.should.have.property('products', null)
 
         done();
     });

--- a/test/src/tests-mparticle-instance-manager.js
+++ b/test/src/tests-mparticle-instance-manager.js
@@ -1,19 +1,14 @@
 import sinon from 'sinon';
 import { urls, MPConfig } from './config';
-
+import Utils from './utils';
+var findEventFromRequest = Utils.findEventFromRequest;
 var mockServer;
 
-function returnEventForMPInstance(server, apiKey, eventName) {
-    var requests = [];
-    var requestsPerApiKey = server.requests.filter(function(request) {
-        return request.url.includes(apiKey);
+function returnEventForMPInstance(calls, apiKey, eventName) {
+    var requestsPerApiKey = calls.filter(function(call) {
+        return call[0].includes(apiKey);
     });
-    requestsPerApiKey.forEach(function(request) {
-        if (request.requestBody && request.requestBody.includes(eventName)) {
-            requests.push(JSON.parse(request.requestBody));
-        }
-    });
-    return requests;
+    return findEventFromRequest(requestsPerApiKey, eventName);
 }
 
 describe('mParticle instance manager', function() {
@@ -210,19 +205,17 @@ describe('mParticle instance manager', function() {
             );
 
             // default instance event mock
-            mockServer.respondWith(
-                'https://jssdkcdns.mparticle.com/JS/v2/apiKey1/Events',
-                [200, {}, JSON.stringify({ store: {} })]
+            window.fetchMock.post(
+                'https://jssdks.mparticle.com/v3/JS/apiKey1/events',
+                200
             );
-            // instance1 event mock
-            mockServer.respondWith(
-                'https://jssdkcdns.mparticle.com/JS/v2/apiKey2/Events',
-                [200, {}, JSON.stringify({ store: {} })]
+            window.fetchMock.post(
+                'https://jssdks.mparticle.com/v3/JS/apiKey2/events',
+                200
             );
-            // instance2 event mock
-            mockServer.respondWith(
-                'https://jssdkcdns.mparticle.com/JS/v2/apiKey3/Events',
-                [200, {}, JSON.stringify({ store: {} })]
+            window.fetchMock.post(
+                'https://jssdks.mparticle.com/v3/JS/apiKey3/events',
+                200
             );
 
             // identity mock
@@ -264,68 +257,68 @@ describe('mParticle instance manager', function() {
             mParticle.getInstance('instance2').logEvent('hi2');
             mParticle.getInstance('instance3').logEvent('hi3');
 
-            var instance1Events = returnEventForMPInstance(
-                mockServer,
+            var instance1Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey1',
                 'hi1'
             );
-            instance1Events.length.should.equal(1);
+            instance1Event.should.be.ok();
 
-            var instance2Events = returnEventForMPInstance(
-                mockServer,
+            var instance2Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey2',
                 'hi2'
             );
-            instance2Events.length.should.equal(1);
+            instance2Event.should.be.ok();
 
-            var instance3Events = returnEventForMPInstance(
-                mockServer,
+            var instance3Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey3',
                 'hi3'
             );
-            instance3Events.length.should.equal(1);
+            instance3Event.should.be.ok();
 
             var instance1EventsFail1 = returnEventForMPInstance(
-                mockServer,
+                window.fetchMock._calls,
                 'apiKey1',
                 'hi2'
             );
-            instance1EventsFail1.length.should.equal(0);
+            Should(instance1EventsFail1).not.be.ok();
 
             var instance1EventsFail2 = returnEventForMPInstance(
-                mockServer,
+                window.fetchMock._calls,
                 'apiKey1',
                 'hi3'
             );
-            instance1EventsFail2.length.should.equal(0);
+            Should(instance1EventsFail2).not.be.ok();
 
             var instance2EventsFail1 = returnEventForMPInstance(
-                mockServer,
+                window.fetchMock._calls,
                 'apiKey2',
                 'hi1'
             );
-            instance2EventsFail1.length.should.equal(0);
+            Should(instance2EventsFail1).not.be.ok();
 
             var instance2EventsFail2 = returnEventForMPInstance(
-                mockServer,
+                window.fetchMock._calls,
                 'apiKey2',
                 'hi3'
             );
-            instance2EventsFail2.length.should.equal(0);
+            Should(instance2EventsFail2).not.be.ok();
 
             var instance3EventsFail1 = returnEventForMPInstance(
-                mockServer,
+                window.fetchMock._calls,
                 'apiKey3',
                 'hi1'
             );
-            instance3EventsFail1.length.should.equal(0);
+            Should(instance3EventsFail1).not.be.ok();
 
             var instance3EventsFail2 = returnEventForMPInstance(
-                mockServer,
+                window.fetchMock._calls,
                 'apiKey3',
                 'hi2'
             );
-            instance3EventsFail2.length.should.equal(0);
+            Should(instance3EventsFail2).not.be.ok();
 
             done();
         });
@@ -377,54 +370,54 @@ describe('mParticle instance manager', function() {
                 .getInstance()
                 .eCommerce.logPurchase(ta, [product1, product2]);
 
-            var instance1Events = returnEventForMPInstance(
-                mockServer,
+            var instance1Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey1',
-                'eCommerce - Purchase'
+                'purchase'
             );
-            var instance2Events = returnEventForMPInstance(
-                mockServer,
+            var instance2Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey2',
-                'eCommerce - Purchase'
+                'purchase'
             );
-            var instance3Events = returnEventForMPInstance(
-                mockServer,
+            var instance3Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey3',
-                'eCommerce - Purchase'
+                'purchase'
             );
-            instance1Events.length.should.equal(1);
-            instance2Events.length.should.equal(0);
-            instance3Events.length.should.equal(0);
+            instance1Event.should.be.ok();
+            Should(instance2Event).not.be.ok();
+            Should(instance3Event).not.be.ok();
 
             mParticle
                 .getInstance('instance2')
                 .eCommerce.logPurchase(ta, [product1, product2]);
 
-            instance2Events = returnEventForMPInstance(
-                mockServer,
+            instance2Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey2',
-                'eCommerce - Purchase'
+                'purchase'
             );
-            instance3Events = returnEventForMPInstance(
-                mockServer,
+            instance3Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey3',
-                'eCommerce - Purchase'
+                'purchase'
             );
 
-            instance2Events.length.should.equal(1);
-            instance3Events.length.should.equal(0);
+            instance2Event.should.be.ok();
+            Should(instance3Event).not.be.ok();
 
             mParticle
                 .getInstance('instance3')
                 .eCommerce.logPurchase(ta, [product1, product2]);
 
-            instance3Events = returnEventForMPInstance(
-                mockServer,
+            instance3Event = returnEventForMPInstance(
+                window.fetchMock._calls,
                 'apiKey3',
-                'eCommerce - Purchase'
+                'purchase'
             );
 
-            instance3Events.length.should.equal(1);
+            instance3Event.should.be.ok();
 
             done();
         });

--- a/test/src/tests-persistence.js
+++ b/test/src/tests-persistence.js
@@ -8,7 +8,7 @@ var findCookie = Utils.findCookie,
     getLocalStorageProducts = Utils.getLocalStorageProducts,
     setCookie = Utils.setCookie,
     setLocalStorage = Utils.setLocalStorage,
-    getEvent = Utils.getEvent,
+    findBatch = Utils.findBatch,
     mockServer;
 
 describe('migrations and persistence-related', function() {
@@ -16,16 +16,12 @@ describe('migrations and persistence-related', function() {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}})
-        ])
         mockServer.respondWith(urls.identify, [
             200,
             {},
             JSON.stringify({ mpid: testMPID, is_logged_in: false }),
         ]);
+
         mParticle.init(apiKey, window.mParticle.config);
     });
 
@@ -413,9 +409,9 @@ describe('migrations and persistence-related', function() {
         mParticle.init(apiKey, window.mParticle.config);
 
         mParticle.logEvent('Test Event');
-        var data = getEvent(mockServer.requests, 'Test Event');
-        data.ia.should.have.property('128');
-        data.ia['128'].should.have.property('MCID', 'abcedfg');
+        const testEvent = findBatch(window.fetchMock._calls, 'Test Event');
+        testEvent.integration_attributes.should.have.property('128');
+        testEvent.integration_attributes['128'].should.have.property('MCID', 'abcedfg');
 
         done();
     });

--- a/test/src/tests-persistence.js
+++ b/test/src/tests-persistence.js
@@ -13,6 +13,7 @@ var findCookie = Utils.findCookie,
 
 describe('migrations and persistence-related', function() {
     beforeEach(function() {
+        window.fetchMock.post(urls.events, 200);
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
@@ -27,6 +28,7 @@ describe('migrations and persistence-related', function() {
 
     afterEach(function() {
         mockServer.restore();
+        window.fetchMock.restore();
     });
 
     it('should move new schema from cookies to localStorage with useCookieStorage = false', function(done) {

--- a/test/src/tests-queue-public-methods.js
+++ b/test/src/tests-queue-public-methods.js
@@ -9,12 +9,6 @@ describe('Queue Public Methods', function () {
         mockServer = sinon.createFakeServer();
         mockServer.respondImmediately = true;
 
-        mockServer.respondWith(urls.eventsV2, [
-            200,
-            {},
-            JSON.stringify({ mpid: testMPID, Store: {}}),
-        ]);
-
         mockServer.respondWith(urls.identify, [
             200,
             {},

--- a/test/src/tests-self-hosting-specific.js
+++ b/test/src/tests-self-hosting-specific.js
@@ -2,7 +2,7 @@ import Utils from './utils';
 import sinon from 'sinon';
 import { urls, apiKey, MPConfig } from './config';
 
-var getEvent = Utils.getEvent;
+const { findEventFromRequest, findBatch } = Utils;
 
 var mockServer;
 
@@ -22,7 +22,7 @@ describe('/config self-hosting integration tests', function() {
             },
         };
 
-        // start fake timer and mock server in order to
+        // start fake timer and mock server in order to mock when certain events happen
         var clock = sinon.useFakeTimers();
         mockServer.autoRespond = true;
         mockServer.autoRespondAfter = 100;
@@ -41,13 +41,13 @@ describe('/config self-hosting integration tests', function() {
 
         // log event before config and identify come back
         mParticle.logEvent('Test');
-        var event = getEvent(mockServer.requests, 'Test');
+        let event = findEventFromRequest(window.fetchMock._calls, 'Test');
         Should(event).not.be.ok();
 
         // config and identify now get triggered, which runs through the event queue
         clock.tick(300);
 
-        event = getEvent(mockServer.requests, 'Test');
+        event = findBatch(window.fetchMock._calls, 'Test');
         event.should.be.ok();
         event.mpid.should.equal('identifyMPID');
 
@@ -106,7 +106,7 @@ describe('/config self-hosting integration tests', function() {
         // config triggers, login triggers immediately before identify
         clock.tick(300);
 
-        var event1 = getEvent(mockServer.requests, 'Test', false, mockServer);
+        const event1 = findBatch(window.fetchMock._calls, 'Test');
         event1.mpid.should.equal('loginMPID');
         messages
             .indexOf('Parsing "login" identity response from server')
@@ -116,7 +116,7 @@ describe('/config self-hosting integration tests', function() {
         messages
             .indexOf('Parsing "identify" identity response from server')
             .should.equal(-1);
-        var event2 = getEvent(mockServer.requests, 'identify callback event', false, mockServer);
+        const event2 = findBatch(window.fetchMock._calls, 'identify callback event', false, mockServer);
         event2.mpid.should.equal('loginMPID');
 
         mockServer.restore();

--- a/test/src/tests-self-hosting-specific.js
+++ b/test/src/tests-self-hosting-specific.js
@@ -9,8 +9,14 @@ var mockServer;
 // Calls to /config are specific to only the self hosting environment
 describe('/config self-hosting integration tests', function() {
     beforeEach(function() {
+        window.fetchMock.post(urls.events, 200);
         mockServer = sinon.createFakeServer();
     });
+
+    afterEach(function() {
+        window.fetchMock.restore();
+        sinon.restore();
+    })
 
     it('queues events in the eventQueue while /config is in flight, then processes them afterwards with correct MPID', function(done) {
         mParticle._resetForTests(MPConfig);

--- a/test/src/tests-serverModel.ts
+++ b/test/src/tests-serverModel.ts
@@ -328,11 +328,6 @@ describe('ServerModel', () => {
             mockServer = sinon.createFakeServer();
             mockServer.respondImmediately = true;
 
-            mockServer.respondWith(urls.eventsV2, [
-                200,
-                {},
-                JSON.stringify({ mpid: testMPID, Store: {} }),
-            ]);
             mockServer.respondWith(urls.identify, [
                 200,
                 {},
@@ -1301,11 +1296,6 @@ describe('ServerModel', () => {
             mockServer = sinon.createFakeServer();
             mockServer.respondImmediately = true;
 
-            mockServer.respondWith(urls.eventsV2, [
-                200,
-                {},
-                JSON.stringify({ mpid: testMPID, Store: {} }),
-            ]);
             mockServer.respondWith(urls.identify, [
                 200,
                 {},

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -112,7 +112,6 @@ describe('Store', () => {
             store.SDKConfig.flags.eventBatchingIntervalMillis,
             'flags.eventBatchingIntervalMillis'
         ).to.eq(0);
-        expect(store.SDKConfig.flags.eventsV3, 'flags.eventsV3').to.eq(0);
         expect(
             store.SDKConfig.flags.reportBatching,
             'flags.reportBatching'
@@ -155,9 +154,6 @@ describe('Store', () => {
         );
         expect(store.SDKConfig.useNativeSdk, 'useNativeSdk').to.eq(false);
 
-        expect(store.SDKConfig.v1SecureServiceUrl, 'v1SecureServiceUrl').to.eq(
-            'jssdks.mparticle.com/v1/JS/'
-        );
         expect(store.SDKConfig.v2SecureServiceUrl, 'v2SecureServiceUrl').to.eq(
             'jssdks.mparticle.com/v2/JS/'
         );

--- a/test/src/tests-temp-session-bug-fix.js
+++ b/test/src/tests-temp-session-bug-fix.js
@@ -93,7 +93,7 @@ describe('session bug fix test', function() {
             {},
             JSON.stringify({ mpid: testMPID, is_logged_in: false }),
         ]);
-        window.fetchMock.post(urls.eventsV3, 200);
+        window.fetchMock.post(urls.events, 200);
         mParticle.init(apiKey, window.mParticle.config);
     });
 

--- a/test/src/utils.js
+++ b/test/src/utils.js
@@ -171,26 +171,30 @@ var pluses = /\+/g,
             return mParticle.getInstance()._Persistence.getLocalStorage();
         }
     },
-    getEvent = function(requests, eventName) {
-        if (requests.length) {
-            var events = requests.filter(function(request) {
-                if (request.requestBody) {
-                    return JSON.parse(request.requestBody).n === eventName
-                } else {
-                    return null;
-                }
-            })
-            .map(function(request) {
-                return JSON.parse(request.requestBody)
-            });
-    
-            return events[0]
-        }
-    },
     findEventFromBatch = function(batch, eventName) {
         if (batch.events.length) {
             return batch.events.find(function(event) {
-                return event.event_type === eventName
+                switch (event.event_type) {
+                    case 'commerce_event':
+                        if (event.data.product_action) {
+                            return event.data.product_action.action === eventName;
+                        }
+                        else if (event.data.promotion_action) {
+                            // return the promotion action
+                            return true;
+                        } else {
+                            // all commerce_events that do not have product_action
+                            // or promotion_action are impression actions
+                            return true;
+                        }
+                    case 'custom_event':
+                        return event.data.event_name === eventName;
+                    case 'crash_report':
+                        return true;
+                    default:
+                        // all other events are lifecycle events (session start, end, AST)
+                        return event.event_type === eventName
+                }
             })
         }
         return null;
@@ -216,11 +220,40 @@ var pluses = /\+/g,
         }
     },
     findRequest = function(requests, eventName) {
-        var reqs = requests.filter(function(request) {
-            return JSON.parse(request.requestBody).n === eventName
+        let matchingRequest;
+        requests.forEach(function(request) {
+            var batch = JSON.parse(request[1].body);
+            for (var i = 0; i<batch.events.length; i++) {
+                var foundEventFromBatch = findEventFromBatch(batch, eventName);
+                if (foundEventFromBatch) {
+                    matchingRequest = request;
+                    break;
+                }
+            }
         })
 
-        return reqs[0]
+        return matchingRequest;
+    },
+    findRequestURL = function(requests, eventName) {
+        return findRequest(requests, eventName)[0]
+    },
+    findBatch = function(requests, eventName) {
+        var request = findRequest(requests, eventName);
+        if (request) {
+            return JSON.parse(findRequest(requests, eventName)[1].body);
+        } else {
+            return null;
+        }
+
+    },
+    findEventFromRequest= function(requests, eventName) {
+        var batch = findBatch(requests, eventName);
+        if (batch) {
+            return findEventFromBatch(batch, eventName);
+        } else {
+            return null;
+        }
+
     },
     getIdentityRequests = function(requests, path) {
         var returnedRequests = [],
@@ -532,7 +565,9 @@ var TestsCore = {
     setCookie: setCookie,
     setLocalStorage: setLocalStorage,
     getLocalStorage: getLocalStorage,
-    getEvent: getEvent,
+    findRequestURL: findRequestURL,
+    findBatch: findBatch,
+    findEventFromRequest: findEventFromRequest,
     findEventFromBatch: findEventFromBatch,
     getForwarderEvent: getForwarderEvent,
     findRequest: findRequest,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
I had to rebase development into the approved PR from https://github.com/mParticle/mparticle-web-sdk/pull/494 due to the potential conflicts.  Fortunately there were no conflicts, but there were a few failing tests. The first commit has already been approved (its commit hash is just difference because of the rebase). The other changes I made can easily be reviewd in commit hash `43a3b20`:
* In order to reduce the flakiness of each test, and make each test module more silo'd, I decided to add `beforeEach/afterEach` clauses where I set and reset the fetchMock each time.  This reduces some of the need to go to test-main.js to figure out what is happening (although it is less DRY, I think it's an improvement).
* The test `should trigger beacon on page visibilitychange events` was flakey and so I updated it to use lastCall instead of getCalls()[0] to always identify the correct call.
* Replaced a string with `url.events` for DRY-ness.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5315
