### PR TITLE
fix: Update audience logic to new backend response

### DIFF
--- a/src/audience.ts
+++ b/src/audience.ts
@@ -1,9 +1,12 @@
 export default class Audience {
-    public id: number;
-    public name: string;
+    public audience_id: number;
+    public expiration_timestamp_ms?: number;
 
-    constructor(id: number, name: string) {
-        this.id = id;
-        this.name = name;
+    constructor(
+        audience_id: number,
+        expiration_timestamp_ms?: number
+    ) {
+        this.audience_id = audience_id;
+        this.expiration_timestamp_ms = expiration_timestamp_ms || null;
     }
 }

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -1,6 +1,5 @@
 export default class Audience {
     public audience_id: number;
-    public expiration_timestamp_ms?: number;
 
     constructor(
         audience_id: number,

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -3,9 +3,7 @@ export default class Audience {
 
     constructor(
         audience_id: number,
-        expiration_timestamp_ms?: number
     ) {
         this.audience_id = audience_id;
-        this.expiration_timestamp_ms = expiration_timestamp_ms || null;
     }
 }

--- a/src/audienceManager.ts
+++ b/src/audienceManager.ts
@@ -29,7 +29,7 @@ export default class AudienceManager {
         logger: SDKLoggerApi
     ) {
         this.logger = logger;
-        this.url = `https://${userAudienceUrl}${apiKey}/audience?mpid=`;
+        this.url = `https://${userAudienceUrl}${apiKey}/audience`;
         this.userAudienceAPI = window.fetch
             ? new FetchUploader(this.url)
             : new XHRUploader(this.url);
@@ -44,7 +44,7 @@ export default class AudienceManager {
                 Accept: '*/*',
             },
         };
-        const audienceURLWithMPID = `${this.url}${mpid}`;
+        const audienceURLWithMPID = `${this.url}?mpid=${mpid}`;
         let userAudiencePromise: Response;
 
         try {

--- a/src/audienceManager.ts
+++ b/src/audienceManager.ts
@@ -11,37 +11,6 @@ export interface IAudienceMemberships {
     audience_memberships: Audience[];
 }
 
-// export interface IAudienceMemberships extends IAudienceServerResponse {}
-
-// export interface IAudienceServerResponse {
-//     dt: AudienceResponseMessage;
-//     id: string;
-//     ct: number;
-//     m: IMinifiedAudienceMembership[];
-// }
-// export interface IMinifiedAudienceMembership {
-//     id: number; // AudienceId
-//     n: string; // External Name
-//     c: AudienceListMembershipUpdateType[]; // AudienceMembershipChanges
-//     s: string[]; // ModuleEndpointExternalReferenceKeys
-// }
-
-// export enum AudienceMembershipChangeAction {
-//     Unknown = 'unknown',
-//     Add = 'add',
-//     Drop = 'drop',
-// }
-
-// export interface AudienceListMembershipUpdateType {
-//     ct: number;
-//     a: AudienceMembershipChangeAction;
-// }
-
-// export interface IMPParsedAudienceMemberships {
-//     currentAudiences: Audience[];
-//     pastAudiences: Audience[];
-// }
-
 export default class AudienceManager {
     public url: string = '';
     public userAudienceAPI: AsyncUploader;
@@ -116,28 +85,3 @@ export default class AudienceManager {
         }
     }
 }
-
-// export const parseUserAudiences = (audienceServerResponse: IAudienceServerResponse): IAudienceMemberships => {
-//     return audienceServerResponse;
-//     // const currentAudiences: Audience[] = [];
-//     // const pastAudiences: Audience[] = [];
-//     // audienceServerResponse.audience_memberships.forEach(audience: Audience) => {
-//         // if (membership.c[0].a === AudienceMembershipChangeAction.Add) {
-//         //     currentAudiences.push(new Audience(
-//         //         membership.id,
-//         //         membership.n
-//         //     ));
-//         // };
-
-//         // if (membership.c[0].a === AudienceMembershipChangeAction.Drop) {
-//         //     pastAudiences.push(new Audience(
-//         //         membership.id,
-//         //         membership.n
-//         //     ));
-//         // };
-//     // });
-
-//     // return {
-//     //     currentAudiences, pastAudiences
-//     // }
-// }

--- a/src/audienceManager.ts
+++ b/src/audienceManager.ts
@@ -26,7 +26,7 @@ export default class AudienceManager {
     constructor(
         userAudienceUrl: string,
         apiKey: string,
-        logger: SDKLoggerApi
+        logger: SDKLoggerApi,
     ) {
         this.logger = logger;
         this.url = `https://${userAudienceUrl}${apiKey}/audience`;
@@ -67,7 +67,7 @@ export default class AudienceManager {
                 try {
                     callback(parsedUserAudienceMemberships);
                 } catch(e) {
-                    this.logger.error('Error invoking callback on IAudienceMemberships.');
+                    this.logger.error('Error invoking callback on user audience response.');
                 }
 
             } else if (userAudiencePromise.status === 401) {

--- a/src/uploaders.ts
+++ b/src/uploaders.ts
@@ -9,7 +9,10 @@ export interface fetchPayload {
 
 export abstract class AsyncUploader {
     url: string;
-    public abstract upload(fetchPayload: fetchPayload): Promise<Response>;
+    public abstract upload(
+        fetchPayload: fetchPayload,
+        url?: string
+    ): Promise<Response>;
 
     constructor(url: string) {
         this.url = url;
@@ -17,8 +20,17 @@ export abstract class AsyncUploader {
 }
 
 export class FetchUploader extends AsyncUploader {
-    public async upload(fetchPayload: fetchPayload): Promise<Response> {
-        const response: Response = await fetch(this.url, fetchPayload);
+    public async upload(
+        fetchPayload: fetchPayload,
+        url?: string
+    ): Promise<Response> {
+        let response: Response;
+
+        if (url) {
+            response = await fetch(url, fetchPayload);
+        } else {
+            response = await fetch(this.url, fetchPayload);
+        }
 
         return response;
     }

--- a/src/uploaders.ts
+++ b/src/uploaders.ts
@@ -26,8 +26,6 @@ export class FetchUploader extends AsyncUploader {
     ): Promise<Response> {
         const url = _url || this.url;
         return await fetch(url, fetchPayload);
-
-        return response;
     }
 }
 

--- a/src/uploaders.ts
+++ b/src/uploaders.ts
@@ -22,15 +22,10 @@ export abstract class AsyncUploader {
 export class FetchUploader extends AsyncUploader {
     public async upload(
         fetchPayload: fetchPayload,
-        url?: string
+        _url?: string
     ): Promise<Response> {
-        let response: Response;
-
-        if (url) {
-            response = await fetch(url, fetchPayload);
-        } else {
-            response = await fetch(this.url, fetchPayload);
-        }
+        const url = _url || this.url;
+        return await fetch(url, fetchPayload);
 
         return response;
     }

--- a/test/jest/audience.spec.ts
+++ b/test/jest/audience.spec.ts
@@ -1,11 +1,19 @@
 import Audience from '../../src/audience';
 
 describe('Audience', () => {
-    it('should return an audience with an id and name', () => {
-        const audience = new Audience(12345, 'foo-audience');
+    it('should return an audience with just an audience_id', () => {
+        const audience = new Audience(12345);
 
         expect(audience).toBeDefined();
-        expect(audience.id).toEqual(12345);
-        expect(audience.name).toEqual('foo-audience');
+        expect(audience.audience_id).toEqual(12345);
+        expect(audience.expiration_timestamp_ms).toEqual(null);
+    });
+
+    it('should return an audience with an audience_id and expiration_timestamp_ms', () => {
+        const audience = new Audience(12345, 12345);
+
+        expect(audience).toBeDefined();
+        expect(audience.audience_id).toEqual(12345);
+        expect(audience.expiration_timestamp_ms).toEqual(12345);
     });
 });

--- a/test/jest/audience.spec.ts
+++ b/test/jest/audience.spec.ts
@@ -6,14 +6,12 @@ describe('Audience', () => {
 
         expect(audience).toBeDefined();
         expect(audience.audience_id).toEqual(12345);
-        expect(audience.expiration_timestamp_ms).toEqual(null);
     });
 
     it('should return an audience with an audience_id and expiration_timestamp_ms', () => {
-        const audience = new Audience(12345, 12345);
+        const audience = new Audience(12345);
 
         expect(audience).toBeDefined();
         expect(audience.audience_id).toEqual(12345);
-        expect(audience.expiration_timestamp_ms).toEqual(12345);
     });
 });

--- a/test/src/tests-audience-manager.ts
+++ b/test/src/tests-audience-manager.ts
@@ -16,7 +16,7 @@ declare global {
     }
 }
 
-const userAudienceUrl = `https://${Constants.DefaultBaseUrls.userAudienceUrl}${apiKey}/audience?mpid=`
+const userAudienceUrl = `https://${Constants.DefaultBaseUrls.userAudienceUrl}${apiKey}/audience`;
 
 describe('AudienceManager', () => {
     let mockServer;
@@ -96,7 +96,7 @@ describe('AudienceManager', () => {
         it('should invoke a callback with user audiences of interface IMPParsedAudienceMemberships', async () => {
             const callback = sinon.spy();
 
-            fetchMock.get(`${userAudienceUrl}${testMPID}`, {
+            fetchMock.get(`${userAudienceUrl}?mpid=${testMPID}`, {
                 status: 200,
                 body: JSON.stringify(audienceMembershipServerResponse)
             });
@@ -106,7 +106,6 @@ describe('AudienceManager', () => {
             expect(audienceManager.logger).to.be.ok;
             expect(audienceManager.url).to.equal(userAudienceUrl);
             expect(callback.calledOnce).to.eq(true);
-            debugger;
             expect(callback.getCall(0).lastArg).to.deep.equal(
                 expectedAudienceMembership
             );
@@ -115,8 +114,8 @@ describe('AudienceManager', () => {
         it('should change the URL endpoint to a new MPID when switching users and attempting to retrieve audiences', async () => {
             const callback = sinon.spy();
             const newMPID = 'newMPID';
-            const testMPIDAudienceEndpoint = `${userAudienceUrl}${testMPID}`;
-            const newMPIDAudienceEndpoint = `${userAudienceUrl}${newMPID}`;
+            const testMPIDAudienceEndpoint = `${userAudienceUrl}?mpid=${testMPID}`;
+            const newMPIDAudienceEndpoint = `${userAudienceUrl}?mpid=${newMPID}`;
 
             fetchMock.get(testMPIDAudienceEndpoint, {
                 status: 200,
@@ -161,7 +160,7 @@ describe('AudienceManager', () => {
             expect(callback.getCall(0).lastArg).to.deep.equal(
                 expectedAudienceMembership
             );
-            
+
             await audienceManager.sendGetUserAudienceRequest(newMPID, callback);
 
             expect(callback.calledTwice).to.eq(true);

--- a/test/src/tests-audience-manager.ts
+++ b/test/src/tests-audience-manager.ts
@@ -9,7 +9,6 @@ import AudienceManager, {
 } from '../../src/audienceManager';
 import Logger from '../../src/logger.js';
 
-
 declare global {
     interface Window {
         mParticle: MParticleWebSDK;
@@ -76,11 +75,9 @@ describe('AudienceManager', () => {
             current_audience_memberships: [
                 {
                     audience_id: 7628,
-                    expiration_timestamp_ms: 1234
                 },
                 {
                     audience_id: 13388,
-                    expiration_timestamp_ms: null
                 },
             ]
         };
@@ -89,11 +86,9 @@ describe('AudienceManager', () => {
             currentAudienceMemberships: [
                 {
                     audience_id: 7628,
-                    expiration_timestamp_ms: 1234
                 },
                 {
                     audience_id: 13388,
-                    expiration_timestamp_ms: null
                 },
             ]
         };
@@ -135,11 +130,9 @@ describe('AudienceManager', () => {
                 current_audience_memberships: [
                     {
                         audience_id: 9876,
-                        expiration_timestamp_ms: 1234
                     },
                     {
                         audience_id: 5432,
-                        expiration_timestamp_ms: null
                     },
                 ]
             };
@@ -148,11 +141,9 @@ describe('AudienceManager', () => {
             currentAudienceMemberships: [
                 {
                     audience_id: 9876,
-                    expiration_timestamp_ms: 1234
                 },
                 {
                     audience_id: 5432,
-                    expiration_timestamp_ms: null
                 },
             ]
         };


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Code has been updated to respect the following simplified backend response:

``` 
{
    ct: 1710441407915,
    dt: 'cam',  // current audience memberships
    id: 'foo-id-2',
    current_audience_memberships: [
        {
            audience_id: 9876,
            expiration_timestamp_ms: 1234
        },
        {
            audience_id: 5432,
            expiration_timestamp_ms: null
        },
    ]
};
```

The response to the user is an object that removes `ct`, `dt`, and `id` from the above, and only returns `current_audience_memberships`.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why. - Tested using PR environment

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6149