### PR TITLE
fix: Combine End Session Logging Messaging flow

### DIFF
--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -149,12 +149,7 @@ export default function SessionManager(
 
         const cookies: IPersistenceMinified = mpInstance._Persistence.getPersistence();
 
-        // TODO: https://go.mparticle.com/work/SQDSDKS-5684
-        if (!cookies) {
-            return;
-        }
-
-        if (cookies.gs && !cookies.gs.sid) {
+        if (!cookies || cookies.gs && !cookies.gs.sid) {
             mpInstance.Logger.verbose(
                 Messages.InformationMessages.NoSessionToEnd
             );

--- a/test/src/tests-session-manager.ts
+++ b/test/src/tests-session-manager.ts
@@ -43,7 +43,7 @@ describe('SessionManager', () => {
         ]);
     });
 
-    afterEach(function () {
+    afterEach(function() {
         sandbox.restore();
         clock.restore();
         mockServer.restore();
@@ -329,7 +329,7 @@ describe('SessionManager', () => {
                 expect(persistenceSpy.called).to.equal(true);
             });
 
-            it('should log StartingEndSession message and return early if Persistence is null', () => {
+            it('should log  NoSessionToEnd Message  and return if Persistence is null', () => {
                 mParticle.init(apiKey, window.mParticle.config);
 
                 const mpInstance = mParticle.getInstance();
@@ -341,18 +341,17 @@ describe('SessionManager', () => {
 
                 mpInstance._SessionManager.endSession();
 
-                // This path currently goes through the !cookies path,
-                // which doesn't really return anything except for logging the
-                // initial StartingEndSession message
-                expect(consoleSpy.getCall(0).firstArg).to.equal(
+                // Should log initial StartingEndSession and NoSessionToEnd messages
+                expect(consoleSpy.getCalls().length).to.equal(2);
+                expect(consoleSpy.firstCall.firstArg).to.equal(
                     Messages.InformationMessages.StartingEndSession
                 );
-
-                // Should only log a single verbose log
-                expect(consoleSpy.getCalls().length).to.equal(1);
+                expect(consoleSpy.lastCall.firstArg).to.equal(
+                    Messages.InformationMessages.NoSessionToEnd
+                );
             });
 
-            it('should log a NoSessionToEnd Message if Persistence Exists but does not return an sid', () => {
+            it('should log a NoSessionToEnd Message if Persistence exists but does not return an sid', () => {
                 mParticle.init(apiKey, window.mParticle.config);
 
                 const mpInstance = mParticle.getInstance();


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Make end session logic clearly log that there is no session to end if persistence is either null or lacks a session id.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Attempt to end a session without persistence or without a session id

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5684
