### PR TITLE
fix: Revise priority of device id when initializing state

### DIFF
--- a/src/mockBatchCreator.ts
+++ b/src/mockBatchCreator.ts
@@ -111,6 +111,7 @@ export default class _BatchValidator {
             getAppVersion: mockFunction,
             getAppName: mockFunction,
             getInstance: mockFunction,
+            getDeviceId: mockFunction,
             init: mockFunction,
             logBaseEvent: mockFunction,
             logEvent: mockFunction,

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -195,7 +195,7 @@ export default function _Persistence(mpInstance) {
                     mpInstance._Store.clientId ||
                     mpInstance._Helpers.generateUniqueId();
 
-                // For most persitence value, we prioritize localstorage/cookie values over
+                // For most persistence values, we prioritize localstorage/cookie values over
                 // Store. However, we allow device ID to be overriden via a config value and
                 // thus if it has been set before we "store in memory", we should prioritize
                 // the existing value. If neither value exist, we generate a new guid.

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -197,8 +197,10 @@ export default function _Persistence(mpInstance) {
 
                 // For most persistence values, we prioritize localstorage/cookie values over
                 // Store. However, we allow device ID to be overriden via a config value and
-                // thus if it has been set before we "store in memory", we should prioritize
-                // the existing value. If neither value exist, we generate a new guid.
+                // thus the priority of the deviceId value is
+                // 1. value passed via config.deviceId
+                // 2. previous value in persistence
+                // 3. generate new guid
                 mpInstance._Store.deviceId =
                     mpInstance._Store.deviceId ||
                     obj.gs.das ||

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -194,10 +194,16 @@ export default function _Persistence(mpInstance) {
                     obj.gs.cgid ||
                     mpInstance._Store.clientId ||
                     mpInstance._Helpers.generateUniqueId();
+
+                // For most persitence value, we prioritize localstorage/cookie values over
+                // Store. However, we allow device ID to be overriden via a config value and
+                // thus if it has been set before we "store in memory", we should prioritize
+                // the existing value. If neither value exist, we generate a new guid.
                 mpInstance._Store.deviceId =
-                    obj.gs.das ||
                     mpInstance._Store.deviceId ||
+                    obj.gs.das ||
                     mpInstance._Helpers.generateUniqueId();
+
                 mpInstance._Store.integrationAttributes = obj.gs.ia || {};
                 mpInstance._Store.context =
                     obj.gs.c || mpInstance._Store.context;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -151,6 +151,7 @@ export interface MParticleWebSDK {
     init(apiKey: string, config: SDKInitConfig, instanceName?: string): void;
     getAppName(): string;
     getAppVersion(): string;
+    getDeviceId(): string;
     getInstance(): MParticleWebSDK; // TODO: Create a new type for MParticleWebSDKInstance
     ServerModel();
     upload();

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -1877,6 +1877,25 @@ describe('migrations and persistence-related', () => {
         done();
     });
 
+    it('should prioritize device id set via mParticle.config instead of local storage', done => {
+        mParticle._resetForTests(MPConfig);
+
+        setLocalStorage();
+
+        mParticle.config.deviceId = 'guid-via-config';
+
+        mParticle.init(apiKey, mParticle.config);
+
+        mParticle.getInstance().getDeviceId().should.equal('guid-via-config');
+
+        mParticle
+            .getInstance()
+            ._Persistence.getLocalStorage()
+            .gs.das.should.equal('guid-via-config');
+
+        done();
+    });
+
     // this test confirms a bug has been fixed where setting a user attribute, then user attribute list
     // with a special character in it results in a cookie decode error, which only happened
     // when config.useCookieStorage was true

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -1878,24 +1878,34 @@ describe('migrations and persistence-related', () => {
     });
 
     it('should prioritize device id set via mParticle.config instead of local storage', done => {
-        const expectedDeviceId = 'guid-via-config';
-
         mParticle._resetForTests(MPConfig);
 
-        setLocalStorage();
+        mParticle.init(apiKey, mParticle.config);
 
-        expect(mParticle.getInstance().getDeviceId()).should.be.null;
+        const initialDeviceId = mParticle.getInstance().getDeviceId();
+
+        expect(initialDeviceId).to.not.be.null;
+
+        const expectedDeviceId = 'guid-via-config';
 
         mParticle.config.deviceId = expectedDeviceId;
 
         mParticle.init(apiKey, mParticle.config);
 
-        mParticle.getInstance().getDeviceId().should.equal(expectedDeviceId);
+        expect(
+            mParticle.getInstance().getDeviceId(),
+            'Device ID should match guid passed in via config'
+        ).to.equal(expectedDeviceId);
 
-        mParticle
-            .getInstance()
-            ._Persistence.getLocalStorage()
-            .gs.das.should.equal(expectedDeviceId);
+        expect(
+            initialDeviceId,
+            'New Device ID should not match Old Device Id'
+        ).to.not.equal(expectedDeviceId);
+
+        expect(
+            mParticle.getInstance()._Persistence.getLocalStorage().gs.das,
+            'Device ID stored in Local Storage should be the new Device ID'
+        ).to.equal(expectedDeviceId);
 
         done();
     });

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -1878,20 +1878,24 @@ describe('migrations and persistence-related', () => {
     });
 
     it('should prioritize device id set via mParticle.config instead of local storage', done => {
+        const expectedDeviceId = 'guid-via-config';
+
         mParticle._resetForTests(MPConfig);
 
         setLocalStorage();
 
-        mParticle.config.deviceId = 'guid-via-config';
+        expect(mParticle.getInstance().getDeviceId()).should.be.null;
+
+        mParticle.config.deviceId = expectedDeviceId;
 
         mParticle.init(apiKey, mParticle.config);
 
-        mParticle.getInstance().getDeviceId().should.equal('guid-via-config');
+        mParticle.getInstance().getDeviceId().should.equal(expectedDeviceId);
 
         mParticle
             .getInstance()
             ._Persistence.getLocalStorage()
-            .gs.das.should.equal('guid-via-config');
+            .gs.das.should.equal(expectedDeviceId);
 
         done();
     });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Change order of priority for device id when constructing SDK state.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, verify that sdk generates a random guid and saves it in local storage by comparing local storage value to running `mParticle.getDeviceId()` via developer console.
 - Then add `deviceId: test-device-id` to the `config` object and verify that the config device id in dev console is the same the value that was added to the config.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5411
