### PR TITLE
Add Sideloaded Kit flag to Batches

### DIFF
--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -640,6 +640,12 @@ export default function Forwarders(mpInstance, kitBlocker) {
                         sideloadedKits.kits[registeredKitKey];
                     self.configureSideloadedKit(kitConstructor);
                 }
+
+                // If Sideloaded Kits are successfully registered,
+                // record this in the Store.
+                if (!isEmpty(sideloadedKits.kits)) {
+                    mpInstance._Store.isUsingSideloadedKits = true;
+                }
             }
         } catch (e) {
             mpInstance.Logger.error(

--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -56,6 +56,13 @@ export function convertEvents(
         currentConsentState = user.getConsentState();
     }
 
+    // TODO: Apply this new attribute to event-models
+    // https://go.mparticle.com/work/SQDSDKS-5458
+    interface AppInfoWithSideLoadedKitBool
+        extends EventsApi.ApplicationInformation {
+        is_using_sideloaded_kits: boolean;
+    }
+
     const upload: EventsApi.Batch = {
         source_request_id: mpInstance._Helpers.generateUniqueId(),
         mpid,
@@ -66,11 +73,18 @@ export function convertEvents(
         events: uploadEvents,
         mp_deviceid: lastEvent.DeviceId,
         sdk_version: lastEvent.SDKVersion,
+
+        // TODO: Refactor this to read from _Store or a global config
         application_info: {
             application_version: lastEvent.AppVersion,
             application_name: lastEvent.AppName,
             package: lastEvent.Package,
-        },
+            is_using_sideloaded_kits:
+                mpInstance._Store.isUsingSideloadedKits || undefined,
+            // TODO: Remove this after update to event-models
+            // https://go.mparticle.com/work/SQDSDKS-5458
+        } as AppInfoWithSideLoadedKitBool,
+
         device_info: {
             platform: EventsApi.DeviceInformationPlatformEnum.web,
             screen_width: window.screen.width,

--- a/src/store.ts
+++ b/src/store.ts
@@ -139,6 +139,7 @@ export interface IStore {
     nonCurrentUserMPIDs: Record<MPID, Dictionary>;
     identifyCalled: boolean;
     isLoggedIn: boolean;
+    isUsingSideloadedKits?: boolean;
     cookieSyncDates: Dictionary<number>;
     integrationAttributes: IntegrationAttributes;
     requireDelay: boolean;


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Add a boolean flag to batches indicating that Sideloaded kits are in use
 - Requires a corresponding PR in the [event-models repo](https://github.com/mParticle/js-models)

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Set up a sample app with a side loaded kit and verify that all batches contain `application_info` with `is_using_sideloaded_kits: true`.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5388
