### PR TITLE
fix: Migrate deviceId methods to Store

### DIFF
--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -86,6 +86,9 @@ export default function mParticleInstance(instanceName) {
     this._Identity = new Identity(this);
     this.Identity = this._Identity.IdentityAPI;
     this.generateHash = this._Helpers.generateHash;
+
+    // https://go.mparticle.com/work/SQDSDKS-6289
+    // TODO: Replace this with Store once Store is moved earlier in the init process
     this.getDeviceId = this._Persistence.getDeviceId;
 
     if (typeof window !== 'undefined') {

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -234,7 +234,7 @@ export default function mParticleInstance(instanceName) {
             self.setDeviceId(guid);
         }, self);
         if (queued) return;
-        this._Persistence.setDeviceId(guid);
+        this._Store.setDeviceId(guid);
     };
     /**
      * Returns a boolean for whether or not the SDKhas been fully initialized

--- a/src/store.ts
+++ b/src/store.ts
@@ -455,8 +455,7 @@ export default function Store(
     this.setDeviceId = (deviceId: string) => {
         this.deviceId = deviceId;
         this.persistenceData.gs.das = deviceId;
-
-        mpInstance._Persistence.savePersistence(this.persistenceData);
+        mpInstance._Persistence.update();
     };
 
     this.nullifySession = (): void => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,6 +23,7 @@ import {
 import { isNumber, isDataPlanSlug, Dictionary, parseNumber } from './utils';
 import { SDKConsentState } from './consent';
 import { Kit, MPForwarder } from './forwarders.interfaces';
+import { IPersistenceMinified } from './persistence.interfaces';
 
 // This represents the runtime configuration of the SDK AFTER
 // initialization has been complete and all settings and
@@ -163,6 +164,14 @@ export interface IStore {
     webviewBridgeEnabled?: boolean;
     wrapperSDKInfo: WrapperSDKInfo;
 
+    persistenceData?: IPersistenceMinified;
+
+    getDeviceId?(): string;
+    setDeviceId?(deviceId: string): void;
+
+    getAllUserAttributes?(mpid: MPID): Dictionary;
+    setUserAttributes?(mpid: MPID, userAttributes: Dictionary): void;
+
     nullifySession?: () => void;
 }
 
@@ -216,6 +225,27 @@ export default function Store(
             version: null,
             isInfoSet: false,
         },
+
+        // Placeholder for in-memory persistence model
+        persistenceData: {
+            cu: null,
+            gs: {
+                sid: null,
+                ie: null,
+                sa: null,
+                ss: null,
+                dt: null,
+                av: null,
+                cgid: null,
+                das: null,
+                ia: null,
+                c: null,
+                csm: null,
+                les: null,
+                ssd: null,
+            },
+            l: null,
+        },
     };
 
     for (var key in defaultStore) {
@@ -233,16 +263,19 @@ export default function Store(
             this.SDKConfig.flags = {};
         }
 
-        this.SDKConfig.flags = processFlags(config, this
-            .SDKConfig as SDKConfig);
+        this.SDKConfig.flags = processFlags(
+            config,
+            this.SDKConfig as SDKConfig
+        );
 
         if (config.deviceId) {
             this.deviceId = config.deviceId;
         }
         if (config.hasOwnProperty('isDevelopmentMode')) {
-            this.SDKConfig.isDevelopmentMode = mpInstance._Helpers.returnConvertedBoolean(
-                config.isDevelopmentMode
-            );
+            this.SDKConfig.isDevelopmentMode =
+                mpInstance._Helpers.returnConvertedBoolean(
+                    config.isDevelopmentMode
+                );
         } else {
             this.SDKConfig.isDevelopmentMode = false;
         }
@@ -420,6 +453,14 @@ export default function Store(
             }
         }
     }
+
+    this.getDeviceId = () => this.deviceId;
+    this.setDeviceId = (deviceId: string) => {
+        this.deviceId = deviceId;
+        this.persistenceData.gs.das = deviceId;
+
+        mpInstance._Persistence.savePersistence(this.persistenceData);
+    };
 
     this.nullifySession = (): void => {
         this.sessionId = null;

--- a/src/store.ts
+++ b/src/store.ts
@@ -169,9 +169,6 @@ export interface IStore {
     getDeviceId?(): string;
     setDeviceId?(deviceId: string): void;
 
-    getAllUserAttributes?(mpid: MPID): Dictionary;
-    setUserAttributes?(mpid: MPID, userAttributes: Dictionary): void;
-
     nullifySession?: () => void;
 }
 

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -249,6 +249,46 @@ describe('Store', () => {
         });
     });
 
+    describe('#getDeviceId', () => {
+        it('should return the deviceId from the store', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.deviceId = 'foo';
+
+            expect(store.getDeviceId()).to.equal('foo');
+        });
+    });
+
+    describe('#setDeviceId', () => {
+        it('should set the deviceId in the store', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.setDeviceId('foo');
+            expect(store.deviceId).to.equal('foo');
+        });
+
+        it('should set the deviceId in persistence', () => {
+            // Since this relies on persistence, we need to make sure
+            // we are using an mParticle instance that shares both
+            // store and persistence modules
+            const store = window.mParticle.getInstance()._Store;
+
+            store.setDeviceId('foo');
+            const fromPersistence = window.mParticle
+                .getInstance()
+                ._Persistence.getPersistence();
+
+            expect(store.deviceId).to.equal('foo');
+            expect(fromPersistence.gs.das).to.equal('foo');
+        });
+    });
+
     describe('#nullifySessionData', () => {
         it('should nullify session data on the store', () => {
             const store: IStore = new Store(

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -274,9 +274,6 @@ describe('Store', () => {
         });
 
         it('should set the deviceId in persistence', () => {
-            // Since this relies on persistence, we need to make sure
-            // we are using an mParticle instance that shares both
-            // store and persistence modules
             const store = window.mParticle.getInstance()._Store;
 
             store.setDeviceId('foo');
@@ -284,8 +281,8 @@ describe('Store', () => {
                 .getInstance()
                 ._Persistence.getPersistence();
 
-            expect(store.deviceId).to.equal('foo');
             expect(fromPersistence.gs.das).to.equal('foo');
+            expect(store.persistenceData.gs.das).to.equal('foo');
         });
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Move device ID methods from Persistence into Store

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Using a sample app, verify that updating device id affects changes in the Store and Persistence.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6290
