### PR TITLE
fix: Add filtered user identities to identity complete methods

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,15 +1,11 @@
 import Constants from './constants';
 import Types from './types';
 import { BatchUploader } from './batchUploader';
-import {
-    MParticleUser,
-    MParticleWebSDK,
-    MPForwarder,
-    SDKEvent,
-} from './sdkRuntimeModels';
+import { MParticleUser, MParticleWebSDK, SDKEvent } from './sdkRuntimeModels';
 import KitBlocker from './kitBlocking';
-import { Dictionary, getRampNumber, isEmpty } from './utils';
+import { Dictionary, isEmpty } from './utils';
 import { IUploadObject } from './serverModel';
+import { MPForwarder } from './forwarders.interfaces';
 
 export type ForwardingStatsData = Dictionary<any>;
 

--- a/src/forwarders.interfaces.ts
+++ b/src/forwarders.interfaces.ts
@@ -9,7 +9,7 @@ import { IKitConfigs } from './configAPIClient';
 import { UserAttributes } from './persistence.interfaces';
 import { IdentityApiData } from '@mparticle/web-sdk';
 
-// TODO: Create Distinct MPForwarder and Kit interfaces
+// TODO: https://go.mparticle.com/work/SQDSDKS-6035
 export type Kit = Dictionary;
 export type MPForwarder = Dictionary;
 

--- a/src/forwarders.interfaces.ts
+++ b/src/forwarders.interfaces.ts
@@ -1,8 +1,17 @@
-import { MParticleUser, SDKEvent, SDKEventCustomFlags, SDKUserIdentity } from './sdkRuntimeModels';
+import {
+    MParticleUser,
+    SDKEvent,
+    SDKEventCustomFlags,
+    SDKUserIdentity,
+} from './sdkRuntimeModels';
 import { Dictionary } from './utils';
 import { IKitConfigs } from './configAPIClient';
 import { UserAttributes } from './persistence.interfaces';
 import { IdentityApiData } from '@mparticle/web-sdk';
+
+// TODO: Create Distinct MPForwarder and Kit interfaces
+export type Kit = Dictionary;
+export type MPForwarder = Dictionary;
 
 // The state of the kit when accessed via window.KitName via CDN
 // or imported as an NPM package
@@ -32,11 +41,24 @@ export interface ConfiguredKit
         appVersion: string,
         appName: string,
         customFlags: SDKEventCustomFlags,
-        clientId: string): string;
-    onIdentifyComplete(user: MParticleUser, filteredIdentityRequest: IdentityApiData): string | KitMappedMethodFailure;
-    onLoginComplete(user: MParticleUser, filteredIdentityRequest: IdentityApiData): string | KitMappedMethodFailure;
-    onLogoutComplete(user: MParticleUser, filteredIdentityRequest: IdentityApiData): string | KitMappedMethodFailure;
-    onModifyComplete(user: MParticleUser, filteredIdentityRequest: IdentityApiData): string | KitMappedMethodFailure;
+        clientId: string
+    ): string;
+    onIdentifyComplete(
+        user: MParticleUser,
+        filteredIdentityRequest: IdentityApiData
+    ): string | KitMappedMethodFailure;
+    onLoginComplete(
+        user: MParticleUser,
+        filteredIdentityRequest: IdentityApiData
+    ): string | KitMappedMethodFailure;
+    onLogoutComplete(
+        user: MParticleUser,
+        filteredIdentityRequest: IdentityApiData
+    ): string | KitMappedMethodFailure;
+    onModifyComplete(
+        user: MParticleUser,
+        filteredIdentityRequest: IdentityApiData
+    ): string | KitMappedMethodFailure;
     onUserIdentified(user: MParticleUser): string | KitMappedMethodFailure;
     process(event: SDKEvent): string;
     setOptOut(isOptingOut: boolean): string | KitMappedMethodFailure;

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -491,30 +491,45 @@ export default function Forwarders(mpInstance, kitBlocker) {
                 mpInstance,
                 kitBlocker
             );
