### PR TITLE
test: Remove unused cookieStorage test setup expressions

### DIFF
--- a/test/src/tests-identity.js
+++ b/test/src/tests-identity.js
@@ -2079,7 +2079,6 @@ describe('identity', function() {
             "{'gs':{'ie':1|'dt':'test_key'|'cgid':'886e874b-862b-4822-a24a-1146cd057101'|'das':'62c91b8d-fef6-44ea-b2cc-b55714b0d827'|'csm':'WyJ0ZXN0TVBJRCJd'|'sid':'2535f9ed-ab19-4a7c-9eeb-ce4e41e0cb06'|'les': " +
             les +
             "|'ssd':1518536950916}|'testMPID':{'ui':'eyIxIjoiY3VzdG9tZXJpZDEifQ=='}|'cu':'testMPID'}";
-        mParticle.config.useCookieStorage = true;
         setCookie(workspaceCookieName, cookies, true);
         //does not actually hit the server because identity request is not sent
         let result;
@@ -2398,7 +2397,6 @@ describe('identity', function() {
         });
 
         setCookie(workspaceCookieName, cookies);
-        mParticle.useCookieStorage = true;
 
         mParticle.init(apiKey, window.mParticle.config);
 
@@ -2453,7 +2451,6 @@ describe('identity', function() {
             cu: 'testMPID',
         });
         setCookie(workspaceCookieName, cookies);
-        mParticle.useCookieStorage = true;
 
         let identityResult;
 
@@ -2488,7 +2485,6 @@ describe('identity', function() {
         });
 
         setCookie(workspaceCookieName, cookies);
-        mParticle.useCookieStorage = true;
 
         mParticle.init(apiKey, window.mParticle.config);
 
@@ -2541,7 +2537,6 @@ describe('identity', function() {
         });
 
         setCookie(workspaceCookieName, cookies);
-        mParticle.useCookieStorage = true;
 
         mParticle.init(apiKey, window.mParticle.config);
 
@@ -2814,7 +2809,6 @@ describe('identity', function() {
         });
 
         setCookie(workspaceCookieName, cookies);
-        mParticle.useCookieStorage = true;
 
         mParticle.init(apiKey, window.mParticle.config);
 
@@ -2854,7 +2848,6 @@ describe('identity', function() {
         });
 
         setCookie(workspaceCookieName, cookies);
-        mParticle.useCookieStorage = true;
 
         mParticle.init(apiKey, window.mParticle.config);
 
@@ -2896,7 +2889,6 @@ describe('identity', function() {
         });
 
         setCookie(workspaceCookieName, cookies);
-        mParticle.useCookieStorage = true;
 
         //set max Alias startTime age to 1 day
         mParticle.config.aliasMaxWindow = 1;
@@ -2950,7 +2942,7 @@ describe('identity', function() {
             cu: '2',
         });
         setCookie(workspaceCookieName, cookies);
-        mParticle.useCookieStorage = true;
+
         //set max Alias startTime age to 1 day
         mParticle.config.aliasMaxWindow = 1;
 

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -1801,10 +1801,6 @@ describe('persistence', () => {
 
         setCookie(workspaceCookieName, cookies, true);
 
-        // TODO: https://go.mparticle.com/work/SQDSDKS-5339
-        // @ts-ignore
-        mParticle.useCookieStorage = true;
-
         mParticle.init(apiKey, mParticle.config);
 
         const clock = sinon.useFakeTimers();


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Remove improper usage of `useCookieStorage` from tests.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Verify tests continue to pass when removing these expressions

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5339
