### PR TITLE
feat: Cache identity responses

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -169,6 +169,7 @@ const Constants = {
         EventBatchingIntervalMillis: 'eventBatchingIntervalMillis',
         OfflineStorage: 'offlineStorage',
         DirectUrlRouting: 'directURLRouting',
+        CacheIdentity: 'cacheIdentity',
     },
     DefaultInstance: 'default_instance',
     CCPAPurpose: 'data_sale_opt_out',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -182,3 +182,7 @@ const Constants = {
 } as const;
 
 export default Constants;
+
+// https://go.mparticle.com/work/SQDSDKS-6080
+export const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+export const MILLIS_IN_ONE_SEC = 1000;

--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -1,0 +1,105 @@
+import { Dictionary } from './utils';
+import { LocalStorageVault } from './vault';
+import Types from './types';
+import { IdentityApiData, UserIdentities } from '@mparticle/web-sdk';
+import { isObject } from './utils';
+
+export interface IKnownIdentities extends UserIdentities {
+    device_application_stamp?: string;
+}
+
+export const cacheIdentityRequest = (
+    method: string,
+    identities: IKnownIdentities,
+    mpid: string,
+    expireTimestamp: number,
+    idCache: LocalStorageVault<Dictionary>
+): void => {
+    let cache = idCache.retrieve() || {};
+
+    let cacheKey = concatenateIdentities(method, identities);
+
+    cache[cacheKey] = { mpid, expireTimestamp };
+    idCache.store(cache);
+};
+
+// We need to ensure that identities are concatenated in a deterministic way, so
+// we sort the identities based on their enum.
+// we create an array, set the user identity at the index of the user identity type
+export const concatenateIdentities = (
+    method: string,
+    userIdentities: IKnownIdentities
+): string => {
+    // set DAS first since it is not an official identity type
+    let cacheKey: string = `${method}:device_application_stamp=${userIdentities.device_application_stamp};`;
+    const idLength: number = Object.keys(userIdentities).length;
+    let concatenatedIdentities: string;
+
+    if (idLength) {
+        let userIDArray: Array<string> = new Array(idLength);
+        // create an array where each index is equal to the user identity type
+        for (let key in userIdentities) {
+            if (key === 'device_application_stamp') {
+                continue;
+            } else {
+                userIDArray[Types.IdentityType.getIdentityType(key)] =
+                    userIdentities[key];
+            }
+        }
+
+        concatenatedIdentities = userIDArray.reduce(
+            (prevValue: string, currentValue: string, index: number) => {
+                let idName: string = Types.IdentityType.getIdentityName(index);
+                return `${prevValue}${idName}=${currentValue};`;
+            },
+            cacheKey
+        );
+    }
+
+    return concatenatedIdentities;
+};
+
+export const shouldCallIdentity = (
+    method: string,
+    proposedUserIdentities: IKnownIdentities,
+    idCache: LocalStorageVault<Dictionary>
+): Boolean => {
+    const cache = idCache.retrieve();
+
+    if (!cache) {
+        return true;
+    }
+
+    const cacheKey: string = concatenateIdentities(
+        method,
+        proposedUserIdentities
+    );
+
+    if (cache.hasOwnProperty(cacheKey)) {
+        const expireTimestamp = cache[cacheKey].expireTimestamp;
+        if (expireTimestamp > new Date().getTime()) return false;
+    }
+
+    return true;
+};
+
+export const createKnownIdentities = (
+    identityApiData: IdentityApiData,
+    deviceId: string
+): IKnownIdentities => {
+    var identitiesResult: IKnownIdentities = {};
+
+    if (
+        identityApiData &&
+        identityApiData.userIdentities &&
+        isObject(identityApiData.userIdentities)
+    ) {
+        for (var identity in identityApiData.userIdentities) {
+            identitiesResult[identity] =
+                identityApiData.userIdentities[identity];
+        }
+    }
+    identitiesResult.device_application_stamp = deviceId;
+
+    return identitiesResult;
+};

