### PR TITLE
ci: Add Browserstack GIthub workflow

### DIFF
--- a/.github/workflows/cross-browser-testing.yml
+++ b/.github/workflows/cross-browser-testing.yml
@@ -1,0 +1,40 @@
+name: 'BrowserStack Test'
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  ubuntu-job:
+    name: 'BrowserStack Test on Ubuntu'
+    runs-on: ubuntu-latest  # Can be self-hosted runner also
+    steps:
+
+      - name: 'BrowserStack Env Setup'  # Invokes the setup-env action
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+      - name: 'BrowserStack Local Tunnel Setup'  # Invokes the setup-local action
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: start
+          local-identifier: random
+
+# The next 3 steps are for building the web application to be tested and starting the web server on the runner environment
+
+      - name: 'Checkout the repository'
+        uses: actions/checkout@v3
+
+      - name: 'Run NPM CI'
+        run: npm ci
+
+        # ensures the tests are es5 compatible
+      - name: 'Run NPM build:CBT'
+        run: npm build:CBT
+
+      - name: 'Run Browserstack Tests'
+        run: npm run test:browserstack
+
+      - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: stop

--- a/.github/workflows/cross-browser-testing.yml
+++ b/.github/workflows/cross-browser-testing.yml
@@ -29,7 +29,7 @@ jobs:
 
         # ensures the tests are es5 compatible
       - name: 'Run NPM build:cbt'
-        run: npm build:cbt
+        run: npm run build:cbt
 
       - name: 'Run Browserstack Tests'
         run: npm run test:browserstack

--- a/.github/workflows/cross-browser-testing.yml
+++ b/.github/workflows/cross-browser-testing.yml
@@ -28,8 +28,8 @@ jobs:
         run: npm ci
 
         # ensures the tests are es5 compatible
-      - name: 'Run NPM build:CBT'
-        run: npm build:CBT
+      - name: 'Run NPM build:cbt'
+        run: npm build:cbt
 
       - name: 'Run Browserstack Tests'
         run: npm run test:browserstack

--- a/test/cross-browser-testing/browserstack.karma.config.js
+++ b/test/cross-browser-testing/browserstack.karma.config.js
@@ -25,19 +25,42 @@ if (DEBUG === 'true') {
 
 const customLaunchers = {
     // Full list of supported browsers - https://www.browserstack.com/list-of-browsers-and-platforms/live
-    // Fails a few tests related to setTimeout
-    bs_chrome_mac_48: {
+    // https://www.w3schools.com/js/js_versions.asp shows a list of browsers that support ES6.  
+    // The below list is primarily the version just before that, or if that version was not available on Browserstack to test, the next version was
+    // All versions below, including earlier versions of each browser, have a combined ~0.37% market share according to
+    // www.browserslist.dev.  Query for "opera < 38, safari < 12, chrome < 51, firefox <52, edge < 15"
+    bs_chrome_mac_50: {
       base: 'BrowserStack',
       browser: 'chrome',
-      browser_version: '48.0',
+      browser_version: '50.0',
       os: 'OS X',
       os_version: 'Mojave'
     },
-    // Oldest Chrome version to pass all tests
-    bs_chrome_mac_49: {
+    bs_firefox_mac_51: {
       base: 'BrowserStack',
-      browser: 'chrome',
-      browser_version: '49.0',
+      browser: 'firefox',
+      browser_version: '51.0',
+      os: 'OS X',
+      os_version: 'Mojave'
+    },
+    bs_edge_windows_15: {
+      base: 'BrowserStack',
+      browser: 'edge',
+      browser_version: '15.0',
+      os: 'Windows',
+      os_version: '10'
+    },
+    bs_safari_mac_11: {
+      base: 'BrowserStack',
+      browser: 'safari',
+      browser_version: '11.1',
+      os: 'OS X',
+      os_version: 'High Sierra'
+    },
+    bs_opera_mac_37: {
+      base: 'BrowserStack',
+      browser: 'opera',
+      browser_version: '37.0',
       os: 'OS X',
       os_version: 'Mojave'
     },

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -100,24 +100,20 @@ describe('core SDK', function() {
     });
 
     it('creates a new dateLastEventSent when logging an event, and retains the previous one when ending session', function(done) {
+        const clock = sinon.useFakeTimers();
         mParticle.logEvent('Test Event1');
         const testEvent1 = findEventFromRequest(fetchMock.calls(), 'Test Event1');
+        clock.tick(100);
 
-        setTimeout(function() {
-            mParticle.logEvent('Test Event2');
-            const testEvent2 = findEventFromRequest(fetchMock.calls(), 'Test Event2');
+        mParticle.logEvent('Test Event2');
+        const testEvent2 = findEventFromRequest(fetchMock.calls(), 'Test Event2');
 
-            mParticle.endSession();
-            const sessionEndEvent = findEventFromRequest(fetchMock.calls(), 'session_end');
+        mParticle.endSession();
+        const sessionEndEvent = findEventFromRequest(fetchMock.calls(), 'session_end');
+        Should(testEvent1.data.timestamp_unixtime_ms).not.equal(testEvent2.data.timestamp_unixtime_ms);
+        Should(testEvent2.data.timestamp_unixtime_ms).equal(sessionEndEvent.data.timestamp_unixtime_ms);
 
-            const result1 = testEvent1.data.timestamp_unixtime_ms === testEvent2.data.timestamp_unixtime_ms;
-            const result2 = testEvent2.data.timestamp_unixtime_ms === sessionEndEvent.data.timestamp_unixtime_ms;
-
-            Should(result1).not.be.ok();
-            Should(result2).be.ok();
-
-            done();
-        }, 5);
+        done();
     });
 
     it('should process ready queue when initialized', function(done) {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
This PR sets up Browserstack tests in a Github Action. It follows the example workflow provided by the Browserstack docs here - https://www.browserstack.com/docs/automate/selenium/github-actions#sample-github-workflow-showing-a-browserstack-test

We originally discussed having it only be on release. However, I think it makes sense for it to be on push/pr also because we wouldn't want something to pass our non-CBT tests, merge them in, then upon release see that something is broken.  Given that it is its own workflow, and our workflow minutes are unlimited for public repos, I see no issue with this.  Note that this successfully runs [here](https://github.com/mParticle/mparticle-web-sdk/actions/runs/6818006161/job/18542716276) (although there are some failed tests, Chrome 48 tests here fail a few in the GHA, which matches the locally run Browserstack npm task, and Chrome 49 simply has a failed flaky test):

 ## Testing Plan
 - [] Was this tested locally? If not, explain why.
Not locally, but the action successfully runs here - https://github.com/mParticle/mparticle-web-sdk/actions/runs/6818006161/job/18542716276

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5792