### PR TITLE
refactor: Replace individual type checks for customFlagProperty

### DIFF
--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -155,7 +155,7 @@ function convertCustomFlags(event: SDKEvent, dto: IServerV2DTO) {
                         valueArray.push(customFlagProperty.toString());
                     }
                 });
-            } else if (isValidCustomFlagProperty(convertCustomFlags)) {
+            } else if (isValidCustomFlagProperty(event.CustomFlags[prop])) {
                 valueArray.push(event.CustomFlags[prop].toString());
             }
 

--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -13,7 +13,12 @@ import {
     SDKProduct,
     SDKUserIdentity,
 } from './sdkRuntimeModels';
-import { parseNumber, parseStringOrNumber, Dictionary } from './utils';
+import {
+    parseNumber,
+    parseStringOrNumber,
+    Dictionary,
+    isValidCustomFlagProperty,
+} from './utils';
 import { ServerSettings } from './store';
 import { MPID } from '@mparticle/web-sdk';
 import {
@@ -145,22 +150,12 @@ function convertCustomFlags(event: SDKEvent, dto: IServerV2DTO) {
 
         if (event.CustomFlags.hasOwnProperty(prop)) {
             if (Array.isArray(event.CustomFlags[prop])) {
-                event.CustomFlags[prop].forEach(function(customFlagProperty) {
-                    // TODO: Can we use our utility functions here?
-                    if (
-                        typeof customFlagProperty === 'number' ||
-                        typeof customFlagProperty === 'string' ||
-                        typeof customFlagProperty === 'boolean'
-                    ) {
+                event.CustomFlags[prop].forEach(customFlagProperty => {
+                    if (isValidCustomFlagProperty(customFlagProperty)) {
                         valueArray.push(customFlagProperty.toString());
                     }
                 });
-            } else if (
-                // TODO: Can we use our utility functions here?
-                typeof event.CustomFlags[prop] === 'number' ||
-                typeof event.CustomFlags[prop] === 'string' ||
-                typeof event.CustomFlags[prop] === 'boolean'
-            ) {
+            } else if (isValidCustomFlagProperty(convertCustomFlags)) {
                 valueArray.push(event.CustomFlags[prop].toString());
             }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -201,7 +201,10 @@ const converted = (s: string): string => {
 
 const isString = (value: any): boolean => typeof value === 'string';
 const isNumber = (value: any): boolean => typeof value === 'number';
+const isBoolean = (value: any): boolean => typeof value === 'boolean';
 const isFunction = (fn: any): boolean => typeof fn === 'function';
+const isValidCustomFlagProperty = (value: any): boolean =>
+    isNumber(value) || isString(value) || isBoolean(value);
 
 const toDataPlanSlug = (value: any): string =>
     // Make sure we are only acting on strings or numbers
@@ -247,4 +250,5 @@ export {
     isFunction,
     isDataPlanSlug,
     isEmpty,
+    isValidCustomFlagProperty,
 };

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -11,6 +11,7 @@ import {
     isEmpty,
     isObject,
     isStringOrNumber,
+    isValidCustomFlagProperty,
     parseNumber,
     parseStringOrNumber,
     replaceApostrophesWithQuotes,
@@ -350,6 +351,26 @@ describe('Utils', () => {
 
         it('returns true if object is undefined', () => {
             expect(isEmpty(undefined)).to.equal(true);
+        });
+    });
+    
+    describe('#isValidCustomFlagProperty', () => {
+        it('returns true if Custom Flag Property is a number', () => {
+            expect(isValidCustomFlagProperty(42)).to.equal(true);
+        });
+
+        it('returns true if Custom Flag Property is a string', () => {
+            expect(isValidCustomFlagProperty('custom_string')).to.equal(true);
+        });
+
+        it('returns true if Custom Flag Property is a boolean', () => {
+            expect(isValidCustomFlagProperty(true)).to.equal(true);
+        });
+
+        it('returns true if Custom Flag Property is not valid', () => {
+            expect(isValidCustomFlagProperty(null), 'null').to.equal(false);
+            expect(isValidCustomFlagProperty(function(){}), 'function').to.equal(false);
+            expect(isValidCustomFlagProperty(undefined), 'undefined').to.equal(false);
         });
     });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Replace type checks for `customFlagProperty` with a utility function.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Send an upload via web sdk with custom flags that contain valid and invalid items, either as an array or not an array.
 - Invalid custom flags should be filtered out

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-4815
