### PR TITLE
fix: Wrap LaunchReferral with check for existence of window.location

### DIFF
--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -166,6 +166,14 @@ function convertCustomFlags(event: SDKEvent, dto: IServerV2DTO) {
     }
 }
 
+function getLaunchReferral(): string | null {
+    if (window.location && window.location.href) {
+        return window.location.href;
+    }
+
+    return null;
+}
+
 function convertProductToV2DTO(product: SDKProduct): IProductV2DTO {
     return {
         id: parseStringOrNumber(product.Sku),
@@ -368,7 +376,7 @@ export default function ServerModel(
 
             if (eventObject.EventDataType === MessageType.AppStateTransition) {
                 eventObject.IsFirstRun = mpInstance._Store.isFirstRun;
-                eventObject.LaunchReferral = window.location.href || null;
+                eventObject.LaunchReferral = getLaunchReferral();
             }
 
             // FIXME: Remove duplicate occurence


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - In cases where window.location.href is not available, AST events will not fire.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Test to see if AST fires with location in `LaunchReferral`

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6153
