### PR TITLE
fix: Remove XHR References from Identity Utils

### DIFF
--- a/src/identity-user-interfaces.ts
+++ b/src/identity-user-interfaces.ts
@@ -84,6 +84,14 @@ export interface IdentityCallback {
     (result: IdentityResult): void;
 }
 
+export interface IIdentityResponse {
+    // https://go.mparticle.com/work/SQDSDKS-6672
+    responseText: IdentityResultBody;
+    status: number;
+    cacheMaxAge?: number; // Default: 86400
+    expireTimestamp?: number;
+}
+
 export interface IdentityResult {
     httpCode: typeof HTTPCodes;
     getPreviousUser(): User;

--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -2,10 +2,24 @@ import Constants, { ONE_DAY_IN_SECONDS, MILLIS_IN_ONE_SEC } from './constants';
 import { Dictionary, parseNumber, isObject, generateHash } from './utils';
 import { BaseVault } from './vault';
 import Types from './types';
-import { IdentityApiData, UserIdentities, IdentityCallback } from '@mparticle/web-sdk';
+import {
+    IdentityApiData,
+    UserIdentities,
+    IdentityCallback,
+} from '@mparticle/web-sdk';
 import { IdentityAPIMethod } from './identity.interfaces';
+import { IdentityResultBody } from './identity-user-interfaces';
 
 const { Identify, Modify, Login, Logout } = Constants.IdentityMethods;
+const CACHE_HEADER = 'x-mp-max-age' as const;
+
+export interface IIdentityResponse {
+    // https://go.mparticle.com/work/SQDSDKS-6672
+    responseText: IdentityResultBody;
+    status: number;
+    cacheMaxAge: number; // Default: 86400
+    expireTimestamp?: number;
+}
 
 export type IdentityCache = BaseVault<Dictionary<ICachedIdentityCall>>;
 
@@ -17,47 +31,69 @@ export type IParseCachedIdentityResponse = (
     identityMethod: string,
     knownIdentities: IKnownIdentities,
     fromCachedIdentity: boolean
-) => void
+) => void;
 
 export interface IKnownIdentities extends UserIdentities {
     device_application_stamp?: string;
 }
 
 export interface ICachedIdentityCall {
+    // https://go.mparticle.com/work/SQDSDKS-6672
     responseText: string;
     status: number;
     expireTimestamp: number;
 }
 
