### PR TITLE
fix: Respect directUrlRouting flag in self hosted environments

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -83,6 +83,7 @@ export interface SDKConfig {
     useNativeSdk?: boolean;
     useCookieStorage?: boolean;
     v1SecureServiceUrl?: string;
+    // https://go.mparticle.com/work/SQDSDKS-6618
     v2SecureServiceUrl?: string;
     v3SecureServiceUrl?: string;
     webviewBridgeName?: string;
@@ -661,10 +662,20 @@ export default function Store(
     this.processConfig = (config: SDKInitConfig) => {
         const { workspaceToken, requiredWebviewBridgeName } = config;
 
-        // We should reprocess the flags in case they have changed when we request an updated config
+        // We should reprocess the flags and baseUrls in case they have changed when we request an updated config
         // such as if the SDK is being self-hosted and the flags are different on the server config
         // https://go.mparticle.com/work/SQDSDKS-6317
         this.SDKConfig.flags = processFlags(config);
+
+        const baseUrls: Dictionary<string> = processBaseUrls(
+            config,
+            this.SDKConfig.flags,
+            apiKey
+        );
+
+        for (const baseUrlKeys in baseUrls) {
+            this.SDKConfig[baseUrlKeys] = baseUrls[baseUrlKeys];
+        }
 
         if (workspaceToken) {
             this.SDKConfig.workspaceToken = workspaceToken;


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
The Direct Url Routing flag currently is respected when customers load us via CDN, but I discovered a bug where it wasn't on self hosted environments.  This is because of how the config is treated and processed in CDN vs self hosted.

* CDN - All of the config and flags are in the same mparticle.js file that the server returns via CDN.  In this set up, the [flags are processed](https://github.com/mParticle/mparticle-web-sdk/blob/master/src/store.ts#L294), then the [baseUrls are configured](https://github.com/mParticle/mparticle-web-sdk/blob/master/src/store.ts#L307-L316) shortly after when creating the `Store`.  This is all done in a method when we initialize mParticle called `runPreConfigFetchInitialization`.
* Self hosted - the mparticle code is bundled into an app, and we have to asyncronously fetch the config from the server.  While we still process a user provided config in `runPreConfigFetchInitialization`, we also need to [reprocess the newly returned config](https://github.com/mParticle/mparticle-web-sdk/blob/master/src/mp-instance.js#L1292-L1297) as it has settings like `flags` on it.  

In this `processConfig` function, we were not reprocessing the baseUrls, which I am now doing.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why. 
 - {explain how this has been tested, and what, if any, additional testing should be done}

Tested locally using a test app, and added integration tests as well

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS