### PR TITLE
feat: Enable passing sourceMessageId to logProductAction

### DIFF
--- a/src/ecommerce.js
+++ b/src/ecommerce.js
@@ -523,7 +523,7 @@ export default function Ecommerce(mpInstance) {
         return appEvents;
     };
 
-    this.createCommerceEventObject = function(customFlags) {
+    this.createCommerceEventObject = function(customFlags, options) {
         var baseEvent;
 
         mpInstance.Logger.verbose(
@@ -533,6 +533,7 @@ export default function Ecommerce(mpInstance) {
         if (mpInstance._Helpers.canLog()) {
             baseEvent = mpInstance._ServerModel.createEventObject({
                 messageType: Types.MessageType.Commerce,
+                sourceMessageId: options?.sourceMessageId,
             });
             baseEvent.EventName = 'eCommerce - ';
 

--- a/src/events.js
+++ b/src/events.js
@@ -129,7 +129,8 @@ export default function Events(mpInstance) {
         options
     ) {
         var event = mpInstance._Ecommerce.createCommerceEventObject(
-            customFlags
+            customFlags,
+            options
         );
 
         var productList = Array.isArray(product) ? product : [product];

--- a/test/src/tests-eCommerce.js
+++ b/test/src/tests-eCommerce.js
@@ -1611,5 +1611,45 @@ describe('eCommerce', function() {
             productAction.ShippingAmount.should.equal(0)
             productAction.TaxAmount.should.equal(0)
         });
+
+        it('should allow a user to pass in a source_message_id to a commerce event', function() {
+             const product = mParticle.eCommerce.createProduct(
+                'iPhone',
+                '12345',
+                '400',
+                2,
+                'Plus',
+                'Phones',
+                'Apple',
+                1,
+                'my-coupon-code',
+                { customkey: 'customvalue' }
+            ),
+
+            transactionAttributes = mParticle.eCommerce.createTransactionAttributes(
+                '12345',
+                'test-affiliation',
+                'coupon-code',
+                44334,
+                600,
+                200
+            );
+            
+            fetchMock.resetHistory();
+            
+            mParticle.eCommerce.logProductAction(
+                mParticle.ProductActionType.Purchase,
+                product,
+                null,
+                null,
+                transactionAttributes,
+                {
+                    sourceMessageId: 'foo-bar'
+                }
+            );
+
+            const purchaseEvent1 = findEventFromRequest(fetchMock.calls(), 'purchase');
+            purchaseEvent1.data.source_message_id.should.equal('foo-bar');
+     });
     });
 });

--- a/test/src/tests-eCommerce.js
+++ b/test/src/tests-eCommerce.js
@@ -1635,7 +1635,6 @@ describe('eCommerce', function() {
                 200
             );
             
-            
             mParticle.eCommerce.logProductAction(
                 mParticle.ProductActionType.Purchase,
                 product,

--- a/test/src/tests-eCommerce.js
+++ b/test/src/tests-eCommerce.js
@@ -1635,7 +1635,6 @@ describe('eCommerce', function() {
                 200
             );
             
-            fetchMock.resetHistory();
             
             mParticle.eCommerce.logProductAction(
                 mParticle.ProductActionType.Purchase,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
`logBaseEvent` allowed for `sourceMessageId` to be passed to it - [docs](https://docs.mparticle.com/integrations/facebook/event/#other-scenarios)

This is a feature so that facebook can de-dupe events based on an id.

However, this only works for custom events.  In the past, we added an options parameter to `logProductAction` (among other APIs), to allow for optional flags to be passed through.  We will leverage this open API to now let a key of `sourceMessageId` to be passed to it, so that commerce events also can have a user defined sourceMessageId.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6606