### PR TITLE
fix: Support suffix in kit initialization

### DIFF
--- a/src/configAPIClient.ts
+++ b/src/configAPIClient.ts
@@ -16,6 +16,7 @@ export type SDKCompleteInitCallback = (
 
 export interface IKitConfigs extends IKitFilterSettings {
     name: string;
+    suffix?: string;
     moduleId: number;
     isDebug: boolean;
     isVisible: boolean;

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -572,9 +572,9 @@ export default function Forwarders(mpInstance, kitBlocker) {
     };
 
     this.configureUIEnabledKit = function(configuration) {
-        var newKit = null,
-            config = configuration,
-            kits = {};
+        let newKit = null;
+        let kits = {};
+        const config = configuration;
 
         // If there are kits inside of mpInstance._Store.SDKConfig.kits, then mParticle is self hosted
         if (!isEmpty(mpInstance._Store.SDKConfig.kits)) {
@@ -592,7 +592,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
                 // If a customer wanted simultaneous GA4 client and server connections,
                 // a suffix allows the SDK to distinguish the two.
                 if (kitConstructor.suffix) {
-                    var kitNameWithConstructorSuffix = `${kitConstructor.name}-${kitConstructor.suffix}`;
+                    const kitNameWithConstructorSuffix = `${kitConstructor.name}-${kitConstructor.suffix}`;
                     kits[kitNameWithConstructorSuffix] = kitConstructor;
                 } else {
                     kits[kitConstructor.name] = kitConstructor;
@@ -600,10 +600,10 @@ export default function Forwarders(mpInstance, kitBlocker) {
             });
         }
 
-        for (var name in kits) {
+        for (let name in kits) {
             // Configs are returned with suffixes also. We need to consider the
             // config suffix here to match the constructor suffix
-            var kitNameWithConfigSuffix;
+            let kitNameWithConfigSuffix;
             if (config.suffix) {
                 kitNameWithConfigSuffix = `${config.name}-${config.suffix}`;
             }

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -557,10 +557,12 @@ export default function Forwarders(mpInstance, kitBlocker) {
     // if there is a match before being initialized.
     // Only kits that are configured properly can be active and used for kit forwarding.
     this.processUIEnabledKits = function(config) {
+        let kits = this.returnKitConstructors();
+
         try {
             if (Array.isArray(config.kitConfigs) && config.kitConfigs.length) {
                 config.kitConfigs.forEach(function(kitConfig) {
-                    self.configureUIEnabledKit(kitConfig);
+                    self.configureUIEnabledKit(kitConfig, kits);
                 });
             }
         } catch (e) {
@@ -571,11 +573,8 @@ export default function Forwarders(mpInstance, kitBlocker) {
         }
     };
 
-    this.configureUIEnabledKit = function(configuration) {
-        let newKit = null;
+    this.returnKitConstructors = function() {
         let kits = {};
-        const config = configuration;
-
         // If there are kits inside of mpInstance._Store.SDKConfig.kits, then mParticle is self hosted
         if (!isEmpty(mpInstance._Store.SDKConfig.kits)) {
             kits = mpInstance._Store.SDKConfig.kits;
@@ -599,6 +598,12 @@ export default function Forwarders(mpInstance, kitBlocker) {
                 }
             });
         }
+        return kits;
+    };
+
+    this.configureUIEnabledKit = function(configuration, kits) {
+        let newKit = null;
+        const config = configuration;
 
         for (let name in kits) {
             // Configs are returned with suffixes also. We need to consider the

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -572,36 +572,52 @@ export default function Forwarders(mpInstance, kitBlocker) {
     };
 
     this.configureUIEnabledKit = function(configuration) {
-        var newForwarder = null,
+        var newKit = null,
             config = configuration,
-            forwarders = {};
+            kits = {};
 
         // If there are kits inside of mpInstance._Store.SDKConfig.kits, then mParticle is self hosted
         if (!isEmpty(mpInstance._Store.SDKConfig.kits)) {
-            forwarders = mpInstance._Store.SDKConfig.kits;
+            kits = mpInstance._Store.SDKConfig.kits;
             // otherwise mParticle is loaded via script tag
         } else if (!isEmpty(mpInstance._preInit.forwarderConstructors)) {
             mpInstance._preInit.forwarderConstructors.forEach(function(
-                forwarder
+                kitConstructor
             ) {
-                forwarders[forwarder.name] = forwarder;
+                // A suffix is added to a kitConstructor and kit config if there are multiple different
+                // versions of a client kit.  This matches the suffix in the DB.  As an example
+                // the GA4 kit has a client kit and a server side kit which has a client side
+                // component.  They share the same name/module ID in the DB, so we include a
+                // suffix to distinguish them in the kits object.
+                // If a customer wanted simultaneous GA4 client and server connections,
+                // a suffix allows the SDK to distinguish the two.
+                if (kitConstructor.suffix) {
+                    var kitNameWithConstructorSuffix = `${kitConstructor.name}-${kitConstructor.suffix}`;
+                    kits[kitNameWithConstructorSuffix] = kitConstructor;
+                } else {
+                    kits[kitConstructor.name] = kitConstructor;
+                }
             });
         }
 
-        for (var name in forwarders) {
-            if (name === config.name) {
+        for (var name in kits) {
+            // Configs are returned with suffixes also. We need to consider the
+            // config suffix here to match the constructor suffix
+            var kitNameWithConfigSuffix;
+            if (config.suffix) {
+                kitNameWithConfigSuffix = `${config.name}-${config.suffix}`;
+            }
+
+            if (name === kitNameWithConfigSuffix || name === config.name) {
                 if (
                     config.isDebug ===
                         mpInstance._Store.SDKConfig.isDevelopmentMode ||
                     config.isSandbox ===
                         mpInstance._Store.SDKConfig.isDevelopmentMode
                 ) {
-                    newForwarder = this.returnConfiguredKit(
-                        forwarders[name],
-                        config
-                    );
+                    newKit = this.returnConfiguredKit(kits[name], config);
 
-                    mpInstance._Store.configuredForwarders.push(newForwarder);
+                    mpInstance._Store.configuredForwarders.push(newKit);
                     break;
                 }
             }

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2573,6 +2573,53 @@ describe('forwarders', function() {
         done();
     });
 
+    describe('kits with suffixes', function() {
+        it('should add forwarders with suffixes and initialize them accordingly if there is a coresponding kit config with the same suffix', function(done) {
+            mParticle._resetForTests(MPConfig);
+
+            const mockForwarder = new MockForwarder('ForwarderWithSuffixV3', 1, 'v3');
+            const mockForwarder2 = new MockForwarder('ForwarderWithSuffixV4', 1, 'v4');
+            mParticle.addForwarder(mockForwarder);
+            mParticle.addForwarder(mockForwarder2);
+
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('ForwarderWithSuffixV3', 1, 'v3')
+            );
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('ForwarderWithSuffixV4', 1, 'v4')
+            );
+
+            mParticle.init(apiKey, window.mParticle.config);
+
+            mParticle
+                .getInstance()
+                ._getActiveForwarders()
+                .length.should.equal(2);
+
+            done();
+        });
+
+        it('should not add a forwarder with suffix if there is not a corresponding kit config with the same suffix', function(done) {
+            mParticle._resetForTests(MPConfig);
+
+            const mockForwarder = new MockForwarder('ForwarderWithSuffix', 1, 'v3');
+            mParticle.addForwarder(mockForwarder);
+
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('ForwarderWithSuffix', 1, 'v4')
+            );
+
+            mParticle.init(apiKey, window.mParticle.config);
+
+            mParticle
+                .getInstance()
+                ._getActiveForwarders()
+                .length.should.equal(0);
+
+            done();
+        });
+    })
+
     describe('side loaded kits', function() {
         describe('initialization', function() {
             beforeEach(function() {

--- a/test/src/utils.js
+++ b/test/src/utils.js
@@ -283,9 +283,11 @@ var pluses = /\+/g,
     forwarderDefaultConfiguration = function(
         forwarderName,
         forwarderId,
+        suffix,
     ) {
         var config = {
             name: forwarderName || 'MockForwarder',
+            suffix: suffix || null,
             moduleId: forwarderId || 1,
             isDebug: false,
             isVisible: true,
@@ -312,7 +314,7 @@ var pluses = /\+/g,
 
         return config;
     },
-    MockForwarder = function(forwarderName, forwarderId) {
+    MockForwarder = function(forwarderName, forwarderId, suffix) {
         var constructor = function() {
             var self = this;
             this.id = forwarderId || 1;
@@ -329,7 +331,6 @@ var pluses = /\+/g,
             this.receivedEvent = null;
             this.isVisible = false;
             this.logOutCalled = false;
-
             this.trackerId = null;
             this.userAttributes = {};
             this.userIdentities = null;
@@ -426,6 +427,7 @@ var pluses = /\+/g,
         };
 
         this.name = forwarderName || 'MockForwarder';
+        this.suffix = suffix || null;
         this.moduleId = forwarderId || 1;
         this.constructor = constructor;
 
@@ -446,6 +448,7 @@ var pluses = /\+/g,
             getId: getId,
             constructor: constructor,
             name: this.name,
+            suffix: this.suffix
         };
     },
     MockSideloadedKit = MockForwarder,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
In order to support allowing multiple versions of our client side kits to be served, we add support for initializing kits based on suffix.  When a client side kit has 2 options (ex Braze v3 and v4), prior to this code, because the `kits` (previously `forwarders`) object is keyed by name, Braze v3 and Braze v4 have the same name (Appboy), and one kit would be replaced when the second Braze kit was added.  Now we suffix the kits so that in the above example, the `kits` object would be:
```
{
  'Appboy-v3': {},
  'Appboy-v4': {}
]
```

I also renamed `forwarder` --> `kits` where I could in this method to avoid any confusion since we are aligning on `kits` instead of `forwarders`.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
This PR was tested along with https://github.com/mparticle-integrations/mparticle-javascript-integration-braze/pull/21 and https://github.com/mparticle-integrations/mparticle-javascript-integration-braze/pull/22 to ensure it worked with multiple suffixes of Braze.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5444