### PR TITLE
ci: Add Pre-release action to push to Release Order Branch

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -49,6 +49,13 @@ jobs:
         - verify-release-order-branch
         - verify-sdk-version-branch
       runs-on: ubuntu-latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+        GIT_AUTHOR_NAME: mparticle-automation
+        GIT_AUTHOR_EMAIL: developers@mparticle.com
+        GIT_COMMITTER_NAME: mparticle-automation
+        GIT_COMMITTER_EMAIL: developers@mparticle.com
+
       steps:
         # TODO: Replace with input string
         - name: Checkout SKD Version (<version number>)

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -43,10 +43,6 @@ jobs:
             ref: release/2.23.7
         
 
-        - name: Check if requested branch exists
-          run: |
-            export BRANCHES=$(git branch -r)
-            echo $BRANCHES | grep relese-order-a
     # SDK release is done from master branch.
     # confirm-public-repo-master-branch:
     #     name: 'Confirm release is run from public/master branch'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,10 +22,10 @@ jobs:
         # TODO: Steps
         # 1. Check if input string for release order branch
         # 2. Check if input string for release/tag branch exists
-        - name: Git checkout (Release Order D - should fail)
+        - name: Git checkout (Release Order A - should pass)
           uses: actions/checkout@v3
           with:
-            ref: release-order-d
+            ref: release-order-a
 
         - name: Echo Branches
           run: 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -29,12 +29,20 @@ jobs:
               uses: actions/checkout@v3
               with:
                     ref: development
-            
-            - name: Update your package.json with an npm pre-release version
-              id: pre-release-version
-              uses: adobe/update-prerelease-npm-version@v1.0.0
+
+            - name: Get SDK Version
+              id: sdk_version
+              uses: ActionsTools/read-json-action@main
               with:
-                pre-release-tag: 'pre-release'
+                file_path: "package.json"
+                prop_path: "version"
+            
+            - name: Tag Package JSON as pre-release
+              uses: jossef/action-set-json-field@v2.1
+              with:
+                file: package.json
+                field: version
+                value: ${{steps.sdk_version.outputs.value}}.pre-release
             
             - name: Check Package.json
               run: cat package.json

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,6 +22,9 @@ jobs:
         # TODO: Steps
         # 1. Check if input string for release order branch
         # 2. Check if input string for release/tag branch exists
+        - name: Git checkout
+          uses: actions/checkout@v3
+
         - name: Check if requested branch exists
           run: |
             export BRANCHES=$(git branch -r)

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,6 +25,11 @@ jobs:
         - name: Git checkout
           uses: actions/checkout@v3
 
+        - name: Echo Branches
+          run: 
+            export BRANCHES=$(git branch -r)
+            echo $BRANCHES
+
         - name: Check if requested branch exists
           run: |
             export BRANCHES=$(git branch -r)

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,66 @@
+name: Pre-release SDK
+
+
+on:
+    workflow_dispatch:
+        inputs:
+            dryRun:
+                description: 'Do a dry run to preview instead of a real release [true/false]'
+                required: true
+                default: 'true'
+            release-order:
+                description: 'Which Phase are you releaseing? [release-order-a/release-order-b/release-order-c]'
+                required: true
+
+jobs:
+    # SDK release is done from master branch.
+    confirm-public-repo-master-branch:
+        name: 'Confirm release is run from public/master branch'
+        uses: mParticle/mparticle-workflows/.github/workflows/sdk-release-repo-branch-check.yml@main
+
+    # TODO: Break this out into a reusable job
+    build-bundle:
+        name: Build Distribution Bundle
+        runs-on: ubuntu-latest
+        needs: confirm-public-repo-master-branch
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                    ref: development
+            
+            - name: Update your package.json with an npm pre-release version
+              id: pre-release-version
+              uses: adobe/update-prerelease-npm-version@v1.0.0
+              with:
+                pre-release-tag: 'pre-release'
+            
+            - name: Check Package.json
+              run: cat package.json
+
+            - name: NPM install
+              uses: actions/setup-node@v3
+              with:
+                    node-version: 16.x
+
+            - name: Run NPM CI
+              run: npm ci
+
+            - name: Lint with ESLint
+              run: npm run lint
+
+            - name: Lint with Prettier
+              run: npm run prettier
+
+            - name: Run Build IIFE
+              run: npm run build:iife
+
+            - name: Display Bundle Diff, but Fancy!
+              run: git diff --unified=3 dist/mparticle.js | npx diff-so-fancy
+
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                    name: npm-logs
+                    path: ~/.npm/_logs

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -14,62 +14,155 @@ on:
     #             required: true
 
 jobs:
