### PR TITLE
refactor: Migrate Consent State Persistence Methods

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -1237,7 +1237,7 @@ export default function Identity(mpInstance) {
              * @return a ConsentState object
              */
             getConsentState: function() {
-                return mpInstance._Persistence.getConsentState(mpid);
+                return mpInstance._Store.getConsentState(mpid);
             },
             /**
              * Sets the Consent State stored locally for this user.
@@ -1245,10 +1245,7 @@ export default function Identity(mpInstance) {
              * @param {Object} consent state
              */
             setConsentState: function(state) {
-                mpInstance._Persistence.saveUserConsentStateToCookies(
-                    mpid,
-                    state
-                );
+                mpInstance._Store.setConsentState(mpid, state);
                 mpInstance._Forwarders.initForwarders(
                     this.getUserIdentities().userIdentities,
                     mpInstance._APIClient.prepareForwardingStats

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1310,6 +1310,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
 
         // Load any settings/identities/attributes from cookie or localStorage
         mpInstance._Persistence.initializeStorage();
+        mpInstance._Store.syncPersistenceData();
 
         // Set up user identitiy variables for later use
         const currentUser = mpInstance.Identity.getCurrentUser();

--- a/src/persistence.interfaces.ts
+++ b/src/persistence.interfaces.ts
@@ -14,8 +14,8 @@ import {
     SessionAttributes,
 } from './store';
 import { Dictionary } from './utils';
+import { IMinifiedConsentJSONObject } from './consent';
 
-export type CookieSyncDate = Dictionary<string>;
 export type UploadsTable = Dictionary<any>;
 export interface iForwardingStatsBatches {
     uploadsTable: UploadsTable;
@@ -49,7 +49,7 @@ export interface IPersistenceMinified extends Dictionary {
 
     // Persistence Minified can also store optional dictionaries with
     // an idex of MPID
-    // [mpid: MPID]: Dictionary<any>;
+    // [mpid: MPID]: Dictionary<IUserPersistenceMinified>;
 
     // For Example:
     // {
@@ -71,12 +71,32 @@ export interface IPersistenceMinified extends Dictionary {
     //     },
     //     l: false,
     //     MPID1: {
-    //         csd: [],
+    //         csd: {
+    //             [moduleid]: 1234567890,
+    //         },
     //         ui: {
     //             customerid: '12346',
     //         },
+    //         ua: {
+    //             age '42',
+    //         },
     //     },
     // };
+}
+
+export type CookieSyncDate = Dictionary<number>;
+
+export interface IUserPersistenceMinified extends Dictionary {
+    csd: CookieSyncDate; // Cookie Sync Dates // list of timestamps for last cookie sync
+    con: IMinifiedConsentJSONObject; // Consent State
+    ui: UserIdentities; // User Identities
+    ua: UserAttributes; // User Attributes
+
+    // https://go.mparticle.com/work/SQDSDKS-6048
+    cp: Product[]; // Cart Products
+
+    fst: number; // First Seen Time
+    lst: number; // Last Seen Time
 }
 
 export interface IPersistence {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,11 +1,11 @@
-import { Batch } from '@mparticle/event-models';
-import { Context } from '@mparticle/event-models';
+import { Batch, Context } from '@mparticle/event-models';
 import {
     DataPlanConfig,
     MPID,
     IdentifyRequest,
     IdentityCallback,
     SDKEventCustomFlags,
+    ConsentState,
 } from '@mparticle/web-sdk';
 import { IKitConfigs } from './configAPIClient';
 import Constants from './constants';
@@ -29,9 +29,12 @@ import {
     parseNumber,
     returnConvertedBoolean,
 } from './utils';
-import { SDKConsentState } from './consent';
+import { IMinifiedConsentJSONObject, SDKConsentState } from './consent';
 import { Kit, MPForwarder } from './forwarders.interfaces';
-import { IPersistenceMinified } from './persistence.interfaces';
+import {
+    IGlobalStoreV2MinifiedKeys,
+    IPersistenceMinified,
+} from './persistence.interfaces';
 
 // This represents the runtime configuration of the SDK AFTER
 // initialization has been complete and all settings and
@@ -178,6 +181,12 @@ export interface IStore {
 
     persistenceData?: IPersistenceMinified;
 
+    getConsentState?(mpid: MPID): ConsentState | null;
+    setConsentState?(mpid: MPID, consentState: ConsentState): void;
+
+    _getFromPersistence?<T>(mpid: MPID, key: string): T;
+    _setPersistence?<T>(mpid: MPID, key: string, value: T): void;
+
     getDeviceId?(): string;
     setDeviceId?(deviceId: string): void;
     getFirstSeenTime?(mpid: MPID): number;
@@ -188,6 +197,7 @@ export interface IStore {
     hasInvalidIdentifyRequest?: () => boolean;
     nullifySession?: () => void;
     processConfig(config: SDKInitConfig): void;
+    syncPersistenceData?: () => void;
 }
 
 // TODO: Merge this with SDKStoreApi in sdkRuntimeModels
@@ -250,24 +260,8 @@ export default function Store(
 
         // Placeholder for in-memory persistence model
         persistenceData: {
-            cu: null,
-            gs: {
-                sid: null,
-                ie: null,
-                sa: null,
-                ss: null,
-                dt: null,
-                av: null,
-                cgid: null,
-                das: null,
-                ia: null,
-                c: null,
-                csm: null,
-                les: null,
-                ssd: null,
-            },
-            l: null,
-        },
+            gs: {} as IGlobalStoreV2MinifiedKeys,
+        } as IPersistenceMinified,
     };
 
     for (var key in defaultStore) {
@@ -476,6 +470,53 @@ export default function Store(
         }
     }
 
+    this._getFromPersistence = <T>(mpid: MPID, key: string): T | null => {
+        if (!mpid) {
+            return null;
+        }
+
+        this.syncPersistenceData();
+
+        if (
+            this.persistenceData &&
+            this.persistenceData[mpid] &&
+            this.persistenceData[mpid][key]
+        ) {
+            return this.persistenceData[mpid][key] as T;
+        } else {
+            return null;
+        }
+    };
+
+    this._setPersistence = <T>(mpid: MPID, key: string, value: T): void => {
+        if (!mpid) {
+            return;
+        }
+
+        this.syncPersistenceData();
+
+        if (this.persistenceData) {
+            if (this.persistenceData[mpid]) {
+                this.persistenceData[mpid][key] = value;
+            } else {
+                this.persistenceData[mpid] = {
+                    [key]: value,
+                };
+            }
+
+            // Clear out persistence attributes that are empty
+            // so that we don't upload empty or undefined values
+            if (
+                isObject(this.persistenceData[mpid][key]) &&
+                isEmpty(this.persistenceData[mpid][key])
+            ) {
+                delete this.persistenceData[mpid][key];
+            }
+
+            mpInstance._Persistence.savePersistence(this.persistenceData);
+        }
+    };
+
     this.hasInvalidIdentifyRequest = (): boolean => {
         const { identifyRequest } = this.SDKConfig;
         return (
@@ -484,6 +525,39 @@ export default function Store(
                 isEmpty(identifyRequest.userIdentities)) ||
             !identifyRequest
         );
+    }
+
+ 
+
+    this.getConsentState = (mpid: MPID): ConsentState => {
+        const {
+            fromMinifiedJsonObject,
+        } = mpInstance._Consent.ConsentSerialization;
+        
+        const serializedConsentState = this._getFromPersistence<
+            IMinifiedConsentJSONObject
+        >(mpid, 'con');
+
+        if (!isEmpty(serializedConsentState)) {
+            return fromMinifiedJsonObject(serializedConsentState);
+        }
+
+        return null;
+    };
+
+    this.setConsentState = (mpid: MPID, consentState: ConsentState) => {
+        const {
+            toMinifiedJsonObject,
+        } = mpInstance._Consent.ConsentSerialization;
+
+        // If ConsentState is null, we assume the intent is to clear out the consent state
+        if (consentState || consentState === null) {
+            this._setPersistence(
+                mpid,
+                'con',
+                toMinifiedJsonObject(consentState)
+            );
+        }
     };
 
     this.getDeviceId = () => this.deviceId;
@@ -493,21 +567,8 @@ export default function Store(
         mpInstance._Persistence.update();
     };
 
-    this.getFirstSeenTime = (mpid: MPID) => {
-        if (!mpid) {
-            return null;
-        }
-
-        if (
-            this.persistenceData &&
-            this.persistenceData[mpid] &&
-            this.persistenceData[mpid].fst
-        ) {
-            return this.persistenceData[mpid].fst;
-        } else {
-            return null;
-        }
-    };
+    this.getFirstSeenTime = (mpid: MPID) =>
+        this._getFromPersistence<number>(mpid, 'fst');
 
     this.setFirstSeenTime = (mpid: MPID, _time?: number) => {
         if (!mpid) {
@@ -516,35 +577,20 @@ export default function Store(
 
         const time = _time || new Date().getTime();
 
-        if (this.persistenceData) {
-            if (!this.persistenceData[mpid]) {
-                this.persistenceData[mpid] = {};
-            }
-            if (!this.persistenceData[mpid].fst) {
-                this.persistenceData[mpid].fst = time;
-                mpInstance._Persistence.savePersistence(this.persistenceData);
-            }
-        }
+        this._setPersistence(mpid, 'fst', time);
     };
 
-    this.getLastSeenTime = (mpid: MPID) => {
+    this.getLastSeenTime = (mpid: MPID): number => {
         if (!mpid) {
             return null;
         }
-        //     // https://go.mparticle.com/work/SQDSDKS-6315
+        // https://go.mparticle.com/work/SQDSDKS-6315
         const currentUser = mpInstance.Identity.getCurrentUser();
         if (mpid === currentUser?.getMPID()) {
             // if the mpid is the current user, its last seen time is the current time
             return new Date().getTime();
-        } else if (
-            this.persistenceData &&
-            this.persistenceData[mpid] &&
-            this.persistenceData[mpid].lst
-        ) {
-            return this.persistenceData[mpid].lst;
-        } else {
-            return null;
         }
+        return this._getFromPersistence<number>(mpid, 'lst');
     };
 
     this.setLastSeenTime = (mpid: MPID, _time?: number) => {
@@ -554,15 +600,17 @@ export default function Store(
 
         const time = _time || new Date().getTime();
 
-        if (this.persistenceData) {
-            if (!this.persistenceData[mpid]) {
-                this.persistenceData[mpid] = {};
-            }
-            if (!this.persistenceData[mpid].lst) {
-                this.persistenceData[mpid].lst = time;
-                mpInstance._Persistence.savePersistence(this.persistenceData);
-            }
-        }
+        this._setPersistence(mpid, 'lst', time);
+    };
+
+    this.syncPersistenceData = () => {
+        const persistenceData = mpInstance._Persistence.getPersistence();
+
+        this.persistenceData = mpInstance._Helpers.extend(
+            {},
+            this.persistenceData,
+            persistenceData,
+        );
     };
 
     this.nullifySession = (): void => {

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -17,6 +17,7 @@ import Utils from './config/utils';
 import { Dictionary } from '../../src/utils';
 import Constants from '../../src/constants';
 import { IGlobalStoreV2MinifiedKeys } from '../../src/persistence.interfaces';
+import { IMinifiedConsentJSONObject } from '../../src/consent';
 const MockSideloadedKit = Utils.MockSideloadedKit;
 
 describe('Store', () => {
@@ -30,6 +31,77 @@ describe('Store', () => {
         package: 'com.mparticle.test',
         flags: {},
     } as SDKInitConfig;
+
+    type ConsentStateSample = Dictionary<IMinifiedConsentJSONObject>;
+
+    const sampleConsentState: ConsentStateSample = {
+        con: {
+            gdpr: {
+                analytics: {
+                    c: true,
+                    d: 'foo gdpr document',
+                    h: 'foo gdpr hardware id',
+                    l: 'foo gdpr location',
+                    ts: 10,
+                },
+            },
+            ccpa: {
+                data_sale_opt_out: {
+                    c: false,
+                    d: 'foo ccpa document',
+                    h: 'foo ccpa hardware id',
+                    l: 'foo ccpa location',
+                    ts: 42,
+                },
+            },
+        },
+    };
+
+    const sampleConsentStateFromStore: ConsentStateSample = {
+        con: {
+            gdpr: {
+                analytics: {
+                    c: false,
+                    d: 'foo gdpr document from store',
+                    h: 'foo gdpr hardware id from store',
+                    l: 'foo gdpr location from store',
+                    ts: 101,
+                },
+            },
+            ccpa: {
+                data_sale_opt_out: {
+                    c: true,
+                    d: 'foo ccpa document from store',
+                    h: 'foo ccpa hardware id from store',
+                    l: 'foo ccpa location from store',
+                    ts: 24,
+                },
+            },
+        },
+    };
+
+    const sampleConsentStateFromPersistence: ConsentStateSample = {
+        con: {
+            gdpr: {
+                analytics: {
+                    c: false,
+                    d: 'foo gdpr document from persistence',
+                    h: 'foo gdpr hardware id from persistence',
+                    l: 'foo gdpr location from persistence',
+                    ts: 101,
+                },
+            },
+            ccpa: {
+                data_sale_opt_out: {
+                    c: true,
+                    d: 'foo ccpa document from persistence',
+                    h: 'foo ccpa hardware id from persistence',
+                    l: 'foo ccpa location from persistence',
+                    ts: 24,
+                },
+            },
+        },
+    };
 
     beforeEach(function() {
         sandbox = sinon.createSandbox();
@@ -133,7 +205,7 @@ describe('Store', () => {
                 .undefined;
 
             expect(
-                store.SDKConfig.flags?.eventBatchingIntervalMillis,
+                store.SDKConfig.flags.eventBatchingIntervalMillis,
                 'flags.eventBatchingIntervalMillis'
             ).to.eq(0);
             expect(store.SDKConfig.forceHttps, 'forceHttps').to.eq(true);
@@ -253,6 +325,319 @@ describe('Store', () => {
         });
     });
 
+    describe('#getConsentState', () => {
+        it('should return a consent state object from the store', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.persistenceData[testMPID] = sampleConsentState;
+
+            expect(store.getConsentState(testMPID)).to.be.ok;
+            expect(store.getConsentState(testMPID)).to.haveOwnProperty(
+                'getGDPRConsentState'
+            );
+            expect(store.getConsentState(testMPID)).to.haveOwnProperty(
+                'getCCPAConsentState'
+            );
+
+            expect(
+                store.getConsentState(testMPID).getGDPRConsentState()
+            ).to.deep.equal({
+                analytics: {
+                    Consented: true,
+                    ConsentDocument: 'foo gdpr document',
+                    HardwareId: 'foo gdpr hardware id',
+                    Location: 'foo gdpr location',
+                    Timestamp: 10,
+                },
+            });
+
+            expect(
+                store.getConsentState(testMPID).getCCPAConsentState()
+            ).to.deep.equal({
+                Consented: false,
+                ConsentDocument: 'foo ccpa document',
+                HardwareId: 'foo ccpa hardware id',
+                Location: 'foo ccpa location',
+                Timestamp: 42,
+            });
+        });
+
+        it('should return null if no consent state is found', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            expect(store.getConsentState(testMPID)).to.deep.equal(null);
+        });
+
+        it('should return in-memory consent state if persistence is empty', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.persistenceData[testMPID] = sampleConsentStateFromStore;
+
+            localStorage.setItem(workspaceCookieName, '');
+
+            expect(store.getConsentState(testMPID)).to.be.ok;
+
+            expect(store.getConsentState(testMPID)).to.haveOwnProperty(
+                'getGDPRConsentState'
+            );
+            expect(
+                store.getConsentState(testMPID).getGDPRConsentState()
+            ).to.deep.equal({
+                analytics: {
+                    Consented: false,
+                    ConsentDocument: 'foo gdpr document from store',
+                    HardwareId: 'foo gdpr hardware id from store',
+                    Location: 'foo gdpr location from store',
+                    Timestamp: 101,
+                },
+            });
+
+            expect(store.getConsentState(testMPID)).to.haveOwnProperty(
+                'getCCPAConsentState'
+            );
+
+            expect(
+                store.getConsentState(testMPID).getCCPAConsentState()
+            ).to.deep.equal({
+                Consented: true,
+                ConsentDocument: 'foo ccpa document from store',
+                HardwareId: 'foo ccpa hardware id from store',
+                Location: 'foo ccpa location from store',
+                Timestamp: 24,
+            });
+        });
+    });
+
+    describe('#setConsentState', () => {
+        it('should set consent state as a minified object in the store', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            const consentState = window.mParticle.Consent.createConsentState();
+
+            const gdprConsent = window.mParticle
+                .getInstance()
+                .Consent.createGDPRConsent(
+                    true,
+                    10,
+                    'foo gdpr document',
+                    'foo gdpr location',
+                    'foo gdpr hardware id'
+                );
+
+            const ccpaConsent = window.mParticle
+                .getInstance()
+                .Consent.createCCPAConsent(
+                    false,
+                    42,
+                    'foo ccpa document',
+                    'foo ccpa location',
+                    'foo ccpa hardware id'
+                );
+
+            const expectedConsentState = sampleConsentState.con;
+
+            consentState.addGDPRConsentState('analytics', gdprConsent);
+            consentState.setCCPAConsentState(ccpaConsent);
+
+            store.setConsentState(testMPID, consentState);
+
+            expect(store.persistenceData[testMPID].con).to.be.ok;
+
+            expect(store.persistenceData[testMPID].con.gdpr).to.be.ok;
+            expect(store.persistenceData[testMPID].con.gdpr).to.deep.equal(
+                expectedConsentState.gdpr
+            );
+
+            expect(store.persistenceData[testMPID].con.ccpa).to.be.ok;
+            expect(store.persistenceData[testMPID].con.ccpa).to.deep.equal(
+                expectedConsentState.ccpa
+            );
+        });
+
+        it('should set consent state as a minified object in persistence', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            const consentState = window.mParticle.Consent.createConsentState();
+
+            const gdprConsent = window.mParticle
+                .getInstance()
+                .Consent.createGDPRConsent(
+                    true,
+                    10,
+                    'foo gdpr document',
+                    'foo gdpr location',
+                    'foo gdpr hardware id'
+                );
+
+            const ccpaConsent = window.mParticle
+                .getInstance()
+                .Consent.createCCPAConsent(
+                    false,
+                    42,
+                    'foo ccpa document',
+                    'foo ccpa location',
+                    'foo ccpa hardware id'
+                );
+
+            const expectedConsentState = sampleConsentState.con;
+
+            consentState.addGDPRConsentState('analytics', gdprConsent);
+            consentState.setCCPAConsentState(ccpaConsent);
+
+            store.setConsentState(testMPID, consentState);
+
+            const fromPersistence = window.mParticle
+                .getInstance()
+                ._Persistence.getPersistence();
+
+            expect(fromPersistence[testMPID]).to.be.ok;
+            expect(fromPersistence[testMPID].con).to.be.ok;
+
+            expect(fromPersistence[testMPID].con.gdpr).to.be.ok;
+            expect(fromPersistence[testMPID].con.gdpr).to.deep.equal(
+                expectedConsentState.gdpr
+            );
+
+            expect(fromPersistence[testMPID].con.ccpa).to.be.ok;
+            expect(fromPersistence[testMPID].con.ccpa).to.deep.equal(
+                expectedConsentState.ccpa
+            );
+        });
+
+        it('should override persistence with store values', () => {
+            const consentState = window.mParticle.Consent.createConsentState();
+
+            const analyticsGdprConsent = window.mParticle
+                .getInstance()
+                .Consent.createGDPRConsent(
+                    false,
+                    101,
+                    'analytics gdpr document from store',
+                    'analytics gdpr location from store',
+                    'analytics gdpr hardware id from store'
+                );
+
+            const marketingGdprConsent = window.mParticle
+                .getInstance()
+                .Consent.createGDPRConsent(
+                    true,
+                    202,
+                    'marketing gdpr document from store',
+                    'marketing gdpr location from store',
+                    'marketing gdpr hardware id from store'
+                );
+
+            const ccpaConsent = window.mParticle
+                .getInstance()
+                .Consent.createCCPAConsent(
+                    true,
+                    24,
+                    'foo ccpa document from store',
+                    'foo ccpa location from store',
+                    'foo ccpa hardware id from store'
+                );
+
+            const expectedConsentState = sampleConsentStateFromStore.con;
+
+            consentState.addGDPRConsentState('analytics', analyticsGdprConsent);
+            consentState.setCCPAConsentState(ccpaConsent);
+
+            const persistenceValue = JSON.stringify({
+                testMPID: {
+                    con: sampleConsentStateFromPersistence.con,
+                },
+            });
+
+            localStorage.setItem(workspaceCookieName, persistenceValue);
+
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.setConsentState(testMPID, consentState);
+
+            const fromPersistence = window.mParticle
+                .getInstance()
+                ._Persistence.getPersistence();
+
+            expect(fromPersistence[testMPID]).to.be.ok;
+            expect(fromPersistence[testMPID].con).to.be.ok;
+            expect(fromPersistence[testMPID].con.gdpr).to.be.ok;
+            expect(fromPersistence[testMPID].con.ccpa).to.be.ok;
+
+            expect(fromPersistence[testMPID].con.gdpr).to.deep.equal({
+                analytics: {
+                    c: false,
+                    ts: 101,
+                    d: 'analytics gdpr document from store',
+                    h: 'analytics gdpr hardware id from store',
+                    l: 'analytics gdpr location from store',
+                },
+            });
+
+            expect(fromPersistence[testMPID].con.ccpa).to.deep.equal(
+                expectedConsentState.ccpa
+            );
+
+            consentState.addGDPRConsentState('marketing', marketingGdprConsent);
+            store.setConsentState(testMPID, consentState);
+
+            const retrieveFromPersistence = window.mParticle
+                .getInstance()
+                ._Persistence.getPersistence();
+
+            expect(retrieveFromPersistence[testMPID].con.gdpr).to.deep.equal({
+                analytics: {
+                    c: false,
+                    ts: 101,
+                    d: 'analytics gdpr document from store',
+                    h: 'analytics gdpr hardware id from store',
+                    l: 'analytics gdpr location from store',
+                },
+                marketing: {
+                    c: true,
+                    ts: 202,
+                    d: 'marketing gdpr document from store',
+                    h: 'marketing gdpr hardware id from store',
+                    l: 'marketing gdpr location from store',
+                },
+            });
+        });
+
+        it('should not set consent state if consent state is null', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            const expectedConsentState = sampleConsentState;
+
+            store.persistenceData[testMPID] = expectedConsentState;
+
+            store.setConsentState(testMPID, null);
+
+            expect(store.persistenceData[testMPID]).to.deep.equal(
+                expectedConsentState
+            );
+        });
+    });
+
     describe('#getDeviceId', () => {
         it('should return the deviceId from the store', () => {
             const store: IStore = new Store(
@@ -303,7 +688,6 @@ describe('Store', () => {
             };
             expect(store.getFirstSeenTime(testMPID)).to.equal(12345);
         });
-
 
         it('should return null if mpid is null', () => {
             const store: IStore = new Store(
@@ -731,6 +1115,64 @@ describe('Store', () => {
             store.processConfig(config);
 
             expect(store.configurationLoaded, 'configurationLoaded').to.be.true;
+        });
+    });
+
+    describe('#syncPersistenceData', () => {
+        it('should sync store with persistence values', () => {
+            const persistenceValue = JSON.stringify({
+                testMPID: {
+                    lst: 12345,
+                    fst: 54321,
+                    con: sampleConsentStateFromPersistence.con,
+                },
+            });
+
+            localStorage.setItem(workspaceCookieName, persistenceValue);
+
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.syncPersistenceData();
+
+            expect(store.persistenceData[testMPID].lst).to.equal(12345);
+            expect(store.persistenceData[testMPID].fst).to.equal(54321);
+            expect(store.persistenceData[testMPID].con).to.deep.equal(
+                sampleConsentStateFromPersistence.con
+            );
+        });
+
+        it('should override store with persistence data', () => {
+            const persistenceValue = JSON.stringify({
+                testMPID: {
+                    lst: 12345,
+                    fst: 54321,
+                    con: sampleConsentStateFromPersistence.con,
+                },
+            });
+
+            localStorage.setItem(workspaceCookieName, persistenceValue);
+
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.persistenceData[testMPID] = {
+                lst: 99999,
+                fst: 88888,
+                con: sampleConsentStateFromStore.con,
+            };
+
+            store.syncPersistenceData();
+
+            expect(store.persistenceData[testMPID].lst).to.equal(12345);
+            expect(store.persistenceData[testMPID].fst).to.equal(54321);
+            expect(store.persistenceData[testMPID].con).to.deep.equal(
+                sampleConsentStateFromPersistence.con
+            );
         });
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - {provide a thorough description of the changes}

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Run through the automated tests
 - Smoke test a new, anonymous user session in a sample app, then attempt to add consent states
 - Subsequent events should have updated consent state properties
 - Refreshing the app should retain the new consent states
 - There should be no changes to expected behavior

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6313
