### PR TITLE
refactor: Migrate cookieSyncDates setters and getters to Store

### DIFF
--- a/docs/store.md
+++ b/docs/store.md
@@ -1,0 +1,8 @@
+# Store
+
+```mermaid
+classDiagram
+class Store {
+    Number integrationDelayTimeoutStart
+}
+```

--- a/docs/store.md
+++ b/docs/store.md
@@ -1,8 +1,0 @@
-# Store
-
-```mermaid
-classDiagram
-class Store {
-    Number integrationDelayTimeoutStart
-}
-```

--- a/src/persistence.interfaces.ts
+++ b/src/persistence.interfaces.ts
@@ -87,10 +87,10 @@ export interface IPersistenceMinified extends Dictionary {
     // };
 }
 
-export type CookieSyncDate = Dictionary<number>;
+export type CookieSyncDates = Dictionary<number>;
 
 export interface IUserPersistenceMinified extends Dictionary {
-    csd: CookieSyncDate; // Cookie Sync Dates // list of timestamps for last cookie sync
+    csd: CookieSyncDates; // Cookie Sync Dates // list of timestamps for last cookie sync
     con: IMinifiedConsentJSONObject; // Consent State
     ui: UserIdentities; // User Identities
     ua: UserAttributes; // User Attributes
@@ -129,7 +129,6 @@ export interface IPersistence {
     getDomain(doc: string, locationHostname: string): string;
     getCartProducts(mpid: MPID): Product[];
     setCartProducts(allProducts: Product[]): void;
-    saveUserCookieSyncDatesToPersistence(mpid: MPID, csd: CookieSyncDate): void;
     saveUserConsentStateToCookies(mpid, consentState: ConsentState): void;
     savePersistence(persistance: IPersistenceMinified): void;
     getPersistence(): IPersistenceMinified;

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -877,22 +877,6 @@ export default function _Persistence(mpInstance) {
         }
     };
 
-    this.saveUserCookieSyncDatesToPersistence = function(mpid, csd) {
-        if (csd) {
-            var persistence = self.getPersistence();
-            if (persistence) {
-                if (persistence[mpid]) {
-                    persistence[mpid].csd = csd;
-                } else {
-                    persistence[mpid] = {
-                        csd: csd,
-                    };
-                }
-            }
-            self.savePersistence(persistence);
-        }
-    };
-
     this.saveUserConsentStateToCookies = function(mpid, consentState) {
         //it's currently not supported to set persistence
         //for any MPID that's not the current one.

--- a/src/store.ts
+++ b/src/store.ts
@@ -34,6 +34,7 @@ import {
 import { IMinifiedConsentJSONObject, SDKConsentState } from './consent';
 import { Kit, MPForwarder } from './forwarders.interfaces';
 import {
+    CookieSyncDate,
     IGlobalStoreV2MinifiedKeys,
     IPersistenceMinified,
     UserAttributes,
@@ -184,6 +185,8 @@ export interface IStore {
 
     persistenceData?: IPersistenceMinified;
 
+    getCookieSyncDates?(mpid: MPID): CookieSyncDate;
+    setCookieSyncDates?(mpid: MPID, cookieSyncDates: CookieSyncDate): void;
     getConsentState?(mpid: MPID): ConsentState | null;
     setConsentState?(mpid: MPID, consentState: ConsentState): void;
 
@@ -552,6 +555,12 @@ export default function Store(
             !identifyRequest
         );
     };
+
+    this.getCookieSyncDates = (mpid: MPID): CookieSyncDate =>
+        this._getFromPersistence<CookieSyncDate>(mpid, 'csd') || {};
+
+    this.setCookieSyncDates = (mpid: MPID, cookieSyncDates: CookieSyncDate) => 
+        this._setPersistence<CookieSyncDate>(mpid, 'csd', cookieSyncDates);
 
     this.getConsentState = (mpid: MPID): ConsentState => {
         const {

--- a/src/store.ts
+++ b/src/store.ts
@@ -34,7 +34,7 @@ import {
 import { IMinifiedConsentJSONObject, SDKConsentState } from './consent';
 import { Kit, MPForwarder } from './forwarders.interfaces';
 import {
-    CookieSyncDate,
+    CookieSyncDates,
     IGlobalStoreV2MinifiedKeys,
     IPersistenceMinified,
     UserAttributes,
@@ -185,8 +185,8 @@ export interface IStore {
 
     persistenceData?: IPersistenceMinified;
 
-    getCookieSyncDates?(mpid: MPID): CookieSyncDate;
-    setCookieSyncDates?(mpid: MPID, cookieSyncDates: CookieSyncDate): void;
+    getCookieSyncDates?(mpid: MPID): CookieSyncDates;
+    setCookieSyncDates?(mpid: MPID, cookieSyncDates: CookieSyncDates): void;
     getConsentState?(mpid: MPID): ConsentState | null;
     setConsentState?(mpid: MPID, consentState: ConsentState): void;
 
@@ -556,11 +556,11 @@ export default function Store(
         );
     };
 
-    this.getCookieSyncDates = (mpid: MPID): CookieSyncDate =>
-        this._getFromPersistence<CookieSyncDate>(mpid, 'csd') || {};
+    this.getCookieSyncDates = (mpid: MPID): CookieSyncDates =>
+        this._getFromPersistence<CookieSyncDates>(mpid, 'csd') || {};
 
-    this.setCookieSyncDates = (mpid: MPID, cookieSyncDates: CookieSyncDate) => 
-        this._setPersistence<CookieSyncDate>(mpid, 'csd', cookieSyncDates);
+    this.setCookieSyncDates = (mpid: MPID, cookieSyncDates: CookieSyncDates) => 
+        this._setPersistence<CookieSyncDates>(mpid, 'csd', cookieSyncDates);
 
     this.getConsentState = (mpid: MPID): ConsentState => {
         const {

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -379,6 +379,130 @@ describe('Store', () => {
         });
     });
 
+    describe('#getCookieSyncDates', () => {
+        it('should return cookie sync dates from the store', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            const expectedCookieSyncDates = {
+                42: 12345,
+            };
+
+            store.persistenceData[testMPID] = {
+                csd: expectedCookieSyncDates,
+            };
+
+            expect(store.getCookieSyncDates(testMPID)).to.deep.equal(
+                expectedCookieSyncDates
+            );
+        });
+
+        it('should return an empty object if no cookie sync dates are found', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            expect(store.getCookieSyncDates(testMPID)).to.deep.equal({});
+        });
+
+        it('should return in-memory cookie sync dates if persistence is empty', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            const expectedCookieSyncDates = {
+                42: 12345,
+            };
+
+            store.persistenceData[testMPID] = {
+                csd: expectedCookieSyncDates,
+            };
+
+            localStorage.setItem(workspaceCookieName, '');
+
+            expect(store.getCookieSyncDates(testMPID)).to.deep.equal(
+                expectedCookieSyncDates
+            );
+        });
+    });
+
+    describe('#setCookieSyncDates', () => {
+        it('should set cookie sync dates in the store', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            const cookieSyncDates = {
+                42: 12345,
+            };
+
+            store.setCookieSyncDates(testMPID, cookieSyncDates);
+
+            expect(store.persistenceData[testMPID].csd).to.deep.equal(
+                cookieSyncDates
+            );
+        });
+
+        it('should set cookie sync dates in persistence', () => {
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            const cookieSyncDates = {
+                42: 12345,
+            };
+
+            store.setCookieSyncDates(testMPID, cookieSyncDates);
+
+            const fromPersistence = window.mParticle
+                .getInstance()
+                ._Persistence.getPersistence();
+
+            expect(fromPersistence[testMPID]).to.be.ok;
+            expect(fromPersistence[testMPID].csd).to.be.ok;
+            expect(fromPersistence[testMPID].csd).to.deep.equal(
+                cookieSyncDates
+            );
+        });
+
+        it('should override persistence with store values', () => {
+            const cookieSyncDates = {
+                42: 12345,
+            };
+
+            const persistenceValue = JSON.stringify({
+                testMPID: {
+                    csd: {
+                        42: 54321,
+                    },
+                },
+            });
+
+            localStorage.setItem(workspaceCookieName, persistenceValue);
+
+            const store: IStore = new Store(
+                sampleConfig,
+                window.mParticle.getInstance()
+            );
+
+            store.setCookieSyncDates(testMPID, cookieSyncDates);
+
+            const fromPersistence = window.mParticle
+                .getInstance()
+                ._Persistence.getPersistence();
+
+            expect(fromPersistence[testMPID].csd).to.deep.equal(
+                cookieSyncDates
+            );
+        });
+    });
+
     describe('#getConsentState', () => {
         it('should return a consent state object from the store', () => {
             const store: IStore = new Store(
@@ -1117,7 +1241,7 @@ describe('Store', () => {
             });
         });
     });
-   
+
     describe('#nullifySessionData', () => {
         it('should nullify session data on the store', () => {
             const store: IStore = new Store(


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Migrate Cookie Sync Dates functionality from Persistence into Store

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Run automated tests and test in a sample app set to use Cookies

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6351
