### PR TITLE
refactor: Add test cases for setting isLoggedIn value via persistence

### DIFF
--- a/src/persistence.interfaces.ts
+++ b/src/persistence.interfaces.ts
@@ -44,7 +44,11 @@ export interface IGlobalStoreV2MinifiedKeys {
 export interface IPersistenceMinified extends Dictionary {
     cu: MPID; // Current User MPID
     gs: IGlobalStoreV2MinifiedKeys;
-    l: boolean; // IsLoggedIn - stored as 0 or 1 but returns a boolean
+
+    // Stored as 0 or 1 in device persistence but returned as a
+    // boolean when decoding from device persistence via
+    // _Persistence.getPersistence and _Persistence.decodePersistence
+    l: boolean; // IsLoggedIn
 
     // Persistence Minified can also store optional dictionaries with
     // an idex of MPID

--- a/src/persistence.interfaces.ts
+++ b/src/persistence.interfaces.ts
@@ -44,7 +44,7 @@ export interface IGlobalStoreV2MinifiedKeys {
 export interface IPersistenceMinified extends Dictionary {
     cu: MPID; // Current User MPID
     gs: IGlobalStoreV2MinifiedKeys;
-    l: boolean; // IsLoggedIn
+    l: boolean; // IsLoggedIn - stored as 0 or 1 but returns a boolean
 
     // Persistence Minified can also store optional dictionaries with
     // an idex of MPID

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -314,6 +314,7 @@ export interface MParticleUser {
     getConsentState(): SDKConsentState;
     getAllUserAttributes(): SDKUserAttribute;
     getUserIdentities(): IdentityApiData;
+    isLoggedIn?(): boolean;
 }
 
 export interface SDKUserIdentityChangeData {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds extra tests around setting logged in state for persistence.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Run automated tests
 - Use a sample app to verify logged in/logged out state changes in persistence

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6352