+// https://go.mparticle.com/work/SQDSDKS-6568
+// Temporary adapter to convert the XMLHttpRequest response to the IIdentityResponse interface
+export const xhrIdentityResponseAdapter = (
+    possiblyXhr: XMLHttpRequest | IIdentityResponse
+): IIdentityResponse => {
+    if (possiblyXhr.hasOwnProperty('expireTimestamp')) {
+        // If there is an `expireTimestamp`, it is an IIdentityResponse object, so just return it.  This indicates it was a previously cached value.
+        return possiblyXhr as IIdentityResponse;
+    } else {
+        // If there is no `expireTimestamp`, then it is an XHR object and needs to be parsed.
+        return {
+            status: possiblyXhr.status,
+            // Sometimes responseText can be an empty string, such as a 404 response
+            responseText: (possiblyXhr as XMLHttpRequest).responseText
+                ? JSON.parse((possiblyXhr as XMLHttpRequest).responseText)
+                : {},
+            cacheMaxAge: parseNumber(
+                (possiblyXhr as XMLHttpRequest)?.getResponseHeader(
+                    CACHE_HEADER
+                ) || ''
+            ),
+            expireTimestamp: 0,
+        };
+    }
+};
+
 export const cacheOrClearIdCache = (
     method: string,
     knownIdentities: IKnownIdentities,
     idCache: BaseVault<Dictionary<ICachedIdentityCall>>,
-    xhr: XMLHttpRequest,
-    parsingCachedResponse: boolean,
+    identityResponse: IIdentityResponse,
+    parsingCachedResponse: boolean
 ): void => {
     // when parsing a response that has already been cached, simply return instead of attempting another cache
-    if (parsingCachedResponse) { return; }
-
-    const CACHE_HEADER = 'x-mp-max-age';
-
-    // default the expire timestamp to one day in milliseconds unless a header comes back
-    let now = new Date().getTime();
-    let expireTimestamp = now + ONE_DAY_IN_SECONDS * MILLIS_IN_ONE_SEC;
-    if (xhr.getAllResponseHeaders().includes(CACHE_HEADER)) {
-        expireTimestamp =
-            now + (parseNumber(xhr.getResponseHeader(CACHE_HEADER)) * MILLIS_IN_ONE_SEC);
+    if (parsingCachedResponse) {
+        return;
     }
 
+    // default the expire timestamp to one day in milliseconds unless a header comes back
+    const expireTimestamp = getExpireTimestamp(identityResponse?.cacheMaxAge);
+
     switch (method) {
-        case Login: 
-        case Identify: 
+        case Login:
+        case Identify:
             cacheIdentityRequest(
                 method,
                 knownIdentities,
                 expireTimestamp,
                 idCache,
-                xhr 
+                identityResponse
             );
             break;
         case Modify:
@@ -65,26 +101,32 @@ export const cacheOrClearIdCache = (
             idCache.purge();
             break;
     }
-}
+};
 
 export const cacheIdentityRequest = (
     method: IdentityAPIMethod,
     identities: IKnownIdentities,
     expireTimestamp: number,
     idCache: IdentityCache,
-    xhr: XMLHttpRequest
+    identityResponse: IIdentityResponse
 ): void => {
-    const cache: Dictionary<ICachedIdentityCall> = idCache.retrieve() || ({} as Dictionary<ICachedIdentityCall>);
+    const { responseText, status } = identityResponse;
+    const cache: Dictionary<ICachedIdentityCall> =
+        idCache.retrieve() || ({} as Dictionary<ICachedIdentityCall>);
     const cacheKey = concatenateIdentities(method, identities);
     const hashedKey = generateHash(cacheKey);
 
-    const { mpid, is_logged_in } = JSON.parse(xhr.responseText);
-    const cachedResponseText = {
+    const { mpid, is_logged_in } = responseText;
+    const cachedResponseBody = {
         mpid,
         is_logged_in,
     };
 
-    cache[hashedKey] = { responseText: JSON.stringify(cachedResponseText), status: xhr.status, expireTimestamp};
+    cache[hashedKey] = {
+        responseText: JSON.stringify(cachedResponseBody),
+        status,
+        expireTimestamp,
+    };
     idCache.store(cache);
 };
 
@@ -115,7 +157,8 @@ export const concatenateIdentities = (
 
         concatenatedIdentities = userIDArray.reduce(
             (prevValue: string, currentValue: string, index: number) => {
-                const idName: string = Types.IdentityType.getIdentityName(index);
+                const idName: string =
+                    Types.IdentityType.getIdentityName(index);
                 return `${prevValue}${idName}=${currentValue};`;
             },
             cacheKey
@@ -128,12 +171,12 @@ export const concatenateIdentities = (
 export const hasValidCachedIdentity = (
     method: IdentityAPIMethod,
     proposedUserIdentities: IKnownIdentities,
-    idCache?: IdentityCache,
+    idCache?: IdentityCache
 ): boolean => {
-    // There is an edge case where multiple identity calls are taking place 
-    // before identify fires, so there may not be a cache.  See what happens when 
+    // There is an edge case where multiple identity calls are taking place
+    // before identify fires, so there may not be a cache.  See what happens when
     // the ? in idCache is removed to the following test
-    // "queued events contain login mpid instead of identify mpid when calling 
+    // "queued events contain login mpid instead of identify mpid when calling
     // login immediately after mParticle initializes"
     const cache = idCache?.retrieve();
 
@@ -152,12 +195,12 @@ export const hasValidCachedIdentity = (
     if (!cache.hasOwnProperty(hashedKey)) {
         return false;
     }
-    
+
     // If there is a valid cache key, compare the expireTimestamp to the current time.
     // If the current time is greater than the expireTimestamp, it is not a valid
     // cached identity.
     const expireTimestamp = cache[hashedKey].expireTimestamp;
-    
+
     if (expireTimestamp < new Date().getTime()) {
         return false;
     } else {
@@ -168,7 +211,7 @@ export const hasValidCachedIdentity = (
 export const getCachedIdentity = (
     method: IdentityAPIMethod,
     proposedUserIdentities: IKnownIdentities,
-    idCache: IdentityCache,
+    idCache: IdentityCache
 ): ICachedIdentityCall | null => {
     const cacheKey: string = concatenateIdentities(
         method,
@@ -200,9 +243,12 @@ export const createKnownIdentities = (
     return identitiesResult;
 };
 
-export const removeExpiredIdentityCacheDates = (idCache: BaseVault<Dictionary<ICachedIdentityCall>>) => {
-    const cache: Dictionary<ICachedIdentityCall> = idCache.retrieve() || {} as Dictionary<ICachedIdentityCall>;
-    
+export const removeExpiredIdentityCacheDates = (
+    idCache: BaseVault<Dictionary<ICachedIdentityCall>>
+) => {
+    const cache: Dictionary<ICachedIdentityCall> =
+        idCache.retrieve() || ({} as Dictionary<ICachedIdentityCall>);
+
     const currentTime: number = new Date().getTime();
 
     // Iterate over the cache and remove any key/value pairs that are expired
@@ -210,10 +256,10 @@ export const removeExpiredIdentityCacheDates = (idCache: BaseVault<Dictionary<IC
         if (cache[key].expireTimestamp < currentTime) {
             delete cache[key];
         }
-    };
+    }
 
     idCache.store(cache);
-}
+};
 
 export const tryCacheIdentity = (
     knownIdentities: IKnownIdentities,
@@ -223,7 +269,7 @@ export const tryCacheIdentity = (
     callback: IdentityCallback,
     identityApiData: IdentityApiData,
     identityMethod: IdentityAPIMethod
-): boolean =>  {
+): boolean => {
     // https://go.mparticle.com/work/SQDSDKS-6095
     const shouldReturnCachedIdentity = hasValidCachedIdentity(
         identityMethod,
@@ -252,4 +298,7 @@ export const tryCacheIdentity = (
         return true;
     }
     return false;
-}
+};
+
+const getExpireTimestamp = (maxAge: number = ONE_DAY_IN_SECONDS): number =>
+    new Date().getTime() + maxAge * MILLIS_IN_ONE_SEC;

--- a/src/identity.interfaces.ts
+++ b/src/identity.interfaces.ts
@@ -10,6 +10,7 @@ import {
     IUserIdentityChangeEvent,
     IMParticleUser,
     mParticleUserCart,
+    IIdentityResponse,
 } from './identity-user-interfaces';
 const { platform, sdkVendor, sdkVersion, HTTPCodes } = Constants;
 
@@ -170,7 +171,7 @@ export interface IIdentity {
         userInMemory: IMParticleUser
     ): IUserIdentityChangeEvent;
     parseIdentityResponse(
-        xhr: XMLHttpRequest,
+        identityResponse: IIdentityResponse,
         previousMPID: MPID,
         callback: IdentityCallback,
         identityApiData: IdentityApiData,

--- a/src/identity.js
+++ b/src/identity.js
@@ -4,6 +4,7 @@ import {
     cacheOrClearIdCache,
     createKnownIdentities,
     tryCacheIdentity,
+    xhrIdentityResponseAdapter,
 } from './identity-utils';
 import AudienceManager from './audienceManager';
 const { Messages, HTTPCodes, FeatureFlags, IdentityMethods } = Constants;
@@ -1515,11 +1516,12 @@ export default function Identity(mpInstance) {
 
             if (xhr.status === 200) {
                 if (getFeatureFlag(CacheIdentity)) {
+                    const identityResponse = xhrIdentityResponseAdapter(xhr);
                     cacheOrClearIdCache(
                         method,
                         knownIdentities,
                         self.idCache,
-                        xhr,
+                        identityResponse,
                         parsingCachedResponse
                     );
                 }

--- a/src/identityApiClient.js
+++ b/src/identityApiClient.js
@@ -1,4 +1,5 @@
 import Constants from './constants';
+import { xhrIdentityResponseAdapter } from './identity-utils';
 
 var HTTPCodes = Constants.HTTPCodes,
     Messages = Constants.Messages;
@@ -78,8 +79,11 @@ export default function IdentityAPIClient(mpInstance) {
                     mpInstance.Logger.verbose(
                         'Received ' + xhr.statusText + ' from server'
                     );
+
+                    // https://go.mparticle.com/work/SQDSDKS-6565
+                    const identityResponse = xhrIdentityResponseAdapter(xhr);
                     parseIdentityResponse(
-                        xhr,
+                        identityResponse,
                         previousMPID,
                         callback,
                         originalIdentityApiData,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,8 @@ export type Dictionary<V = any> = Record<string, V>;
 
 export type Environment = 'development' | 'production';
 
+export const HTTP_SUCCESS = 200 as const;
+
 const createCookieString = (value: string): string =>
     replaceCommasWithPipes(replaceQuotesWithApostrophes(value));
 

--- a/test/src/tests-identity-utils.ts
+++ b/test/src/tests-identity-utils.ts
@@ -7,7 +7,8 @@ import {
     removeExpiredIdentityCacheDates,
     tryCacheIdentity,
     IKnownIdentities,
-    ICachedIdentityCall
+    ICachedIdentityCall,
+    IIdentityResponse
 } from "../../src/identity-utils";
 import { LocalStorageVault } from "../../src/vault";
 import { Dictionary, generateHash } from "../../src/utils";
@@ -23,9 +24,11 @@ import { IdentityApiData } from '@mparticle/web-sdk';
 import Identity from "../../src/identity";
 
 import Constants from '../../src/constants';
-const { Identify, Modify, Login, Logout } = Constants.IdentityMethods;
+const { Identify, Login, Logout } = Constants.IdentityMethods;
 
 import sinon from 'sinon';
+// https://go.mparticle.com/work/SQDSDKS-6671
+import { IdentityResultBody } from "../../src/identity-user-interfaces";
 
 const DEVICE_ID = 'test-device-id'
 
@@ -36,7 +39,7 @@ const knownIdentities: IKnownIdentities = createKnownIdentities({
 
 const cacheVault = new LocalStorageVault<Dictionary>(localStorageIDKey);
 
-const identifyResponse = {
+const identifyResponse: IdentityResultBody = {
     context: null,
     matched_identities: {
         device_application_stamp: "test-das"
@@ -46,16 +49,16 @@ const identifyResponse = {
     is_logged_in: false
 };
 
-const jsonString = JSON.stringify(identifyResponse);
+const loginResponse: IdentityResultBody = {
+    ...identifyResponse,
+    is_logged_in: true,
+};
 
-const xhr: XMLHttpRequest = {
+const identityResponse: IIdentityResponse = {
     status: 200,
-    responseText: jsonString,
-    getAllResponseHeaders: ()=> {return 'x-mp-max-age: 1'},
-    getResponseHeader: (name: string) => {
-        return '1';
-    },
-} as XMLHttpRequest;
+    responseText: identifyResponse,
+    cacheMaxAge: 86400,
+}
 
 describe('identity-utils', () => {
     beforeEach(()=> {
@@ -76,7 +79,7 @@ describe('identity-utils', () => {
                 Identify,
                 knownIdentities,
                 cacheVault,
-                xhr,
+                identityResponse,
                 false
             );
 
@@ -94,7 +97,7 @@ describe('identity-utils', () => {
                 Login,
                 knownIdentities,
                 cacheVault,
-                xhr,
+                identityResponse,
                 false
             );
 
@@ -112,7 +115,7 @@ describe('identity-utils', () => {
                 Logout,
                 knownIdentities,
                 cacheVault,
-                xhr,
+                identityResponse,
                 false
             );
                 
@@ -130,7 +133,7 @@ describe('identity-utils', () => {
                 Identify,
                 knownIdentities,
                 cacheVault,
-                xhr,
+                identityResponse,
                 true
             );
 
@@ -152,7 +155,7 @@ describe('identity-utils', () => {
                 knownIdentities,
                 currentTime,
                 cacheVault,
-                xhr
+                identityResponse
             );
 
             const updatedMpIdCache = cacheVault.retrieve();
@@ -182,18 +185,6 @@ describe('identity-utils', () => {
             const mpIdCache = window.localStorage.getItem(localStorageIDKey);
             expect(mpIdCache).to.equal(null);
             
-            const loginResponse = {
-                ...identifyResponse,
-                is_logged_in: true,
-            };
-
-            const jsonString = JSON.stringify(loginResponse);
-
-            const xhr: XMLHttpRequest = {
-                status: 200,
-                responseText: jsonString,
-            } as XMLHttpRequest;
-
             const currentTime = new Date().getTime();
 
             cacheIdentityRequest(
@@ -201,7 +192,7 @@ describe('identity-utils', () => {
                 knownIdentities,
                 currentTime,
                 cacheVault,
-                xhr
+                { ...identityResponse, responseText: loginResponse }
             );
 
             const updatedMpIdCache = cacheVault.retrieve();
@@ -221,9 +212,9 @@ describe('identity-utils', () => {
             expect(cachedLoginCall.status).to.equal(200);
             expect(cachedLoginCall.expireTimestamp).to.equal(currentTime);
 
-            const cachedResponseText = JSON.parse(cachedLoginCall.responseText);
-            const expectedResponseText = {mpid: testMPID, is_logged_in: true};
-            expect(cachedResponseText).to.deep.equal(expectedResponseText);
+            const cachedResponseBody = JSON.parse(cachedLoginCall.responseText);
+            const expectedResponseBody = {mpid: testMPID, is_logged_in: true};
+            expect(cachedResponseBody).to.deep.equal(expectedResponseBody);
         });
     });
 
@@ -326,7 +317,7 @@ describe('identity-utils', () => {
                 userIdentities,
                 expireTime,
                 cacheVault,
-                xhr
+                identityResponse
             );
 
             // tick forward less than oneDayInMS
@@ -348,7 +339,7 @@ describe('identity-utils', () => {
                 userIdentities,
                 expireTime,
                 cacheVault,
-                xhr
+                identityResponse
             );
 
             clock.tick(oneDayInMS +1);
@@ -413,28 +404,13 @@ describe('identity-utils', () => {
                 DEVICE_ID
             );
 
-            const identifyResponse = {
-                context: null,
-                matched_identities: {
-                    device_application_stamp: "test-das"
-                },
-                is_ephemeral: false,
-                mpid: testMPID,
-                is_logged_in: false
-            };
-
-            const xhr: XMLHttpRequest = {
-                status: 200,
-                responseText: JSON.stringify(identifyResponse),
-            } as XMLHttpRequest;
-
             // Cache 1st identity response to expire in 1 day
             cacheIdentityRequest(
                 'identify',
                 knownIdentities1,
                 MILLISECONDS_IN_ONE_DAY,
                 cacheVault,
-                xhr
+                identityResponse
             );
 
             // Cache 2nd identity response to expire in 1 day + 100ms
@@ -443,7 +419,7 @@ describe('identity-utils', () => {
                 knownIdentities2,
                 MILLISECONDS_IN_ONE_DAY + 100,
                 cacheVault,
-                xhr
+                identityResponse
             );
 
             const updatedMpIdCache = cacheVault.retrieve();
@@ -490,21 +466,6 @@ describe('identity-utils', () => {
 
             const cacheVault = new LocalStorageVault<Dictionary>(localStorageIDKey);
 
-            const identifyResponse = {
-                context: null,
-                matched_identities: {
-                    device_application_stamp: "test-das"
-                },
-                is_ephemeral: false,
-                mpid: testMPID,
-                is_logged_in: false
-            };
-
-            const xhr: XMLHttpRequest = {
-                status: 200,
-                responseText: JSON.stringify(identifyResponse),
-            } as XMLHttpRequest;
-
             const customerId = {customerid: 'id1'}
             const knownIdentities1: IKnownIdentities = createKnownIdentities({
                 userIdentities: customerId},
@@ -517,7 +478,7 @@ describe('identity-utils', () => {
                 knownIdentities,
                 MILLISECONDS_IN_ONE_DAY,
                 cacheVault,
-                xhr
+                identityResponse
             );
 
             const identityInstance = new Identity(mpInstance);

--- a/test/src/tests-identity-utils.ts
+++ b/test/src/tests-identity-utils.ts
@@ -8,7 +8,6 @@ import {
     tryCacheIdentity,
     IKnownIdentities,
     ICachedIdentityCall,
-    IIdentityResponse
 } from "../../src/identity-utils";
 import { LocalStorageVault } from "../../src/vault";
 import { Dictionary, generateHash } from "../../src/utils";
@@ -28,7 +27,7 @@ const { Identify, Login, Logout } = Constants.IdentityMethods;
 
 import sinon from 'sinon';
 // https://go.mparticle.com/work/SQDSDKS-6671
-import { IdentityResultBody } from "../../src/identity-user-interfaces";
+import { IdentityResultBody, IIdentityResponse } from "../../src/identity-user-interfaces";
 
 const DEVICE_ID = 'test-device-id'
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Replaces usage of `XHttpRequest` with a `IdentityResponse` Object so we can cache the actual data of the response rather than having our caching logic tightly coupled to XHR.
 - Uses a temporary `xhrIdentityResponseAdapter` to facility the conversion of an XHR response to an `IdentityResponse` object. This will conversion logic eventually be moved into `IdentityApiClient` in a future revision but is necessary to reduce the scope of changes in this PR.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - All automated tests should pass and all identity request caching logic should behave as expected 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6657