+
+    verify-release-branch:
+      name: Verify Release Order Branch
+      runs-on: ubuntu-latest
+      steps:
+        # TODO: Steps
+        # 1. Check if input string for release order branch
+        # 2. Check if input string for release/tag branch exists
+        - name: Check if requested branch exists
+          run: |
+            export BRANCHES=$(git branch -r)
+            echo $BRANCHES | grep relese-order-a
     # SDK release is done from master branch.
     # confirm-public-repo-master-branch:
     #     name: 'Confirm release is run from public/master branch'
     #     uses: mParticle/mparticle-workflows/.github/workflows/sdk-release-repo-branch-check.yml@main
 
     # TODO: Break this out into a reusable job
-    build-bundle:
-        name: Build Distribution Bundle
-        runs-on: ubuntu-latest
-        # needs: confirm-public-repo-master-branch
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-              with:
-                    ref: development
+    # build-bundle:
+    #     name: Build Distribution Bundle
+    #     runs-on: ubuntu-latest
+    #     # needs: confirm-public-repo-master-branch
+    #     steps:
+    #         - name: Checkout
+    #           uses: actions/checkout@v3
+    #           with:
+    #                 ref: development
 
-            - name: Get SDK Version
-              id: sdk_version
-              uses: ActionsTools/read-json-action@main
-              with:
-                file_path: "package.json"
-                prop_path: "version"
+    #         - name: Get SDK Version
+    #           id: sdk_version
+    #           uses: ActionsTools/read-json-action@main
+    #           with:
+    #             file_path: "package.json"
+    #             prop_path: "version"
             
-            - name: Tag Package JSON as pre-release
-              uses: jossef/action-set-json-field@v2.1
-              with:
-                file: package.json
-                field: version
-                value: ${{steps.sdk_version.outputs.value}}.pre-release
+    #         - name: Tag Package JSON as pre-release
+    #           uses: jossef/action-set-json-field@v2.1
+    #           with:
+    #             file: package.json
+    #             field: version
+    #             value: ${{steps.sdk_version.outputs.value}}.pre-release
             
-            - name: Check Package.json
-              run: cat package.json
+    #         - name: Check Package.json
+    #           run: cat package.json
 
-            - name: NPM install
-              uses: actions/setup-node@v3
-              with:
-                    node-version: 16.x
+    #         - name: NPM install
+    #           uses: actions/setup-node@v3
+    #           with:
+    #                 node-version: 16.x
 
-            - name: Run NPM CI
-              run: npm ci
+    #         - name: Run NPM CI
+    #           run: npm ci
 
-            - name: Lint with ESLint
-              run: npm run lint
+    #         - name: Lint with ESLint
+    #           run: npm run lint
 
-            - name: Lint with Prettier
-              run: npm run prettier
+    #         - name: Lint with Prettier
+    #           run: npm run prettier
 
-            - name: Run Build IIFE
-              run: npm run build:iife
+    #         - name: Run Build IIFE
+    #           run: npm run build:iife
 
-            - name: Display Bundle Diff, but Fancy!
-              run: git diff --unified=3 dist/mparticle.js | npx diff-so-fancy
+    #         - name: Display Bundle Diff, but Fancy!
+    #           run: git diff --unified=3 dist/mparticle.js | npx diff-so-fancy
 
