### PR TITLE
feat: Implement a flag to disable persistence

### DIFF
--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -130,16 +130,22 @@ export class BatchUploader {
     private addEventListeners() {
         const _this = this;
 
-        // visibility change is a document property, not window
-        document.addEventListener('visibilitychange', () => {
-            _this.prepareAndUpload(false, _this.isBeaconAvailable());
-        });
-        window.addEventListener('beforeunload', () => {
-            _this.prepareAndUpload(false, _this.isBeaconAvailable());
-        });
-        window.addEventListener('pagehide', () => {
-            _this.prepareAndUpload(false, _this.isBeaconAvailable());
-        });
+        try {
+            // visibility change is a document property, not window
+            window.document.addEventListener('visibilitychange', () => {
+                _this.prepareAndUpload(false, _this.isBeaconAvailable());
+            });
+            window.addEventListener('beforeunload', () => {
+                _this.prepareAndUpload(false, _this.isBeaconAvailable());
+            });
+            window.addEventListener('pagehide', () => {
+                _this.prepareAndUpload(false, _this.isBeaconAvailable());
+            });
+        } catch (error) {
+            this.mpInstance.Logger.error(
+                'Cannot addEventListeners for Batch Uploader: ' + error
+            );
+        }
     }
 
     private isBeaconAvailable(): boolean {

--- a/src/cookieSyncManager.js
+++ b/src/cookieSyncManager.js
@@ -7,6 +7,10 @@ export default function cookieSyncManager(mpInstance) {
 
     // Public
     this.attemptCookieSync = function(previousMPID, mpid, mpidIsNotInCookies) {
+        if (!mpInstance._Persistence.isEnabled()) {
+            return false;
+        }
+
         // TODO: These should move inside the for loop
         var pixelConfig,
             lastSyncDateForModule,

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1316,14 +1316,18 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
     // because it depends on _Store.storageName, which is not sent until above
     // because it is a setting on config which returns asyncronously
     // in self hosted mode
-    mpInstance._Identity.idCache = new LocalStorageVault(
-        `${mpInstance._Store.storageName}-id-cache`,
-        {
-            logger: mpInstance.Logger,
-        }
-    );
+    if (
+        mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.CacheIdentity)
+    ) {
+        mpInstance._Identity.idCache = new LocalStorageVault(
+            `${mpInstance._Store.storageName}-id-cache`,
+            {
+                logger: mpInstance.Logger,
+            }
+        );
 
-    removeExpiredIdentityCacheDates(mpInstance._Identity.idCache);
+        removeExpiredIdentityCacheDates(mpInstance._Identity.idCache);
+    }
 
     if (config.hasOwnProperty('workspaceToken')) {
         mpInstance._Store.SDKConfig.workspaceToken = config.workspaceToken;

--- a/src/persistence.interfaces.ts
+++ b/src/persistence.interfaces.ts
@@ -82,6 +82,7 @@ export interface IPersistenceMinified extends Dictionary {
 export interface IPersistence {
     useLocalStorage(): boolean;
     initializeStorage(): void;
+    isEnabled?(): boolean;
     update(): void;
     storeProductsInMemory(products: Product[], mpid: MPID): void;
     storeDataInMemory(obj: IPersistenceMinified, currentMPID: MPID): void;

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -11,6 +11,10 @@ var Base64 = Polyfill.Base64,
 export default function _Persistence(mpInstance) {
     var self = this;
 
+    this.isEnabled = function() {
+        return mpInstance._Store.SDKConfig.usePersistence;
+    };
+
     // https://go.mparticle.com/work/SQDSDKS-5022
     this.useLocalStorage = function() {
         return (
@@ -42,7 +46,9 @@ export default function _Persistence(mpInstance) {
 
             // https://go.mparticle.com/work/SQDSDKS-6046
             if (mpInstance._Store.isLocalStorageAvailable) {
-                storage = window.localStorage;
+                if (this.isEnabled()) {
+                    storage = window.localStorage;
+                }
                 if (mpInstance._Store.SDKConfig.useCookieStorage) {
                     // For migrating from localStorage to cookies -- If an instance switches from localStorage to cookies, then
                     // no mParticle cookie exists yet and there is localStorage. Get the localStorage, set them to cookies, then delete the localStorage item.
@@ -57,7 +63,9 @@ export default function _Persistence(mpInstance) {
                         } else {
                             allData = localStorageData;
                         }
-                        storage.removeItem(mpInstance._Store.storageName);
+                        if (this.isEnabled()) {
+                            storage.removeItem(mpInstance._Store.storageName);
+                        }
                     } else if (cookies) {
                         allData = cookies;
                     }
@@ -77,7 +85,10 @@ export default function _Persistence(mpInstance) {
                             allData = cookies;
                         }
                         self.storeDataInMemory(allData);
-                        self.expireCookies(mpInstance._Store.storageName);
+
+                        if (this.isEnabled()) {
+                            self.expireCookies(mpInstance._Store.storageName);
+                        }
                     } else {
                         self.storeDataInMemory(localStorageData);
                     }
@@ -142,6 +153,9 @@ export default function _Persistence(mpInstance) {
     };
 
     this.update = function() {
+        if (!this.isEnabled()) {
+            return;
+        }
         if (!mpInstance._Store.webviewBridgeEnabled) {
             if (mpInstance._Store.SDKConfig.useCookieStorage) {
                 self.setCookie();
@@ -250,6 +264,9 @@ export default function _Persistence(mpInstance) {
 
     // https://go.mparticle.com/work/SQDSDKS-5022
     this.determineLocalStorageAvailability = function(storage) {
+        if (!this.isEnabled()) {
+            return;
+        }
         var result;
 
         if (window.mParticle && window.mParticle._forceNoLocalStorage) {
@@ -326,6 +343,9 @@ export default function _Persistence(mpInstance) {
 
     // https://go.mparticle.com/work/SQDSDKS-6021
     this.setLocalStorage = function() {
+        if (!this.isEnabled()) {
+            return;
+        }
         if (!mpInstance._Store.isLocalStorageAvailable) {
             return;
         }
@@ -417,6 +437,10 @@ export default function _Persistence(mpInstance) {
     }
 
     this.getLocalStorage = function() {
+        if (!this.isEnabled()) {
+            return null;
+        }
+
         if (!mpInstance._Store.isLocalStorageAvailable) {
             return null;
         }
@@ -467,6 +491,9 @@ export default function _Persistence(mpInstance) {
     };
 
     this.getCookie = function() {
+        if (!this.isEnabled()) {
+            return null;
+        }
         var cookies = window.document.cookie.split('; '),
             key = mpInstance._Store.storageName,
             i,
@@ -510,6 +537,9 @@ export default function _Persistence(mpInstance) {
     // https://go.mparticle.com/work/SQDSDKS-5022
     // https://go.mparticle.com/work/SQDSDKS-6021
     this.setCookie = function() {
+        if (!this.isEnabled()) {
+            return;
+        }
         var mpid,
             currentUser = mpInstance.Identity.getCurrentUser();
         if (currentUser) {
@@ -845,6 +875,9 @@ export default function _Persistence(mpInstance) {
     };
 
     this.getCookieDomain = function() {
+        if (!this.isEnabled()) {
+            return '';
+        }
         if (mpInstance._Store.SDKConfig.cookieDomain) {
             return mpInstance._Store.SDKConfig.cookieDomain;
         } else {
@@ -922,6 +955,9 @@ export default function _Persistence(mpInstance) {
     };
 
     this.setCartProducts = function(allProducts) {
+        if (!this.isEnabled()) {
+            return;
+        }
         if (!mpInstance._Store.isLocalStorageAvailable) {
             return;
         }
@@ -1014,6 +1050,9 @@ export default function _Persistence(mpInstance) {
 
     // https://go.mparticle.com/work/SQDSDKS-6021
     this.savePersistence = function(persistence) {
+        if (!this.isEnabled()) {
+            return;
+        }
         var encodedPersistence = self.encodePersistence(
                 JSON.stringify(persistence)
             ),
@@ -1157,6 +1196,9 @@ export default function _Persistence(mpInstance) {
     };
 
     this.resetPersistence = function() {
+        if (!this.isEnabled()) {
+            return;
+        }
         removeLocalStorage(StorageNames.localStorageName);
         removeLocalStorage(StorageNames.localStorageNameV3);
         removeLocalStorage(StorageNames.localStorageNameV4);

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -220,6 +220,7 @@ export interface SDKInitConfig
     sessionTimeout?: number;
     useNativeSdk?: boolean;
     useCookieStorage?: boolean;
+    usePersistence?: boolean;
     v1SecureServiceUrl?: string;
     v2SecureServiceUrl?: string;
     v3SecureServiceUrl?: string;

--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -77,8 +77,8 @@ export function convertEvents(
 
         device_info: {
             platform: EventsApi.DeviceInformationPlatformEnum.web,
-            screen_width: window.screen.width,
-            screen_height: window.screen.height,
+            screen_width: window?.screen?.width || 0,
+            screen_height: window?.screen?.height || 0,
         },
         user_attributes: lastEvent.UserAttributes,
         user_identities: convertUserIdentities(lastEvent.UserIdentities),

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -224,9 +224,7 @@ export default function SessionManager(
     };
 
     function nullifySession(): void {
-        mpInstance._Store.sessionId = null;
-        mpInstance._Store.dateLastEventSent = null;
-        mpInstance._Store.sessionAttributes = {};
+        mpInstance._Store.nullifySession();
         mpInstance._Persistence.update();
     }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -163,6 +163,7 @@ export interface IStore {
     integrationDelayTimeoutStart: number; // UNIX Timestamp
     webviewBridgeEnabled?: boolean;
     wrapperSDKInfo: WrapperSDKInfo;
+    nullifySession?(): void;
 }
 
 // TODO: Merge this with SDKStoreApi in sdkRuntimeModels
@@ -425,6 +426,12 @@ export default function Store(
             }
         }
     }
+
+    this.nullifySession = (): void => {
+        this.sessionId = null;
+        this.dateLastEventSent = null;
+        this.sessionAttributes = {};
+    };
 }
 
 export function processFlags(

--- a/src/store.ts
+++ b/src/store.ts
@@ -66,6 +66,7 @@ export interface SDKConfig {
     sessionTimeout?: number;
     useNativeSdk?: boolean;
     useCookieStorage?: boolean;
+    usePersistence?: boolean;
     v1SecureServiceUrl?: string;
     v2SecureServiceUrl?: string;
     v3SecureServiceUrl?: string;
@@ -278,6 +279,12 @@ export default function Store(
             this.SDKConfig.useCookieStorage = config.useCookieStorage;
         } else {
             this.SDKConfig.useCookieStorage = false;
+        }
+
+        if (config.hasOwnProperty('usePersistence')) {
+            this.SDKConfig.usePersistence = config.usePersistence;
+        } else {
+            this.SDKConfig.usePersistence = true;
         }
 
         if (config.hasOwnProperty('maxProducts')) {

--- a/test/src/tests-event-logging.js
+++ b/test/src/tests-event-logging.js
@@ -1135,10 +1135,10 @@ describe('event logging without persistence', function() {
             testEventBatch.timestamp_unixtime_ms,
             'batch timestamp'
         ).to.not.equal(null);
-        expect(testEventBatch.user_attributes, 'batch user attributes').to.eqls(
+        expect(testEventBatch.user_attributes, 'batch user attributes').to.deep.equal(
             {}
         );
-        expect(testEventBatch.user_identities, 'batch user identities').to.eqls(
+        expect(testEventBatch.user_identities, 'batch user identities').to.deep.equal(
             null
         );
 

--- a/test/src/tests-event-logging.js
+++ b/test/src/tests-event-logging.js
@@ -1,10 +1,14 @@
 import Utils from './config/utils';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock/esm/client';
-import { urls, apiKey,
+import {
+    urls,
+    apiKey,
     testMPID,
     MPConfig,
-    MessageType } from './config/constants';
+    MessageType,
+} from './config/constants';
+import { expect } from 'chai';
 
 const getIdentityEvent = Utils.getIdentityEvent,
     findEventFromRequest = Utils.findEventFromRequest,

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -1214,7 +1214,71 @@ describe('identities and attributes', function() {
         event4.data.deleted.should.equal(false);
         event4.data.is_new_attribute.should.equal(false);
 
-        done()
+        done();
+    });
+});
+
+describe('identities and attributes without Persistence', () => {
+    beforeEach(function() {
+        mockServer = sinon.createFakeServer();
+        mockServer.respondImmediately = true;
+
+        fetchMock.post(urls.events, 200);
+        mockServer.respondWith(urls.identify, [
+            200,
+            {},
+            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
+        ]);
+        mParticle.init(apiKey, {
+            ...window.mParticle.config,
+            usePersistence: false,
+        });
     });
 
+    afterEach(function() {
+        mockServer.restore();
+        fetchMock.restore();
+    });
+
+    it('shoulds et session attribute', done => {
+        mParticle.setSessionAttribute('name', 'test');
+
+        mParticle.logEvent('test event');
+
+        const event = findEventFromRequest(fetchMock.calls(), 'test event');
+
+        Should(event.data.custom_attributes).equal(null);
+
+        mParticle.endSession();
+        const sessionEndEvent = findEventFromRequest(
+            fetchMock.calls(),
+            'session_end'
+        );
+
+        sessionEndEvent.data.custom_attributes.should.have.property(
+            'name',
+            'test'
+        );
+
+        done();
+    });
+
+    it('should remove session attributes when session ends', function(done) {
+        mParticle.startNewSession();
+        mParticle.setSessionAttribute('name', 'test');
+        mParticle.endSession();
+
+        fetchMock.resetHistory();
+        mParticle.startNewSession();
+        mParticle.endSession();
+
+        const sessionEndEvent = findEventFromRequest(
+            fetchMock.calls(),
+            'session_end'
+        );
+
+        sessionEndEvent.data.custom_attributes.should.not.have.property('name');
+
+        done();
+    });
 });

--- a/test/src/tests-identities-attributes.js
+++ b/test/src/tests-identities-attributes.js
@@ -1240,7 +1240,7 @@ describe('identities and attributes without Persistence', () => {
         fetchMock.restore();
     });
 
-    it('shoulds et session attribute', done => {
+    it('should set session attribute', done => {
         mParticle.setSessionAttribute('name', 'test');
 
         mParticle.logEvent('test event');

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -2053,9 +2053,13 @@ describe('persistence disabled', () => {
     it('should inititalize the SDK without reading or writing to cookies', () => {
         mParticle.config.useCookieStorage = true;
         mParticle.config.usePersistence = false;
+        mParticle.config.flags = {
+            offlineStorage: '0',
+            cacheIdentity: '0',
+        };
         mParticle.init(apiKey, mParticle.config);
 
-        expect(window.document.cookie).to.eq('');
+        expect(window.document.cookie).to.eqls('');
     });
 
     it('should inititalize the SDK without reading or writing to local storage', () => {
@@ -2065,10 +2069,17 @@ describe('persistence disabled', () => {
 
         mParticle.config.useCookieStorage = false;
         mParticle.config.usePersistence = false;
+        mParticle.config.flags = {
+            offlineStorage: '0',
+            cacheIdentity: '0',
+        };
+
         mParticle.init(apiKey, mParticle.config);
 
-        expect(getItemSpy.called).to.eq(false);
-        expect(setItemSpy.called).to.eq(false);
-        expect(removeItemSpy.called).to.eq(false);
+        expect(getItemSpy.called, 'localStorage.getItem called').to.eq(false);
+        expect(setItemSpy.called, 'localStorage.setItem called').to.eq(false);
+        expect(removeItemSpy.called, 'localStorage.removeItem called').to.eq(
+            false
+        );
     });
 });

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -11,7 +11,7 @@ import {
     localStorageProductsV4,
     LocalStorageProductsV4WithWorkSpaceName,
     workspaceCookieName,
-    v4LSKey
+    v4LSKey,
 } from './config/constants';
 import { expect } from 'chai';
 import {
@@ -440,7 +440,10 @@ describe('persistence', () => {
         mParticle.logEvent('Test Event');
         const testEvent = findBatch(fetchMock.calls(), 'Test Event');
         testEvent.integration_attributes.should.have.property('128');
-        testEvent.integration_attributes['128'].should.have.property('MCID', 'abcedfg');
+        testEvent.integration_attributes['128'].should.have.property(
+            'MCID',
+            'abcedfg'
+        );
 
         done();
     });
@@ -758,9 +761,9 @@ describe('persistence', () => {
 
         const userIdentities1 = {
             userIdentities: {
-                customerid: 'foo1'
-            }
-        }
+                customerid: 'foo1',
+            },
+        };
 
         mockServer.respondWith(urls.login, [
             200,

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -201,6 +201,23 @@ describe('Store', () => {
         expect(store.devToken, 'devToken').to.equal(apiKey);
     });
 
+
+    describe('#nullifySession', () => {
+
+        it('should clear out a session', () => {
+            const config = { ...sampleConfig};
+            const store: IStore = new Store(config, window.mParticle.getInstance(), apiKey);
+
+            store.nullifySession();
+
+            expect(store.sessionId).to.eq(null);
+            expect(store.dateLastEventSent).to.eq(null);
+            expect(store.sessionAttributes).to.eql({});
+            expect(store.sessionStartDate).to.eq(null);
+        })
+    });
+
+
     describe('#processFlags', () => {
         it('should return an empty object if no featureFlags are passed', () => {
             const flags = processFlags({} as SDKInitConfig, {} as SDKConfig);

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -146,6 +146,7 @@ describe('Store', () => {
             false
         );
         expect(store.SDKConfig.useNativeSdk, 'useNativeSdk').to.eq(false);
+        expect(store.SDKConfig.usePersistence, 'usePersistence').to.eq(true);
 
         expect(store.SDKConfig.v1SecureServiceUrl, 'v1SecureServiceUrl').to.eq(
             'jssdks.mparticle.com/v1/JS/'


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Provide a simple means to disable persistence so that neither cookie or local storage are directly accessed.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - When the `usePersistence` flag is set to `false`, neither cookie or localStorage should be accessed via the Persistence layer
 - Note: This is independent of Offline Storage, as that can be controlled via a feature flag for the time being.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6072
