### PR TITLE
feat: Support direct url routing from config (#797)

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -3,7 +3,7 @@ import Types from './types';
 import { BatchUploader } from './batchUploader';
 import { MParticleUser, MParticleWebSDK, SDKEvent } from './sdkRuntimeModels';
 import KitBlocker from './kitBlocking';
-import { Dictionary, isEmpty } from './utils';
+import { Dictionary, getRampNumber, isEmpty, parseNumber } from './utils';
 import { IUploadObject } from './serverModel';
 import { MPForwarder } from './forwarders.interfaces';
 
@@ -38,9 +38,9 @@ export default function APIClient(
     const self = this;
     this.queueEventForBatchUpload = function(event: SDKEvent) {
         if (!this.uploader) {
-            const millis = mpInstance._Helpers.getFeatureFlag(
+            const millis: number = parseNumber(mpInstance._Helpers.getFeatureFlag(
                 Constants.FeatureFlags.EventBatchingIntervalMillis
-            );
+            ));
             this.uploader = new BatchUploader(mpInstance, millis);
         }
         this.uploader.queueEvent(event);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -126,9 +126,9 @@ const Constants = {
         integrationDelayTimeout: 5000, // Milliseconds for forcing the integration delay to un-suspend event queueing due to integration partner errors
         maxCookieSize: 3000, // Number of bytes for cookie size to not exceed
         aliasMaxWindow: 90, // Max age of Alias request startTime, in days
-        uploadInterval: 0, // Maximum milliseconds in between batch uploads, below 500 will mean immediate upload
+        uploadInterval: 0, // Maximum milliseconds in between batch uploads, below 500 will mean immediate upload.  The server returns this as a string, but we are using it as a number internally
     },
-    DefaultUrls: {
+    DefaultBaseUrls: {
         v1SecureServiceUrl: 'jssdks.mparticle.com/v1/JS/',
         v2SecureServiceUrl: 'jssdks.mparticle.com/v2/JS/',
         v3SecureServiceUrl: 'jssdks.mparticle.com/v3/JS/',
@@ -168,6 +168,7 @@ const Constants = {
         ReportBatching: 'reportBatching',
         EventBatchingIntervalMillis: 'eventBatchingIntervalMillis',
         OfflineStorage: 'offlineStorage',
+        DirectUrlRouting: 'directURLRouting',
     },
     DefaultInstance: 'default_instance',
     CCPAPurpose: 'data_sale_opt_out',

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1526,9 +1526,8 @@ function createKitBlocker(config, mpInstance) {
 
 function runPreConfigFetchInitialization(mpInstance, apiKey, config) {
     mpInstance.Logger = new Logger(config);
-    mpInstance._Store = new Store(config, mpInstance);
+    mpInstance._Store = new Store(config, mpInstance, apiKey);
     window.mParticle.Store = mpInstance._Store;
-    mpInstance._Store.devToken = apiKey || null;
     mpInstance.Logger.verbose(
         Messages.InformationMessages.StartingInitialization
     );


### PR DESCRIPTION
Duplicating this PR - https://github.com/mParticle/mparticle-web-sdk/pull/797 which was already approved and merged into development, but undone due to blackout requirements.

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
This PR provides logic to incorporate the new `directURLRouting` feature flag.  The feature routes all external requests to the equivalent silo ie `jssdkcdn.us1.mparticle.com` as opposed to the default which is going through a generic fastly endpoint ie `jssdkcdn.mparticle.com`.  The logic is as follows:
* When `true`, set any custom endpoints passed to confirm, then set remaining endpoints to be the silo-specific url
* When `false`, set any custom endpoints passed to confirm, then set remaining endpoints to be the generic fastly URL
 
 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}
 * Added unit tests.
 * Also tested in a local app to see if silos were respected when feature flag is true, and if custom URLs took priority over thos still

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5899
