### PR TITLE
ci: Build mparticle.js before running CBT tests

### DIFF
--- a/.github/workflows/cross-browser-testing.yml
+++ b/.github/workflows/cross-browser-testing.yml
@@ -30,6 +30,9 @@ jobs:
       - name: 'Run NPM CI'
         run: npm ci
 
+      - name: Run Build IIFE
+        run: npm run build:iife
+
         # ensures the tests are es5 compatible
       - name: 'Run NPM build:cbt'
         run: npm run build:cbt


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
The browserstack workflow does not have any build of the mparticle.js file. This means it will run new tests against a previous mparticle.js file, thus failing whenever new code is added to the core sdk.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Checked out a different branch and ran the build step in order to get tests to pass.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6052