-            - name: Archive npm failure logs
-              uses: actions/upload-artifact@v2
-              if: failure()
-              with:
-                    name: npm-logs
-                    path: ~/.npm/_logs
+    #         - name: Archive npm failure logs
+    #           uses: actions/upload-artifact@v2
+    #           if: failure()
+    #           with:
+    #                 name: npm-logs
+    #                 path: ~/.npm/_logs
+
+    #         # TODO: Run all the tests
+
+    #         create-release-branch:
+    #           name: Create release branch
+    #           runs-on: ubuntu-latest
+    #           needs:
+    #             - build-bundle
+    #           steps:
+    #               - name: Checkout development branch
+    #                 uses: actions/checkout@v2
+    #                 with:
+    #                     repository: mparticle/mparticle-web-sdk
+    #                     ref: development
+      
+    #               - name: Create and push release branch
+    #                 run: |
+    #                     git checkout -b release/${{ github.run_number }}
+    #                     git push origin release/${{ github.run_number }}
+
+    #           pre-release:
+    #               name: Perform Pre-Release
+    #               runs-on: ubuntu-latest
+    #               needs:
+    #                   - create-release-branch
+    #               env:
+    #                   GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+    #                   GIT_AUTHOR_NAME: mparticle-automation
+    #                   GIT_AUTHOR_EMAIL: developers@mparticle.com
+    #                   GIT_COMMITTER_NAME: mparticle-automation
+    #                   GIT_COMMITTER_EMAIL: developers@mparticle.com
+    #                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    #               steps:
+    #                   - name: Checkout release branch
+    #                     uses: actions/checkout@v3
+    #                     with:
+    #                         fetch-depth: 0
+    #                         ref: master
+
+    #                   - name: Import GPG Key
+    #                     uses: crazy-max/ghaction-import-gpg@v4
+    #                     with:
+    #                         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+    #                         passphrase: ${{ secrets.GPG_PASSPHRASE }}
+    #                         git_user_signingkey: true
+    #                         git_commit_gpgsign: true
+
+    #                   - name: Merge release branch into master branch
+    #                     run: |
+    #                         git pull origin release/${{ github.run_number }}
+
+    #                   - name: Setup Node.js
+    #                     uses: actions/setup-node@v3
+    #                     with:
+    #                         node-version: 16.x
+
+    #                   - name: Install dependencies
+    #                     run: npm ci
+
+    #                   - name: Release --dry-run
+    #                     if: ${{ github.event.inputs.dryRun == 'true'}}
+    #                     run: |
+    #                         npx semantic-release --dry-run
+
+    #                   - name: Release
+    #                     if: ${{ github.event.inputs.dryRun == 'false'}}
+    #                     run: |
+    #                         npx semantic-release
+
+    #                   - name: Archive npm failure logs
+    #                     uses: actions/upload-artifact@v3
+    #                     if: failure()
+    #                     with:
+    #                         name: npm-logs
+    #                         path: ~/.npm/_logs
+
+    #                   - name: Push automated release commits to release branch
+    #                     if: ${{ github.event.inputs.dryRun == 'false' }}
+    #                     run: |
+    #                         git push origin HEAD:release/${{ github.run_number }}    

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,18 +19,33 @@ jobs:
       name: Verify Release Order Branch
       runs-on: ubuntu-latest
       steps:
-        # TODO: Steps
+  # TODO: Steps
         # 1. Check if input string for release order branch
         # 2. Check if input string for release/tag branch exists
-        - name: Git checkout (Release Order A - should pass)
+
+    # TODO: Maybe Refactor into reusable job
+    verify-release-order-branch:
+      name: Verify Requested Release Order Branch
+      runs-on: ubuntu-latest
+      steps:
+        # TODO: Replace with input string
+        - name: Git checkout Release Order Branch (<branch name>)
           uses: actions/checkout@v3
           with:
+            # TODO: Replace with input
             ref: release-order-a
 
-        - name: Echo Branches
-          run: 
-            export BRANCHES=$(git branch -r)
-            echo $BRANCHES
+    verify-sdk-version-branch:
+      name: Verify Requested SDK Version
+      runs-on: ubuntu-latest
+      steps:
+        # TODO: Replace with input string
+        - name: Git checkout Versioned Release Branch
+          uses: actions/checkout@v3
+          with:
+            # TODO: Replace with input
+            ref: release/2.23.7
+        
 
         - name: Check if requested branch exists
           run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,146 +40,25 @@ jobs:
           uses: actions/checkout@v3
           with:
             # TODO: Replace with input
-            ref: release/2.23.7
+            ref: release/2.23.4
+
+    push-pre-release-branch:
+      # TODO: Replace with branch name
+      name: Deploy Pre-Release to (<branch name>)
+      needs:
+        - verify-release-order-branch
+        - verify-sdk-version-branch
+      runs-on: ubuntu-latest
+      steps:
+        # TODO: Replace with input string
+        - name: Checkout SKD Version (<version number>)
+          uses: actions/checkout@v3
+          with:
+            # TODO: Replace with input
+            ref: release/2.23.4
         
