### PR TITLE
feat:Add config for omitting the batch timestamp

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -112,7 +112,8 @@ export default function APIClient(
         );
 
         // set the batch timestamp override in the store if provided as an event option
-        if (options.batchTimestampUnixtimeMsOverride !== undefined) {
+        // setting this to undefined/null will cause no override to be applied
+        if (options.hasOwnProperty('batchTimestampUnixtimeMsOverride')) {
             mpInstance._Store.batchTimestampUnixtimeMsOverride = options.batchTimestampUnixtimeMsOverride;
         }
 

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -110,6 +110,12 @@ export default function APIClient(
             mpInstance._Store.integrationDelayTimeoutStart,
             Date.now()
         );
+
+        // set the batch timestamp override in the store if provided as an event option
+        if (options.batchTimestampUnixtimeMsOverride !== undefined) {
+            mpInstance._Store.batchTimestampUnixtimeMsOverride = options.batchTimestampUnixtimeMsOverride;
+        }
+
         // We queue events if there is no MPID (MPID is null, or === 0), or there are integrations that that require this to stall because integration attributes
         // need to be set, or if we are still fetching the config (self hosted only), and so require delaying events
         if (

--- a/src/cookieSyncManager.interfaces.ts
+++ b/src/cookieSyncManager.interfaces.ts
@@ -1,0 +1,23 @@
+import { MPID } from "@mparticle/web-sdk";
+import { Dictionary } from "./utils";
+import { IConsentRules } from "./consent";
+
+export interface ICookieSyncManager {
+    attemptCookieSync: (previousMPID: MPID, mpid: MPID, mpidIsNotInCookies: boolean) => void;
+    performCookieSync: (
+        url: string,
+        moduleId: number,
+        mpid: MPID,
+        cookieSyncDates: Dictionary<number>,
+        filteringConsentRuleValues: IConsentRules,
+        mpidIsNotInCookies: boolean,
+        requiresConsent: boolean
+    ) => void;
+    replaceAmpWithAmpersand: (string: string) => string;
+    replaceMPID: (string: string, mpid: MPID) => string;
+
+    /**
+     * @deprecated replaceAmp has been deprecated, use replaceAmpersandWithAmp instead
+     */
+    replaceAmp: (string: string) => string;
+}

--- a/src/cookieSyncManager.js
+++ b/src/cookieSyncManager.js
@@ -146,8 +146,15 @@ export default function cookieSyncManager(mpInstance) {
     };
 
     // Private
-    // TODO: Rename function to replaceAmpWithAmpersand
+    /**
+     * @deprecated replaceAmp has been deprecated, use replaceAmpersandWithAmp instead
+     */
     this.replaceAmp = function(string) {
+        return this.replaceAmpWithAmpersand(string);
+    };
+
+    // Private
+    this.replaceAmpWithAmpersand = function(string) {
         return string.replace(/&amp;/g, '&');
     };
 

--- a/src/mockBatchCreator.ts
+++ b/src/mockBatchCreator.ts
@@ -6,11 +6,26 @@ import { convertEvents } from './sdkToEventsApiConverter';
 import * as EventsApi from '@mparticle/event-models';
 import { Batch } from '@mparticle/event-models';
 import { IMPSideloadedKit } from './sideloadedKit';
+import { IStore, SDKConfig } from './store';
 
 const mockFunction = function() {
     return null;
 };
 export default class _BatchValidator {
+    private configOverride?: Partial<Pick<SDKConfig, 'omitBatchTimestamp'>>;
+    private storeOverride?: Partial<Pick<IStore, 'batchTimestampUnixtimeMsOverride'>>;
+
+    constructor({
+        configOverride = {},
+        storeOverride = {}
+    }: {
+        configOverride?: Partial<Pick<SDKConfig, 'omitBatchTimestamp'>>,
+        storeOverride?: Partial<Pick<IStore, 'batchTimestampUnixtimeMsOverride'>>
+    } = {}) {
+        this.configOverride = configOverride
+        this.storeOverride = storeOverride
+    }
+
     private getMPInstance() {
         return ({
             // Certain Helper, Store, and Identity properties need to be mocked to be used in the `returnBatch` method
@@ -87,7 +102,9 @@ export default class _BatchValidator {
                 SDKConfig: {
                     isDevelopmentMode: false,
                     onCreateBatch: mockFunction,
+                    omitBatchTimestamp: this.configOverride?.omitBatchTimestamp,
                 },
+                batchTimestampUnixtimeMsOverride: this.storeOverride?.batchTimestampUnixtimeMsOverride
             },
             config: null,
             eCommerce: null,

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -31,6 +31,7 @@ import {
 } from './identity-user-interfaces';
 import { IIdentityType } from './types.interfaces';
 import IntegrationCapture from './integrationCapture';
+import { ICookieSyncManager } from './cookieSyncManager.interfaces';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;
@@ -158,6 +159,7 @@ export interface MParticleWebSDK {
     Logger: SDKLoggerApi;
     MPSideloadedKit: IMPSideloadedKit;
     _APIClient: any; // TODO: Set up API Client
+    _CookieSyncManager: ICookieSyncManager;
     _Store: IStore;
     _Forwarders: any;
     _Helpers: SDKHelpersApi;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -250,6 +250,7 @@ export interface SDKInitConfig
 
     workspaceToken?: string;
     isDevelopmentMode?: boolean;
+    omitBatchTimestamp?: boolean;
 
     // https://go.mparticle.com/work/SQDSDKS-6460
     identityCallback?: IdentityCallback;

--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -13,7 +13,7 @@ import {
     SDKCCPAConsentState,
 } from './consent';
 import Types from './types';
-import { isEmpty } from './utils';
+import { isEmpty, isNumber } from './utils';
 import { ISDKUserIdentity } from './identity-user-interfaces';
 import { SDKIdentityTypeEnum } from './identity.interfaces';
 
@@ -62,7 +62,7 @@ export function convertEvents(
 
     let timestamp_unixtime_ms: number | null;
 
-    if (batchTimestampUnixtimeMsOverride) {
+    if (isNumber(batchTimestampUnixtimeMsOverride)) {
         timestamp_unixtime_ms = batchTimestampUnixtimeMsOverride;
     } else if (omitBatchTimestamp) {
         timestamp_unixtime_ms = null;

--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -60,7 +60,7 @@ export function convertEvents(
     const { omitBatchTimestamp } = mpInstance._Store.SDKConfig;
     const { batchTimestampUnixtimeMsOverride } = mpInstance._Store;
 
-    let timestamp_unixtime_ms: number | null
+    let timestamp_unixtime_ms: number | null;
 
     if (batchTimestampUnixtimeMsOverride) {
         timestamp_unixtime_ms = batchTimestampUnixtimeMsOverride;

--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -56,10 +56,25 @@ export function convertEvents(
         currentConsentState = user.getConsentState();
     }
 
+    // determine what timestamp, if any, to use for the batch
+    const { omitBatchTimestamp } = mpInstance._Store.SDKConfig;
+    const { batchTimestampUnixtimeMsOverride } = mpInstance._Store;
+
+    let timestamp_unixtime_ms: number | null
+
+    if (batchTimestampUnixtimeMsOverride) {
+        timestamp_unixtime_ms = batchTimestampUnixtimeMsOverride;
+    } else if (omitBatchTimestamp) {
+        timestamp_unixtime_ms = null;
+    } else {
+        timestamp_unixtime_ms = new Date().getTime();
+    }
+
+
     const upload: EventsApi.Batch = {
         source_request_id: mpInstance._Helpers.generateUniqueId(),
         mpid,
-        timestamp_unixtime_ms: new Date().getTime(),
+        timestamp_unixtime_ms,
         environment: lastEvent.Debug
             ? EventsApi.BatchEnvironmentEnum.development
             : EventsApi.BatchEnvironmentEnum.production,

--- a/src/store.ts
+++ b/src/store.ts
@@ -89,6 +89,7 @@ export interface SDKConfig {
     webviewBridgeName?: string;
     workspaceToken?: string;
     requiredWebviewBridgeName?: string;
+    omitBatchTimestamp?: boolean;
 }
 
 function createSDKConfig(config: SDKInitConfig): SDKConfig {
@@ -182,6 +183,7 @@ export interface IStore {
     integrationDelayTimeoutStart: number; // UNIX Timestamp
     webviewBridgeEnabled?: boolean;
     wrapperSDKInfo: WrapperSDKInfo;
+    batchTimestampUnixtimeMsOverride?: number
 
     persistenceData?: IPersistenceMinified;
 
@@ -476,6 +478,10 @@ export default function Store(
                 // set to undefined because all items are set on createSDKConfig
                 this.SDKConfig.onCreateBatch = undefined;
             }
+        }
+
+        if (config.hasOwnProperty('omitBatchTimestamp')) {
+            this.SDKConfig.omitBatchTimestamp = config.omitBatchTimestamp;
         }
     }
 

--- a/test/src/tests-apiClient.ts
+++ b/test/src/tests-apiClient.ts
@@ -115,4 +115,34 @@ describe('Api Client', () => {
 
         done();
     });
+
+    [undefined, null, new Date().getTime()].forEach(
+        (batchTimestampUnixtimeMsOverride) => {
+            it("sendEventToServer should update batchTimestampUnixtimeMsOverride", (done) => {
+                const event = {
+                    messageType: Types.MessageType.PageEvent,
+                    name: "foo page",
+                    data: { "foo-attr": "foo-val" },
+                    eventType: Types.EventType.Navigation,
+                    customFlags: { "foo-flag": "foo-flag-val" },
+                };
+
+                const options = { batchTimestampUnixtimeMsOverride };
+
+                expect(mParticle.getInstance()._Store).to.be.ok;
+
+                mParticle
+                    .getInstance()
+                    ._APIClient.sendEventToServer(event, options);
+
+                expect(
+                    mParticle.getInstance()._Store.batchTimestampUnixtimeMsOverride,
+                ).to.equal(batchTimestampUnixtimeMsOverride);
+
+                done();
+            });
+        },
+    );
+
+
 });

--- a/test/src/tests-mockBatchCreator.ts
+++ b/test/src/tests-mockBatchCreator.ts
@@ -93,12 +93,27 @@ describe('Create a batch from a base event', () => {
         const oneDayAgo = new Date().getTime() - (24 * 3600 * 1000);
         const batchValidator = new _BatchValidator({
             configOverride: {omitBatchTimestamp: true},
-            storeOverride: {batchTimestampUnixtimeMsOverride: oneDayAgo}}
-        );
+            storeOverride: {batchTimestampUnixtimeMsOverride: oneDayAgo}
+        });
         const batch = batchValidator.returnBatch(baseEvent);
 
         expect(batch).to.have.property('timestamp_unixtime_ms').greaterThanOrEqual(oneDayAgo);
 
         done();
     });
+
+    [undefined, null].forEach(batchTimestampUnixtimeMsOverride => {
+        it(`a non-number batch timestamp override of ${batchTimestampUnixtimeMsOverride} is not sent`, done => {
+            const now = new Date().getTime();
+
+            const batchValidator = new _BatchValidator({
+                storeOverride: {batchTimestampUnixtimeMsOverride}
+            });
+            const batch = batchValidator.returnBatch(baseEvent);
+
+            expect(batch).to.have.property('timestamp_unixtime_ms').greaterThanOrEqual(now);
+
+            done();
+        });
+    })
 });


### PR DESCRIPTION
## Summary

The [mParticle docs](https://support.mparticle.com/hc/en-us/articles/7004272100365-What-is-the-Difference-Between-Batch-and-Event-Timestamp) describe the batch timestamp:

>mParticle adds a top-level batch timestamp — timestamp_unixtime_ms — representing the time the batch was received by mParticle. This field is created by mParticle and should not be set manually when sending data via the Events API. 

The same is [confirmed in my Reddit question here](https://www.reddit.com/r/mparticle/comments/1fedk2t/is_there_an_event_received_at_timestamp). However, the docs also says that

>NOTE: the SDK sets the batch time to the time the batch was originally created. This relies on the current device date. If you see forwarded data with an old date, please check if the device date is properly set.

For web applications, checking the device date is not feasible because the devices can belong to millions of users, but knowing when mParticle received a batch of events is extremely valuable when considering that a user's device clock is not always accurate.

This PR adds a config setting to instruct the web SDK to omit the batch timestamp from the batch upload request to mParticle. This is an opt-in config, so the existing behavior remains the default. 

This PR closes #916 (an issue I opened).

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally using `npm run test`
 - Manually tested sending a `null` value for the batch's `timestmap_unixtime_ms` value -- it seems to be populated by the server

### Additional Testing Request

Testing the new bundle script on a demo instance would be great if a maintainer could help with that.