### PR TITLE
 test: Change url of pixel for cookie sync

### DIFF
--- a/test/src/tests-cookie-syncing.js
+++ b/test/src/tests-cookie-syncing.js
@@ -8,7 +8,7 @@ const setLocalStorage = Utils.setLocalStorage,
 let mockServer;
 
 // single pixel to load
-const pixelUrl = 'https://i.imgur.com/fvfcfpZ_d.webp';
+const pixelUrl = 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png';
 
 describe('cookie syncing', function() {
     const timeout = 500;


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Current cookie sync URL is using an imgur pixel, and imgur recently updated TOS and our cookie sync tests are breaking.  This fixes the issue.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5372
