### PR TITLE
ci: Revise dependabot to only weekly production updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
       directory: '/'
       schedule:
           interval: weekly
+          day: 'sunday'
       target-branch: 'chore/dependabot'
       labels: ['dependabot', 'dependencies']
       open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ updates:
     - package-ecosystem: npm
       directory: '/'
       schedule:
-          interval: daily
+          interval: weekly
       target-branch: 'chore/dependabot'
       labels: ['dependabot', 'dependencies']
       open-pull-requests-limit: 10
       commit-message:
-          prefix: "chore"
+          prefix: 'chore'
       allow:
-          - dependency-type: "direct"
+          - dependency-type: 'production'


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Update Dependabot frequency to be weekly (on Sunday) instead of daily, so we can process updates on Monday before a release, if necessary.
 - Update dependency types to limit to production only.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - N/A as this is a CI/CD update

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5756
