### PR TITLE
fix: Respect sideloaded kit filter dictionaries

### DIFF
--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -629,61 +629,47 @@ export default function Forwarders(mpInstance, kitBlocker) {
         }
     };
 
-    // Sideloaded kits are not configured in the UI and do not have kit configurations
-    // They are automatically added to active forwarders.
+    // Unlike UI enabled kits, sideloaded kits are always added to active forwarders.
 
-    // TODO: Sideloading kits currently requires the use of a register method
+    // TODO: Sideloading kits currently require the use of a register method
     // which requires an object on which to be registered.
-    // In the future, when all kits are moved to the config rather than
+    // In the future, when all kits are moved to the mpConfig rather than
     // there being a separate process for MP configured kits and
     // sideloaded kits, this will need to be refactored.
-    this.processSideloadedKits = function(config) {
+    this.processSideloadedKits = function(mpConfig) {
         try {
-            if (Array.isArray(config.sideloadedKits)) {
-                const sideloadedKits = { kits: {} };
-                // First register each kit's constructor onto sideloadedKits,
-                // which is typed { kits: Dictionary<constructor> }.
-                // The constructors are keyed by the name of the kit.
-                config.sideloadedKits.forEach(function(sideloadedKit) {
+            if (Array.isArray(mpConfig.sideloadedKits)) {
+                const registeredSideloadedKits = { kits: {} };
+                const unregisteredSideloadedKits = mpConfig.sideloadedKits;
+                unregisteredSideloadedKits.forEach(function(unregisteredKit) {
                     try {
-                        // The name of a kit exists only inside each kit when the constructor
-                        // is invoked, and the name gets set on the sideloadedKits.kits object
-                        // We cannot determine the name of it unless we compare what the
-                        // sideloadedkit object looks like before and after a kit is registered
-                        const previousKitNames = Object.keys(
-                            sideloadedKits.kits
+                        // Register each kit's constructor onto unregisteredKits.
+                        // Then add the kit filters.
+                        let kitName = unregisteredKit.kitInstance.name;
+                        unregisteredKit.kitInstance.register(
+                            registeredSideloadedKits
                         );
-                        let currentKitName = null;
-                        sideloadedKit.kitInstance.register(sideloadedKits);
-                        const newKitNames = Object.keys(sideloadedKits.kits);
-
-                        newKitNames.forEach(function(newKitName) {
-                            if (previousKitNames.indexOf(newKitName) === -1) {
-                                currentKitName = newKitName;
-                            }
-                        });
-
-                        sideloadedKits.kits[currentKitName].config =
-                            sideloadedKit.filterDictionary;
+                        registeredSideloadedKits.kits[kitName].filters =
+                            unregisteredKit.filterDictionary;
                     } catch (e) {
                         console.error(
                             'Error registering sideloaded kit ' +
-                                sideloadedKit.kitInstance.name
+                                unregisteredKit.kitInstance.name
                         );
                     }
                 });
 
-                // Then configure each kit
-                for (const registeredKitKey in sideloadedKits.kits) {
-                    const kitConstructor =
-                        sideloadedKits.kits[registeredKitKey];
-                    self.configureSideloadedKit(kitConstructor);
+                // Then configure each registered kit
+                for (const registeredKitKey in registeredSideloadedKits.kits) {
+                    const registeredKit =
+                        registeredSideloadedKits.kits[registeredKitKey];
+                    self.configureSideloadedKit(registeredKit);
                 }
 
                 // If Sideloaded Kits are successfully registered,
                 // record this in the Store.
-                if (!isEmpty(sideloadedKits.kits)) {
-                    const kitKeys = Object.keys(sideloadedKits.kits);
+                if (!isEmpty(registeredSideloadedKits.kits)) {
+                    const kitKeys = Object.keys(registeredSideloadedKits.kits);
                     mpInstance._Store.sideloadedKitsCount = kitKeys.length;
                 }
             }
@@ -698,7 +684,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
     // kits can be included via mParticle UI, or via sideloaded kit config API
     this.configureSideloadedKit = function(kitConstructor) {
         mpInstance._Store.configuredForwarders.push(
-            this.returnConfiguredKit(kitConstructor, kitConstructor.config)
+            this.returnConfiguredKit(kitConstructor, kitConstructor.filters)
         );
     };
 

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -641,6 +641,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
             if (Array.isArray(mpConfig.sideloadedKits)) {
                 const registeredSideloadedKits = { kits: {} };
                 const unregisteredSideloadedKits = mpConfig.sideloadedKits;
+
                 unregisteredSideloadedKits.forEach(function(unregisteredKit) {
                     try {
                         // Register each sideloaded kit, which adds a key of the sideloaded kit name
@@ -648,7 +649,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
                         unregisteredKit.kitInstance.register(
                             registeredSideloadedKits
                         );
-                        let kitName = unregisteredKit.kitInstance.name;
+                        const kitName = unregisteredKit.kitInstance.name;
                         // Then add the kit filters to each registered kit.
                         registeredSideloadedKits.kits[kitName].filters =
                             unregisteredKit.filterDictionary;

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -646,7 +646,25 @@ export default function Forwarders(mpInstance, kitBlocker) {
                 // The constructors are keyed by the name of the kit.
                 config.sideloadedKits.forEach(function(sideloadedKit) {
                     try {
+                        // The name of a kit exists only inside each kit when the constructor
+                        // is invoked, and the name gets set on the sideloadedKits.kits object
+                        // We cannot determine the name of it unless we compare what the
+                        // sideloadedkit object looks like before and after a kit is registered
+                        const previousKitNames = Object.keys(
+                            sideloadedKits.kits
+                        );
+                        let currentKitName = null;
                         sideloadedKit.kitInstance.register(sideloadedKits);
+                        const newKitNames = Object.keys(sideloadedKits.kits);
+
+                        newKitNames.forEach(function(newKitName) {
+                            if (previousKitNames.indexOf(newKitName) === -1) {
+                                currentKitName = newKitName;
+                            }
+                        });
+
+                        sideloadedKits.kits[currentKitName].config =
+                            sideloadedKit.filterDictionary;
                     } catch (e) {
                         console.error(
                             'Error registering sideloaded kit ' +
@@ -680,7 +698,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
     // kits can be included via mParticle UI, or via sideloaded kit config API
     this.configureSideloadedKit = function(kitConstructor) {
         mpInstance._Store.configuredForwarders.push(
-            this.returnConfiguredKit(kitConstructor)
+            this.returnConfiguredKit(kitConstructor, kitConstructor.config)
         );
     };
 

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -643,12 +643,13 @@ export default function Forwarders(mpInstance, kitBlocker) {
                 const unregisteredSideloadedKits = mpConfig.sideloadedKits;
                 unregisteredSideloadedKits.forEach(function(unregisteredKit) {
                     try {
-                        // Register each kit's constructor onto unregisteredKits.
-                        // Then add the kit filters.
-                        let kitName = unregisteredKit.kitInstance.name;
+                        // Register each sideloaded kit, which adds a key of the sideloaded kit name
+                        // and a value of the sideloaded kit constructor.
                         unregisteredKit.kitInstance.register(
                             registeredSideloadedKits
                         );
+                        let kitName = unregisteredKit.kitInstance.name;
+                        // Then add the kit filters to each registered kit.
                         registeredSideloadedKits.kits[kitName].filters =
                             unregisteredKit.filterDictionary;
                     } catch (e) {

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2739,7 +2739,7 @@ describe('forwarders', function() {
                 );
             });
 
-            describe('filter dictionary integration tests', function() {
+            describe.only('filter dictionary integration tests', function() {
                 let sideloadedKit1;
                 let sideloadedKit2;
                 let mpSideloadedKit1;
@@ -2783,11 +2783,13 @@ describe('forwarders', function() {
 
                     // The received event gets replaced by the last event sent to the forwarder
                     // SideloadedKit11 has received the session start event, but not the Test Event
+                    // SideloadedKit22 will receive the Test Event
                     window.SideloadedKit11.instance.receivedEvent.EventName.should.not.equal('Test Event');
                     window.SideloadedKit22.instance.receivedEvent.EventName.should.equal('Test Event');
 
                     mParticle.logEvent('Test Event2');
 
+                    // SideloadedKit11 receives Test Event2, but SideloadedKit22 does not
                     window.SideloadedKit11.instance.receivedEvent.EventName.should.equal('Test Event2');
                     window.SideloadedKit22.instance.receivedEvent.EventName.should.not.equal('Test Event2');
                 });
@@ -2804,17 +2806,19 @@ describe('forwarders', function() {
                     mParticle.logEvent('Test Event', mParticle.EventType.Unknown);
 
                     // The received event gets replaced by the last event sent to the forwarder
-                    // SideloadedKit11 has received the session start event, but not the Test Event
+                    // SideloadedKit11 has received the session start event, but not the Test Event of EventType.Unknown 
+                    // SideloadedKit22 will receive the Test Event of EventType.Unknown 
                     window.SideloadedKit11.instance.receivedEvent.EventName.should.not.equal('Test Event');
                     window.SideloadedKit22.instance.receivedEvent.EventName.should.equal('Test Event');
 
                     mParticle.logEvent('Test Event2', mParticle.EventType.Navigation);
 
+                    // SideloadedKit11 receives the Navigation Event, SideloadedKit22 does not
                     window.SideloadedKit11.instance.receivedEvent.EventName.should.equal('Test Event2');
                     window.SideloadedKit22.instance.receivedEvent.EventName.should.not.equal('Test Event2');
                 });
 
-                it('should filter event attribute out properly when set', function() {
+                it('should filter event attributes out properly when set', function() {
                     mpSideloadedKit1.addEventAttributeFilter(mParticle.EventType.Navigation, 'Test Event', 'testAttr1');
                     mpSideloadedKit2.addEventAttributeFilter(mParticle.EventType.Navigation, 'Test Event', 'testAttr2');
 
@@ -2831,10 +2835,9 @@ describe('forwarders', function() {
 
                     mParticle.logEvent('Test Event', mParticle.EventType.Navigation, attrs);
 
-                    // The received event gets replaced by the last event sent to the forwarder
-                    // SideloadedKit11 has received the session start event, but not the Test Event
                     window.SideloadedKit11.instance.receivedEvent.EventAttributes.should.have.property('testAttr2', 'bar');
                     window.SideloadedKit11.instance.receivedEvent.EventAttributes.should.not.property('testAttr1');
+s
                     window.SideloadedKit22.instance.receivedEvent.EventAttributes.should.have.property('testAttr1', 'foo');
                     window.SideloadedKit22.instance.receivedEvent.EventAttributes.should.not.property('testAttr2');
                 });
@@ -2852,14 +2855,14 @@ describe('forwarders', function() {
                     mParticle.logPageView('Test Screen Name 1')
 
                     // The received event gets replaced by the last event sent to the forwarder
-                    // SideloadedKit11 has received the session start event, but not the Test Event
+                    // SideloadedKit11 has received the session start event, but not the Test Screen Name 1 event
+                    // SideloadedKit22 does receive it
                     window.SideloadedKit11.instance.receivedEvent.EventName.should.not.equal('Test Screen Name 1');
                     window.SideloadedKit22.instance.receivedEvent.EventName.should.equal('Test Screen Name 1');
 
                     mParticle.logPageView('Test Screen Name 2')
 
-                    // The received event gets replaced by the last event sent to the forwarder
-                    // SideloadedKit11 has received the session start event, but not the Test Event
+                    // SideloadedKit11 will receive Test Screen Name 2, but SideloadedKit22 does not
                     window.SideloadedKit11.instance.receivedEvent.EventName.should.equal('Test Screen Name 2');
                     window.SideloadedKit22.instance.receivedEvent.EventName.should.not.equal('Test Screen Name 2');
                 });
@@ -2881,8 +2884,6 @@ describe('forwarders', function() {
 
                     mParticle.logPageView('Test Screen Name 1', attrs)
 
-                    // The received event gets replaced by the last event sent to the forwarder
-                    // SideloadedKit11 has received the session start event, but not the Test Event
                     window.SideloadedKit11.instance.receivedEvent.EventAttributes.should.have.property('testAttr2', 'bar');
                     window.SideloadedKit11.instance.receivedEvent.EventAttributes.should.not.property('testAttr1');
                     window.SideloadedKit22.instance.receivedEvent.EventAttributes.should.have.property('testAttr1', 'foo');
@@ -2908,13 +2909,13 @@ describe('forwarders', function() {
 
                     mParticle.logPageView('Test Screen Name 1');
 
-                    // The received event gets replaced by the last event sent to the forwarder
-                    // SideloadedKit11 has received the session start event, but not the Test Event
+                    // SideloadedKit11 will receive an event with only an Other identity type
                     window.SideloadedKit11.instance.receivedEvent.UserIdentities.length.should.equal(1)
-                    window.SideloadedKit11.instance.receivedEvent.UserIdentities[0].Type.should.equal(0)
+                    window.SideloadedKit11.instance.receivedEvent.UserIdentities[0].Type.should.equal(mParticle.IdentityType.Other)
                     window.SideloadedKit11.instance.receivedEvent.UserIdentities[0].Identity.should.equal('test')
+                    // SideloadedKit22 will receive an event with only an Email identity type
                     window.SideloadedKit22.instance.receivedEvent.UserIdentities.length.should.equal(1)
-                    window.SideloadedKit22.instance.receivedEvent.UserIdentities[0].Type.should.equal(7)
+                    window.SideloadedKit22.instance.receivedEvent.UserIdentities[0].Type.should.equal(mParticle.IdentityType.Other)
                     window.SideloadedKit22.instance.receivedEvent.UserIdentities[0].Identity.should.equal('test@gmail.com')
                 });
 
@@ -2933,10 +2934,9 @@ describe('forwarders', function() {
 
                     mParticle.logPageView('Test Screen Name 1');
 
-                    // The received event gets replaced by the last event sent to the forwarder
-                    // SideloadedKit11 has received the session start event, but not the Test Event
                     window.SideloadedKit11.instance.receivedEvent.UserAttributes.should.have.property('testAttr2', 'bar');
                     window.SideloadedKit11.instance.receivedEvent.UserAttributes.should.not.have.property('testAttr1');
+
                     window.SideloadedKit22.instance.receivedEvent.UserAttributes.should.have.property('testAttr1', 'foo');
                     window.SideloadedKit22.instance.receivedEvent.UserAttributes.should.not.have.property('testAttr2');
                 });

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2837,7 +2837,7 @@ describe('forwarders', function() {
 
                     window.SideloadedKit11.instance.receivedEvent.EventAttributes.should.have.property('testAttr2', 'bar');
                     window.SideloadedKit11.instance.receivedEvent.EventAttributes.should.not.property('testAttr1');
-s
+
                     window.SideloadedKit22.instance.receivedEvent.EventAttributes.should.have.property('testAttr1', 'foo');
                     window.SideloadedKit22.instance.receivedEvent.EventAttributes.should.not.property('testAttr2');
                 });

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -2739,7 +2739,7 @@ describe('forwarders', function() {
                 );
             });
 
-            describe.only('filter dictionary integration tests', function() {
+            describe('filter dictionary integration tests', function() {
                 let sideloadedKit1;
                 let sideloadedKit2;
                 let mpSideloadedKit1;
@@ -2915,7 +2915,7 @@ describe('forwarders', function() {
                     window.SideloadedKit11.instance.receivedEvent.UserIdentities[0].Identity.should.equal('test')
                     // SideloadedKit22 will receive an event with only an Email identity type
                     window.SideloadedKit22.instance.receivedEvent.UserIdentities.length.should.equal(1)
-                    window.SideloadedKit22.instance.receivedEvent.UserIdentities[0].Type.should.equal(mParticle.IdentityType.Other)
+                    window.SideloadedKit22.instance.receivedEvent.UserIdentities[0].Type.should.equal(mParticle.IdentityType.Email)
                     window.SideloadedKit22.instance.receivedEvent.UserIdentities[0].Identity.should.equal('test@gmail.com')
                 });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Filtered dictionaries were added after supporting side loaded kits.  However, after I added the filtered dictionaries support to the sideloaded kit class, I never included it when configuring the kits in the initialization flow, so all events were sent regardless of what filters were added.  This fixes that.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Added local tests, tested in a local app.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5893