### PR TITLE
fix: Prevent caching of UIs

### DIFF
--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -76,7 +76,13 @@ export const cacheIdentityRequest = (
     const cacheKey = concatenateIdentities(method, identities);
     const hashedKey = generateHash(cacheKey);
 
-    cache[hashedKey] = { responseText: xhr.responseText, status: xhr.status, expireTimestamp};
+    const { mpid, is_logged_in } = JSON.parse(xhr.responseText);
+    const cachedResponseText = {
+        mpid,
+        is_logged_in,
+    };
+
+    cache[hashedKey] = { responseText: JSON.stringify(cachedResponseText), status: xhr.status, expireTimestamp};
     idCache.store(cache);
 };
 

--- a/test/src/tests-identity-utils.ts
+++ b/test/src/tests-identity-utils.ts
@@ -172,8 +172,10 @@ describe('identity-utils', () => {
             expect(cachedIdentityCall.status).to.equal(200);
             expect(cachedIdentityCall.expireTimestamp).to.equal(currentTime);
 
-            const responseText = JSON.parse(cachedIdentityCall.responseText);
-            expect(responseText).to.deep.equal(identifyResponse);
+            const cachedResponseText = JSON.parse(cachedIdentityCall.responseText);
+            
+            const expectedResponseText = {mpid: testMPID, is_logged_in: false};
+            expect(cachedResponseText).to.deep.equal(expectedResponseText);
         });
 
         it('should save a login request to local storage', () => {
@@ -184,7 +186,6 @@ describe('identity-utils', () => {
                 ...identifyResponse,
                 is_logged_in: true,
             };
-            
 
             const jsonString = JSON.stringify(loginResponse);
 
@@ -220,8 +221,9 @@ describe('identity-utils', () => {
             expect(cachedLoginCall.status).to.equal(200);
             expect(cachedLoginCall.expireTimestamp).to.equal(currentTime);
 
-            const responseText = JSON.parse(cachedLoginCall.responseText);
-            expect(responseText).to.deep.equal(loginResponse);
+            const cachedResponseText = JSON.parse(cachedLoginCall.responseText);
+            const expectedResponseText = {mpid: testMPID, is_logged_in: true};
+            expect(cachedResponseText).to.deep.equal(expectedResponseText);
         });
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
There were a few items on the xhr.responseText that we never use.  Rather than cache everything, just cache the items we need.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Updated unit tests
Tested on local sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6103