-
-    # SDK release is done from master branch.
-    # confirm-public-repo-master-branch:
-    #     name: 'Confirm release is run from public/master branch'
-    #     uses: mParticle/mparticle-workflows/.github/workflows/sdk-release-repo-branch-check.yml@main
-
-    # TODO: Break this out into a reusable job
-    # build-bundle:
-    #     name: Build Distribution Bundle
-    #     runs-on: ubuntu-latest
-    #     # needs: confirm-public-repo-master-branch
-    #     steps:
-    #         - name: Checkout
-    #           uses: actions/checkout@v3
-    #           with:
-    #                 ref: development
-
-    #         - name: Get SDK Version
-    #           id: sdk_version
-    #           uses: ActionsTools/read-json-action@main
-    #           with:
-    #             file_path: "package.json"
-    #             prop_path: "version"
-            
-    #         - name: Tag Package JSON as pre-release
-    #           uses: jossef/action-set-json-field@v2.1
-    #           with:
-    #             file: package.json
-    #             field: version
-    #             value: ${{steps.sdk_version.outputs.value}}.pre-release
-            
-    #         - name: Check Package.json
-    #           run: cat package.json
-
-    #         - name: NPM install
-    #           uses: actions/setup-node@v3
-    #           with:
-    #                 node-version: 16.x
-
-    #         - name: Run NPM CI
-    #           run: npm ci
-
-    #         - name: Lint with ESLint
-    #           run: npm run lint
-
-    #         - name: Lint with Prettier
-    #           run: npm run prettier
-
-    #         - name: Run Build IIFE
-    #           run: npm run build:iife
-
-    #         - name: Display Bundle Diff, but Fancy!
-    #           run: git diff --unified=3 dist/mparticle.js | npx diff-so-fancy
-
-    #         - name: Archive npm failure logs
-    #           uses: actions/upload-artifact@v2
-    #           if: failure()
-    #           with:
-    #                 name: npm-logs
-    #                 path: ~/.npm/_logs
-
-    #         # TODO: Run all the tests
-
-    #         create-release-branch:
-    #           name: Create release branch
-    #           runs-on: ubuntu-latest
-    #           needs:
-    #             - build-bundle
-    #           steps:
-    #               - name: Checkout development branch
-    #                 uses: actions/checkout@v2
-    #                 with:
-    #                     repository: mparticle/mparticle-web-sdk
-    #                     ref: development
-      
-    #               - name: Create and push release branch
-    #                 run: |
-    #                     git checkout -b release/${{ github.run_number }}
-    #                     git push origin release/${{ github.run_number }}
-
-    #           pre-release:
-    #               name: Perform Pre-Release
-    #               runs-on: ubuntu-latest
-    #               needs:
-    #                   - create-release-branch
-    #               env:
-    #                   GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-    #                   GIT_AUTHOR_NAME: mparticle-automation
-    #                   GIT_AUTHOR_EMAIL: developers@mparticle.com
-    #                   GIT_COMMITTER_NAME: mparticle-automation
-    #                   GIT_COMMITTER_EMAIL: developers@mparticle.com
-    #                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-    #               steps:
-    #                   - name: Checkout release branch
-    #                     uses: actions/checkout@v3
-    #                     with:
-    #                         fetch-depth: 0
-    #                         ref: master
-
-    #                   - name: Import GPG Key
-    #                     uses: crazy-max/ghaction-import-gpg@v4
-    #                     with:
-    #                         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-    #                         passphrase: ${{ secrets.GPG_PASSPHRASE }}
-    #                         git_user_signingkey: true
-    #                         git_commit_gpgsign: true
-
-    #                   - name: Merge release branch into master branch
-    #                     run: |
-    #                         git pull origin release/${{ github.run_number }}
-
-    #                   - name: Setup Node.js
-    #                     uses: actions/setup-node@v3
-    #                     with:
-    #                         node-version: 16.x
-
-    #                   - name: Install dependencies
-    #                     run: npm ci
-
-    #                   - name: Release --dry-run
-    #                     if: ${{ github.event.inputs.dryRun == 'true'}}
-    #                     run: |
-    #                         npx semantic-release --dry-run
-
-    #                   - name: Release
-    #                     if: ${{ github.event.inputs.dryRun == 'false'}}
-    #                     run: |
-    #                         npx semantic-release
-
-    #                   - name: Archive npm failure logs
-    #                     uses: actions/upload-artifact@v3
-    #                     if: failure()
-    #                     with:
-    #                         name: npm-logs
-    #                         path: ~/.npm/_logs
-
-    #                   - name: Push automated release commits to release branch
-    #                     if: ${{ github.event.inputs.dryRun == 'false' }}
-    #                     run: |
-    #                         git push origin HEAD:release/${{ github.run_number }}    
+        - name: Force Push Pre-Release Branch
+          # TODO: Add when dryRun is enabled
+          # if: ${{ github.event.inputs.dryRun == 'false' }}
+          run: |
+                git push origin HEAD:release-order-a -f

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,8 +22,10 @@ jobs:
         # TODO: Steps
         # 1. Check if input string for release order branch
         # 2. Check if input string for release/tag branch exists
