### PR TITLE
fix: Reject xhr only on errors

### DIFF
--- a/src/uploaders.ts
+++ b/src/uploaders.ts
@@ -58,12 +58,13 @@ export class XHRUploader extends AsyncUploader {
                 if (xhr.readyState !== 4) return;
 
                 // Process the response
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    resolve(xhr as unknown as Response);
-                } else {
-                    reject(xhr);
-                }
+                resolve((xhr as unknown) as Response);
             };
+
+            xhr.onerror = () => {
+                reject((xhr as unknown) as Response);
+            };
+
 
             xhr.open(method, url);
             xhr.send(data);

--- a/src/uploaders.ts
+++ b/src/uploaders.ts
@@ -58,9 +58,12 @@ export class XHRUploader extends AsyncUploader {
                 if (xhr.readyState !== 4) return;
 
                 // Process the response
+                // We resolve all xhr responses whose ready state is 4 regardless of HTTP codes that may be errors (400+)
+                // because these are valid HTTP responses.
                 resolve((xhr as unknown) as Response);
             };
 
+            // Reject a promise only when there is an xhr error
             xhr.onerror = () => {
                 reject((xhr as unknown) as Response);
             };


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary


 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why. - No tests break because nothing is using the xhr uploader and testing a status greater than 300.  However, [this test in Alias Requests](https://github.com/mParticle/mparticle-web-sdk/pull/915/files#diff-a9de58eb911df4bbbd9dca116fbe25478ca72ccc45c5c24e81511256a5ea8fdcR2984-R2998) fails before this fix, and passes afterwards, showing that this change works.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6748