### PR TITLE
fix: Migrate First and Last Seen Time Setters and Getters to Store

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -169,6 +169,11 @@ export interface IStore {
     getDeviceId?(): string;
     setDeviceId?(deviceId: string): void;
 
+    getFirstSeenTime?(mpid: MPID): number;
+    setFirstSeenTime?(mpid: MPID, time?: number): void;
+    getLastSeenTime?(mpid: MPID): number;
+    setLastSeenTime?(mpid: MPID, time?: number): void;
+
     nullifySession?: () => void;
 }
 
@@ -463,6 +468,83 @@ export default function Store(
         this.dateLastEventSent = null;
         this.sessionAttributes = {};
         mpInstance._Persistence.update();
+    };
+
+    this.getFirstSeenTime = (mpid: MPID) => {
+        if (!mpid) {
+            return null;
+        }
+
+        if (
+            this.persistenceData &&
+            this.persistenceData[mpid] &&
+            this.persistenceData[mpid].fst
+        ) {
+            return this.persistenceData[mpid].fst;
+        } else {
+            return null;
+        }
+    };
+
+    this.setFirstSeenTime = (mpid: MPID, _time?: number) => {
+        if (!mpid) {
+            return;
+        }
+
+        const time = _time || new Date().getTime();
+
+        if (this.persistenceData) {
+            if (!this.persistenceData[mpid]) {
+                this.persistenceData[mpid] = {};
+            }
+            if (!this.persistenceData[mpid].fst) {
+                this.persistenceData[mpid].fst = time;
+                mpInstance._Persistence.savePersistence(this.persistenceData);
+            }
+        }
+    };
+
+    this.getLastSeenTime = (mpid: MPID) => {
+        if (!mpid) {
+            return null;
+        }
+
+        // TODO: We should store the current user in the Store's mpid rather than
+        //       relying on the Identity object
+        const currentUser = mpInstance.Identity.getCurrentUser();
+
+        if (mpid === currentUser?.getMPID()) {
+            // if the mpid is the current user, its last seen time is the current time
+            return new Date().getTime();
+        } else {
+            if (
+                this.persistenceData &&
+                this.persistenceData[mpid] &&
+                this.persistenceData[mpid].lst
+            ) {
+                return this.persistenceData[mpid].lst;
+            } else {
+                return null;
+            }
+        }
+    };
+
+    this.setLastSeenTime = (mpid: MPID, _time?: number) => {
+        if (!mpid) {
+            return;
+        }
+
+        const time = _time || new Date().getTime();
+
+        if (this.persistenceData) {
+            if (!this.persistenceData[mpid]) {
+                this.persistenceData[mpid] = {};
+            }
+            if (!this.persistenceData[mpid].lst) {
+                this.persistenceData[mpid].lst = time;
+                mpInstance._Persistence.savePersistence(this.persistenceData);
+            }
+        }
     };
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -515,15 +515,14 @@ export default function Store(
         if (mpid === currentUser?.getMPID()) {
             // if the mpid is the current user, its last seen time is the current time
             return new Date().getTime();
+        } else if (
+            this.persistenceData &&
+            this.persistenceData[mpid] &&
+            this.persistenceData[mpid].lst
+        ) {
+            return this.persistenceData[mpid].lst;
         } else {
-            if (
-                this.persistenceData &&
-                this.persistenceData[mpid] &&
-                this.persistenceData[mpid].lst
-            ) {
-                return this.persistenceData[mpid].lst;
-            } else {
-                return null;
+            return null;
             }
         }
     };

--- a/src/store.ts
+++ b/src/store.ts
@@ -509,8 +509,7 @@ export default function Store(
             return null;
         }
 
-        // TODO: We should store the current user in the Store's mpid rather than
-        //       relying on the Identity object
+        // https://go.mparticle.com/work/SQDSDKS-6315
         const currentUser = mpInstance.Identity.getCurrentUser();
 
         if (mpid === currentUser?.getMPID()) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -265,19 +265,16 @@ export default function Store(
             this.SDKConfig.flags = {};
         }
 
-        this.SDKConfig.flags = processFlags(
-            config,
-            this.SDKConfig as SDKConfig
-        );
+        this.SDKConfig.flags = processFlags(config, this
+            .SDKConfig as SDKConfig);
 
         if (config.deviceId) {
             this.deviceId = config.deviceId;
         }
         if (config.hasOwnProperty('isDevelopmentMode')) {
-            this.SDKConfig.isDevelopmentMode =
-                mpInstance._Helpers.returnConvertedBoolean(
-                    config.isDevelopmentMode
-                );
+            this.SDKConfig.isDevelopmentMode = mpInstance._Helpers.returnConvertedBoolean(
+                config.isDevelopmentMode
+            );
         } else {
             this.SDKConfig.isDevelopmentMode = false;
         }
@@ -508,10 +505,8 @@ export default function Store(
         if (!mpid) {
             return null;
         }
-
-        // https://go.mparticle.com/work/SQDSDKS-6315
+        //     // https://go.mparticle.com/work/SQDSDKS-6315
         const currentUser = mpInstance.Identity.getCurrentUser();
-
         if (mpid === currentUser?.getMPID()) {
             // if the mpid is the current user, its last seen time is the current time
             return new Date().getTime();
@@ -523,7 +518,6 @@ export default function Store(
             return this.persistenceData[mpid].lst;
         } else {
             return null;
-            }
         }
     };
 

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -385,7 +385,6 @@ describe('Store', () => {
 
     describe('#getFirstSeenTime', () => {
         it('should return the firstSeenTime from the store', () => {
-            debugger;
             const store: IStore = new Store(
                 sampleConfig,
                 window.mParticle.getInstance()
@@ -468,7 +467,6 @@ describe('Store', () => {
 
     describe('#getLastSeenTime', () => {
         it('should return the lastSeenTime from the store', () => {
-            debugger;
             const store: IStore = new Store(
                 sampleConfig,
                 window.mParticle.getInstance()

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -443,14 +443,9 @@ describe('Store', () => {
 
         it('should override persistence with store values', () => {
             const persistenceValue = JSON.stringify({
-                gs: {
-                    sid: 'sid',
-                    les: new Date().getTime(),
-                },
                 testMPID: {
                     fst: 12345,
                 },
-                cu: testMPID,
             });
 
             localStorage.setItem(workspaceCookieName, persistenceValue);
@@ -551,14 +546,9 @@ describe('Store', () => {
 
         it('should override persistence with store values', () => {
             const persistenceValue = JSON.stringify({
-                gs: {
-                    sid: 'sid',
-                    les: new Date().getTime(),
-                },
                 testMPID: {
                     lst: 12345,
                 },
-                cu: testMPID,
             });
 
             localStorage.setItem(workspaceCookieName, persistenceValue);

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -395,6 +395,16 @@ describe('Store', () => {
             expect(store.getFirstSeenTime(testMPID)).to.equal(12345);
         });
 
+
+        it('should return null if mpid is null', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            expect(store.getFirstSeenTime(null)).to.equal(null);
+        });
+
         it('should return null if no firstSeenTime is found', () => {
             const store: IStore = new Store(
                 sampleConfig,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Migrate First and Last Seen Time Setters and Getters to Store

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Run automated tests
 - Functions are not integrated into main SDK logic and cannot be locally tested yet.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6308