-        - name: Git checkout
+        - name: Git checkout (Release Order D - should fail)
           uses: actions/checkout@v3
+          with:
+            ref: release-order-d
 
         - name: Echo Branches
           run: 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -2,15 +2,16 @@ name: Pre-release SDK
 
 
 on:
-    workflow_dispatch:
-        inputs:
-            dryRun:
-                description: 'Do a dry run to preview instead of a real release [true/false]'
-                required: true
-                default: 'true'
-            release-order:
-                description: 'Which Phase are you releaseing? [release-order-a/release-order-b/release-order-c]'
-                required: true
+  pull_request
+    # workflow_dispatch:
+    #     inputs:
+    #         dryRun:
+    #             description: 'Do a dry run to preview instead of a real release [true/false]'
+    #             required: true
+    #             default: 'true'
+    #         release-order:
+    #             description: 'Which Phase are you releaseing? [release-order-a/release-order-b/release-order-c]'
+    #             required: true
 
 jobs:
     # SDK release is done from master branch.

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,10 +15,6 @@ on:
 
 jobs:
 
-    verify-release-branch:
-      name: Verify Release Order Branch
-      runs-on: ubuntu-latest
-      steps:
   # TODO: Steps
         # 1. Check if input string for release order branch
         # 2. Check if input string for release/tag branch exists

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,71 +1,86 @@
-name: Pre-release SDK
-
+name: Publish SDK Pre-Release
 
 on:
-  pull_request
-    # workflow_dispatch:
-    #     inputs:
-    #         dryRun:
-    #             description: 'Do a dry run to preview instead of a real release [true/false]'
-    #             required: true
-    #             default: 'true'
-    #         release-order:
-    #             description: 'Which Phase are you releaseing? [release-order-a/release-order-b/release-order-c]'
-    #             required: true
+    workflow_dispatch:
+        inputs:
+            dryRun:
+                description: 'Do a dry run to preview instead of a real release [true/false]'
+                required: true
+                type: boolean
+                default: true
+            versionNumber:
+                description: 'Which SDK version to publish? [X.XX.XX]'
+                required: true
+                type: string
+            releaseOrderBranch:
+                description: 'Which Release Order Branch are you targeting? [release-order-a/release-order-b/release-order-c]'
+                required: true
+                type: choice
+                default: release-order-a
+                options:
+                    - release-order-a
+                    - release-order-b
+                    - release-order-c
 
 jobs:
+    verify-version-number:
+        name: Verify SDK Version (${{ github.event.inputs.versionNumber}})
+        runs-on: ubuntu-latest
+        steps:
+            # As a safe guard, if a valid version number does not exist,
+            # this step will fail and throw an error
+            - name: Checkout SDK Version (${{ github.event.inputs.versionNumber}})
+              uses: actions/checkout@v3
+              with:
+                  ref: release/${{ github.event.inputs.versionNumber}}
 
-  # TODO: Steps
-        # 1. Check if input string for release order branch
-        # 2. Check if input string for release/tag branch exists
-
-    # TODO: Maybe Refactor into reusable job
     verify-release-order-branch:
-      name: Verify Release Order Branch
-      runs-on: ubuntu-latest
-      steps:
-        # TODO: Replace with input string
-        - name: Checkout Release Order (<branch name>)
-          uses: actions/checkout@v3
-          with:
-            # TODO: Replace with input
-            ref: release-order-a
+        name: Verify Release Order Branch
+        runs-on: ubuntu-latest
+        steps:
+            # As a safe guard, if a valid release branch does not exist,
+            # this step will fail and throw an error
+            - name: Checkout Release Order (${{ github.event.inputs.releaseOrderBranch }})
+              uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.event.inputs.releaseOrderBranch }}
 