+
+            const filteredUserIdentities = filteredUser.getUserIdentities();
+
             if (identityMethod === Identify) {
                 if (forwarder.onIdentifyComplete) {
-                    result = forwarder.onIdentifyComplete(filteredUser);
+                    result = forwarder.onIdentifyComplete(
+                        filteredUser,
+                        filteredUserIdentities
+                    );
                     if (result) {
                         mpInstance.Logger.verbose(result);
                     }
                 }
             } else if (identityMethod === Login) {
                 if (forwarder.onLoginComplete) {
-                    result = forwarder.onLoginComplete(filteredUser);
+                    result = forwarder.onLoginComplete(
+                        filteredUser,
+                        filteredUserIdentities
+                    );
                     if (result) {
                         mpInstance.Logger.verbose(result);
                     }
                 }
             } else if (identityMethod === Logout) {
                 if (forwarder.onLogoutComplete) {
-                    result = forwarder.onLogoutComplete(filteredUser);
+                    result = forwarder.onLogoutComplete(
+                        filteredUser,
+                        filteredUserIdentities
+                    );
                     if (result) {
                         mpInstance.Logger.verbose(result);
                     }
                 }
             } else if (identityMethod === Modify) {
                 if (forwarder.onModifyComplete) {
-                    result = forwarder.onModifyComplete(filteredUser);
+                    result = forwarder.onModifyComplete(
+                        filteredUser,
+                        filteredUserIdentities
+                    );
                     if (result) {
                         mpInstance.Logger.verbose(result);
                     }

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -10,6 +10,7 @@ import { SDKConsentApi, SDKConsentState } from './consent';
 import { IPersistence } from './persistence.interfaces';
 import { IMPSideloadedKit } from './sideloadedKit';
 import { ISessionManager } from './sessionManager';
+import { Kit, MPForwarder } from './forwarders.interfaces';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;
@@ -183,10 +184,6 @@ export type BooleanStringLowerCase = 'false' | 'true';
 export type BooleanStringTitleCase = 'False' | 'True';
 
 export type LogLevelType = 'none' | 'verbose' | 'warning' | 'error';
-
-// TODO: Create true types for Kits and Kit Configs
-export type Kit = Dictionary;
-export type MPForwarder = Dictionary;
 
 // TODO: This should eventually be moved into wherever init logic lives
 // TODO: Replace/Merge this with MPConfiguration in @types/mparticle__web-sdk

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,11 +11,9 @@ import { IKitConfigs } from './configAPIClient';
 import Constants from './constants';
 import {
     DataPlanResult,
-    Kit,
     KitBlockerOptions,
     LogLevelType,
     MParticleWebSDK,
-    MPForwarder,
     SDKDataPlan,
     SDKEvent,
     SDKGeoLocation,
@@ -24,6 +22,7 @@ import {
 } from './sdkRuntimeModels';
 import { isNumber, isDataPlanSlug, Dictionary } from './utils';
 import { SDKConsentState } from './consent';
+import { Kit, MPForwarder } from './forwarders.interfaces';
 
 // This represents the runtime configuration of the SDK AFTER
 // initialization has been complete and all settings and

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -1503,6 +1503,161 @@ describe('forwarders', function() {
         done();
     });
 
+    it('should pass filteredUser and filteredUserIdentities to onIdentifyComplete methods', function(done) {
+        mParticle._resetForTests(MPConfig);
+        const mockForwarder = new MockForwarder();
+        mockForwarder.register(window.mParticle.config);
+
+        const config1 = forwarderDefaultConfiguration('MockForwarder', 1);
+
+        // This removes the Google User Identity
+        config1.userIdentityFilters = [mParticle.IdentityType.Google];
+        window.mParticle.config.kitConfigs.push(config1);
+
+        mParticle.init(apiKey, window.mParticle.config);
+
+        mParticle.Identity.identify({
+            userIdentities: {
+                google: 'test@google.com',
+                email: 'test@gmail.com',
+                customerid: '123',
+            },
+        });
+
+        expect(window.MockForwarder1.instance.onIdentifyCompleteCalled).to.eq(
+            true
+        );
+        expect(window.MockForwarder1.instance.onIdentifyCompleteUser).to.be.ok;
+        expect(
+            window.MockForwarder1.instance
+                .onIdentifyCompleteFilteredUserIdentities
+        ).to.deep.equal({
+            userIdentities: {
+                // Filtered Identity should no longer have `google` as an identity
+                email: 'test@gmail.com',
+                customerid: '123',
+            },
+        });
+
+        done();
+    });
+
+    it('should pass filteredUser and filteredUserIdentities to onLoginComplete methods', function(done) {
+        mParticle._resetForTests(MPConfig);
+        const mockForwarder = new MockForwarder();
+        mockForwarder.register(window.mParticle.config);
+
+        const config1 = forwarderDefaultConfiguration('MockForwarder', 1);
+
+        // This removes the Google User Identity
+        config1.userIdentityFilters = [mParticle.IdentityType.Google];
+        window.mParticle.config.kitConfigs.push(config1);
+
+        mParticle.init(apiKey, window.mParticle.config);
+
+        mParticle.Identity.login({
+            userIdentities: {
+                google: 'test@google.com',
+                email: 'test@gmail.com',
+                customerid: '123',
+            },
+        });
+
+        expect(window.MockForwarder1.instance.onLoginCompleteCalled).to.eq(
+            true
+        );
+        expect(window.MockForwarder1.instance.onLoginCompleteUser).to.be.ok;
+        expect(
+            window.MockForwarder1.instance.onLoginCompleteFilteredUserIdentities
+        ).to.deep.equal({
+            userIdentities: {
+                // Filtered Identity should no longer have `google` as an identity
+                email: 'test@gmail.com',
+                customerid: '123',
+            },
+        });
+
+        done();
+    });
+
+    it('should pass filteredUser and filteredUserIdentities to onLogoutComplete methods', function(done) {
+        mParticle._resetForTests(MPConfig);
+        const mockForwarder = new MockForwarder();
+        mockForwarder.register(window.mParticle.config);
+
+        const config1 = forwarderDefaultConfiguration('MockForwarder', 1);
+
+        // This removes the Google User Identity
+        config1.userIdentityFilters = [mParticle.IdentityType.Google];
+        window.mParticle.config.kitConfigs.push(config1);
+
+        mParticle.init(apiKey, window.mParticle.config);
+
+        mParticle.Identity.logout({
+            userIdentities: {
+                google: 'test@google.com',
+                email: 'test@gmail.com',
+                customerid: '123',
+            },
+        });
+
+        expect(window.MockForwarder1.instance.onLogoutCompleteCalled).to.eq(
+            true
+        );
+        expect(window.MockForwarder1.instance.onLogoutCompleteUser).to.be.ok;
+        expect(
+            window.MockForwarder1.instance
+                .onLogoutCompleteFilteredUserIdentities
+        ).to.deep.equal({
+            userIdentities: {
+                // Filtered Identity should no longer have `google` as an identity
+                email: 'test@gmail.com',
+                customerid: '123',
+            },
+        });
+
+        done();
+    });
+
+    it('should pass filteredUser and filteredUserIdentities to onModifyComplete methods', function(done) {
+        mParticle._resetForTests(MPConfig);
+        const mockForwarder = new MockForwarder();
+        mockForwarder.register(window.mParticle.config);
+
+        const config1 = forwarderDefaultConfiguration('MockForwarder', 1);
+
+        // This removes the Google User Identity
+        config1.userIdentityFilters = [mParticle.IdentityType.Google];
+        window.mParticle.config.kitConfigs.push(config1);
+
+        mParticle.init(apiKey, window.mParticle.config);
+
+        mParticle.Identity.modify({
+            userIdentities: {
+                google: 'test@google.com',
+                email: 'test@gmail.com',
+                customerid: '123',
+            },
+        });
+
+        expect(window.MockForwarder1.instance.onModifyCompleteCalled).to.eq(
+            true
+        );
+        expect(window.MockForwarder1.instance.onModifyCompleteUser).to.be.ok;
+        expect(
+            window.MockForwarder1.instance
+                .onModifyCompleteFilteredUserIdentities
+        ).to.deep.equal({
+            userIdentities: {
+                // Filtered Identity should no longer have `google` as an identity
+                email: 'test@gmail.com',
+                customerid: '123',
+            },
+        });
+
+        done();
+    });
+
     it('should not forward event if attribute forwarding rule is set', function(done) {
         mParticle._resetForTests(MPConfig);
         const mockForwarder = new MockForwarder();

--- a/test/src/utils.js
+++ b/test/src/utils.js
@@ -391,24 +391,40 @@ var pluses = /\+/g,
                 this.onUserIdentifiedUser = user;
             };
 
-            this.onIdentifyComplete = function(user) {
+            this.onIdentifyComplete = function(
+                filteredUser,
+                filteredUserIdentities
+            ) {
                 this.onIdentifyCompleteCalled = true;
-                this.onIdentifyCompleteUser = user;
+                this.onIdentifyCompleteUser = filteredUser;
+                this.onIdentifyCompleteFilteredUserIdentities = filteredUserIdentities;
             };
 
-            this.onLoginComplete = function(user) {
+            this.onLoginComplete = function(
+                filteredUser,
+                filteredUserIdentities
+            ) {
                 this.onLoginCompleteCalled = true;
-                this.onLoginCompleteUser = user;
+                this.onLoginCompleteUser = filteredUser;
+                this.onLoginCompleteFilteredUserIdentities = filteredUserIdentities;
             };
 
-            this.onLogoutComplete = function(user) {
+            this.onLogoutComplete = function(
+                filteredUser,
+                filteredUserIdentities
+            ) {
                 this.onLogoutCompleteCalled = true;
-                this.onLogoutCompleteUser = user;
+                this.onLogoutCompleteUser = filteredUser;
+                this.onLogoutCompleteFilteredUserIdentities = filteredUserIdentities;
             };
 
-            this.onModifyComplete = function(user) {
+            this.onModifyComplete = function(
+                filteredUser,
+                filteredUserIdentities
+            ) {
                 this.onModifyCompleteCalled = true;
-                this.onModifyCompleteUser = user;
+                this.onModifyCompleteUser = filteredUser;
+                this.onModifyCompleteFilteredUserIdentities = filteredUserIdentities;
             };
 
             this.setUserAttribute = function(key, value) {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds `filteredUserIdentities` parameter to IdentityComplete methods which some kits are expecting

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app with a web kit that uses the [web kit wrapper](https://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper), verify that onIdentifyComplete, onModifyComplete, onLoginComplete and onLogoutComplete pass a second argument within the kit code.
 - [Google Analytics 4](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4) is a kit that expects this second parameter

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5221
 - Should be merged after #817 
