### PR TITLE
refactor: Migrate globalStorageAttribute getter

### DIFF
--- a/src/persistence.interfaces.ts
+++ b/src/persistence.interfaces.ts
@@ -37,7 +37,7 @@ export interface IGlobalStoreV2MinifiedKeys {
     das: string; // Device ID/ Device Application String
     ia: IntegrationAttributes;
     c: Context;
-    csm: MPID[]; // Current Session MPIDs
+    csm?: MPID[]; // Current Session MPIDs
     les: number; // Last Event Sent Timestamp
     ssd: number; // Session Start Date
 }

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -356,15 +356,8 @@ export default function _Persistence(mpInstance) {
         }
 
         if (!mpInstance._Store.SDKConfig.useCookieStorage) {
-            localStorageData.gs = localStorageData.gs || {};
-
             localStorageData.l = mpInstance._Store.isLoggedIn ? 1 : 0;
-
-            if (mpInstance._Store.sessionId) {
-                localStorageData.gs.csm = mpInstance._Store.currentSessionMPIDs;
-            }
-
-            localStorageData.gs.ie = mpInstance._Store.isEnabled;
+            localStorageData.gs = mpInstance._Store.getGlobalStorageAttributes();
 
             if (mpid) {
                 localStorageData.cu = mpid;
@@ -379,8 +372,6 @@ export default function _Persistence(mpInstance) {
                 mpInstance._Store.nonCurrentUserMPIDs = {};
             }
 
-            localStorageData = setGlobalStorageAttributes(localStorageData);
-
             try {
                 window.localStorage.setItem(
                     encodeURIComponent(key),
@@ -393,28 +384,6 @@ export default function _Persistence(mpInstance) {
             }
         }
     };
-
-    function setGlobalStorageAttributes(data) {
-        var store = mpInstance._Store;
-        data.gs.sid = store.sessionId;
-        data.gs.ie = store.isEnabled;
-        data.gs.sa = store.sessionAttributes;
-        data.gs.ss = store.serverSettings;
-        data.gs.dt = store.devToken;
-        data.gs.les = store.dateLastEventSent
-            ? store.dateLastEventSent.getTime()
-            : null;
-        data.gs.av = store.SDKConfig.appVersion;
-        data.gs.cgid = store.clientId;
-        data.gs.das = store.deviceId;
-        data.gs.c = store.context;
-        data.gs.ssd = store.sessionStartDate
-            ? store.sessionStartDate.getTime()
-            : 0;
-        data.gs.ia = store.integrationAttributes;
-
-        return data;
-    }
 
     this.getLocalStorage = function() {
         if (!mpInstance._Store.isLocalStorageAvailable) {
@@ -538,19 +507,13 @@ export default function _Persistence(mpInstance) {
             domain = ';domain=' + cookieDomain;
         }
 
-        cookies.gs = cookies.gs || {};
-
-        if (mpInstance._Store.sessionId) {
-            cookies.gs.csm = mpInstance._Store.currentSessionMPIDs;
-        }
+        cookies.gs = mpInstance._Store.getGlobalStorageAttributes();
 
         if (mpid) {
             cookies.cu = mpid;
         }
 
         cookies.l = mpInstance._Store.isLoggedIn ? 1 : 0;
-
-        cookies = setGlobalStorageAttributes(cookies);
 
         if (Object.keys(mpInstance._Store.nonCurrentUserMPIDs).length) {
             cookies = mpInstance._Helpers.extend(

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -330,16 +330,17 @@ export default function _Persistence(mpInstance) {
             return;
         }
 
-        var key = mpInstance._Store.storageName,
-            allLocalStorageProducts = self.getAllUserProductsFromLS(),
-            localStorageData = self.getLocalStorage() || {},
-            currentUser = mpInstance.Identity.getCurrentUser(),
-            mpid = currentUser ? currentUser.getMPID() : null,
-            currentUserProducts = {
-                cp: allLocalStorageProducts[mpid]
-                    ? allLocalStorageProducts[mpid].cp
-                    : [],
-            };
+        const mpid = mpInstance._Store.mpid;
+
+        const key = mpInstance._Store.storageName;
+        let allLocalStorageProducts = self.getAllUserProductsFromLS();
+        let localStorageData = self.getLocalStorage() || {};
+        const currentUserProducts = {
+            cp: allLocalStorageProducts[mpid]
+                ? allLocalStorageProducts[mpid].cp
+                : [],
+        };
+
         if (mpid) {
             allLocalStorageProducts = allLocalStorageProducts || {};
             allLocalStorageProducts[mpid] = currentUserProducts;
@@ -479,27 +480,22 @@ export default function _Persistence(mpInstance) {
     // https://go.mparticle.com/work/SQDSDKS-5022
     // https://go.mparticle.com/work/SQDSDKS-6021
     this.setCookie = function() {
-        var mpid,
-            currentUser = mpInstance.Identity.getCurrentUser();
-        if (currentUser) {
-            mpid = currentUser.getMPID();
-        }
-        var date = new Date(),
-            key = mpInstance._Store.storageName,
-            cookies = self.getCookie() || {},
-            expires = new Date(
-                date.getTime() +
-                    mpInstance._Store.SDKConfig.cookieExpiration *
-                        24 *
-                        60 *
-                        60 *
-                        1000
-            ).toGMTString(),
-            cookieDomain,
-            domain,
-            encodedCookiesWithExpirationAndPath;
+        const mpid = mpInstance._Store.mpid;
 
-        cookieDomain = self.getCookieDomain();
+        const date = new Date();
+        const key = mpInstance._Store.storageName;
+        let cookies = self.getCookie() || {};
+        const expires = new Date(
+            date.getTime() +
+                mpInstance._Store.SDKConfig.cookieExpiration *
+                    24 *
+                    60 *
+                    60 *
+                    1000
+        ).toGMTString();
+        const cookieDomain = self.getCookieDomain();
+        let domain;
+        let encodedCookiesWithExpirationAndPath;
 
         if (cookieDomain === '') {
             domain = '';

--- a/src/store.ts
+++ b/src/store.ts
@@ -197,6 +197,7 @@ export interface IStore {
     getUserIdentities?(mpid: MPID): UserIdentities;
     setUserIdentities?(mpid: MPID, userIdentities: UserIdentities): void;
 
+    getGlobalStorageAttributes?(): IGlobalStoreV2MinifiedKeys;
     hasInvalidIdentifyRequest?: () => boolean;
     nullifySession?: () => void;
     processConfig(config: SDKInitConfig): void;
@@ -519,6 +520,23 @@ export default function Store(
             mpInstance._Persistence.savePersistence(this.persistenceData);
         }
     };
+
+    this.getGlobalStorageAttributes = () => ({
+        sid: this.sessionId,
+        ie: this.isEnabled,
+        sa: this.sessionAttributes,
+        ss: this.serverSettings,
+        dt: this.devToken,
+        les: this.dateLastEventSent ? this.dateLastEventSent.getTime() : null,
+        av: this.SDKConfig.appVersion,
+        cgid: this.clientId,
+        das: this.deviceId,
+        c: this.context,
+        ssd: this.sessionStartDate ? this.sessionStartDate.getTime() : 0,
+        ia: this.integrationAttributes,
+
+        csm: this.sessionId ? this.currentSessionMPIDs : undefined,
+    });
 
     this.hasInvalidIdentifyRequest = (): boolean => {
         const { identifyRequest } = this.SDKConfig;

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1209,6 +1209,116 @@ describe('Store', () => {
         });
     });
 
+    describe('#getGlobalStorageAttributes', () => {
+        it('should return the global storage attributes from the store', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            const dateLastEventSent = new Date();
+            const sessionStartDate = new Date();
+
+            store.sessionId = 'test-session-id';
+            store.isEnabled = true;
+            store.sessionAttributes = { foo: 'bar ' };
+            store.serverSettings = { fizz: 'buzz' };
+            store.devToken = 'test-dev';
+            store.dateLastEventSent = dateLastEventSent;
+            store.SDKConfig.appVersion = '1.0';
+            store.clientId = 'test-client-id';
+            store.deviceId = 'test-device-id';
+            store.context = { data_plan: { plan_id: 'test-plan-id' } };
+            store.sessionStartDate = sessionStartDate;
+            store.integrationAttributes = { 128: { MCID: 'abcdefg' } };
+            store.currentSessionMPIDs = ['test-mpid', 'another-mpid'];
+
+            const expectedGS = {
+                sid: 'test-session-id',
+                ie: true,
+                sa: { foo: 'bar ' },
+                ss: { fizz: 'buzz' },
+                dt: 'test-dev',
+                av: '1.0',
+                cgid: 'test-client-id',
+                das: 'test-device-id',
+                ia: { 128: { MCID: 'abcdefg' } },
+                c: { data_plan: { plan_id: 'test-plan-id' } },
+                les: dateLastEventSent.getTime(),
+                ssd: sessionStartDate.getTime(),
+                csm: ['test-mpid', 'another-mpid'],
+            };
+
+            const actualGS = store.getGlobalStorageAttributes();
+
+            expect(actualGS.sid, 'session id').to.deep.equal(expectedGS.sid);
+            expect(actualGS.ie, 'is enabled').to.deep.equal(expectedGS.ie);
+            expect(actualGS.sa, 'session attributes').to.deep.equal(
+                expectedGS.sa
+            );
+            expect(actualGS.ss, 'server settings').to.deep.equal(expectedGS.ss);
+            expect(actualGS.dt, 'dev token').to.deep.equal(expectedGS.dt);
+            expect(actualGS.av, 'app version').to.deep.equal(expectedGS.av);
+            expect(actualGS.cgid, 'client id').to.deep.equal(expectedGS.cgid);
+            expect(actualGS.das, 'device id').to.deep.equal(expectedGS.das);
+            expect(actualGS.ia, 'integration attributes').to.deep.equal(
+                expectedGS.ia
+            );
+            expect(actualGS.c, 'context').to.deep.equal(expectedGS.c);
+            expect(actualGS.les, 'last event sent').to.deep.equal(
+                expectedGS.les
+            );
+            expect(actualGS.ssd, 'session start date').to.deep.equal(
+                expectedGS.ssd
+            );
+            expect(actualGS.csm, 'current session mpids').to.deep.equal(
+                expectedGS.csm
+            );
+
+            // Tests to make sure we're not accidentally adding anything extra to the global storage attributes
+            expect(actualGS).to.deep.equal(expectedGS);
+        });
+
+        it('should return null if last event sent is null', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.dateLastEventSent = null;
+
+            const actualGS = store.getGlobalStorageAttributes();
+
+            expect(actualGS.les).to.be.null;
+        });
+
+        it('should return 0 if session start date is null', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.sessionStartDate = null;
+
+            const actualGS = store.getGlobalStorageAttributes();
+
+            expect(actualGS.ssd).to.equal(0);
+        });
+
+        it('should not include csm if there is no session', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.sessionId = null;
+
+            const actualGS = store.getGlobalStorageAttributes();
+
+            expect(actualGS.csm).to.be.undefined;
+        });
+    });
+
     describe('#syncPersistenceData', () => {
         it('should sync store with persistence values', () => {
             const persistenceValue = JSON.stringify({


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Refactors `globalStorageAttribute` setter into a getter and cleans up generation of the `gs` attribute of Persistence.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Run through the automated tests
 - Smoke test an anonymous user session in a sample app, then attempt to login and log out
 - There should be no changes to expected behavior

## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6349