-    verify-sdk-version-branch:
-      name: Verify SDK Version
-      runs-on: ubuntu-latest
-      steps:
-        # TODO: Replace with input string
-        - name: Checkout SKD Version (<version number>)
-          uses: actions/checkout@v3
-          with:
-            # TODO: Replace with input
-            ref: release/2.23.4
+    push-release-branch:
+        name: Deploy v${{ github.event.inputs.versionNumber}} to ${{ github.event.inputs.releaseOrderBranch}}
+        needs:
+            - verify-version-number
+            - verify-release-order-branch
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+            GIT_AUTHOR_NAME: mparticle-automation
+            GIT_AUTHOR_EMAIL: developers@mparticle.com
+            GIT_COMMITTER_NAME: mparticle-automation
+            GIT_COMMITTER_EMAIL: developers@mparticle.com
 
-    push-pre-release-branch:
-      # TODO: Replace with branch name
-      name: Deploy Pre-Release to (<branch name>)
-      needs:
-        - verify-release-order-branch
-        - verify-sdk-version-branch
-      runs-on: ubuntu-latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-        GIT_AUTHOR_NAME: mparticle-automation
-        GIT_AUTHOR_EMAIL: developers@mparticle.com
-        GIT_COMMITTER_NAME: mparticle-automation
-        GIT_COMMITTER_EMAIL: developers@mparticle.com
+        steps:
+            - name: Checkout master branch
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+                  repository: ${{ github.repository }}
+                  token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+                  ref: master
 
-      steps:
-        # TODO: Replace with input string
-        - name: Checkout SDK Version (<version number>)
-          uses: actions/checkout@v3
-          with:
-            # TODO: Replace with input
-            ref: release/2.23.4
-        
-        - name: Force Push Pre-Release Branch
-          # TODO: Add when dryRun is enabled
-          # if: ${{ github.event.inputs.dryRun == 'false' }}
-          run: |
-                git push origin HEAD:release-order-a -f
+            - name: Import GPG Key
+              uses: crazy-max/ghaction-import-gpg@v4
+              with:
+                  gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.GPG_PASSPHRASE }}
+                  git_user_signingkey: true
+                  git_commit_gpgsign: true
+
+            - name: Merge release/${{ github.event.inputs.versionNumber}} into master branch
+              if: ${{ github.event.inputs.dryRun == false }}
+              run: |
+                  git pull origin release/${{ github.event.inputs.versionNumber}}
+
+            - name: Push v${{ github.event.inputs.versionNumber}} to ${{ github.event.inputs.releaseOrderBranch }}
+              if: ${{ github.event.inputs.dryRun == false }}
+              run: |
+                  git push origin HEAD:${{ github.event.inputs.releaseOrderBranch }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,22 +21,22 @@ jobs:
 
     # TODO: Maybe Refactor into reusable job
     verify-release-order-branch:
-      name: Verify Requested Release Order Branch
+      name: Verify Release Order Branch
       runs-on: ubuntu-latest
       steps:
         # TODO: Replace with input string
-        - name: Git checkout Release Order Branch (<branch name>)
+        - name: Checkout Release Order (<branch name>)
           uses: actions/checkout@v3
           with:
             # TODO: Replace with input
             ref: release-order-a
 
     verify-sdk-version-branch:
-      name: Verify Requested SDK Version
+      name: Verify SDK Version
       runs-on: ubuntu-latest
       steps:
         # TODO: Replace with input string
-        - name: Git checkout Versioned Release Branch
+        - name: Checkout SKD Version (<version number>)
           uses: actions/checkout@v3
           with:
             # TODO: Replace with input

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -58,7 +58,7 @@ jobs:
 
       steps:
         # TODO: Replace with input string
-        - name: Checkout SKD Version (<version number>)
+        - name: Checkout SDK Version (<version number>)
           uses: actions/checkout@v3
           with:
             # TODO: Replace with input

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,15 +15,15 @@ on:
 
 jobs:
     # SDK release is done from master branch.
-    confirm-public-repo-master-branch:
-        name: 'Confirm release is run from public/master branch'
-        uses: mParticle/mparticle-workflows/.github/workflows/sdk-release-repo-branch-check.yml@main
+    # confirm-public-repo-master-branch:
+    #     name: 'Confirm release is run from public/master branch'
+    #     uses: mParticle/mparticle-workflows/.github/workflows/sdk-release-repo-branch-check.yml@main
 
     # TODO: Break this out into a reusable job
     build-bundle:
         name: Build Distribution Bundle
         runs-on: ubuntu-latest
-        needs: confirm-public-repo-master-branch
+        # needs: confirm-public-repo-master-branch
         steps:
             - name: Checkout
               uses: actions/checkout@v3


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Pushes a release branch to a release order branch

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - N/A - This is a CI/CD Update

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5964
