### PR TITLE
fix: Remove XHR References from Parse Identity Response

### DIFF
--- a/src/identity-user-interfaces.ts
+++ b/src/identity-user-interfaces.ts
@@ -84,6 +84,14 @@ export interface IdentityCallback {
     (result: IdentityResult): void;
 }
 
+export interface IIdentityResponse {
+    // https://go.mparticle.com/work/SQDSDKS-6672
+    responseText: IdentityResultBody;
+    status: number;
+    cacheMaxAge?: number; // Default: 86400
+    expireTimestamp?: number;
+}
+
 export interface IdentityResult {
     httpCode: typeof HTTPCodes;
     getPreviousUser(): User;

--- a/src/identity.interfaces.ts
+++ b/src/identity.interfaces.ts
@@ -10,6 +10,7 @@ import {
     IUserIdentityChangeEvent,
     IMParticleUser,
     mParticleUserCart,
+    IIdentityResponse,
 } from './identity-user-interfaces';
 const { platform, sdkVendor, sdkVersion, HTTPCodes } = Constants;
 
@@ -170,7 +171,7 @@ export interface IIdentity {
         userInMemory: IMParticleUser
     ): IUserIdentityChangeEvent;
     parseIdentityResponse(
-        xhr: XMLHttpRequest,
+        identityResponse: IIdentityResponse,
         previousMPID: MPID,
         callback: IdentityCallback,
         identityApiData: IdentityApiData,

--- a/src/identityApiClient.js
+++ b/src/identityApiClient.js
@@ -1,4 +1,5 @@
 import Constants from './constants';
+import { xhrIdentityResponseAdapter } from './identity-utils';
 
 var HTTPCodes = Constants.HTTPCodes,
     Messages = Constants.Messages;
@@ -78,8 +79,11 @@ export default function IdentityAPIClient(mpInstance) {
                     mpInstance.Logger.verbose(
                         'Received ' + xhr.statusText + ' from server'
                     );
+
+                    // https://go.mparticle.com/work/SQDSDKS-6565
+                    const identityResponse = xhrIdentityResponseAdapter(xhr);
                     parseIdentityResponse(
-                        xhr,
+                        identityResponse,
                         previousMPID,
                         callback,
                         originalIdentityApiData,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,8 @@ export type Dictionary<V = any> = Record<string, V>;
 
 export type Environment = 'development' | 'production';
 
+export const HTTP_SUCCESS = 200 as const;
+
 const createCookieString = (value: string): string =>
     replaceCommasWithPipes(replaceQuotesWithApostrophes(value));
 

--- a/test/src/tests-identity-utils.ts
+++ b/test/src/tests-identity-utils.ts
@@ -8,7 +8,6 @@ import {
     tryCacheIdentity,
     IKnownIdentities,
     ICachedIdentityCall,
-    IIdentityResponse
 } from "../../src/identity-utils";
 import { LocalStorageVault } from "../../src/vault";
 import { Dictionary, generateHash } from "../../src/utils";
@@ -28,7 +27,7 @@ const { Identify, Login, Logout } = Constants.IdentityMethods;
 
 import sinon from 'sinon';
 // https://go.mparticle.com/work/SQDSDKS-6671
-import { IdentityResultBody } from "../../src/identity-user-interfaces";
+import { IdentityResultBody, IIdentityResponse } from "../../src/identity-user-interfaces";
 
 const DEVICE_ID = 'test-device-id'
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Replaces usage of `XHttpRequest` with an IdentityResponse Object within `parseIdentityResponse` using the data of the Identity Response rather than having our logic tightly coupled to XHR.
- Uses a temporary xhrIdentityResponseAdapter to facility the conversion of an XHR response to an IdentityResponse object. This will conversion logic eventually be moved into IdentityApiClient in a future revision but is necessary to reduce the scope of changes in this PR.
- Splits up the scope of work originally started in #905 to reduce the surface area of the change and to make the code review easier to understand.
- This PR will be merged in with #905

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, verify that Identity methods continue to function and are properly cached.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6658
