### PR TITLE
fix: Replace identify method strings with constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -169,6 +169,12 @@ const Constants = {
     },
     DefaultInstance: 'default_instance',
     CCPAPurpose: 'data_sale_opt_out',
+    IdentityMethods: {
+        Modify: 'modify',
+        Logout: 'logout',
+        Login: 'login',
+        Identify: 'identify',
+    },
 } as const;
 
 export default Constants;

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -4,7 +4,7 @@ import { isEmpty } from './utils';
 import KitFilterHelper from './kitFilterHelper';
 import Constants from './constants';
 
-const { Modify } = Constants.IdentityMethods;
+const { Modify, Identify, Login, Logout } = Constants.IdentityMethods;
 
 export default function Forwarders(mpInstance, kitBlocker) {
     var self = this;

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -2,6 +2,9 @@ import Types from './types';
 import filteredMparticleUser from './filteredMparticleUser';
 import { isEmpty } from './utils';
 import KitFilterHelper from './kitFilterHelper';
+import Constants from './constants';
+
+const { Modify } = Constants.IdentityMethods;
 
 export default function Forwarders(mpInstance, kitBlocker) {
     var self = this;
@@ -440,6 +443,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
         });
     };
 
+    // TODO: This is a v1 method, we should deprecate
     this.setForwarderUserIdentities = function(userIdentities) {
         mpInstance._Store.activeForwarders.forEach(function(forwarder) {
             var filteredUserIdentities = mpInstance._Helpers.filterUserIdentities(
@@ -487,28 +491,28 @@ export default function Forwarders(mpInstance, kitBlocker) {
                 mpInstance,
                 kitBlocker
             );
-            if (identityMethod === 'identify') {
+            if (identityMethod === Identify) {
                 if (forwarder.onIdentifyComplete) {
                     result = forwarder.onIdentifyComplete(filteredUser);
                     if (result) {
                         mpInstance.Logger.verbose(result);
                     }
                 }
-            } else if (identityMethod === 'login') {
+            } else if (identityMethod === Login) {
                 if (forwarder.onLoginComplete) {
                     result = forwarder.onLoginComplete(filteredUser);
                     if (result) {
                         mpInstance.Logger.verbose(result);
                     }
                 }
-            } else if (identityMethod === 'logout') {
+            } else if (identityMethod === Logout) {
                 if (forwarder.onLogoutComplete) {
                     result = forwarder.onLogoutComplete(filteredUser);
                     if (result) {
                         mpInstance.Logger.verbose(result);
                     }
                 }
-            } else if (identityMethod === 'modify') {
+            } else if (identityMethod === Modify) {
                 if (forwarder.onModifyComplete) {
                     result = forwarder.onModifyComplete(filteredUser);
                     if (result) {

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -443,7 +443,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
         });
     };
 
-    // TODO: This is a v1 method, we should deprecate
+    // TODO: https://go.mparticle.com/work/SQDSDKS-6036
     this.setForwarderUserIdentities = function(userIdentities) {
         mpInstance._Store.activeForwarders.forEach(function(forwarder) {
             var filteredUserIdentities = mpInstance._Helpers.filterUserIdentities(

--- a/src/identity.js
+++ b/src/identity.js
@@ -1623,7 +1623,7 @@ export default function Identity(mpInstance) {
                         );
                     }
 
-                    // TODO: This is a v1 method. We should deprecate
+                    // TODO: https://go.mparticle.com/work/SQDSDKS-6036
                     mpInstance._Forwarders.setForwarderUserIdentities(
                         newUser.getUserIdentities().userIdentities
                     );

--- a/src/identity.js
+++ b/src/identity.js
@@ -4,6 +4,8 @@ import Types from './types';
 var Messages = Constants.Messages,
     HTTPCodes = Constants.HTTPCodes;
 
+const { Identify, Modify } = Constants.IdentityMethods;
+
 export default function Identity(mpInstance) {
     var self = this;
     this.checkIdentitySwap = function(
@@ -1476,7 +1478,7 @@ export default function Identity(mpInstance) {
             }
 
             if (xhr.status === 200) {
-                if (method === 'modify') {
+                if (method === Modify) {
                     newIdentitiesByType = mpInstance._Identity.IdentityRequest.combineUserIdentities(
                         previousUIByName,
                         identityApiData.userIdentities
@@ -1507,7 +1509,7 @@ export default function Identity(mpInstance) {
                     //will not have a value for "fst" until the current MPID changes, and in some cases,
                     //the current MPID will never change
                     if (
-                        method === 'identify' &&
+                        method === Identify &&
                         prevUser &&
                         identityApiResult.mpid === prevUser.getMPID()
                     ) {
@@ -1620,6 +1622,8 @@ export default function Identity(mpInstance) {
                             mpInstance._APIClient.prepareForwardingStats
                         );
                     }
+
+                    // TODO: This is a v1 method. We should deprecate
                     mpInstance._Forwarders.setForwarderUserIdentities(
                         newUser.getUserIdentities().userIdentities
                     );
@@ -1628,8 +1632,7 @@ export default function Identity(mpInstance) {
                         method
                     );
                     mpInstance._Forwarders.setForwarderOnUserIdentified(
-                        newUser,
-                        method
+                        newUser
                     );
                 }
                 var newIdentitiesByName = {};
@@ -1646,7 +1649,7 @@ export default function Identity(mpInstance) {
                     newIdentitiesByName,
                     method,
                     identityApiResult.mpid,
-                    method === 'modify'
+                    method === Modify
                         ? previousUIByNameCopy
                         : incomingMpidUIByNameCopy
                 );

--- a/src/identityApiClient.js
+++ b/src/identityApiClient.js
@@ -3,6 +3,8 @@ import Constants from './constants';
 var HTTPCodes = Constants.HTTPCodes,
     Messages = Constants.Messages;
 
+const { Modify } = Constants.IdentityMethods;
+
 export default function IdentityAPIClient(mpInstance) {
     this.sendAliasRequest = function(aliasRequest, callback) {
         var xhr,
@@ -107,7 +109,7 @@ export default function IdentityAPIClient(mpInstance) {
                     );
                 } else {
                     previousMPID = mpid || null;
-                    if (method === 'modify') {
+                    if (method === Modify) {
                         xhr.open(
                             'post',
                             mpInstance._Helpers.createServiceUrl(

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,5 +1,11 @@
 import Types from './types';
-import { isFunction, isNumber, isObject, isStringOrNumber, valueof } from './utils';
+import {
+    isFunction,
+    isNumber,
+    isObject,
+    isStringOrNumber,
+    valueof,
+} from './utils';
 import Constants from './constants';
 import { IdentityApiData } from '@mparticle/web-sdk';
 
@@ -9,6 +15,8 @@ type ValidationIdentitiesReturn = {
     valid: boolean;
     error?: valueof<typeof Constants.Messages.ValidationMessages>;
 };
+
+const { Modify } = Constants.IdentityMethods;
 
 const Validators = {
     // From ./utils
@@ -43,7 +51,7 @@ const Validators = {
             copyUserAttributes: 1,
         };
         if (identityApiData) {
-            if (method === 'modify') {
+            if (method === Modify) {
                 if (
                     (isObject(identityApiData.userIdentities) &&
                         !Object.keys(identityApiData.userIdentities).length) ||


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Replace Identify method strings with constants
 - Also removes an unused parameter from `setForwarderOnUserIdentified`

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, verify that Identify, Modify, Login and Logout have no changes in behavior.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6029