--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -27,7 +27,6 @@ export const cacheOrClearIdCache = (
     idCache: LocalStorageVault<Dictionary>,
     xhr: XMLHttpRequest
 ): void => {
-    debugger;
     // default the expire timestamp to one day in milliseconds unless a header comes back
     let expireTimestamp = new Date().getTime() + ONE_DAY_IN_SECONDS * MILLIS_IN_ONE_SEC;
 

--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -1,7 +1,8 @@
-import { Dictionary } from './utils';
+import { Dictionary, parseNumber } from './utils';
 import { LocalStorageVault } from './vault';
 import Types from './types';
 import { IdentityApiData, UserIdentities } from '@mparticle/web-sdk';
+import { IdentityAPIMethod } from './validators';
 import { isObject } from './utils';
 import { MParticleWebSDK } from './sdkRuntimeModels';
 
@@ -16,7 +17,7 @@ export interface ICachedIdentityCall extends UserIdentities {
 }
 
 export const cacheIdentityRequest = (
-    method: string,
+    method: IdentityAPIMethod,
     identities: IKnownIdentities,
     expireTimestamp: number,
     idCache: LocalStorageVault<Dictionary>,
@@ -33,7 +34,7 @@ export const cacheIdentityRequest = (
 // we sort the identities based on their enum.
 // we create an array, set the user identity at the index of the user identity type
 export const concatenateIdentities = (
-    method: string,
+    method: IdentityAPIMethod,
     userIdentities: IKnownIdentities
 ): string => {
     // set DAS first since it is not an official identity type
@@ -42,7 +43,7 @@ export const concatenateIdentities = (
     let concatenatedIdentities: string = '';
 
     if (idLength) {
-        let userIDArray: Array<string> = new Array(idLength);
+        let userIDArray: Array<string> = new Array();
         // create an array where each index is equal to the user identity type
         for (let key in userIdentities) {
             if (key === 'device_application_stamp') {
@@ -66,11 +67,11 @@ export const concatenateIdentities = (
 };
 
 export const hasValidCachedIdentity = (
-    method: string,
+    method: IdentityAPIMethod,
     proposedUserIdentities: IKnownIdentities,
     idCache?: LocalStorageVault<Dictionary>
 ): Boolean => {
-    // There is an edhge case where multiple identity calls are taking place 
+    // There is an edge case where multiple identity calls are taking place 
     // before identify fires, so there may not be a cache.  See what happens when 
     // the ? in idCache is removed to the following test
     // "queued events contain login mpid instead of identify mpid when calling 
@@ -106,7 +107,7 @@ export const hasValidCachedIdentity = (
 };
 
 export const getCachedIdentity = (
-    method: string,
+    method: IdentityAPIMethod,
     proposedUserIdentities: IKnownIdentities,
     idCache: LocalStorageVault<Dictionary>
 ): Dictionary<string | number | boolean> | null => {
@@ -142,7 +143,7 @@ export const createKnownIdentities = (
     return identitiesResult;
 };
 
-export const removeExpiredIdentityCacheDates = function(idCache: LocalStorageVault<Dictionary>): void {
+export const removeExpiredIdentityCacheDates = (idCache: LocalStorageVault<Dictionary>): void => {
     const cache: Dictionary<ICachedIdentityCall> = idCache.retrieve() || {};
 
     idCache.purge();

--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -3,23 +3,29 @@ import { LocalStorageVault } from './vault';
 import Types from './types';
 import { IdentityApiData, UserIdentities } from '@mparticle/web-sdk';
 import { isObject } from './utils';
+import { MParticleWebSDK } from './sdkRuntimeModels';
 
 export interface IKnownIdentities extends UserIdentities {
     device_application_stamp?: string;
 }
 
+export interface ICachedIdentityCall extends UserIdentities {
+    responseText: string;
+    status: number;
+    expireTimestamp: number;
+}
+
 export const cacheIdentityRequest = (
     method: string,
     identities: IKnownIdentities,
-    mpid: string,
     expireTimestamp: number,
-    idCache: LocalStorageVault<Dictionary>
+    idCache: LocalStorageVault<Dictionary>,
+    xhr: XMLHttpRequest
 ): void => {
-    let cache = idCache.retrieve() || {};
-
+    let cache: Dictionary<ICachedIdentityCall> = idCache.retrieve() || {};
     let cacheKey = concatenateIdentities(method, identities);
 
-    cache[cacheKey] = { mpid, expireTimestamp };
+    cache[cacheKey] = { responseText: xhr.responseText, status: xhr.status, expireTimestamp};
     idCache.store(cache);
 };
 
@@ -33,7 +39,7 @@ export const concatenateIdentities = (
     // set DAS first since it is not an official identity type
     let cacheKey: string = `${method}:device_application_stamp=${userIdentities.device_application_stamp};`;
     const idLength: number = Object.keys(userIdentities).length;
-    let concatenatedIdentities: string;
+    let concatenatedIdentities: string = '';
 
     if (idLength) {
         let userIDArray: Array<string> = new Array(idLength);
@@ -83,6 +89,22 @@ export const shouldCallIdentity = (
     return true;
 };
 
+export const getCachedIdentity = (
+    method: string,
+    proposedUserIdentities: IKnownIdentities,
+    idCache: LocalStorageVault<Dictionary>
+): Dictionary<string | number | boolean> | null => {
+    const cacheKey: string = concatenateIdentities(
+        method,
+        proposedUserIdentities
+    );
+
+    const cache = idCache.retrieve();
+    const cachedIdentity = cache ? cache[cacheKey] : null;
+
+    return cachedIdentity;
+};
+
 export const createKnownIdentities = (
     identityApiData: IdentityApiData,
     deviceId: string
@@ -103,3 +125,294 @@ export const createKnownIdentities = (
 
     return identitiesResult;
 };
+
+// export const parseCachedIdentityResponse = (
+//     cachedIdentity: ICachedIdentityCall,
+//     previousMPID: string,
+//     callback,
+//     // identityApiData,
+//     // method,
+//     // knownIdentities,
+//     mpInstance: MParticleWebSDK
+// ) {
+//     var prevUser = mpInstance.Identity.getUser(previousMPID),
+//         newUser,
+//         mpidIsNotInCookies,
+//         identityApiResult,
+//         indexOfMPID,
+//         newIdentitiesByType = {},
+//         previousUIByName = prevUser
+//             ? prevUser.getUserIdentities().userIdentities
+//             : {},
+//         previousUIByNameCopy = mpInstance._Helpers.extend(
+//             {},
+//             previousUIByName
+//         );
+//     // mpInstance._Store.identityCallInFlight = false;
+
+//     mpInstance._Store.isLoggedIn = cachedIdentity.isLoggedIn;
+
+//         // set currentUser
+//         if (
+//             !prevUser ||
+//             (prevUser.getMPID() &&
+//                 identityApiResult.mpid &&
+//                 identityApiResult.mpid !== prevUser.getMPID())
+//         ) {
+//             mpInstance._Store.mpid = identityApiResult.mpid;
+
+//             if (prevUser) {
+//                 mpInstance._Persistence.setLastSeenTime(previousMPID);
+//             }
+
+//             if (
+//                 !mpInstance._Persistence.getFirstSeenTime(
+//                     identityApiResult.mpid
+//                 )
+//             )
+//                 mpidIsNotInCookies = true;
+//             mpInstance._Persistence.setFirstSeenTime(
+//                 identityApiResult.mpid
+//             );
+//         }
+
+//         if (xhr.status === 200) {
+//             // const CACHE_HEADER = 'X-MP-Max-Age';
+//             // const idCacheTimeout = xhr.getAllResponseHeaders();
+//             // magic code to get CACHE_HEADER
+//             const oneDayInMS = 86400 * 60 * 60 * 24;
+//             const timeout = new Date().getTime() + oneDayInMS;
+
+//             if (method === 'login' || method === 'identify') {
+//                 cacheIdentityRequest(
+//                     method,
+//                     knownIdentities,
+//                     identityApiResult.mpid,
+//                     timeout,
+//                     self.idCache
+//                 );
+//             }
+
+//             if (method === 'modify') {
+//                 newIdentitiesByType = mpInstance._Identity.IdentityRequest.combineUserIdentities(
+//                     previousUIByName,
+//                     identityApiData.userIdentities
+//                 );
+
+//                 mpInstance._Persistence.saveUserIdentitiesToPersistence(
+//                     previousMPID,
+//                     newIdentitiesByType
+//                 );
+//             } else {
+//                 var incomingUser = self.IdentityAPI.getUser(
+//                     identityApiResult.mpid
+//                 );
+
+//                 var incomingMpidUIByName = incomingUser
+//                     ? incomingUser.getUserIdentities().userIdentities
+//                     : {};
+
+//                 var incomingMpidUIByNameCopy = mpInstance._Helpers.extend(
+//                     {},
+//                     incomingMpidUIByName
+//                 );
+//                 mpInstance.Logger.verbose(
+//                     'Successfully parsed Identity Response'
+//                 );
+
+//                 //this covers an edge case where, users stored before "firstSeenTime" was introduced
+//                 //will not have a value for "fst" until the current MPID changes, and in some cases,
+//                 //the current MPID will never change
+//                 if (
+//                     method === 'identify' &&
+//                     prevUser &&
+//                     identityApiResult.mpid === prevUser.getMPID()
+//                 ) {
+//                     mpInstance._Persistence.setFirstSeenTime(
+//                         identityApiResult.mpid
+//                     );
+//                 }
+
+//                 indexOfMPID = mpInstance._Store.currentSessionMPIDs.indexOf(
+//                     identityApiResult.mpid
+//                 );
+
+//                 if (
+//                     mpInstance._Store.sessionId &&
+//                     identityApiResult.mpid &&
+//                     previousMPID !== identityApiResult.mpid &&
+//                     indexOfMPID < 0
+//                 ) {
+//                     mpInstance._Store.currentSessionMPIDs.push(
+//                         identityApiResult.mpid
+//                     );
+//                 }
+
+//                 if (indexOfMPID > -1) {
+//                     mpInstance._Store.currentSessionMPIDs = mpInstance._Store.currentSessionMPIDs
+//                         .slice(0, indexOfMPID)
+//                         .concat(
+//                             mpInstance._Store.currentSessionMPIDs.slice(
+//                                 indexOfMPID + 1,
+//                                 mpInstance._Store.currentSessionMPIDs
+//                                     .length
+//                             )
+//                         );
+//                     mpInstance._Store.currentSessionMPIDs.push(
+//                         identityApiResult.mpid
+//                     );
+//                 }
+
+//                 mpInstance._CookieSyncManager.attemptCookieSync(
+//                     previousMPID,
+//                     identityApiResult.mpid,
+//                     mpidIsNotInCookies
+//                 );
+
+//                 self.checkIdentitySwap(
+//                     previousMPID,
+//                     identityApiResult.mpid,
+//                     mpInstance._Store.currentSessionMPIDs
+//                 );
+
+//                 if (
+//                     identityApiData &&
+//                     identityApiData.userIdentities &&
+//                     Object.keys(identityApiData.userIdentities).length
+//                 ) {
+//                     newIdentitiesByType = self.IdentityRequest.combineUserIdentities(
+//                         incomingMpidUIByName,
+//                         identityApiData.userIdentities
+//                     );
+//                 }
+
+//                 mpInstance._Persistence.saveUserIdentitiesToPersistence(
+//                     identityApiResult.mpid,
+//                     newIdentitiesByType
+//                 );
+//                 mpInstance._Persistence.update();
+
+//                 mpInstance._Persistence.findPrevCookiesBasedOnUI(
+//                     identityApiData
+//                 );
+
+//                 mpInstance._Store.context =
+//                     identityApiResult.context ||
+//                     mpInstance._Store.context;
+//             }
+
+//             newUser = mpInstance.Identity.getCurrentUser();
+
+//             if (
+//                 identityApiData &&
+//                 identityApiData.onUserAlias &&
+//                 mpInstance._Helpers.Validators.isFunction(
+//                     identityApiData.onUserAlias
+//                 )
+//             ) {
+//                 try {
+//                     mpInstance.Logger.warning(
+//                         'Deprecated function onUserAlias will be removed in future releases'
+//                     );
+//                     identityApiData.onUserAlias(prevUser, newUser);
+//                 } catch (e) {
+//                     mpInstance.Logger.error(
+//                         'There was an error with your onUserAlias function - ' +
+//                             e
+//                     );
+//                 }
+//             }
+//             var persistence = mpInstance._Persistence.getPersistence();
+
+//             if (newUser) {
+//                 mpInstance._Persistence.storeDataInMemory(
+//                     persistence,
+//                     newUser.getMPID()
+//                 );
+//                 if (
+//                     !prevUser ||
+//                     newUser.getMPID() !== prevUser.getMPID() ||
+//                     prevUser.isLoggedIn() !== newUser.isLoggedIn()
+//                 ) {
+//                     mpInstance._Forwarders.initForwarders(
+//                         newUser.getUserIdentities().userIdentities,
+//                         mpInstance._APIClient.prepareForwardingStats
+//                     );
+//                 }
+//                 mpInstance._Forwarders.setForwarderUserIdentities(
+//                     newUser.getUserIdentities().userIdentities
+//                 );
+//                 mpInstance._Forwarders.setForwarderOnIdentityComplete(
+//                     newUser,
+//                     method
+//                 );
+//                 mpInstance._Forwarders.setForwarderOnUserIdentified(
+//                     newUser,
+//                     method
+//                 );
+//             }
+//             var newIdentitiesByName = {};
+
+//             for (var key in newIdentitiesByType) {
+//                 newIdentitiesByName[
+//                     Types.IdentityType.getIdentityName(
+//                         mpInstance._Helpers.parseNumber(key)
+//                     )
+//                 ] = newIdentitiesByType[key];
+//             }
+
+//             self.sendUserIdentityChangeEvent(
+//                 newIdentitiesByName,
+//                 method,
+//                 identityApiResult.mpid,
+//                 method === 'modify'
+//                     ? previousUIByNameCopy
+//                     : incomingMpidUIByNameCopy
+//             );
+//         }
+
+//         if (callback) {
+//             if (xhr.status === 0) {
+//                 mpInstance._Helpers.invokeCallback(
+//                     callback,
+//                     HTTPCodes.noHttpCoverage,
+//                     identityApiResult || null,
+//                     newUser
+//                 );
+//             } else {
+//                 mpInstance._Helpers.invokeCallback(
+//                     callback,
+//                     xhr.status,
+//                     identityApiResult || null,
+//                     newUser
+//                 );
+//             }
+//         } else {
+//             if (
+//                 identityApiResult &&
+//                 identityApiResult.errors &&
+//                 identityApiResult.errors.length
+//             ) {
+//                 mpInstance.Logger.error(
+//                     'Received HTTP response code of ' +
+//                         xhr.status +
+//                         ' - ' +
+//                         identityApiResult.errors[0].message
+//                 );
+//             }
+//         }
+
+//         mpInstance._APIClient.processQueuedEvents();
+//     } catch (e) {
+//         if (callback) {
+//             mpInstance._Helpers.invokeCallback(
+//                 callback,
+//                 xhr.status,
+//                 identityApiResult || null
+//             );
+//         }
+//         mpInstance.Logger.error(
+//             'Error parsing JSON response from Identity server: ' + e
+//         );
+//     }
+// };

--- a/src/identity.js
+++ b/src/identity.js
@@ -1472,8 +1472,8 @@ export default function Identity(mpInstance) {
         callback,
         identityApiData,
         method,
-        knownIdentities,
-        fromCache,
+        knownIdentities
+        // fromCache,
     ) {
         var prevUser = mpInstance.Identity.getUser(previousMPID),
             newUser,

--- a/src/identity.js
+++ b/src/identity.js
@@ -1,7 +1,7 @@
 import Constants from './constants';
 import Types from './types';
 import {
-    cacheIdentityRequest,
+    cacheOrClearIdCache,
     hasValidCachedIdentity,
     getCachedIdentity,
     createKnownIdentities,
@@ -10,7 +10,7 @@ import {
 var Messages = Constants.Messages,
     HTTPCodes = Constants.HTTPCodes;
 
-const { Identify, Modify } = Constants.IdentityMethods;
+const { Identify, Modify, Login, Logout } = Constants.IdentityMethods;
 
 export default function Identity(mpInstance) {
     var self = this;
@@ -337,7 +337,7 @@ export default function Identity(mpInstance) {
                 preProcessResult = mpInstance._Identity.IdentityRequest.preProcessIdentityRequest(
                     identityApiData,
                     callback,
-                    'logout'
+                    Logout
                 );
             if (currentUser) {
                 mpid = currentUser.getMPID();
@@ -373,7 +373,7 @@ export default function Identity(mpInstance) {
                     } else {
                         mpInstance._IdentityAPIClient.sendIdentityRequest(
                             identityApiRequest,
-                            'logout',
+                            Logout,
                             callback,
                             identityApiData,
                             self.parseIdentityResponse,
@@ -426,7 +426,7 @@ export default function Identity(mpInstance) {
                 preProcessResult = mpInstance._Identity.IdentityRequest.preProcessIdentityRequest(
                     identityApiData,
                     callback,
-                    'login'
+                    Login
                 );
 
             if (currentUser) {
@@ -445,7 +445,7 @@ export default function Identity(mpInstance) {
                 );
 
                 let shouldReturnCachedIdentity = hasValidCachedIdentity(
-                    'login',
+                    Login,
                     identityApiRequest.known_identities,
                     self.idCache
                 );
@@ -489,7 +489,7 @@ export default function Identity(mpInstance) {
                     } else {
                         mpInstance._IdentityAPIClient.sendIdentityRequest(
                             identityApiRequest,
-                            'login',
+                            Login,
                             callback,
                             identityApiData,
                             self.parseIdentityResponse,
@@ -1528,23 +1528,7 @@ export default function Identity(mpInstance) {
             }
 
             if (xhr.status === 200) {
-                // const CACHE_HEADER = 'X-MP-Max-Age';
-                // const idCacheTimeout = xhr.getAllResponseHeaders();
-                // magic code to get CACHE_HEADER
-                const oneDayInMS = 1000 * 60 * 60 * 24;
-                const expireTimestamp = new Date().getTime() + oneDayInMS;
-
-                if (method === 'login' || method === 'identify') {
-                    // if (fromCache) {
-                    cacheIdentityRequest(
-                        method,
-                        knownIdentities,
-                        expireTimestamp,
-                        self.idCache,
-                        xhr
-                    );
-                    // }
-                }
+                cacheOrClearIdCache(method, knownIdentities, self.idCache, xhr);
 
                 if (method === Modify) {
                     newIdentitiesByType = mpInstance._Identity.IdentityRequest.combineUserIdentities(

--- a/src/identity.js
+++ b/src/identity.js
@@ -464,7 +464,7 @@ export default function Identity(mpInstance) {
                     // If Identity is cached, then immediately parse the identity response
                     if (shouldReturnCachedIdentity) {
                         const cachedIdentity = getCachedIdentity(
-                            Identify,
+                            Login,
                             identityApiRequest.known_identities,
                             self.idCache
                         );
@@ -474,7 +474,7 @@ export default function Identity(mpInstance) {
                             mpid,
                             callback,
                             identityApiData,
-                            Identify,
+                            Login,
                             identityApiRequest.known_identities,
                             true
                         );

--- a/src/identity.js
+++ b/src/identity.js
@@ -236,7 +236,7 @@ export default function Identity(mpInstance) {
                 preProcessResult = mpInstance._Identity.IdentityRequest.preProcessIdentityRequest(
                     identityApiData,
                     callback,
-                    'identify'
+                    Identify
                 );
             if (currentUser) {
                 mpid = currentUser.getMPID();
@@ -253,31 +253,37 @@ export default function Identity(mpInstance) {
                     mpid
                 );
 
-                const shouldReturnCachedIdentity = hasValidCachedIdentity(
-                    'identify',
-                    identityApiRequest.known_identities,
-                    self.idCache
-                );
-
-                // If Identity is cached, then immediately parse the identity response
-                if (shouldReturnCachedIdentity) {
-                    const cachedIdentity = getCachedIdentity(
-                        'identify',
+                if (
+                    mpInstance._Helpers.getFeatureFlag(
+                        Constants.FeatureFlags.CacheIdentity
+                    )
+                ) {
+                    const shouldReturnCachedIdentity = hasValidCachedIdentity(
+                        Identify,
                         identityApiRequest.known_identities,
                         self.idCache
                     );
 
-                    self.parseIdentityResponse(
-                        cachedIdentity,
-                        mpid,
-                        callback,
-                        identityApiData,
-                        'identify',
-                        identityApiRequest.known_identities,
-                        true
-                    );
+                    // If Identity is cached, then immediately parse the identity response
+                    if (shouldReturnCachedIdentity) {
+                        const cachedIdentity = getCachedIdentity(
+                            Identify,
+                            identityApiRequest.known_identities,
+                            self.idCache
+                        );
 
-                    return;
+                        self.parseIdentityResponse(
+                            cachedIdentity,
+                            mpid,
+                            callback,
+                            identityApiData,
+                            Identify,
+                            identityApiRequest.known_identities,
+                            true
+                        );
+
+                        return;
+                    }
                 }
 
                 if (mpInstance._Helpers.canLog()) {
@@ -298,7 +304,7 @@ export default function Identity(mpInstance) {
                     } else {
                         mpInstance._IdentityAPIClient.sendIdentityRequest(
                             identityApiRequest,
-                            'identify',
+                            Identify,
                             callback,
                             identityApiData,
                             self.parseIdentityResponse,
@@ -444,31 +450,37 @@ export default function Identity(mpInstance) {
                     mpid
                 );
 
-                let shouldReturnCachedIdentity = hasValidCachedIdentity(
-                    Login,
-                    identityApiRequest.known_identities,
-                    self.idCache
-                );
-
-                // If Identity is cached, then immediately parse the identity response
-                if (shouldReturnCachedIdentity) {
-                    const cachedIdentity = getCachedIdentity(
-                        'identify',
+                if (
+                    mpInstance._Helpers.getFeatureFlag(
+                        Constants.FeatureFlags.CacheIdentity
+                    )
+                ) {
+                    let shouldReturnCachedIdentity = hasValidCachedIdentity(
+                        Login,
                         identityApiRequest.known_identities,
                         self.idCache
                     );
 
-                    self.parseIdentityResponse(
-                        cachedIdentity,
-                        mpid,
-                        callback,
-                        identityApiData,
-                        'identify',
-                        identityApiRequest.known_identities,
-                        true
-                    );
+                    // If Identity is cached, then immediately parse the identity response
+                    if (shouldReturnCachedIdentity) {
+                        const cachedIdentity = getCachedIdentity(
+                            Identify,
+                            identityApiRequest.known_identities,
+                            self.idCache
+                        );
 
-                    return;
+                        self.parseIdentityResponse(
+                            cachedIdentity,
+                            mpid,
+                            callback,
+                            identityApiData,
+                            Identify,
+                            identityApiRequest.known_identities,
+                            true
+                        );
+
+                        return;
+                    }
                 }
 
                 if (mpInstance._Helpers.canLog()) {
@@ -528,7 +540,7 @@ export default function Identity(mpInstance) {
                 preProcessResult = mpInstance._Identity.IdentityRequest.preProcessIdentityRequest(
                     identityApiData,
                     callback,
-                    'modify'
+                    Modify
                 );
             if (currentUser) {
                 mpid = currentUser.getMPID();
@@ -567,7 +579,7 @@ export default function Identity(mpInstance) {
                     } else {
                         mpInstance._IdentityAPIClient.sendIdentityRequest(
                             identityApiRequest,
-                            'modify',
+                            Modify,
                             callback,
                             identityApiData,
                             self.parseIdentityResponse,
@@ -1473,7 +1485,6 @@ export default function Identity(mpInstance) {
         identityApiData,
         method,
         knownIdentities
-        // fromCache,
     ) {
         var prevUser = mpInstance.Identity.getUser(previousMPID),
             newUser,
@@ -1528,7 +1539,18 @@ export default function Identity(mpInstance) {
             }
 
             if (xhr.status === 200) {
-                cacheOrClearIdCache(method, knownIdentities, self.idCache, xhr);
+                if (
+                    mpInstance._Helpers.getFeatureFlag(
+                        Constants.FeatureFlags.CacheIdentity
+                    )
+                ) {
+                    cacheOrClearIdCache(
+                        method,
+                        knownIdentities,
+                        self.idCache,
+                        xhr
+                    );
+                }
 
                 if (method === Modify) {
                     newIdentitiesByType = mpInstance._Identity.IdentityRequest.combineUserIdentities(
@@ -1767,7 +1789,7 @@ export default function Identity(mpInstance) {
         var currentUserInMemory, userIdentityChangeEvent;
 
         if (!mpid) {
-            if (method !== 'modify') {
+            if (method !== Modify) {
                 return;
             }
         }

--- a/src/identityApiClient.js
+++ b/src/identityApiClient.js
@@ -66,7 +66,8 @@ export default function IdentityAPIClient(mpInstance) {
         callback,
         originalIdentityApiData,
         parseIdentityResponse,
-        mpid
+        mpid,
+        knownIdentities
     ) {
         var xhr,
             previousMPID,
@@ -80,7 +81,8 @@ export default function IdentityAPIClient(mpInstance) {
                         previousMPID,
                         callback,
                         originalIdentityApiData,
-                        method
+                        method,
+                        knownIdentities
                     );
                 }
             };

--- a/src/mockBatchCreator.ts
+++ b/src/mockBatchCreator.ts
@@ -12,7 +12,7 @@ const mockFunction = function() {
 };
 export default class _BatchValidator {
     private getMPInstance() {
-        return {
+        return ({
             // Certain Helper, Store, and Identity properties need to be mocked to be used in the `returnBatch` method
             _Helpers: {
                 sanitizeAttributes: window.mParticle.getInstance()._Helpers
@@ -119,7 +119,7 @@ export default class _BatchValidator {
             logLevel: 'none',
             setPosition: mockFunction,
             upload: mockFunction,
-        } as MParticleWebSDK;
+        } as unknown) as MParticleWebSDK;
     }
 
     private createSDKEventFunction(event): SDKEvent {

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -36,6 +36,7 @@ import Consent from './consent';
 import KitBlocker from './kitBlocking';
 import ConfigAPIClient from './configAPIClient';
 import IdentityAPIClient from './identityApiClient';
+import { LocalStorageVault } from './vault';
 
 var Messages = Constants.Messages,
     HTTPCodes = Constants.HTTPCodes;
@@ -1302,11 +1303,18 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
         }
     }
 
+    // add a new function to apply items to the store that require config to be returned
     mpInstance._Store.storageName = mpInstance._Helpers.createMainStorageName(
         config.workspaceToken
     );
     mpInstance._Store.prodStorageName = mpInstance._Helpers.createProductStorageName(
         config.workspaceToken
+    );
+    mpInstance._Identity.idCache = new LocalStorageVault(
+        `${mpInstance._Store.storageName}-id-cache`,
+        {
+            logger: mpInstance.Logger,
+        }
     );
     if (config.hasOwnProperty('workspaceToken')) {
         mpInstance._Store.SDKConfig.workspaceToken = config.workspaceToken;

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -37,6 +37,7 @@ import KitBlocker from './kitBlocking';
 import ConfigAPIClient from './configAPIClient';
 import IdentityAPIClient from './identityApiClient';
 import { LocalStorageVault } from './vault';
+import { removeExpiredIdentityCacheDates } from './identity-utils';
 
 var Messages = Constants.Messages,
     HTTPCodes = Constants.HTTPCodes;
@@ -1316,6 +1317,8 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             logger: mpInstance.Logger,
         }
     );
+
+    removeExpiredIdentityCacheDates(mpInstance._Identity.idCache);
     if (config.hasOwnProperty('workspaceToken')) {
         mpInstance._Store.SDKConfig.workspaceToken = config.workspaceToken;
     } else {

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1311,6 +1311,11 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
     mpInstance._Store.prodStorageName = mpInstance._Helpers.createProductStorageName(
         config.workspaceToken
     );
+
+    // idCache is instantiated here as opposed to when _Identity is instantiated
+    // because it depends on _Store.storageName, which is not sent until above
+    // because it is a setting on config which returns asyncronously
+    // in self hosted mode
     mpInstance._Identity.idCache = new LocalStorageVault(
         `${mpInstance._Store.storageName}-id-cache`,
         {
@@ -1319,6 +1324,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
     );
 
     removeExpiredIdentityCacheDates(mpInstance._Identity.idCache);
+
     if (config.hasOwnProperty('workspaceToken')) {
         mpInstance._Store.SDKConfig.workspaceToken = config.workspaceToken;
     } else {

--- a/src/mparticle-instance-manager.js
+++ b/src/mparticle-instance-manager.js
@@ -355,7 +355,7 @@ function mParticle() {
     };
 
     this.Identity = {
-        HTTPCodes: self.getInstance().Identity.HTTPCodes,
+        HTTPCodes: Constants.HTTPCodes,
         aliasUsers: function(aliasRequest, callback) {
             self.getInstance().Identity.aliasUsers(aliasRequest, callback);
         },

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -11,7 +11,6 @@ import { IPersistence } from './persistence.interfaces';
 import { IMPSideloadedKit } from './sideloadedKit';
 import { ISessionManager } from './sessionManager';
 import { Kit, MPForwarder } from './forwarders.interfaces';
-// import { LocalStorageVault } from './vault';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -11,6 +11,7 @@ import { IPersistence } from './persistence.interfaces';
 import { IMPSideloadedKit } from './sideloadedKit';
 import { ISessionManager } from './sessionManager';
 import { Kit, MPForwarder } from './forwarders.interfaces';
+import { LocalStorageVault } from './vault';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -11,7 +11,7 @@ import { IPersistence } from './persistence.interfaces';
 import { IMPSideloadedKit } from './sideloadedKit';
 import { ISessionManager } from './sessionManager';
 import { Kit, MPForwarder } from './forwarders.interfaces';
-import { LocalStorageVault } from './vault';
+// import { LocalStorageVault } from './vault';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;
@@ -239,7 +239,7 @@ export interface SDKIdentityApi {
     login;
     logout;
     modify;
-    getUser(mpid: string);
+    getUser(mpid: string): MParticleUser;
 }
 
 export interface SDKHelpersApi {

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -239,6 +239,7 @@ export interface SDKIdentityApi {
     login;
     logout;
     modify;
+    getUser();
 }
 
 export interface SDKHelpersApi {

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -11,6 +11,8 @@ import { IPersistence } from './persistence.interfaces';
 import { IMPSideloadedKit } from './sideloadedKit';
 import { ISessionManager } from './sessionManager';
 import { Kit, MPForwarder } from './forwarders.interfaces';
+import Constants from './constants';
+import { valueof } from './utils';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;
@@ -51,6 +53,8 @@ export interface SDKEvent {
     DataPlan?: SDKDataPlan;
     LaunchReferral?: string;
 }
+
+export type IdentityAPIMethod = valueof<typeof Constants.IdentityMethods>;
 
 export interface SDKGeoLocation {
     lat: number | string;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -239,7 +239,7 @@ export interface SDKIdentityApi {
     login;
     logout;
     modify;
-    getUser();
+    getUser(mpid: string);
 }
 
 export interface SDKHelpersApi {

--- a/src/store.ts
+++ b/src/store.ts
@@ -116,6 +116,7 @@ export interface IFeatureFlags {
     eventBatchingIntervalMillis?: number;
     offlineStorage?: string;
     directURLRouting?: boolean;
+    cacheIdentity?: boolean;
 }
 
 // Temporary Interface until Store can be refactored as a class
@@ -429,6 +430,7 @@ export function processFlags(
         EventBatchingIntervalMillis,
         OfflineStorage,
         DirectUrlRouting,
+        CacheIdentity,
     } = Constants.FeatureFlags;
 
     if (!config.flags) {
@@ -443,6 +445,7 @@ export function processFlags(
         Constants.DefaultConfig.uploadInterval;
     flags[OfflineStorage] = config.flags[OfflineStorage] || '0';
     flags[DirectUrlRouting] = config.flags[DirectUrlRouting] === 'True';
+    flags[CacheIdentity] = config.flags[CacheIdentity] === 'True';
 
     return flags;
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -8,8 +8,7 @@ import {
 } from './utils';
 import Constants from './constants';
 import { IdentityApiData } from '@mparticle/web-sdk';
-
-export type IdentityAPIMethod = 'login' | 'logout' | 'identify' | 'modify';
+import { IdentityAPIMethod } from './sdkRuntimeModels';
 
 type ValidationIdentitiesReturn = {
     valid: boolean;

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -9,7 +9,7 @@ import {
 import Constants from './constants';
 import { IdentityApiData } from '@mparticle/web-sdk';
 
-type IdentityAPIMethod = 'login' | 'logout' | 'identify' | 'modify';
+export type IdentityAPIMethod = 'login' | 'logout' | 'identify' | 'modify';
 
 type ValidationIdentitiesReturn = {
     valid: boolean;

--- a/test/jest/utils.ts
+++ b/test/jest/utils.ts
@@ -1,4 +1,3 @@
-import { MPConfiguration } from "@mparticle/web-sdk";
 import { UnregisteredKit } from "../../src/forwarders.interfaces";
 import { SDKInitConfig } from "../../src/sdkRuntimeModels";
 

--- a/test/src/_test.index.ts
+++ b/test/src/_test.index.ts
@@ -29,4 +29,4 @@ import './tests-utils';
 import './tests-session-manager';
 import './tests-store';
 import './tests-config-api-client';
-import './tests-identity-utils.ts'
+import './tests-identity-utils';

--- a/test/src/_test.index.ts
+++ b/test/src/_test.index.ts
@@ -29,3 +29,4 @@ import './tests-utils';
 import './tests-session-manager';
 import './tests-store';
 import './tests-config-api-client';
+import './tests-identity-utils.ts'

--- a/test/src/config/constants.ts
+++ b/test/src/config/constants.ts
@@ -22,6 +22,7 @@ export const testMPID = 'testMPID';
 export const v3CookieKey = 'mprtcl-v3';
 export const v3LSKey = v3CookieKey;
 export const localStorageProductsV4 = 'mprtcl-prodv4';
+export const localStorageIDKey = 'mparticle-id-cache';
 export const v4CookieKey = 'mprtcl-v4';
 export const v4LSKey = 'mprtcl-v4';
 export const workspaceToken = 'abcdef';

--- a/test/src/config/constants.ts
+++ b/test/src/config/constants.ts
@@ -12,6 +12,8 @@ export const urls = {
 };
 
 export const MILLISECONDS_IN_ONE_MINUTE = 60000;
+export const MILLISECONDS_IN_ONE_DAY = MILLISECONDS_IN_ONE_MINUTE * 60 * 24;
+export const MILLISECONDS_IN_ONE_DAY_PLUS_ONE_SECOND = MILLISECONDS_IN_ONE_DAY + 1;
 
 export const mParticle = window.mParticle;
 

--- a/test/src/config/constants.ts
+++ b/test/src/config/constants.ts
@@ -1,4 +1,5 @@
 import { SDKInitConfig } from "../../../src/sdkRuntimeModels";
+import { MILLIS_IN_ONE_SEC, ONE_DAY_IN_SECONDS } from "../../../src/constants";
 
 export const urls = {
     events: 'https://jssdks.mparticle.com/v3/JS/test_key/events',
@@ -11,8 +12,7 @@ export const urls = {
     forwarding: 'https://jssdks.mparticle.com/v1/JS/test_key/Forwarding'
 };
 
-export const MILLISECONDS_IN_ONE_MINUTE = 60000;
-export const MILLISECONDS_IN_ONE_DAY = MILLISECONDS_IN_ONE_MINUTE * 60 * 24;
+export const MILLISECONDS_IN_ONE_DAY = ONE_DAY_IN_SECONDS * MILLIS_IN_ONE_SEC
 export const MILLISECONDS_IN_ONE_DAY_PLUS_ONE_SECOND = MILLISECONDS_IN_ONE_DAY + 1;
 
 export const mParticle = window.mParticle;

--- a/test/src/config/utils.js
+++ b/test/src/config/utils.js
@@ -279,6 +279,7 @@ var pluses = /\+/g,
         if (returnedReqs[0] && returnedReqs[0].requestBody) {
             return JSON.parse(returnedReqs[0].requestBody);
         }
+        return null;
     },
     forwarderDefaultConfiguration = function(
         forwarderName,

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -960,7 +960,6 @@ describe('batch uploader', () => {
                 window.localStorage.getItem(batchStorageKey),
                 'Offline Batch Storage should be empty'
             ).to.equal('');
-            debugger;
 
             // To verify the sequence, we should look at what has been uploaded
             // as the upload queue and Offline Storage should be empty

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -3,7 +3,9 @@ import sinon from 'sinon';
 import fetchMock from 'fetch-mock/esm/client';
 import { urls, apiKey,
     testMPID,
-    MPConfig } from './config/constants';
+    MPConfig, 
+    MILLISECONDS_IN_ONE_DAY_PLUS_ONE_SECOND
+} from './config/constants';
 
 const findEventFromRequest = Utils.findEventFromRequest,
     findBatch = Utils.findBatch,
@@ -981,6 +983,7 @@ describe('identities and attributes', function() {
     });
 
     it('should send historical UIs on batches when MPID changes', function(done) {
+        const clock = sinon.useFakeTimers();
         mParticle._resetForTests(MPConfig);
 
         window.mParticle.config.identifyRequest = {
@@ -1043,6 +1046,8 @@ describe('identities and attributes', function() {
             JSON.stringify({ mpid: testMPID, is_logged_in: true }),
         ]);
 
+        clock.tick(MILLISECONDS_IN_ONE_DAY_PLUS_ONE_SECOND)
+
         mParticle.Identity.login(loginUser);
 
         // switching back to logged in user shoudl not result in any UIC events
@@ -1054,6 +1059,7 @@ describe('identities and attributes', function() {
         batch.user_identities.should.have.property('email', 'initial@gmail.com');
         batch.user_identities.should.have.property('customer_id', 'customerid1');
 
+        clock.restore();
         done();
     });
 

--- a/test/src/tests-identity-utils.ts
+++ b/test/src/tests-identity-utils.ts
@@ -10,7 +10,11 @@ import {
 import { LocalStorageVault } from "../../src/vault";
 import { Dictionary } from "../../src/utils";
 import { expect } from 'chai';
-import { MILLISECONDS_IN_ONE_DAY, MILLISECONDS_IN_ONE_DAY_PLUS_ONE_SECOND, testMPID } from './config';
+import { 
+    MILLISECONDS_IN_ONE_DAY,
+    MILLISECONDS_IN_ONE_DAY_PLUS_ONE_SECOND,
+    testMPID
+} from './config/constants';
 
 import sinon from 'sinon';
 

--- a/test/src/tests-identity-utils.ts
+++ b/test/src/tests-identity-utils.ts
@@ -1,0 +1,178 @@
+import {
+    cacheIdentityRequest,
+    concatenateIdentities,
+    shouldCallIdentity,
+    createKnownIdentities,
+    IKnownIdentities
+} from "../../src/identity-utils";
+import { LocalStorageVault } from "../../src/vault";
+import { Dictionary } from "../../src/utils";
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+const DEVICE_ID = 'test-device-id'
+
+describe('identity-utils', () => {
+    const mpLocalStorageKey = 'mparticle-id-cache';
+    beforeEach(()=> {
+        window.localStorage.clear();
+    });
+
+    describe('#cacheIdentityRequest', () => {
+        it('should save an identify request to local storage', () => {
+            const mpIdCache = window.localStorage.getItem(mpLocalStorageKey);
+            expect(mpIdCache).to.equal(null);
+            
+            const cacheVault = new LocalStorageVault<Dictionary>(mpLocalStorageKey);
+            const knownIdentities: IKnownIdentities = createKnownIdentities({
+                userIdentities: {customerid: 'id1}'}},
+                DEVICE_ID
+            );
+
+            cacheIdentityRequest('identify', knownIdentities, 'testMpid', new Date().getTime(), cacheVault);
+            
+            const updatedMpIdCache = cacheVault.retrieve();
+
+            expect(Object.keys(updatedMpIdCache).length).to.equal(1)
+            const cachedKey = 'identify:device_application_stamp=test-das;';
+
+            expect(updatedMpIdCache.hasOwnProperty(cachedKey)).to.equal(true);
+            expect(updatedMpIdCache[cachedKey]).hasOwnProperty('mpid');
+            expect(updatedMpIdCache[cachedKey]).hasOwnProperty('expireTimestamp');
+        });
+
+        it('should save an login request to local storage', () => {
+            const mpIdCache = window.localStorage.getItem(mpLocalStorageKey);
+            expect(mpIdCache).to.equal(null);
+            
+            const cacheVault = new LocalStorageVault<Dictionary>(mpLocalStorageKey);
+            const knownIdentities: IKnownIdentities = createKnownIdentities({
+                userIdentities: {customerid: 'id1}'}},
+                DEVICE_ID
+            );
+            cacheIdentityRequest('login', knownIdentities, 'testMpid', new Date().getTime(), cacheVault);
+
+            const updatedMpIdCache = cacheVault.retrieve();
+
+            expect(Object.keys(updatedMpIdCache).length).to.equal(1);
+            const cachedKey = 'login:device_application_stamp=test-das;';
+
+            expect(updatedMpIdCache.hasOwnProperty(cachedKey)).to.equal(true);
+            expect(updatedMpIdCache[cachedKey]).hasOwnProperty('mpid');
+            expect(updatedMpIdCache[cachedKey]).hasOwnProperty('expireTimestamp');
+        });
+    });
+
+    describe('#concatenateIdentities', () => {
+        it('should return a concatenated user identity string based on the order of IdentityType enum', () => {
+            const userIdentities: IKnownIdentities = {
+                device_application_stamp: 'first',
+                customerid: '01',
+                email: '07',
+                other: '00',
+                other2: '10',
+                other3: '11',
+                other4: '12',
+                other5: '13',
+                other6: '14',
+                other7: '15',
+                other8: '16',
+                other9: '17',
+                other10: '18',
+                mobile_number: '19',
+                phone_number_2: '20',
+                phone_number_3: '21',
+                facebook: '02',
+                facebookcustomaudienceid: '09',
+                google: '04',
+                twitter: '03',
+                microsoft: '05',
+                yahoo: '06',
+            };
+
+            const key: string = concatenateIdentities('identify', userIdentities);
+            const expectedResult: string = 'identify:device_application_stamp=first;other=00;customerid=01;facebook=02;twitter=03;google=04;microsoft=05;yahoo=06;email=07;facebookcustomaudienceid=09;other2=10;other3=11;other4=12;other5=13;other6=14;other7=15;other8=16;other9=17;other10=18;mobile_number=19;phone_number_2=20;phone_number_3=21;';
+
+            expect(key).to.equal(expectedResult);
+        });
+    });
+
+    describe('#shouldCallIdentity', () => {
+        let clock;
+
+        beforeEach(() => {
+            clock = sinon.useFakeTimers();
+        });
+
+        afterEach(() => {
+            clock.restore();
+        });
+
+        const userIdentities = {
+            device_application_stamp: 'first',
+            customerid: '01',
+            email: '07',
+            other: '00',
+            other2: '10',
+            other3: '11',
+            other4: '12',
+            other5: '13',
+            other6: '14',
+            other7: '15',
+            other8: '16',
+            other9: '17',
+            other10: '18',
+            mobile_number: '19',
+            phone_number_2: '20',
+            phone_number_3: '21',
+            facebook: '02',
+            facebookcustomaudienceid: '09',
+            google: '04',
+            twitter: '03',
+            microsoft: '05',
+            yahoo: '06',
+        };
+
+        it('should return true if idCache is empty', () => {
+            const mpIdCache = window.localStorage.getItem(mpLocalStorageKey);
+            expect(mpIdCache).to.equal(null);
+            
+            const cacheVault = new LocalStorageVault<Dictionary>(mpLocalStorageKey);
+
+            const result = shouldCallIdentity('identify', userIdentities, cacheVault);
+            expect(result).to.equal(true);
+        });
+
+        it('should return false if idCache has the identity method and new identity call is within 1 day of previously cached identity call', () => {
+            const mpIdCache = window.localStorage.getItem(mpLocalStorageKey);
+            expect(mpIdCache).to.equal(null);
+
+            const cacheVault = new LocalStorageVault<Dictionary>(mpLocalStorageKey);
+
+            const result1 = shouldCallIdentity('identify', userIdentities, cacheVault);
+            expect(result1).to.equal(true);
+
+            const oneDayInMS = 86400 * 60 * 60 * 24;
+
+            cacheIdentityRequest('identify', userIdentities, 'testMpid', new Date().getTime() + oneDayInMS, cacheVault);
+
+            clock.tick(5000);
+            const result2 = shouldCallIdentity('identify', userIdentities, cacheVault);
+            expect(result2).to.equal(false);
+        });
+
+        it('should return true if idCache has the identity method and new identity call is beyond of 1 day of previously cached identity call', () => {
+            const mpIdCache = window.localStorage.getItem(mpLocalStorageKey);
+            expect(mpIdCache).to.equal(null);
+
+            const cacheVault = new LocalStorageVault<Dictionary>(mpLocalStorageKey);
+
+            const oneDayInMS = 86400 * 60 * 60 * 24;
+            cacheIdentityRequest('identify', userIdentities, 'testMpid', new Date().getTime() + oneDayInMS, cacheVault);
+
+            clock.tick(oneDayInMS +1);
+            const result3 = shouldCallIdentity('identify', userIdentities, cacheVault);
+            expect(result3).to.equal(true);
+        });
+    });
+});

--- a/test/src/tests-identity.js
+++ b/test/src/tests-identity.js
@@ -1094,7 +1094,7 @@ describe('identity', function() {
             {},
             JSON.stringify({ mpid: 'user1', is_logged_in: false }),
         ]);
-        debugger;
+
         mParticle.Identity.login(userIdentities1);
 
         // get user 2 into cookies
@@ -3115,16 +3115,15 @@ describe('identity', function() {
             }
 
             mParticle.config.identifyRequest = identities;
-            debugger;
+
             mParticle.init(apiKey, window.mParticle.config);
 
             const initialIdentityCall = getIdentityEvent(mockServer.requests, 'identify');
             initialIdentityCall.should.be.ok();
             mockServer.requests = [];
-            function callback(result) {
-                debugger;
+            function callback() {
+                // debugger;
             }
-            debugger;
             mParticle.Identity.identify(identities, callback);
             const duplicateIdentityCall = getIdentityEvent(mockServer.requests, 'identify');
 

--- a/test/src/tests-identity.js
+++ b/test/src/tests-identity.js
@@ -3092,7 +3092,7 @@ describe('identity', function() {
             // add a callback to confirm it gets called
         });
 
-        it.only('should not call login if previously cached', function() {
+        it('should not call login if previously cached', function() {
             mParticle._resetForTests(MPConfig);
             mockServer.respondWith(urls.identify, [
                 200,
@@ -3118,10 +3118,6 @@ describe('identity', function() {
             mParticle.config.identifyRequest = identities;
 
             mParticle.init(apiKey, window.mParticle.config);
-
-            // const initialIdentityCall = getIdentityEvent(mockServer.requests, 'identify');
-            // initialIdentityCall.should.be.ok();
-            // mockServer.requests = [];
 
             mParticle.Identity.login(identities);
             const firstLoginCall = getIdentityEvent(mockServer.requests, 'login');

--- a/test/src/tests-identity.js
+++ b/test/src/tests-identity.js
@@ -3247,7 +3247,7 @@ describe('identity', function() {
             Should(callback.called).equal(true);
         });
 
-        it.only('should call login if duplicate login happens after expiration time', function() {
+        it('should call login if duplicate login happens after expiration time', function() {
             const clock = sinon.useFakeTimers();
             const X_MP_MAX_AGE = '1';
             mParticle._resetForTests(MPConfig);

--- a/test/src/tests-identity.js
+++ b/test/src/tests-identity.js
@@ -3323,7 +3323,7 @@ describe('identity', function() {
             Should(secondIdCache).not.be.ok();
         });
 
-        it.only('should clear cache when logout is called', function() {
+        it('should clear cache when logout is called', function() {
             mParticle._resetForTests(MPConfig);
             
             mockServer.respondWith(urls.identify, [

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -582,12 +582,10 @@ describe('persistence', () => {
     });
 
     it('should transfer user attributes and revert to user identities properly', done => {
-        let clock = sinon.useFakeTimers();
         mParticle._resetForTests(MPConfig);
         const user1 = { userIdentities: { customerid: 'customerid1' } };
 
         const user2 = { userIdentities: { customerid: 'customerid2' } };
-        window.localStorage.clear();
         mParticle.init(apiKey, mParticle.config);
 
         // set user attributes on testMPID
@@ -659,8 +657,6 @@ describe('persistence', () => {
             JSON.stringify({ mpid: 'mpid1', is_logged_in: false }),
         ]);
 
-        // tick clock forward to go beyond the 1 day identity caching
-        clock.tick(MILLISECONDS_IN_ONE_DAY_PLUS_ONE_SECOND);
         mParticle.Identity.login(user1);
         const user1RelogInData = mParticle
             .getInstance()
@@ -672,7 +668,6 @@ describe('persistence', () => {
 
         Object.keys(user1RelogInData.mpid1.ui).length.should.equal(2);
         user1RelogInData.mpid1.ua.should.have.property('test2', 'test2');
-        clock.restore();
 
         done();
     });
@@ -817,7 +812,7 @@ describe('persistence', () => {
         done();
     });
 
-    // this test needs to update the cookie size in order to 
+    // Why is this test breaking?
     xit('integration test - should remove a previous MPID as a key from cookies if new user attribute added and exceeds the size of the max cookie size', done => {
         mParticle._resetForTests(MPConfig);
         mParticle.config.useCookieStorage = true;
@@ -1017,8 +1012,7 @@ describe('persistence', () => {
         done();
     });
 
-    // figure out cookie size here too
-    xit('integration test - should remove a random MPID from storage if there is a new session and there are no MPIDs in currentSessionMPIDs', done => {
+    it('integration test - should remove a random MPID from storage if there is a new session and there are no MPIDs in currentSessionMPIDs', done => {
         mParticle._resetForTests(MPConfig);
         mParticle.config.useCookieStorage = true;
         mParticle.config.maxCookieSize = 600;
@@ -1127,8 +1121,7 @@ describe('persistence', () => {
         done();
     });
 
-    // change cooke size
-    xit('integration test - migrates a large localStorage cookie to cookies and properly remove MPIDs', done => {
+    it('integration test - migrates a large localStorage cookie to cookies and properly remove MPIDs', done => {
         mParticle._resetForTests(MPConfig);
         mParticle.config.useCookieStorage = false;
         mParticle.config.maxCookieSize = 700;
@@ -1876,41 +1869,41 @@ describe('persistence', () => {
         done();
     });
 
-    // it.only('fst should be set when the user does not change, after an identify request', done => {
-    //     mParticle._resetForTests(MPConfig);
-    //     debugger;
-    //     const cookies = JSON.stringify({
-    //         gs: {
-    //             sid: 'fst Test',
-    //             les: new Date().getTime(),
-    //         },
-    //         current: {},
-    //         cu: 'current',
-    //     });
+    it('fst should be set when the user does not change, after an identify request', done => {
+        mParticle._resetForTests(MPConfig);
+        debugger;
+        const cookies = JSON.stringify({
+            gs: {
+                sid: 'fst Test',
+                les: new Date().getTime(),
+            },
+            current: {},
+            cu: 'current',
+        });
 
-    //     mockServer.respondWith(urls.identify, [
-    //         200,
-    //         {},
-    //         JSON.stringify({ mpid: 'current', is_logged_in: false }),
-    //     ]);
+        mockServer.respondWith(urls.identify, [
+            200,
+            {},
+            JSON.stringify({ mpid: 'current', is_logged_in: false }),
+        ]);
 
-    //     setCookie(workspaceCookieName, cookies, true);
-    //     // FIXME: Should this be in configs or global?
-    //     mParticle.config.useCookieStorage = true;
+        setCookie(workspaceCookieName, cookies, true);
+        // FIXME: Should this be in configs or global?
+        mParticle.config.useCookieStorage = true;
 
-    //     mParticle.init(apiKey, mParticle.config);
-    //     expect(
-    //         mParticle.getInstance()._Persistence.getFirstSeenTime('current')
-    //     ).to.equal(null);
+        mParticle.init(apiKey, mParticle.config);
+        expect(
+            mParticle.getInstance()._Persistence.getFirstSeenTime('current')
+        ).to.equal(null);
 
-    //     mParticle.Identity.identify();
+        mParticle.Identity.identify();
 
-    //     expect(
-    //         mParticle.getInstance()._Persistence.getFirstSeenTime('current')
-    //     ).to.not.equal(null);
+        expect(
+            mParticle.getInstance()._Persistence.getFirstSeenTime('current')
+        ).to.not.equal(null);
 
-    //     done();
-    // });
+        done();
+    });
 
     it('lastSeenTime should be null for users in storage without an lst value', done => {
         const cookies = JSON.stringify({

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -32,7 +32,7 @@ const {
 
 let mockServer;
 
-describe('migrations and persistence-related', () => {
+describe('persistence', () => {
     beforeEach(() => {
         fetchMock.post(urls.events, 200);
         mockServer = sinon.createFakeServer();
@@ -1767,7 +1767,7 @@ describe('migrations and persistence-related', () => {
 
         const cookies = JSON.stringify({
             gs: {
-                sid: 'lst Test',
+                sid: 'fst Test',
                 les: new Date().getTime(),
             },
             cu: 'test',
@@ -1794,41 +1794,41 @@ describe('migrations and persistence-related', () => {
         done();
     });
 
-    it('fst should be set when the user does not change, after an identify request', done => {
-        mParticle._resetForTests(MPConfig);
+    // it.only('fst should be set when the user does not change, after an identify request', done => {
+    //     mParticle._resetForTests(MPConfig);
+    //     debugger;
+    //     const cookies = JSON.stringify({
+    //         gs: {
+    //             sid: 'fst Test',
+    //             les: new Date().getTime(),
+    //         },
+    //         current: {},
+    //         cu: 'current',
+    //     });
 
-        const cookies = JSON.stringify({
-            gs: {
-                sid: 'lst Test',
-                les: new Date().getTime(),
-            },
-            current: {},
-            cu: 'current',
-        });
+    //     mockServer.respondWith(urls.identify, [
+    //         200,
+    //         {},
+    //         JSON.stringify({ mpid: 'current', is_logged_in: false }),
+    //     ]);
 
-        mockServer.respondWith(urls.identify, [
-            200,
-            {},
-            JSON.stringify({ mpid: 'current', is_logged_in: false }),
-        ]);
+    //     setCookie(workspaceCookieName, cookies, true);
+    //     // FIXME: Should this be in configs or global?
+    //     mParticle.config.useCookieStorage = true;
 
-        setCookie(workspaceCookieName, cookies, true);
-        // FIXME: Should this be in configs or global?
-        mParticle.config.useCookieStorage = true;
+    //     mParticle.init(apiKey, mParticle.config);
+    //     expect(
+    //         mParticle.getInstance()._Persistence.getFirstSeenTime('current')
+    //     ).to.equal(null);
 
-        mParticle.init(apiKey, mParticle.config);
-        expect(
-            mParticle.getInstance()._Persistence.getFirstSeenTime('current')
-        ).to.equal(null);
+    //     mParticle.Identity.identify();
 
-        mParticle.Identity.identify();
+    //     expect(
+    //         mParticle.getInstance()._Persistence.getFirstSeenTime('current')
+    //     ).to.not.equal(null);
 
-        expect(
-            mParticle.getInstance()._Persistence.getFirstSeenTime('current')
-        ).to.not.equal(null);
-
-        done();
-    });
+    //     done();
+    // });
 
     it('lastSeenTime should be null for users in storage without an lst value', done => {
         const cookies = JSON.stringify({

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -919,7 +919,6 @@ describe('persistence', () => {
 
         cookieData = findCookie();
 
-        debugger;
         expect(cookieData['testMPID']).to.not.be.ok;
         cookieData['MPID1'].ua.should.have.property('id', 'id2');
         cookieData['MPID1'].ua.should.have.property('gender', 'male');
@@ -1871,7 +1870,7 @@ describe('persistence', () => {
 
     it('fst should be set when the user does not change, after an identify request', done => {
         mParticle._resetForTests(MPConfig);
-        debugger;
+
         const cookies = JSON.stringify({
             gs: {
                 sid: 'fst Test',

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -812,11 +812,10 @@ describe('persistence', () => {
         done();
     });
 
-    // Why is this test breaking?
-    xit('integration test - should remove a previous MPID as a key from cookies if new user attribute added and exceeds the size of the max cookie size', done => {
+    it('integration test - should remove a previous MPID as a key from cookies if new user attribute added and exceeds the size of the max cookie size', done => {
         mParticle._resetForTests(MPConfig);
         mParticle.config.useCookieStorage = true;
-        mParticle.config.maxCookieSize = 650;
+        mParticle.config.maxCookieSize = 700;
 
         mParticle.init(apiKey, mParticle.config);
 

--- a/test/src/tests-self-hosting-specific.js
+++ b/test/src/tests-self-hosting-specific.js
@@ -64,6 +64,7 @@ describe('/config self-hosting integration tests', function() {
         done();
     });
 
+    // TODO: LOGIN needs self.idCache to exist, but 
     it('queued events contain login mpid instead of identify mpid when calling login immediately after mParticle initializes', function(done) {
         const messages = [];
         mParticle._resetForTests(MPConfig);
@@ -94,6 +95,8 @@ describe('/config self-hosting integration tests', function() {
             urls.config,
             [200, {}, JSON.stringify({ workspaceToken: 'workspaceTokenTest' })]
         );
+
+        debugger;
         mockServer.respondWith(urls.identify, [
             200,
             {},

--- a/test/src/tests-self-hosting-specific.js
+++ b/test/src/tests-self-hosting-specific.js
@@ -96,7 +96,6 @@ describe('/config self-hosting integration tests', function() {
             [200, {}, JSON.stringify({ workspaceToken: 'workspaceTokenTest' })]
         );
 
-        debugger;
         mockServer.respondWith(urls.identify, [
             200,
             {},

--- a/test/src/tests-self-hosting-specific.js
+++ b/test/src/tests-self-hosting-specific.js
@@ -64,7 +64,6 @@ describe('/config self-hosting integration tests', function() {
         done();
     });
 
-    // TODO: LOGIN needs self.idCache to exist, but 
     it('queued events contain login mpid instead of identify mpid when calling login immediately after mParticle initializes', function(done) {
         const messages = [];
         mParticle._resetForTests(MPConfig);

--- a/test/src/tests-session-manager.ts
+++ b/test/src/tests-session-manager.ts
@@ -7,9 +7,9 @@ import {
     testMPID,
     urls,
     MessageType,
-    MILLISECONDS_IN_ONE_MINUTE,
 } from './config/constants';
 import { IdentityApiData } from '@mparticle/web-sdk';
+import { MILLIS_IN_ONE_SEC } from '../../src/constants';
 import Constants from '../../src/constants';
 
 const { Messages } = Constants;
@@ -75,7 +75,7 @@ describe('SessionManager', () => {
             });
 
             it('ends the previous session and creates a new session if Store contains a sessionId and dateLastEventSent beyond the timeout window', () => {
-                const timePassed = 11 * MILLISECONDS_IN_ONE_MINUTE;
+                const timePassed = 11 * (MILLIS_IN_ONE_SEC * 60);
 
                 const generateUniqueIdSpy = sinon.stub(
                     mParticle.getInstance()._Helpers,
@@ -98,7 +98,7 @@ describe('SessionManager', () => {
             });
 
             it('resumes the previous session if session ID exists and dateLastSent is within the timeout window', () => {
-                const timePassed = 8 * MILLISECONDS_IN_ONE_MINUTE;
+                const timePassed = 8 * (MILLIS_IN_ONE_SEC * 60);
 
                 mParticle.init(apiKey, window.mParticle.config);
                 const mpInstance = mParticle.getInstance();
@@ -298,7 +298,7 @@ describe('SessionManager', () => {
                     'update'
                 );
 
-                clock.tick(31 * MILLISECONDS_IN_ONE_MINUTE);
+                clock.tick(31 * (MILLIS_IN_ONE_SEC * 60));
                 mpInstance._SessionManager.endSession();
 
                 expect(mpInstance._Store.sessionId).to.equal(null);
@@ -591,11 +591,11 @@ describe('SessionManager', () => {
                 mpInstance._SessionManager.setSessionTimer();
 
                 // Progress 29 minutes to make sure end session has not fired
-                clock.tick(29 * MILLISECONDS_IN_ONE_MINUTE);
+                clock.tick(29 * (MILLIS_IN_ONE_SEC * 60));
                 expect(endSessionSpy.called).to.equal(false);
 
                 // Progress one minute to make sure end session fires
-                clock.tick(1 * MILLISECONDS_IN_ONE_MINUTE);
+                clock.tick(1 * (MILLIS_IN_ONE_SEC * 60));
                 expect(endSessionSpy.called).to.equal(true);
             });
 
@@ -871,7 +871,7 @@ describe('SessionManager', () => {
             });
 
             // trigger a session end
-            clock.tick(60 * MILLISECONDS_IN_ONE_MINUTE);
+            clock.tick(60 * (MILLIS_IN_ONE_SEC * 60));
 
             expect(mpInstance._Store.sessionId).to.equal(null);
             expect(mpInstance._Store.dateLastEventSent).to.equal(null);

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -213,6 +213,7 @@ describe('Store', () => {
                 eventBatchingIntervalMillis: 0,
                 offlineStorage: '0',
                 directURLRouting: false,
+                cacheIdentity: false,
             };
 
             expect(flags).to.deep.equal(expectedResult);
@@ -224,6 +225,7 @@ describe('Store', () => {
                 eventBatchingIntervalMillis: 5000,
                 offlineStorage: '100',
                 directURLRouting: 'True',
+                cacheIdentity: 'True',
             };
 
             const flags = processFlags({flags: cutomizedFlags} as unknown as SDKInitConfig, {} as SDKConfig);
@@ -233,6 +235,7 @@ describe('Store', () => {
                 eventBatchingIntervalMillis: 5000,
                 offlineStorage: '100',
                 directURLRouting: true,
+                cacheIdentity: true
             }
 
             expect(flags).to.deep.equal(expectedResult);


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
We want to cache our identity responses to limit superfluous identity calls.  This applies to login and identify for now.  In this PR, I leveraged the vault in order to create a new `idCache`.  

The keys for the idCache are a concatenation of the identities being passed to it along with the `das`.  An example value is as follows:

```
{
    mpid: 'foo',
    responseText: // cached response from the XHR request
    expirationTimestamp: // number - the date being 1 day added to the time the identity call was made
}
```

When an identify or login call is attempted, the idCache is checked.  If it is valid, we simply return the cached information, and do not make an identity call.  If the key does not exist, or it has expired, then we fire another identity call, and cache that one.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Integration tests. Unit tests.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5976