### PR TITLE
feat: Implement fetching user audiences

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -40,7 +40,7 @@ export default function APIClient(
         if (!this.uploader) {
             const millis: number = parseNumber(mpInstance._Helpers.getFeatureFlag(
                 Constants.FeatureFlags.EventBatchingIntervalMillis
-            ));
+            ) as string);
             this.uploader = new BatchUploader(mpInstance, millis);
         }
         this.uploader.queueEvent(event);

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -1,0 +1,9 @@
+export default class Audience {
+    public id: number;
+    public name: string;
+
+    constructor(id: number, name: string) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/audienceManager.ts
+++ b/src/audienceManager.ts
@@ -4,7 +4,7 @@ import {
     XHRUploader,
     AsyncUploader,
     fetchPayload
-} from './batchUploader';
+} from './uploaders';
 import Audience from './audience';
 
 type AudienceResponseMessage = 'ar';
@@ -12,9 +12,9 @@ export interface IAudienceServerResponse {
     dt: AudienceResponseMessage;
     id: string;
     ct: number;
-    m: IAudienceMembership[];
+    m: IMinifiedAudienceMembership[];
 }
-export interface IAudienceMembership {
+export interface IMinifiedAudienceMembership {
     id: number; // AudienceId
     n: string; // External Name
     c: AudienceListMembershipUpdateType[]; // AudienceMembershipChanges
@@ -116,7 +116,7 @@ export default class AudienceManager {
 export const parseUserAudiences = (audienceServerResponse: IAudienceServerResponse): IMPParsedAudienceMemberships => {
     const currentAudiences: Audience[] = [];
     const pastAudiences: Audience[] = [];
-    audienceServerResponse?.m?.forEach((membership: IAudienceMembership) => {
+    audienceServerResponse?.m?.forEach((membership: IMinifiedAudienceMembership) => {
         if (membership.c[0].a === AudienceMembershipChangeAction.Add) {
             currentAudiences.push(new Audience(
                 membership.id,

--- a/src/audienceManager.ts
+++ b/src/audienceManager.ts
@@ -1,0 +1,143 @@
+import { SDKLoggerApi } from './sdkRuntimeModels';
+import {
+    FetchUploader,
+    XHRUploader,
+    AsyncUploader,
+    fetchPayload
+} from './batchUploader';
+import Audience from './audience';
+
+type AudienceResponseMessage = 'ar';
+export interface IAudienceServerResponse {
+    dt: AudienceResponseMessage;
+    id: string;
+    ct: number;
+    m: IAudienceMembership[];
+}
+export interface IAudienceMembership {
+    id: number; // AudienceId
+    n: string; // External Name
+    c: AudienceListMembershipUpdateType[]; // AudienceMembershipChanges
+    s: string[]; // ModuleEndpointExternalReferenceKeys
+}
+
+export enum AudienceMembershipChangeAction {
+    Unknown = 'unkown',
+    Add = 'add',
+    Drop = 'drop',
+}
+
+export interface AudienceListMembershipUpdateType {
+    ct: number;
+    a: AudienceMembershipChangeAction;
+}
+
+export interface IMPParsedAudienceMemberships {
+    currentAudiences: IMPAudience[];
+    pastAudiences: IMPAudience[];
+}
+
+export interface IMPAudience {
+    id: number;
+    name: string;
+}
+
+export default class AudienceManager {
+    public url: string = '';
+    public userAudienceAPI: AsyncUploader;
+    public logger: SDKLoggerApi;
+
+    constructor(
+        userAudienceUrl: string,
+        apiKey: string,
+        logger: SDKLoggerApi,
+        mpid: string
+    ) {
+        this.logger = logger;
+        this.url = `https://${userAudienceUrl}${apiKey}/audience?mpid=${mpid}`;
+        this.userAudienceAPI = window.fetch
+            ? new FetchUploader(this.url)
+            : new XHRUploader(this.url);
+    }
+
+    public async sendGetUserAudienceRequest(callback: (userAudiences: IMPParsedAudienceMemberships) => void) {
+        this.logger.verbose('Fetching user audiences from server');
+
+        const fetchPayload: fetchPayload = {
+            method: 'GET',
+            headers: {
+                Accept: '*/*',
+            },
+        };
+        let userAudiencePromise: Response;
+
+        try {
+             userAudiencePromise = await this.userAudienceAPI.upload(
+                fetchPayload
+            );
+
+            if (
+                userAudiencePromise.status >= 200 &&
+                userAudiencePromise.status < 300
+            ) {
+                this.logger.verbose(`User Audiences successfully received`);
+
+                const userAudienceResponse: IAudienceServerResponse = await userAudiencePromise.json();
+                const parsedUserAudiences: IMPParsedAudienceMemberships = parseUserAudiences(userAudienceResponse)
+                
+                try {
+                    callback(parsedUserAudiences);
+                } catch(e) {
+                    this.logger.error('Error invoking callback on user audience response.')
+                }
+
+            } else if (userAudiencePromise.status === 401) {
+                this.logger.error(
+                    `HTTP error status ${userAudiencePromise.status} while retrieving User Audiences - please verify your API key.`
+                );
+            } else if (userAudiencePromise.status === 403) {
+                this.logger.error(
+                    `HTTP error status ${userAudiencePromise.status} while retrieving User Audiences - please verify your workspace is enabled for audiences.`
+                );
+            } else {
+                // In case there is an HTTP error we did not anticipate.
+                console.error(
+                    `HTTP error status ${userAudiencePromise.status} while uploading events.`,
+                    userAudiencePromise
+                );
+
+                throw new Error(
+                    `Uncaught HTTP Error ${userAudiencePromise.status}.`
+                );
+            }
+        } catch (e) {
+            this.logger.error(
+                `Error retrieving audiences. ${e}`
+            );
+        }
+    }
+}
+
+export const parseUserAudiences = (audienceServerResponse: IAudienceServerResponse): IMPParsedAudienceMemberships => {
+    const currentAudiences: IMPAudience[] = [];
+    const pastAudiences: IMPAudience[] = [];
+    audienceServerResponse?.m?.forEach((membership: IAudienceMembership) => {
+        if (membership.c[0].a === AudienceMembershipChangeAction.Add) {
+            currentAudiences.push(new Audience(
+                membership.id,
+                membership.n
+            ));
+        };
+
+        if (membership.c[0].a === AudienceMembershipChangeAction.Drop) {
+            pastAudiences.push(new Audience(
+                membership.id,
+                membership.n
+            ));
+        };
+    });
+
+    return {
+        currentAudiences, pastAudiences
+    }
+}

--- a/src/audienceManager.ts
+++ b/src/audienceManager.ts
@@ -33,13 +33,8 @@ export interface AudienceListMembershipUpdateType {
 }
 
 export interface IMPParsedAudienceMemberships {
-    currentAudiences: IMPAudience[];
-    pastAudiences: IMPAudience[];
-}
-
-export interface IMPAudience {
-    id: number;
-    name: string;
+    currentAudiences: Audience[];
+    pastAudiences: Audience[];
 }
 
 export default class AudienceManager {
@@ -119,8 +114,8 @@ export default class AudienceManager {
 }
 
 export const parseUserAudiences = (audienceServerResponse: IAudienceServerResponse): IMPParsedAudienceMemberships => {
-    const currentAudiences: IMPAudience[] = [];
-    const pastAudiences: IMPAudience[] = [];
+    const currentAudiences: Audience[] = [];
+    const pastAudiences: Audience[] = [];
     audienceServerResponse?.m?.forEach((membership: IAudienceMembership) => {
         if (membership.c[0].a === AudienceMembershipChangeAction.Add) {
             currentAudiences.push(new Audience(

--- a/src/audienceManager.ts
+++ b/src/audienceManager.ts
@@ -22,7 +22,7 @@ export interface IMinifiedAudienceMembership {
 }
 
 export enum AudienceMembershipChangeAction {
-    Unknown = 'unkown',
+    Unknown = 'unknown',
     Add = 'add',
     Drop = 'drop',
 }

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -10,6 +10,7 @@ import { convertEvents } from './sdkToEventsApiConverter';
 import Types from './types';
 import { getRampNumber, isEmpty } from './utils';
 import { SessionStorageVault, LocalStorageVault } from './vault';
+import { AsyncUploader, FetchUploader, XHRUploader, fetchPayload } from './uploaders';
 
 /**
  * BatchUploader contains all the logic to store/retrieve events and batches
@@ -422,62 +423,4 @@ export class BatchUploader {
         }
         return null;
     }
-}
-
-export abstract class AsyncUploader {
-    url: string;
-    public abstract upload(fetchPayload: fetchPayload): Promise<Response>;
-
-    constructor(url: string) {
-        this.url = url;
-    }
-}
-
-export class FetchUploader extends AsyncUploader {
-    public async upload(fetchPayload: fetchPayload): Promise<Response> {
-        const response: Response = await fetch(this.url,fetchPayload);
-
-        return response;
-    }
-}
-
-export class XHRUploader extends AsyncUploader {
-    public async upload(fetchPayload: fetchPayload): Promise<Response> {
-        const response: Response = await this.makeRequest(
-            this.url,
-            fetchPayload.body
-        );
-        return response;
-    }
-
-    private async makeRequest(
-        url: string,
-        data: string
-    ): Promise<Response> {
-        const xhr: XMLHttpRequest = new XMLHttpRequest();
-        return new Promise((resolve, reject) => {
-            xhr.onreadystatechange = () => {
-                if (xhr.readyState !== 4) return;
-
-                // Process the response
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    resolve(xhr as unknown as Response);
-                } else {
-                    reject(xhr);
-                }
-            };
-
-            xhr.open('post', url);
-            xhr.send(data);
-        });
-    }
-}
-
-export interface fetchPayload {
-    method: string;
-    headers: {
-        Accept: string;
-        'Content-Type'?: string;
-    };
-    body?: string;
 }

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -108,11 +108,11 @@ export class BatchUploader {
             _Store: { deviceId },
         } = this.mpInstance;
 
-        const offlineStorageFeatureFlagValue = getFeatureFlag(
+        const offlineStorageFeatureFlagValue: string = getFeatureFlag(
             Constants.FeatureFlags.OfflineStorage
-        );
+        ) as string;
 
-        const offlineStoragePercentage = parseInt(
+        const offlineStoragePercentage: number = parseInt(
             offlineStorageFeatureFlagValue,
             10
         );
@@ -424,25 +424,26 @@ export class BatchUploader {
     }
 }
 
-abstract class AsyncUploader {
+export abstract class AsyncUploader {
     url: string;
-    public abstract upload(fetchPayload: fetchPayload): Promise<XHRResponse>;
+    public abstract upload(fetchPayload: fetchPayload): Promise<Response>;
 
     constructor(url: string) {
         this.url = url;
     }
 }
 
-class FetchUploader extends AsyncUploader {
-    public async upload(fetchPayload: fetchPayload): Promise<XHRResponse> {
-        const response: XHRResponse = await fetch(this.url, fetchPayload);
+export class FetchUploader extends AsyncUploader {
+    public async upload(fetchPayload: fetchPayload): Promise<Response> {
+        const response: Response = await fetch(this.url,fetchPayload);
+
         return response;
     }
 }
 
-class XHRUploader extends AsyncUploader {
-    public async upload(fetchPayload: fetchPayload): Promise<XHRResponse> {
-        const response: XHRResponse = await this.makeRequest(
+export class XHRUploader extends AsyncUploader {
+    public async upload(fetchPayload: fetchPayload): Promise<Response> {
+        const response: Response = await this.makeRequest(
             this.url,
             fetchPayload.body
         );
@@ -452,7 +453,7 @@ class XHRUploader extends AsyncUploader {
     private async makeRequest(
         url: string,
         data: string
-    ): Promise<XMLHttpRequest> {
+    ): Promise<Response> {
         const xhr: XMLHttpRequest = new XMLHttpRequest();
         return new Promise((resolve, reject) => {
             xhr.onreadystatechange = () => {
@@ -460,7 +461,7 @@ class XHRUploader extends AsyncUploader {
 
                 // Process the response
                 if (xhr.status >= 200 && xhr.status < 300) {
-                    resolve(xhr);
+                    resolve(xhr as unknown as Response);
                 } else {
                     reject(xhr);
                 }
@@ -472,16 +473,11 @@ class XHRUploader extends AsyncUploader {
     }
 }
 
-interface XHRResponse {
-    status: number;
-    statusText?: string;
-}
-
-interface fetchPayload {
+export interface fetchPayload {
     method: string;
     headers: {
         Accept: string;
-        'Content-Type': string;
+        'Content-Type'?: string;
     };
-    body: string;
+    body?: string;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -135,6 +135,7 @@ const Constants = {
         configUrl: 'jssdkcdns.mparticle.com/JS/v2/',
         identityUrl: 'identity.mparticle.com/v1/',
         aliasUrl: 'jssdks.mparticle.com/v1/identity/',
+        userAudienceUrl: 'nativesdks.mparticle.com/v1/',
     },
     Base64CookieKeys: {
         csm: 1,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -135,7 +135,7 @@ const Constants = {
         configUrl: 'jssdkcdns.mparticle.com/JS/v2/',
         identityUrl: 'identity.mparticle.com/v1/',
         aliasUrl: 'jssdks.mparticle.com/v1/identity/',
-        userAudienceUrl: 'nativesdks.mparticle.com/v1/',
+        userAudienceUrl: 'jssdks.mparticle.com/v1/',
     },
     Base64CookieKeys: {
         csm: 1,

--- a/src/identity.js
+++ b/src/identity.js
@@ -5,6 +5,7 @@ import {
     createKnownIdentities,
     tryCacheIdentity,
 } from './identity-utils';
+import AudienceManager from './audienceManager';
 
 var Messages = Constants.Messages,
     HTTPCodes = Constants.HTTPCodes;
@@ -14,6 +15,7 @@ const { Identify, Modify, Login, Logout } = Constants.IdentityMethods;
 export default function Identity(mpInstance) {
     var self = this;
     this.idCache = null;
+    this.audienceManager = null;
 
     this.checkIdentitySwap = function(
         previousMPID,
@@ -1264,6 +1266,23 @@ export default function Identity(mpInstance) {
             },
             getFirstSeenTime: function() {
                 return mpInstance._Persistence.getFirstSeenTime(mpid);
+            },
+            /**
+             * Get user segments for user
+             * @method getUserSegments
+             * @return {Object} an array with user segments????
+             */
+            getUserAudiences: function(callback) {
+                if (self.audienceManager === null) {
+                    self.audienceManager = new AudienceManager(
+                        mpInstance._Store.SDKConfig.userSegmentUrl,
+                        mpInstance._Store.devToken,
+                        mpInstance.Logger,
+                        mpid
+                    );
+                }
+
+                self.audienceManager.sendGetUserAudienceRequest(mpid, callback);
             },
         };
     };

--- a/src/identity.js
+++ b/src/identity.js
@@ -1268,14 +1268,14 @@ export default function Identity(mpInstance) {
                 return mpInstance._Persistence.getFirstSeenTime(mpid);
             },
             /**
-             * Get user segments for user
-             * @method getUserSegments
-             * @return {Object} an array with user segments????
+             * Get user audiences
+             * @method getuserAudiences
+             * @param {Function} [callback] A callback function that is invoked when the user audience request completes
              */
             getUserAudiences: function(callback) {
                 if (self.audienceManager === null) {
                     self.audienceManager = new AudienceManager(
-                        mpInstance._Store.SDKConfig.userSegmentUrl,
+                        mpInstance._Store.SDKConfig.userAudienceUrl,
                         mpInstance._Store.devToken,
                         mpInstance.Logger,
                         mpid

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -246,19 +246,26 @@ export interface SDKIdentityApi {
 
 export interface SDKHelpersApi {
     canLog?(): boolean;
-    createServiceUrl(arg0: string, arg1: string): void;
+    createServiceUrl(url: string, devToken?: string): void;
     createXHR?(cb: () => void): XMLHttpRequest;
     extend?(...args: any[]);
     parseNumber?(value: string | number): number;
     generateUniqueId();
     generateHash?(value: string): string;
-    getFeatureFlag?(feature: string); // TODO: Feature Constants should be converted to enum
+    getFeatureFlag?(feature: string): boolean | string; // TODO: Feature Constants should be converted to enum
     isDelayedByIntegration?(
         delayedIntegrations: Dictionary<boolean>,
         timeoutStart: number,
         now: number
     ): boolean;
     isObject?(item: any);
+    invokeCallback?(
+        cb: ()=> void,
+        code: string,
+        body: string,
+        mParticleUser?: MParticleUser,
+        previousMpid?: string
+    ): void;
     returnConvertedBoolean(data: string | boolean | number): boolean;
     sanitizeAttributes?(
         attrs: Dictionary<string>,

--- a/src/store.ts
+++ b/src/store.ts
@@ -60,6 +60,7 @@ export interface SDKConfig {
     aliasUrl?: string;
     configUrl?: string;
     identityUrl?: string;
+    userSegmentUrl?: string;
     isIOS?: boolean;
     maxProducts: number;
     requestConfig?: boolean;

--- a/src/store.ts
+++ b/src/store.ts
@@ -60,7 +60,7 @@ export interface SDKConfig {
     aliasUrl?: string;
     configUrl?: string;
     identityUrl?: string;
-    userSegmentUrl?: string;
+    userAudienceUrl?: string;
     isIOS?: boolean;
     maxProducts: number;
     requestConfig?: boolean;

--- a/src/uploaders.ts
+++ b/src/uploaders.ts
@@ -1,0 +1,54 @@
+export interface fetchPayload {
+    method: string;
+    headers: {
+        Accept: string;
+        'Content-Type'?: string;
+    };
+    body?: string;
+}
+
+export abstract class AsyncUploader {
+    url: string;
+    public abstract upload(fetchPayload: fetchPayload): Promise<Response>;
+
+    constructor(url: string) {
+        this.url = url;
+    }
+}
+
+export class FetchUploader extends AsyncUploader {
+    public async upload(fetchPayload: fetchPayload): Promise<Response> {
+        const response: Response = await fetch(this.url, fetchPayload);
+
+        return response;
+    }
+}
+
+export class XHRUploader extends AsyncUploader {
+    public async upload(fetchPayload: fetchPayload): Promise<Response> {
+        const response: Response = await this.makeRequest(
+            this.url,
+            fetchPayload.body
+        );
+        return response;
+    }
+
+    private async makeRequest(url: string, data: string): Promise<Response> {
+        const xhr: XMLHttpRequest = new XMLHttpRequest();
+        return new Promise((resolve, reject) => {
+            xhr.onreadystatechange = () => {
+                if (xhr.readyState !== 4) return;
+
+                // Process the response
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    resolve((xhr as unknown) as Response);
+                } else {
+                    reject(xhr);
+                }
+            };
+
+            xhr.open('post', url);
+            xhr.send(data);
+        });
+    }
+}

--- a/test/jest/audience.spec.ts
+++ b/test/jest/audience.spec.ts
@@ -1,13 +1,11 @@
-import { expect } from 'chai';
 import Audience from '../../src/audience';
-
 
 describe('Audience', () => {
     it('should return an audience with an id and name', () => {
         const audience = new Audience(12345, 'foo-audience');
 
-        expect(audience).to.be.ok;
-        expect(audience.id).to.equal(12345);
-        expect(audience.name).to.equal('foo-audience');
+        expect(audience).toBeDefined();
+        expect(audience.id).toEqual(12345);
+        expect(audience.name).toEqual('foo-audience');
     });
 });

--- a/test/src/_test.index.ts
+++ b/test/src/_test.index.ts
@@ -30,3 +30,5 @@ import './tests-session-manager';
 import './tests-store';
 import './tests-config-api-client';
 import './tests-identity-utils';
+import './tests-audience';
+import './tests-audience-manager';

--- a/test/src/_test.index.ts
+++ b/test/src/_test.index.ts
@@ -30,5 +30,4 @@ import './tests-session-manager';
 import './tests-store';
 import './tests-config-api-client';
 import './tests-identity-utils';
-import './tests-audience';
 import './tests-audience-manager';

--- a/test/src/tests-audience-manager.ts
+++ b/test/src/tests-audience-manager.ts
@@ -5,7 +5,7 @@ import { urls, apiKey, MPConfig, testMPID } from './config/constants';
 import Constants from '../../src/constants';
 import { MParticleWebSDK, SDKLoggerApi } from '../../src/sdkRuntimeModels';
 import AudienceManager, {
-    IAudienceMembership,
+    IMinifiedAudienceMembership,
     IAudienceServerResponse,
     AudienceMembershipChangeAction,
     IMPParsedAudienceMemberships,
@@ -67,7 +67,7 @@ describe('AudienceManager', () => {
 
         expect(audienceManager.logger).to.be.ok;
         expect(audienceManager.url).to.equal(userAudienceUrl);
-        expect(audienceManager.url).to.equal(userAudienceUrl);
+        expect(audienceManager.userAudienceAPI).to.be.ok;
     });
 
     describe('#sendGetUserAudienceRequest', () => {
@@ -79,7 +79,7 @@ describe('AudienceManager', () => {
             testMPID
         );
 
-        const audienceMembership1: IAudienceMembership = {
+        const audienceMembership1: IMinifiedAudienceMembership = {
             'id': 7628,
             'n': 'foo-audience-1',
             'c': [{
@@ -89,7 +89,7 @@ describe('AudienceManager', () => {
             's': []
         };
 
-        const audienceMembership2: IAudienceMembership = {
+        const audienceMembership2: IMinifiedAudienceMembership = {
             'id': 13388,
             'n': 'foo-audience-2',
             'c': [

--- a/test/src/tests-audience-manager.ts
+++ b/test/src/tests-audience-manager.ts
@@ -57,7 +57,7 @@ describe('AudienceManager', () => {
     });
 
     it('should have proper properties on AudienceManager initialization', () => {
-        const newLogger:SDKLoggerApi = new Logger(window.mParticle.config);
+        const newLogger: SDKLoggerApi = new Logger(window.mParticle.config);
         const audienceManager = new AudienceManager(
             Constants.DefaultBaseUrls.userAudienceUrl,
             apiKey,

--- a/test/src/tests-audience-manager.ts
+++ b/test/src/tests-audience-manager.ts
@@ -1,0 +1,147 @@
+import sinon from 'sinon';
+import fetchMock from 'fetch-mock/esm/client';
+import { expect } from 'chai';
+import { urls, apiKey, MPConfig, testMPID } from './config/constants';
+import Constants from '../../src/constants';
+import { MParticleWebSDK, SDKLoggerApi } from '../../src/sdkRuntimeModels';
+import AudienceManager, {
+    IAudienceMembership,
+    IAudienceServerResponse,
+    AudienceMembershipChangeAction,
+    IMPParsedAudienceMemberships,
+    parseUserAudiences
+} from '../../src/audienceManager';
+import Logger from '../../src/logger.js';
+
+
+declare global {
+    interface Window {
+        mParticle: MParticleWebSDK;
+        fetchMock: any;
+    }
+}
+
+const enableBatchingConfigFlags = {
+    eventBatchingIntervalMillis: 1000,
+};
+
+const userAudienceUrl = `https://${Constants.DefaultBaseUrls.userAudienceUrl}${apiKey}/audience?mpid=${testMPID}`
+
+describe('AudienceManager', () => {
+    let mockServer;
+    before(function() {
+        fetchMock.restore();
+        sinon.restore();
+    });
+
+    beforeEach(function() {
+        fetchMock.restore();
+        mockServer = sinon.createFakeServer();
+        mockServer.respondImmediately = true;
+
+        mockServer.respondWith(urls.identify, [
+            200,
+            {},
+            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
+        ]);
+
+        window.mParticle.config.flags = {
+            eventBatchingIntervalMillis: 1000,
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        mockServer.reset();
+        fetchMock.restore();
+    });
+
+    it('should have proper properties on AudienceManager initialization', () => {
+        const newLogger:SDKLoggerApi = new Logger(window.mParticle.config);
+        const audienceManager = new AudienceManager(
+            Constants.DefaultBaseUrls.userAudienceUrl,
+            apiKey,
+            newLogger,
+            testMPID
+        );
+
+        expect(audienceManager.logger).to.be.ok;
+        expect(audienceManager.url).to.equal(userAudienceUrl);
+        expect(audienceManager.url).to.equal(userAudienceUrl);
+    });
+
+    describe('#sendGetUserAudienceRequest', () => {
+        const newLogger = new Logger(window.mParticle.config);
+        const audienceManager = new AudienceManager(
+            Constants.DefaultBaseUrls.userAudienceUrl,
+            apiKey,
+            newLogger,
+            testMPID
+        );
+
+        const audienceMembership1: IAudienceMembership = {
+            'id': 7628,
+            'n': 'foo-audience-1',
+            'c': [{
+                'ct': 0,
+                'a': AudienceMembershipChangeAction.Drop
+                }],
+            's': []
+        };
+
+        const audienceMembership2: IAudienceMembership = {
+            'id': 13388,
+            'n': 'foo-audience-2',
+            'c': [
+                {
+                    'ct': 1706713126180,
+                    'a': AudienceMembershipChangeAction.Add
+                }
+            ],
+            's': []
+        }
+        const audiencePayloadResponse: IAudienceServerResponse = {
+            'dt': 'ar', // audience response message
+            'id': '399a6b02-6c38-4146-a7e2-144a2b803c24',
+            'ct': 1706714266028,
+            'm': [audienceMembership1, audienceMembership2]
+        };
+
+        const userAudienceResult: IMPParsedAudienceMemberships = {
+            currentAudiences: [{
+                id: 13388,
+                name: 'foo-audience-2',
+            },],
+            pastAudiences: [{
+                id: 7628,
+                name: 'foo-audience-1',
+
+            }]
+        };
+
+        it('should invoke a callback with user audiences of interface IMPParsedAudienceMemberships', async () => {
+            const callback = sinon.spy();
+
+            fetchMock.get(userAudienceUrl, {
+                status: 200,
+                body: JSON.stringify(audiencePayloadResponse)
+            });
+
+            await audienceManager.sendGetUserAudienceRequest(callback);
+
+            expect(audienceManager.logger).to.be.ok;
+            expect(audienceManager.url).to.equal(userAudienceUrl);
+            expect(callback.called).to.eq(true);
+            expect(callback.getCall(0).lastArg).to.deep.equal(
+                userAudienceResult
+            );
+        });
+        
+        it('#parseUserAudiences', () => {
+            const parsedAudienceResponse: IMPParsedAudienceMemberships = parseUserAudiences(audiencePayloadResponse)
+
+            expect(parsedAudienceResponse).to.deep.equal(userAudienceResult);
+        })
+    });
+
+});

--- a/test/src/tests-audience-manager.ts
+++ b/test/src/tests-audience-manager.ts
@@ -21,10 +21,6 @@ declare global {
     }
 }
 
-const enableBatchingConfigFlags = {
-    eventBatchingIntervalMillis: 1000,
-};
-
 const userAudienceUrl = `https://${Constants.DefaultBaseUrls.userAudienceUrl}${apiKey}/audience?mpid=${testMPID}`
 
 describe('AudienceManager', () => {

--- a/test/src/tests-audience.ts
+++ b/test/src/tests-audience.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import Audience from '../../src/audience';
+
+
+describe('Audience', () => {
+    it('should return an audience with an id and name', () => {
+        const audience = new Audience(12345, 'foo-audience');
+
+        expect(audience).to.be.ok;
+        expect(audience.id).to.equal(12345);
+        expect(audience.name).to.equal('foo-audience');
+    });
+});

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -248,6 +248,7 @@ describe('Store', () => {
 
             it('should return default baseUrls if no baseUrls are passed', () => {
                 const baseUrls: Dictionary = Constants.DefaultBaseUrls;
+
                 const result = processBaseUrls(
                     {} as unknown as SDKInitConfig,
                     featureFlags as unknown as IFeatureFlags,
@@ -263,6 +264,7 @@ describe('Store', () => {
                     configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
                     identityUrl: 'foo-identity.customer.mp.com/',
                     aliasUrl: 'foo-alias.customer.mp.com/',
+                    userAudienceUrl: 'foo-user-segment.customer.mp.com/',
                 };
 
                 const result = processBaseUrls(
@@ -275,6 +277,7 @@ describe('Store', () => {
                     v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
                     configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
                     identityUrl: 'foo-identity.customer.mp.com/',
+                    userAudienceUrl: 'foo-user-segment.customer.mp.com/',
                     aliasUrl: 'foo-alias.customer.mp.com/',
                     v1SecureServiceUrl: "jssdks.mparticle.com/v1/JS/",
                     v2SecureServiceUrl: "jssdks.mparticle.com/v2/JS/",
@@ -318,6 +321,7 @@ describe('Store', () => {
                     v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
                     configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
                     identityUrl: 'foo-identity.customer.mp.com/',
+                    userAudienceUrl: 'foo-user-segment.customer.mp.com/',
                     aliasUrl: 'foo-alias.customer.mp.com/',
                 };
 
@@ -331,6 +335,7 @@ describe('Store', () => {
                     v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
                     configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
                     identityUrl: 'foo-identity.customer.mp.com/',
+                    userAudienceUrl: 'foo-user-segment.customer.mp.com/',
                     aliasUrl: 'foo-alias.customer.mp.com/',
                     v1SecureServiceUrl: "jssdks.us1.mparticle.com/v1/JS/",
                     v2SecureServiceUrl: "jssdks.us1.mparticle.com/v2/JS/",


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
This PR provides for a new API on the current user: mParticle.Identity.getCurrentUser().getUserAudiences(callback).

The url it accesses is: https://jssdks.mparticle.com/v1/{apikey}/audiences?mpid=3984273492347328 and will return to the user the following schema to a callback:

```
{
  currentAudiences: Audience[],
  pastAudiences: Audience[]
}
```

 ## Testing Plan
 - [] Was this tested locally? If not, explain why.
We are waiting for the backend to be updated before 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5994