### PR TITLE
ci: Add legacy browsers for testing

### DIFF
--- a/test/cross-browser-testing/browserstack.karma.config.js
+++ b/test/cross-browser-testing/browserstack.karma.config.js
@@ -28,7 +28,7 @@ const customLaunchers = {
     // https://www.w3schools.com/js/js_versions.asp shows a list of browsers that support ES6.  
     // The below list is primarily the version just before that, or if that version was not available on Browserstack to test, the next version was
     // All versions below, including earlier versions of each browser, have a combined ~0.37% market share according to
-    // www.browserlist.dev.  Query for "opera < 38, safari < 12, chrome < 51, firefox <52, edge < 15"
+    // www.browserslist.dev.  Query for "opera < 38, safari < 12, chrome < 51, firefox <52, edge < 15"
     bs_chrome_mac_50: {
       base: 'BrowserStack',
       browser: 'chrome',

--- a/test/cross-browser-testing/browserstack.karma.config.js
+++ b/test/cross-browser-testing/browserstack.karma.config.js
@@ -25,22 +25,53 @@ if (DEBUG === 'true') {
 
 const customLaunchers = {
     // Full list of supported browsers - https://www.browserstack.com/list-of-browsers-and-platforms/live
-    // Fails a few tests related to setTimeout
-    bs_chrome_mac_48: {
+    // https://www.w3schools.com/js/js_versions.asp shows a list of browsers that support ES6.  
+    // The below list is primarily the version just before that, or if that version was not available on Browserstack to test, the next version was
+    // All versions below, including earlier versions of each browser, have a combined ~0.37% market share according to
+    // www.browserlist.dev.  Query for "opera < 38, safari < 12, chrome < 51, firefox <52, edge < 15"
+    bs_chrome_mac_50: {
       base: 'BrowserStack',
       browser: 'chrome',
-      browser_version: '48.0',
+      browser_version: '50.0',
+      os: 'OS X',
+      os_version: 'Mojave'
+    },
+    bs_firefox_mac_51: {
+      base: 'BrowserStack',
+      browser: 'firefox',
+      browser_version: '51.0',
+      os: 'OS X',
+      os_version: 'Mojave'
+    },
+    bs_edge_windows_15: {
+      base: 'BrowserStack',
+      browser: 'edge',
+      browser_version: '15.0',
+      os: 'Windows',
+      os_version: '10'
+    },
+    bs_safari_mac_11: {
+      base: 'BrowserStack',
+      browser: 'safari',
+      browser_version: '11.1',
+      os: 'OS X',
+      os_version: 'High Sierra'
+    },
+    bs_opera_mac_37: {
+      base: 'BrowserStack',
+      browser: 'opera',
+      browser_version: '37.0',
       os: 'OS X',
       os_version: 'Mojave'
     },
     // Oldest Chrome version to pass all tests
-    bs_chrome_mac_49: {
-      base: 'BrowserStack',
-      browser: 'chrome',
-      browser_version: '49.0',
-      os: 'OS X',
-      os_version: 'Mojave'
-    },
+    // bs_chrome_mac_49: {
+    //   base: 'BrowserStack',
+    //   browser: 'chrome',
+    //   browser_version: '49.0',
+    //   os: 'OS X',
+    //   os_version: 'Mojave'
+    // },
 }
 
 module.exports = function(config) {

--- a/test/cross-browser-testing/browserstack.karma.config.js
+++ b/test/cross-browser-testing/browserstack.karma.config.js
@@ -64,14 +64,6 @@ const customLaunchers = {
       os: 'OS X',
       os_version: 'Mojave'
     },
-    // Oldest Chrome version to pass all tests
-    // bs_chrome_mac_49: {
-    //   base: 'BrowserStack',
-    //   browser: 'chrome',
-    //   browser_version: '49.0',
-    //   os: 'OS X',
-    //   os_version: 'Mojave'
-    // },
 }
 
 module.exports = function(config) {

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -100,24 +100,20 @@ describe('core SDK', function() {
     });
 
     it('creates a new dateLastEventSent when logging an event, and retains the previous one when ending session', function(done) {
+        let clock = sinon.useFakeTimers();
         mParticle.logEvent('Test Event1');
         const testEvent1 = findEventFromRequest(fetchMock.calls(), 'Test Event1');
+        clock.tick(100);
 
-        setTimeout(function() {
-            mParticle.logEvent('Test Event2');
-            const testEvent2 = findEventFromRequest(fetchMock.calls(), 'Test Event2');
+        mParticle.logEvent('Test Event2');
+        const testEvent2 = findEventFromRequest(fetchMock.calls(), 'Test Event2');
 
-            mParticle.endSession();
-            const sessionEndEvent = findEventFromRequest(fetchMock.calls(), 'session_end');
+        mParticle.endSession();
+        const sessionEndEvent = findEventFromRequest(fetchMock.calls(), 'session_end');
+        Should(testEvent1.data.timestamp_unixtime_ms).not.equal(testEvent2.data.timestamp_unixtime_ms);
+        Should(testEvent2.data.timestamp_unixtime_ms).equal(sessionEndEvent.data.timestamp_unixtime_ms);
 
-            const result1 = testEvent1.data.timestamp_unixtime_ms === testEvent2.data.timestamp_unixtime_ms;
-            const result2 = testEvent2.data.timestamp_unixtime_ms === sessionEndEvent.data.timestamp_unixtime_ms;
-
-            Should(result1).not.be.ok();
-            Should(result2).be.ok();
-
-            done();
-        }, 5);
+        done();
     });
 
     it('should process ready queue when initialized', function(done) {

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -100,7 +100,7 @@ describe('core SDK', function() {
     });
 
     it('creates a new dateLastEventSent when logging an event, and retains the previous one when ending session', function(done) {
-        let clock = sinon.useFakeTimers();
+        const clock = sinon.useFakeTimers();
         mParticle.logEvent('Test Event1');
         const testEvent1 = findEventFromRequest(fetchMock.calls(), 'Test Event1');
         clock.tick(100);


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
To select browsers, I selected the version prior to what [this page](https://www.w3schools.com/js/js_versions.asp) says supports ES6 in order to ensure the browsers would fail with any es6 code.  

Safari and Edge were failing, so I incremented the versions until they passed, and then determined that those versions were still barely used and considered this to be sufficient.

Percentages were found by using these browsers have a combined ~.37% market share as of today, 11/14/2023. See www.browserlist.dev and quey for "opera < 38, safari < 12, chrome < 51, firefox <52, edge < 15"

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5827