### PR TITLE
fix: Update url to nativesdks and update server response

### DIFF
--- a/src/audienceManager.ts
+++ b/src/audienceManager.ts
@@ -11,7 +11,7 @@ export interface IAudienceMembershipsServerResponse {
     dt: 'cam';  // current audience memberships
     ct: number; // timestamp
     id: string;
-    current_audience_memberships: Audience[];
+    audience_memberships: Audience[];
 }
 
 export interface IAudienceMemberships {
@@ -61,7 +61,7 @@ export default class AudienceManager {
 
                 const userAudienceMembershipsServerResponse: IAudienceMembershipsServerResponse = await userAudiencePromise.json();
                 const parsedUserAudienceMemberships: IAudienceMemberships = {
-                    currentAudienceMemberships: userAudienceMembershipsServerResponse?.current_audience_memberships
+                    currentAudienceMemberships: userAudienceMembershipsServerResponse?.audience_memberships
                 }
 
                 try {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -135,7 +135,7 @@ const Constants = {
         configUrl: 'jssdkcdns.mparticle.com/JS/v2/',
         identityUrl: 'identity.mparticle.com/v1/',
         aliasUrl: 'jssdks.mparticle.com/v1/identity/',
-        userAudienceUrl: 'jssdks.mparticle.com/v1/',
+        userAudienceUrl: 'nativesdks.mparticle.com/v1/',
     },
     Base64CookieKeys: {
         csm: 1,

--- a/test/src/tests-audience-manager.ts
+++ b/test/src/tests-audience-manager.ts
@@ -72,7 +72,7 @@ describe('AudienceManager', () => {
             ct: 1710441407914,
             dt: 'cam',
             id: 'foo-id',
-            current_audience_memberships: [
+            audience_memberships: [
                 {
                     audience_id: 7628,
                 },
@@ -126,7 +126,7 @@ describe('AudienceManager', () => {
                 ct: 1710441407915,
                 dt: 'cam',
                 id: 'foo-id-2',
-                current_audience_memberships: [
+                audience_memberships: [
                     {
                         audience_id: 9876,
                     },


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- This PR updates the url endpoint for audiences to be `nativesdks`, which expects `audience_memberships` and not `current_audience_memberships`

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

See screenshots for successful return of audiences 

![Identity Test App 2024-04-08 at 11 02 43 AM](https://github.com/mParticle/mparticle-web-sdk/assets/5377436/798dcf78-df5d-4e65-9765-d43ee21198b1)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6278