### PR TITLE
fix: Remove slugify dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
             "version": "2.23.5",
             "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime": "^7.6.0",
-                "slugify": "^1.3.6"
+                "@babel/runtime": "^7.6.0"
             },
             "devDependencies": {
                 "@babel/core": "^7.18.6",
@@ -19659,14 +19658,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/slugify": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-            "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
-            "engines": {
-                "node": ">=8.0.0"
             }
         },
         "node_modules/socket.io": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
         "webpack-cli": "^5.0.2"
     },
     "dependencies": {
-        "@babel/runtime": "^7.6.0",
-        "slugify": "^1.3.6"
+        "@babel/runtime": "^7.6.0"
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -203,7 +203,7 @@ const isString = (value: any): boolean => typeof value === 'string';
 const isNumber = (value: any): boolean => typeof value === 'number';
 const isFunction = (fn: any): boolean => typeof fn === 'function';
 
-const toSlug = (value: any): string =>
+const toDataPlanSlug = (value: any): string =>
     // Make sure we are only acting on strings or numbers
     isStringOrNumber(value)
         ? value
@@ -212,7 +212,7 @@ const toSlug = (value: any): string =>
               .replace(/[^0-9a-zA-Z]+/g, '_')
         : '';
 
-const isDataPlanSlug = (str: string): boolean => str === toSlug(str);
+const isDataPlanSlug = (str: string): boolean => str === toDataPlanSlug(str);
 
 const isStringOrNumber = (value: any): boolean =>
     isString(value) || isNumber(value);
@@ -241,7 +241,7 @@ export {
     replaceApostrophesWithQuotes,
     replaceQuotesWithApostrophes,
     returnConvertedBoolean,
-    toSlug,
+    toDataPlanSlug,
     isString,
     isNumber,
     isFunction,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import slugify from 'slugify';
 import Constants from './constants';
 
 const { Messages } = Constants;
@@ -204,9 +203,16 @@ const isString = (value: any): boolean => typeof value === 'string';
 const isNumber = (value: any): boolean => typeof value === 'number';
 const isFunction = (fn: any): boolean => typeof fn === 'function';
 
-// TODO: Refactor this to a regex
-const isDataPlanSlug = (str: string): boolean =>
-    isString(str) && str === slugify(str);
+const toSlug = (value: any): string =>
+    // Make sure we are only acting on strings or numbers
+    isStringOrNumber(value)
+        ? value
+              .toString()
+              .toLowerCase()
+              .replace(/[^0-9a-zA-Z]+/g, '_')
+        : '';
+
+const isDataPlanSlug = (str: string): boolean => str === toSlug(str);
 
 const isStringOrNumber = (value: any): boolean =>
     isString(value) || isNumber(value);
@@ -235,6 +241,7 @@ export {
     replaceApostrophesWithQuotes,
     replaceQuotesWithApostrophes,
     returnConvertedBoolean,
+    toSlug,
     isString,
     isNumber,
     isFunction,

--- a/test/src/tests-event-logging.js
+++ b/test/src/tests-event-logging.js
@@ -809,7 +809,7 @@ describe('event logging', function() {
             eventBatchingIntervalMillis: 0,
         }
         mParticle.config.dataPlan = {
-            planId: 'plan-slug',
+            planId: 'plan_slug',
             planVersion: 10,
         };
 
@@ -822,7 +822,7 @@ describe('event logging', function() {
         batch.should.have.property('context');
         batch.context.should.have.property('data_plan');
         batch.context.data_plan.should.have.property('plan_version', 10);
-        batch.context.data_plan.should.have.property('plan_id', 'plan-slug');
+        batch.context.data_plan.should.have.property('plan_id', 'plan_slug');
 
         delete window.mParticle.config.flags
 
@@ -834,7 +834,7 @@ describe('event logging', function() {
             eventBatchingIntervalMillis: 0,
         }
         mParticle.config.dataPlan = {
-            planId: 'plan-slug'
+            planId: 'plan_slug'
         };
 
         mParticle.init(apiKey, mParticle.config);
@@ -846,7 +846,7 @@ describe('event logging', function() {
         batch.should.have.property('context');
         batch.context.should.have.property('data_plan');
         batch.context.data_plan.should.not.have.property('plan_version');
-        batch.context.data_plan.should.have.property('plan_id', 'plan-slug');
+        batch.context.data_plan.should.have.property('plan_id', 'plan_slug');
 
         delete window.mParticle.config.flags
 

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -964,7 +964,7 @@ describe('forwarders', function() {
 
         window.mParticle.config.dataPlan = {
             planVersion: 10,
-            planId: 'plan-slug',
+            planId: 'plan_slug',
         };
 
         window.mParticle.config.flags = {
@@ -990,7 +990,7 @@ describe('forwarders', function() {
         event.should.have.property('attrs');
         event.should.have.property('dp');
         event.dp.should.have.property('PlanVersion', 10);
-        event.dp.should.have.property('PlanId', 'plan-slug');
+        event.dp.should.have.property('PlanId', 'plan_slug');
         event.should.have.property('dp');
         event.should.have.property('sdk', mParticle.getVersion());
         event.should.have.property('dt', MessageType.PageEvent);

--- a/test/src/tests-serverModel.ts
+++ b/test/src/tests-serverModel.ts
@@ -1325,7 +1325,7 @@ describe('ServerModel', () => {
         it('Should convert data plan id to server DTO', function(done) {
             mParticle._resetForTests();
             mParticle.config.dataPlan = {
-                planId: 'plan-slug',
+                planId: 'plan_slug',
             };
 
             mParticle.init('foo', mParticle.config);
@@ -1336,7 +1336,7 @@ describe('ServerModel', () => {
                 .getInstance()
                 ._ServerModel.convertEventToV2DTO(sdkEvent as IUploadObject);
 
-            upload.should.have.property('dp_id', 'plan-slug');
+            upload.should.have.property('dp_id', 'plan_slug');
             upload.should.not.have.property('dp_v');
             done();
         });
@@ -1363,7 +1363,7 @@ describe('ServerModel', () => {
         it('Should convert entire data plan object to server DTO', function(done) {
             mParticle._resetForTests();
             mParticle.config.dataPlan = {
-                planId: 'plan-slug',
+                planId: 'plan_slug',
                 planVersion: 10,
             };
 
@@ -1375,7 +1375,7 @@ describe('ServerModel', () => {
                 .getInstance()
                 ._ServerModel.convertEventToV2DTO(sdkEvent as IUploadObject);
 
-            upload.should.have.property('dp_id', 'plan-slug');
+            upload.should.have.property('dp_id', 'plan_slug');
             upload.should.have.property('dp_v', 10);
             done();
         });

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -164,14 +164,14 @@ describe('Store', () => {
         const dataPlanConfig = {
             ...sampleConfig,
             dataPlan: {
-                planId: 'test-data-plan',
+                planId: 'test_data_plan',
                 planVersion: 3,
             },
         };
         const store: IStore = new Store(dataPlanConfig, window.mParticle);
 
         expect(store.SDKConfig.dataPlan, 'dataPlan').to.deep.equal({
-            PlanId: 'test-data-plan',
+            PlanId: 'test_data_plan',
             PlanVersion: 3,
         });
     });

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -19,7 +19,7 @@ import {
     replaceQuotesWithApostrophes,
     returnConvertedBoolean,
     revertCookieString,
-    toSlug,
+    toDataPlanSlug,
 } from '../../src/utils';
 import { expect } from 'chai';
 
@@ -274,24 +274,24 @@ describe('Utils', () => {
         })
     });
 
-    describe('#isSlug', () => {
+    describe('#toDataPlanSlug', () => {
         it('should convert a string to a slug', () => {
-            expect(toSlug('string')).to.equal('string');
-            expect(toSlug('42')).to.equal('42');
-            expect(toSlug(37)).to.equal('37');
-            expect(toSlug('string with spaces')).to.equal('string_with_spaces');
-            expect(toSlug('kabob-case-string')).to.equal('kabob_case_string');
-            expect(toSlug('PascalSlug')).to.equal('pascalslug');
-            expect(toSlug('under_score_slug')).to.equal('under_score_slug');
+            expect(toDataPlanSlug('string')).to.equal('string');
+            expect(toDataPlanSlug('42')).to.equal('42');
+            expect(toDataPlanSlug(37)).to.equal('37');
+            expect(toDataPlanSlug('string with spaces')).to.equal('string_with_spaces');
+            expect(toDataPlanSlug('kabob-case-string')).to.equal('kabob_case_string');
+            expect(toDataPlanSlug('PascalSlug')).to.equal('pascalslug');
+            expect(toDataPlanSlug('under_score_slug')).to.equal('under_score_slug');
         });
 
         it('should convert non-strings to an empty string', () => {
-            expect(toSlug(true)).to.equal('');
-            expect(toSlug([])).to.equal('');
-            expect(toSlug({})).to.equal('');
-            expect(toSlug(null)).to.equal('');
-            expect(toSlug(undefined)).to.equal('');
-            expect(toSlug(()=>{})).to.equal('');
+            expect(toDataPlanSlug(true)).to.equal('');
+            expect(toDataPlanSlug([])).to.equal('');
+            expect(toDataPlanSlug({})).to.equal('');
+            expect(toDataPlanSlug(null)).to.equal('');
+            expect(toDataPlanSlug(undefined)).to.equal('');
+            expect(toDataPlanSlug(()=>{})).to.equal('');
         });
     });
 

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -19,6 +19,7 @@ import {
     replaceQuotesWithApostrophes,
     returnConvertedBoolean,
     revertCookieString,
+    toSlug,
 } from '../../src/utils';
 import { expect } from 'chai';
 
@@ -273,8 +274,31 @@ describe('Utils', () => {
         })
     });
 
+    describe('#isSlug', () => {
+        it('should convert a string to a slug', () => {
+            expect(toSlug('string')).to.equal('string');
+            expect(toSlug('42')).to.equal('42');
+            expect(toSlug(37)).to.equal('37');
+            expect(toSlug('string with spaces')).to.equal('string_with_spaces');
+            expect(toSlug('kabob-case-string')).to.equal('kabob_case_string');
+            expect(toSlug('PascalSlug')).to.equal('pascalslug');
+            expect(toSlug('under_score_slug')).to.equal('under_score_slug');
+        });
+
+        it('should convert non-strings to an empty string', () => {
+            expect(toSlug(true)).to.equal('');
+            expect(toSlug([])).to.equal('');
+            expect(toSlug({})).to.equal('');
+            expect(toSlug(null)).to.equal('');
+            expect(toSlug(undefined)).to.equal('');
+            expect(toSlug(()=>{})).to.equal('');
+        });
+    });
+
     describe('#isDataPlanSlug', function () {
         it('handles numbers', function () {
+            // Non-strings will be rejected. This is to simply validate
+            // that it returns false
             expect(isDataPlanSlug(35 as unknown as string)).to.equal(false);
         });
 
@@ -283,13 +307,11 @@ describe('Utils', () => {
         });
 
         it('handles PascalCase', function () {
-            // TODO: Remove support for kabob case once we remove slugify
-            expect(isDataPlanSlug('PascalSlug')).to.equal(true);
+            expect(isDataPlanSlug('PascalSlug')).to.equal(false);
         });
 
         it('handles kabob-case-slug', function () {
-            // TODO: Remove support for kabob case once we remove slugify
-            expect(isDataPlanSlug('kabob-case-slug')).to.equal(true);
+            expect(isDataPlanSlug('kabob-case-slug')).to.equal(false);
         });
 
         it('handles simple string', function () {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Replace Dependency on `Slugify` without using any polyfills or JS functions that are incompatible with ES5.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, attempt to create a config with a data plan that does not conform to our Data Plan naming format.
 - Verify that this will be rejected via an error in the Dev Console.
 - Verify that a data plan that is correct will send valid data to the live stream.

### Invalid Data Plan Slug
![Screenshot 2023-10-09 at 4 20 57 PM](https://github.com/mParticle/mparticle-web-sdk/assets/49695018/24adcb14-1616-4583-8079-6a2132a21326)

### Valid Data Plan Slug

![Screenshot 2023-10-09 at 4 22 59 PM](https://github.com/mParticle/mparticle-web-sdk/assets/49695018/8498d558-e10e-41d1-ae55-ef381a16817b)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-4077
