### PR TITLE
feat: Capture Integration Ids and assign to events

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -174,6 +174,7 @@ const Constants = {
         DirectUrlRouting: 'directURLRouting',
         CacheIdentity: 'cacheIdentity',
         AudienceAPI: 'audienceAPI',
+        CaptureIntegrationSpecificIds: 'captureIntegrationSpecificIds',
     },
     DefaultInstance: 'default_instance',
     CCPAPurpose: 'data_sale_opt_out',

--- a/src/integrationCapture.ts
+++ b/src/integrationCapture.ts
@@ -3,7 +3,7 @@ import { Dictionary, queryStringParser, getCookies, getHref } from './utils';
 
 const integrationIdMapping: Dictionary<string> = {
     fbclid: 'Facebook.ClickId',
-    _fbp: 'FaceBook.BrowserId',
+    _fbp: 'Facebook.BrowserId',
 };
 
 export default class IntegrationCapture {
@@ -29,11 +29,16 @@ export default class IntegrationCapture {
      * Captures query parameters based on the integration ID mapping.
      */
     public captureQueryParams(): void {
-        const parsedQueryParams = queryStringParser(
-            getHref(),
-            Object.keys(integrationIdMapping)
-        );
+        const parsedQueryParams = this.getQueryParams();
         this.clickIds = { ...this.clickIds, ...parsedQueryParams };
+    }
+
+    /**
+     * Gets the query parameters based on the integration ID mapping.
+     * @returns {Dictionary<string>} The query parameters.
+     */
+    public getQueryParams(): Dictionary<string> {
+        return queryStringParser(getHref(), Object.keys(integrationIdMapping));
     }
 
     /**

--- a/src/integrationCapture.ts
+++ b/src/integrationCapture.ts
@@ -23,23 +23,23 @@ export const facebookClickIdProcessor: IntegrationCaptureProcessorFunction = (
     url: string,
     timestamp?: number,
 ): string => {
-    if (!clickId && !url) {
+    if (!clickId || !url) {
         return '';
     }
 
-    const urlPrefix = url?.split('//')
-    if (!urlPrefix) {
+    const urlSegments = url?.split('//')
+    if (!urlSegments) {
         return '';
     }
 
-    const urlParts = urlPrefix[1].split('/');
-    const hostParts = urlParts[0].split('.');
+    const urlParts = urlSegments[1].split('/');
+    const domainParts = urlParts[0].split('.');
     let subdomainIndex: number = 1;
 
     // The rules for subdomainIndex are for parsing the domain portion
     // of the URL for cookies, but in this case we are parsing the URL 
     // itself, so we can ignore the use of 0 for 'com'
-    if (hostParts.length >= 3) {
+    if (domainParts.length >= 3) {
         subdomainIndex = 2;
     }
 

--- a/src/integrationCapture.ts
+++ b/src/integrationCapture.ts
@@ -1,45 +1,80 @@
 import { SDKEventCustomFlags } from './sdkRuntimeModels';
-import { Dictionary, queryStringParser, getCookies, getHref } from './utils';
+import {
+    Dictionary,
+    queryStringParser,
+    getCookies,
+    getHref,
+    isEmpty,
+} from './utils';
 
+export interface IntegrationCaptureProcessorFunction {
+    (clickId: string, url: string, timestamp?: number): string;
+}
 
-export const facebookClickIdProcessor = (clickId: string): string => {
-    if (!clickId) {
+// Facebook Click ID has specific formatting rules
+// The formatted ClickID value must be of the form version.subdomainIndex.creationTime.<fbclid>, where:
+// - version is always this prefix: fb
+// - subdomainIndex is which domain the cookie is defined on ('com' = 0, 'example.com' = 1, 'www.example.com' = 2)
+// - creationTime is the UNIX time since epoch in milliseconds when the _fbc was stored. If you don't save the _fbc cookie, use the timestamp when you first observed or received this fbclid value
+// - <fbclid> is the value for the fbclid query parameter in the page URL.
+// https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc
+export const facebookClickIdProcessor: IntegrationCaptureProcessorFunction = (
+    clickId: string,
+    url: string,
+    timestamp?: number,
+): string => {
+    if (!clickId && !url) {
         return '';
     }
 
-    const clickIdParts = clickId.split('.');
-    if (clickIdParts.length === 4) {
-        return clickIdParts[3];
-    };
+    const urlPrefix = url?.split('//')
+    if (!urlPrefix) {
+        return '';
+    }
 
-    return clickId;
+    const urlParts = urlPrefix[1].split('/');
+    const hostParts = urlParts[0].split('.');
+    let subdomainIndex: number = 1;
+
+    // The rules for subdomainIndex are for parsing the domain portion
+    // of the URL for cookies, but in this case we are parsing the URL 
+    // itself, so we can ignore the use of 0 for 'com'
+    if (hostParts.length >= 3) {
+        subdomainIndex = 2;
+    }
+
+    // If timestamp is not provided, use the current time
+    const _timestamp = timestamp || Date.now();
+
+    return `fb.${subdomainIndex}.${_timestamp}.${clickId}`;
 };
-interface ProcessorFunction {
-    (clickId: string): string;
-}
 interface IntegrationIdMapping {
     [key: string]: {
-        mappingValue: string;
-        processor?: ProcessorFunction;
+        mappedKey: string;
+        processor?: IntegrationCaptureProcessorFunction;
     };
 }
 
 const integrationMapping: IntegrationIdMapping = {
     fbclid: {
-        mappingValue: 'Facebook.ClickId',
+        mappedKey: 'Facebook.ClickId',
         processor: facebookClickIdProcessor,
     },
     _fbp: {
-        mappingValue: 'Facebook.BrowserId',
+        mappedKey: 'Facebook.BrowserId',
     },
     _fbc: {
-        mappingValue: 'Facebook.ClickId',
-        processor: facebookClickIdProcessor,
+        mappedKey: 'Facebook.ClickId',
     },
 };
 
 export default class IntegrationCapture {
     public clickIds: Dictionary<string>;
+    public readonly initialTimestamp: number;
+
+    constructor() {
+        this.initialTimestamp = Date.now();
+    }
 
     /**
      * Captures Integration Ids from cookies and query params and stores them in clickIds object
@@ -48,8 +83,9 @@ export default class IntegrationCapture {
         const queryParams = this.captureQueryParams() || {};
         const cookies = this.captureCookies() || {};
 
+        // Exclude _fbc if fbclid is present
+        // https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc#retrieve-from-fbclid-url-query-parameter
         if (queryParams['fbclid'] && cookies['_fbc']) {
-            // Exclude fbclid if _fbc is present
             delete cookies['_fbc'];
         }
 
@@ -69,7 +105,7 @@ export default class IntegrationCapture {
      */
     public captureQueryParams(): Dictionary<string> {
         const queryParams = this.getQueryParams();
-        return this.applyProcessors(queryParams);
+        return this.applyProcessors(queryParams, getHref(), this.initialTimestamp);
     }
 
     /**
@@ -92,26 +128,26 @@ export default class IntegrationCapture {
         }
 
         for (const [key, value] of Object.entries(this.clickIds)) {
-            const mappedKey = integrationMapping[key]?.mappingValue;
-            if (mappedKey) {
+            const mappedKey = integrationMapping[key]?.mappedKey;
+            if (!isEmpty(mappedKey)) {
                 customFlags[mappedKey] = value;
             }
         }
         return customFlags;
     }
 
-    private applyProcessors(clickIds: Dictionary<string>): Dictionary<string> {
+    private applyProcessors(clickIds: Dictionary<string>, url?: string, timestamp?: number): Dictionary<string> {
         const processedClickIds: Dictionary<string> = {};
 
         for (const [key, value] of Object.entries(clickIds)) {
             const processor = integrationMapping[key]?.processor;
             if (processor) {
-                processedClickIds[key] = processor(value);
+                processedClickIds[key] = processor(value, url, timestamp);
             } else {
                 processedClickIds[key] = value;
             }
         }
 
         return processedClickIds;
-    };
+    }
 }

--- a/src/integrationCapture.ts
+++ b/src/integrationCapture.ts
@@ -1,0 +1,41 @@
+import { SDKEventCustomFlags } from "./sdkRuntimeModels";
+import { Dictionary } from "./utils";
+
+const integrationIdMapping = {
+    'ttclid': 'TikTok.ClickId',
+    'fbclid': 'Facebook.ClickId',
+    'fbp': 'FaceBook.BrowserId',
+};
+
+// TODO: Do we need to put this in the store?
+export default class IntegrationCapture {
+    public clickIds: Dictionary<string> = {};
+
+    public captureQueryParams(): void {
+        // TODO: Make this a utility with a fallback
+        const urlParams = new URLSearchParams(window.location.search);
+
+        Object.keys(integrationIdMapping).forEach((key) => {
+            const value = urlParams.get(key);
+            if (value) {
+                this.clickIds[key] = value;
+            }
+        });
+
+        console.log('captured params', this.clickIds);
+    }
+
+    public getClickIdsAsCustomFlags(): SDKEventCustomFlags {
+        let customFlags: SDKEventCustomFlags = {};
+
+        debugger;
+
+        for(const [key, value] of Object.entries(this.clickIds)) {
+            customFlags[integrationIdMapping[key]] = value;
+        }
+
+        console.log('returning custom flags', customFlags);
+
+        return customFlags;
+    }
+}

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -1376,33 +1376,6 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
     if (mpInstance._Store.isFirstRun) {
         mpInstance._Store.isFirstRun = false;
     }
-
-    // TODO: CAPI CHECKLIST
-    // Check for capi setting
-    // Parse URL for Click ID
-    // Place in store
-    // On event creation, add capi data to event
-
-    // *** Quick solution
-    // const urlParams = new URLSearchParams(window.location.search);
-    // const fbClickId = urlParams.get('fbclid');
-    // const tikTokId = urlParams.get('ttclid');
-    // console.warn('fbClickId', fbClickId);
-
-    // if (fbClickId) {
-    //     mpInstance._Store.configuredClickIds['fbclid'] = fbClickId;
-    // }
-
-    // if (tikTokId) {
-    //     mpInstance._Store.configuredClickIds['ttclid'] = tikTokId;
-    // }
-    // *** End Quick Solution
-
-    // *** Long term solution
-
-    mpInstance._CapturedIntegrations.captureQueryParams();
-
-    // *** End Long term solution
 }
 
 function createKitBlocker(config, mpInstance) {

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -42,7 +42,7 @@ import { removeExpiredIdentityCacheDates } from './identity-utils';
 import IntegrationCapture from './integrationCapture';
 
 const { Messages, HTTPCodes, FeatureFlags } = Constants;
-const { ReportBatching } = FeatureFlags;
+const { ReportBatching, CaptureIntegrationSpecificIds } = FeatureFlags;
 const { StartingInitialization } = Messages.InformationMessages;
 
 /**
@@ -1336,6 +1336,10 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
 
         if (mpInstance._Helpers.getFeatureFlag(ReportBatching)) {
             mpInstance._ForwardingStatsUploader.startForwardingStatsTimer();
+        }
+
+        if (mpInstance._Helpers.getFeatureFlag(CaptureIntegrationSpecificIds)) {
+            mpInstance._CapturedIntegrations.capture();
         }
 
         mpInstance._Forwarders.processForwarders(

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -78,7 +78,7 @@ export default function mParticleInstance(instanceName) {
         integrationDelays: {},
         forwarderConstructors: [],
     };
-    this._CapturedIntegrations = new IntegrationCapture();
+    this._IntegrationCapture = new IntegrationCapture();
 
     // required for forwarders once they reference the mparticle instance
     this.IdentityType = Types.IdentityType;
@@ -1339,7 +1339,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
         }
 
         if (mpInstance._Helpers.getFeatureFlag(CaptureIntegrationSpecificIds)) {
-            mpInstance._CapturedIntegrations.capture();
+            mpInstance._IntegrationCapture.capture();
         }
 
         mpInstance._Forwarders.processForwarders(

--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -39,6 +39,7 @@ import IdentityAPIClient from './identityApiClient';
 import { isEmpty, isFunction } from './utils';
 import { LocalStorageVault } from './vault';
 import { removeExpiredIdentityCacheDates } from './identity-utils';
+import IntegrationCapture from './integrationCapture';
 
 const { Messages, HTTPCodes, FeatureFlags } = Constants;
 const { ReportBatching } = FeatureFlags;
@@ -77,6 +78,7 @@ export default function mParticleInstance(instanceName) {
         integrationDelays: {},
         forwarderConstructors: [],
     };
+    this._CapturedIntegrations = new IntegrationCapture();
 
     // required for forwarders once they reference the mparticle instance
     this.IdentityType = Types.IdentityType;
@@ -1370,6 +1372,33 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
     if (mpInstance._Store.isFirstRun) {
         mpInstance._Store.isFirstRun = false;
     }
+
+    // TODO: CAPI CHECKLIST
+    // Check for capi setting
+    // Parse URL for Click ID
+    // Place in store
+    // On event creation, add capi data to event
+
+    // *** Quick solution
+    // const urlParams = new URLSearchParams(window.location.search);
+    // const fbClickId = urlParams.get('fbclid');
+    // const tikTokId = urlParams.get('ttclid');
+    // console.warn('fbClickId', fbClickId);
+
+    // if (fbClickId) {
+    //     mpInstance._Store.configuredClickIds['fbclid'] = fbClickId;
+    // }
+
+    // if (tikTokId) {
+    //     mpInstance._Store.configuredClickIds['ttclid'] = tikTokId;
+    // }
+    // *** End Quick Solution
+
+    // *** Long term solution
+
+    mpInstance._CapturedIntegrations.captureQueryParams();
+
+    // *** End Long term solution
 }
 
 function createKitBlocker(config, mpInstance) {

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -151,7 +151,7 @@ interface IEvents {
 
 export interface MParticleWebSDK {
     addForwarder(mockForwarder: MPForwarder): void;
-    _CapturedIntegrations: IntegrationCapture;
+    _IntegrationCapture: IntegrationCapture;
     IdentityType: IIdentityType;
     _Identity: IIdentity;
     Identity: SDKIdentityApi;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -30,6 +30,7 @@ import {
     ISDKUserAttributes,
 } from './identity-user-interfaces';
 import { IIdentityType } from './types.interfaces';
+import IntegrationCapture from './integrationCapture';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;
@@ -150,6 +151,7 @@ interface IEvents {
 
 export interface MParticleWebSDK {
     addForwarder(mockForwarder: MPForwarder): void;
+    _CapturedIntegrations: IntegrationCapture;
     IdentityType: IIdentityType;
     _Identity: IIdentity;
     Identity: SDKIdentityApi;

--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -323,9 +323,7 @@ export default function ServerModel(
             } else {
                 let customFlags: SDKEventCustomFlags = {...event.customFlags};
 
-                // FIXME: In our testing framework, there is a case where `createEventObject` is called
-                // before the Web SDK is initialized by the BatchValidator. This should be refactored or
-                // decoupled.
+                // https://go.mparticle.com/work/SQDSDKS-5053
                 if (mpInstance._Helpers.getFeatureFlag && mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.CaptureIntegrationSpecificIds)) {
                     const transformedClickIDs = mpInstance._CapturedIntegrations.getClickIdsAsCustomFlags();
                     customFlags = {...transformedClickIDs, ...customFlags};

--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -318,21 +318,21 @@ export default function ServerModel(
             event.messageType === Types.MessageType.OptOut ||
             mpInstance._Store.webviewBridgeEnabled
         ) {
+            let customFlags: SDKEventCustomFlags = {...event.customFlags};
+
+            // https://go.mparticle.com/work/SQDSDKS-5053
+            if (mpInstance._Helpers.getFeatureFlag && mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.CaptureIntegrationSpecificIds)) {
+
+                // Attempt to recapture click IDs in case a third party integration
+                // has added or updated  new click IDs since the last event was sent.
+                mpInstance._IntegrationCapture.capture();
+                const transformedClickIDs = mpInstance._IntegrationCapture.getClickIdsAsCustomFlags();
+                customFlags = {...transformedClickIDs, ...customFlags};
+            }
+
             if (event.hasOwnProperty('toEventAPIObject')) {
                 eventObject = event.toEventAPIObject();
             } else {
-                let customFlags: SDKEventCustomFlags = {...event.customFlags};
-
-                // https://go.mparticle.com/work/SQDSDKS-5053
-                if (mpInstance._Helpers.getFeatureFlag && mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.CaptureIntegrationSpecificIds)) {
-
-                    // Attempt to recapture click IDs in case a third party integration
-                    // has added or updated  new click IDs since the last event was sent.
-                    mpInstance._IntegrationCapture.capture();
-                    const transformedClickIDs = mpInstance._IntegrationCapture.getClickIdsAsCustomFlags();
-                    customFlags = {...transformedClickIDs, ...customFlags};
-                }
-
                 eventObject = {
                     // This is an artifact from v2 events where SessionStart/End and AST event
                     //  names are numbers (1, 2, or 10), but going forward with v3, these lifecycle

--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -325,7 +325,7 @@ export default function ServerModel(
 
                 // https://go.mparticle.com/work/SQDSDKS-5053
                 if (mpInstance._Helpers.getFeatureFlag && mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.CaptureIntegrationSpecificIds)) {
-                    const transformedClickIDs = mpInstance._CapturedIntegrations.getClickIdsAsCustomFlags();
+                    const transformedClickIDs = mpInstance._IntegrationCapture.getClickIdsAsCustomFlags();
                     customFlags = {...transformedClickIDs, ...customFlags};
                 }
 

--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -325,6 +325,7 @@ export default function ServerModel(
 
                 // https://go.mparticle.com/work/SQDSDKS-5053
                 if (mpInstance._Helpers.getFeatureFlag && mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.CaptureIntegrationSpecificIds)) {
+                    mpInstance._IntegrationCapture.capture();
                     const transformedClickIDs = mpInstance._IntegrationCapture.getClickIdsAsCustomFlags();
                     customFlags = {...transformedClickIDs, ...customFlags};
                 }

--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -321,14 +321,14 @@ export default function ServerModel(
             if (event.hasOwnProperty('toEventAPIObject')) {
                 eventObject = event.toEventAPIObject();
             } else {
-                let customFlags: SDKEventCustomFlags = {};
+                let customFlags: SDKEventCustomFlags = {...event.customFlags};
 
                 // FIXME: In our testing framework, there is a case where `createEventObject` is called
                 // before the Web SDK is initialized by the BatchValidator. This should be refactored or
                 // decoupled.
                 if (mpInstance._Helpers.getFeatureFlag && mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.CaptureIntegrationSpecificIds)) {
                     const transformedClickIDs = mpInstance._CapturedIntegrations.getClickIdsAsCustomFlags();
-                    customFlags = {...transformedClickIDs, ...event.customFlags};
+                    customFlags = {...transformedClickIDs, ...customFlags};
                 }
 
                 eventObject = {

--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -320,6 +320,32 @@ export default function ServerModel(
             if (event.hasOwnProperty('toEventAPIObject')) {
                 eventObject = event.toEventAPIObject();
             } else {
+
+                // TODO: Add click ids to custom flags
+                // console.log('configured click ids', mpInstance._Store.configuredClickIds);
+
+                // const clickIdTransform = {
+                //     'ttclid': 'TikTok.ClickId',
+                //     'fbclid': 'Facebook.ClickId',
+                //     'fbp': 'FaceBook.BrowserId',
+                // };
+
+                // let transformedClickIDs = {};
+
+                // // TODO: Maybe use Object.entries?
+                // Object.keys(mpInstance._Store.configuredClickIds).forEach((clickId) => {
+                //     console.log('clickId', clickId);
+                //     transformedClickIDs[clickIdTransform[clickId]] = mpInstance._Store.configuredClickIds[clickId];
+                // });
+
+                const transformedClickIDs = mpInstance._CapturedIntegrations.getClickIdsAsCustomFlags();
+
+                console.log('transformed click ids', transformedClickIDs);
+
+                const customFlags = {...transformedClickIDs, ...event.customFlags};
+
+                console.log('updated custom flags', customFlags);
+
                 eventObject = {
                     // This is an artifact from v2 events where SessionStart/End and AST event
                     //  names are numbers (1, 2, or 10), but going forward with v3, these lifecycle
@@ -336,7 +362,7 @@ export default function ServerModel(
                         event.sourceMessageId ||
                         mpInstance._Helpers.generateUniqueId(),
                     EventDataType: event.messageType,
-                    CustomFlags: event.customFlags || {},
+                    CustomFlags: customFlags,
                     UserAttributeChanges: event.userAttributeChanges,
                     UserIdentityChanges: event.userIdentityChanges,
                 };

--- a/src/serverModel.ts
+++ b/src/serverModel.ts
@@ -325,6 +325,9 @@ export default function ServerModel(
 
                 // https://go.mparticle.com/work/SQDSDKS-5053
                 if (mpInstance._Helpers.getFeatureFlag && mpInstance._Helpers.getFeatureFlag(Constants.FeatureFlags.CaptureIntegrationSpecificIds)) {
+
+                    // Attempt to recapture click IDs in case a third party integration
+                    // has added or updated  new click IDs since the last event was sent.
                     mpInstance._IntegrationCapture.capture();
                     const transformedClickIDs = mpInstance._IntegrationCapture.getClickIdsAsCustomFlags();
                     customFlags = {...transformedClickIDs, ...customFlags};

--- a/src/store.ts
+++ b/src/store.ts
@@ -710,6 +710,7 @@ export function processFlags(config: SDKInitConfig): IFeatureFlags {
         DirectUrlRouting,
         CacheIdentity,
         AudienceAPI,
+        CaptureIntegrationSpecificIds,
     } = Constants.FeatureFlags;
 
     if (!config.flags) {
@@ -727,6 +728,7 @@ export function processFlags(config: SDKInitConfig): IFeatureFlags {
     flags[DirectUrlRouting] = config.flags[DirectUrlRouting] === 'True';
     flags[CacheIdentity] = config.flags[CacheIdentity] === 'True';
     flags[AudienceAPI] = config.flags[AudienceAPI] === 'True';
+    flags[CaptureIntegrationSpecificIds] = config.flags[CaptureIntegrationSpecificIds] === 'True';
 
     return flags;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -232,6 +232,78 @@ const mergeObjects = <T extends object>(...objects: T[]): T => {
 const moveElementToEnd = <T>(array: T[], index: number): T[] =>
     array.slice(0, index).concat(array.slice(index + 1), array[index]);
 
+const queryStringParser = (url: string, keys: string[]): Dictionary<string> => {
+    let urlParams;
+    let results = {};
+
+    if (!url) return results;
+
+    if (typeof URL !== 'undefined' && typeof URLSearchParams !== 'undefined') {
+        const urlObject = new URL(url);
+        urlParams = new URLSearchParams(urlObject.search);
+    } else {
+        console.log('use fallback')
+        urlParams = queryStringParserFallback(url);
+    }
+
+    keys.forEach((key) => {
+        const value = urlParams.get(key);
+        if (value) {
+            results[key] = value;
+        }
+    });
+
+    return results;
+};
+
+interface URLSearchParamsFallback {
+    get: (key: string) => string | null;
+}
+
+const queryStringParserFallback = (url: string): URLSearchParamsFallback=> {
+    var params = {};
+    var queryString = url.split('?')[1];
+    var paris = queryString.split('&');
+
+    paris.forEach((pair) => {
+        var [key, value] = pair.split('=');
+        if (key && value) {
+            params[key] = decodeURIComponent(value || '');
+        };
+    });
+
+    return {
+        get: function(key: string) {
+            return params[key];
+        }
+    };
+};
+
+// Get cookies as a dictionary
+const getCookies = (keys?: string[]): Dictionary<string> => {
+    // TODO: Make a fallback
+    console.log('document.cookie', document.cookie);
+    const cookies = window.document.cookie.split(';').map((cookie) => cookie.trim());
+    const results = {};
+
+    console.log('cookies', cookies);
+
+    for (const cookie of cookies) {
+        const [key, value] = cookie.split('=');
+        if (isEmpty(keys)) {
+            results[key] = value;
+        } else if (keys.includes(key)) {
+            results[key] = value;
+        }
+    }
+
+    return results;
+};
+
+const getHref = (): string => {
+    return typeof window !== "undefined" && window.location ? window.location.href : '';
+}
+
 export {
     createCookieString,
     revertCookieString,
@@ -262,4 +334,7 @@ export {
     isValidCustomFlagProperty,
     mergeObjects,
     moveElementToEnd,
+    queryStringParser,
+    getCookies,
+    getHref,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -242,11 +242,10 @@ const queryStringParser = (url: string, keys: string[]): Dictionary<string> => {
         const urlObject = new URL(url);
         urlParams = new URLSearchParams(urlObject.search);
     } else {
-        console.log('use fallback')
         urlParams = queryStringParserFallback(url);
     }
 
-    keys.forEach((key) => {
+    keys.forEach(key => {
         const value = urlParams.get(key);
         if (value) {
             results[key] = value;
@@ -260,49 +259,59 @@ interface URLSearchParamsFallback {
     get: (key: string) => string | null;
 }
 
-const queryStringParserFallback = (url: string): URLSearchParamsFallback=> {
+const queryStringParserFallback = (url: string): URLSearchParamsFallback => {
     var params = {};
     var queryString = url.split('?')[1];
-    var paris = queryString.split('&');
+    var pairs = queryString.split('&');
 
-    paris.forEach((pair) => {
+    pairs.forEach(pair => {
         var [key, value] = pair.split('=');
         if (key && value) {
             params[key] = decodeURIComponent(value || '');
-        };
+        }
     });
 
     return {
         get: function(key: string) {
             return params[key];
-        }
+        },
     };
 };
 
 // Get cookies as a dictionary
 const getCookies = (keys?: string[]): Dictionary<string> => {
-    // TODO: Make a fallback
-    console.log('document.cookie', document.cookie);
-    const cookies = window.document.cookie.split(';').map((cookie) => cookie.trim());
-    const results = {};
+    // Helper function to parse cookies from document.cookie
+    const parseCookies = (): string[] => {
+        if (typeof window === 'undefined') {
+            return [];
+        }
+        return window.document.cookie.split(';').map(cookie => cookie.trim());
+    };
 
-    console.log('cookies', cookies);
-
+    // Helper function to filter cookies by keys
+    const filterCookies = (cookies: string[], keys?: string[]): Dictionary<string> => {
+        const results: Dictionary<string> = {};
     for (const cookie of cookies) {
         const [key, value] = cookie.split('=');
-        if (isEmpty(keys)) {
-            results[key] = value;
-        } else if (keys.includes(key)) {
+            if (!keys || keys.includes(key)) {
             results[key] = value;
         }
     }
-
     return results;
+    };
+
+    // Parse cookies from document.cookie
+    const cookies = parseCookies();
+
+    // Filter cookies by keys if provided
+    return filterCookies(cookies, keys);
 };
 
 const getHref = (): string => {
-    return typeof window !== "undefined" && window.location ? window.location.href : '';
-}
+    return typeof window !== 'undefined' && window.location
+        ? window.location.href
+        : '';
+};
 
 export {
     createCookieString,

--- a/test/jest/integration-capture.spec.ts
+++ b/test/jest/integration-capture.spec.ts
@@ -1,0 +1,132 @@
+import IntegrationCapture from "../../src/integrationCapture";
+
+function deleteAllCookies() {
+    document.cookie.split(';').forEach(cookie => {
+        const eqPos = cookie.indexOf('=');
+        const name = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    });
+}
+
+describe('Integration Capture', () => {
+    describe('constructor', () => {
+        it('should initialize with clickIds as undefined', () => {
+            const integrationCapture = new IntegrationCapture();
+            expect(integrationCapture.clickIds).toBeUndefined();
+        });
+    });
+
+    describe('#capture', () => {
+        it('should call captureCookies and captureQueryParams', () => {
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.captureCookies = jest.fn();
+            integrationCapture.captureQueryParams = jest.fn();
+
+            integrationCapture.capture();
+
+            expect(integrationCapture.captureCookies).toHaveBeenCalled();
+            expect(integrationCapture.captureQueryParams).toHaveBeenCalled();
+        });
+    });
+
+    describe('#captureQueryParams', () => {
+        const originalLocation = window.location;
+
+        beforeEach(() => {
+            delete (window as any).location;
+            (window as any).location = {
+                href: '',
+                search: '',
+                assign: jest.fn(),
+                replace: jest.fn(),
+                reload: jest.fn(),
+            };
+        });
+
+        afterEach(() => {
+            window.location = originalLocation;
+        });
+
+        it('should capture specific query params into clickIds object', () => {
+            const url = new URL("https://www.example.com/?ttclid=12345&fbclid=67890&_fbp=54321");
+
+            window.location.href = url.href;
+            window.location.search = url.search;
+
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.captureQueryParams();
+
+            expect(integrationCapture.clickIds).toEqual({
+                fbclid: '67890',
+                '_fbp': '54321',
+            });
+        });
+
+        it('should NOT capture query params if they are not mapped', () => {
+            const url = new URL("https://www.example.com/?invalidid=12345&foo=bar");
+
+            window.location.href = url.href;
+            window.location.search = url.search;
+
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.captureQueryParams();
+
+            expect(integrationCapture.clickIds).toEqual({});
+        });
+    });
+
+    describe('#captureCookies', () => {
+        beforeEach(() => {
+            deleteAllCookies();
+        });
+
+        it('should capture specific cookies into clickIds object', () => {
+            window.document.cookie = '_cookie1=1234';
+            window.document.cookie = '_cookie2=39895811.9165333198';
+            window.document.cookie = '_fbp=54321';
+            window.document.cookie = 'baz=qux';
+
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.captureCookies();
+
+            expect(integrationCapture.clickIds).toEqual({
+                '_fbp': '54321',
+            });
+        });
+
+        it('should NOT capture cookies if they are not mapped', () => {
+            window.document.cookie = '_cookie1=1234';
+            window.document.cookie = '_cookie2=39895811.9165333198';
+            window.document.cookie = 'baz=qux';
+
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.captureCookies();
+
+            expect(integrationCapture.clickIds).toEqual({});
+        });
+    });
+
+    describe('#getClickIdsAsCustomFlags', () => {
+        it('should return clickIds as custom flags', () => {
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.clickIds = {
+                fbclid: '67890',
+                '_fbp': '54321',
+            };
+
+            const customFlags = integrationCapture.getClickIdsAsCustomFlags();
+
+            expect(customFlags).toEqual({
+                'Facebook.ClickId': '67890',
+                'FaceBook.BrowserId': '54321',
+            });
+        });
+
+        it('should return empty object if clickIds is empty or undefined', () => {
+            const integrationCapture = new IntegrationCapture();
+            const customFlags = integrationCapture.getClickIdsAsCustomFlags();
+
+            expect(customFlags).toEqual({});
+        });
+    });
+});

--- a/test/jest/integration-capture.spec.ts
+++ b/test/jest/integration-capture.spec.ts
@@ -1,5 +1,7 @@
-import IntegrationCapture, { facebookClickIdProcessor } from "../../src/integrationCapture";
-import { deleteAllCookies } from "./utils";
+import IntegrationCapture, {
+    facebookClickIdProcessor,
+} from '../../src/integrationCapture';
+import { deleteAllCookies } from './utils';
 
 describe('Integration Capture', () => {
     describe('constructor', () => {
@@ -27,6 +29,7 @@ describe('Integration Capture', () => {
 
         afterEach(() => {
             window.location = originalLocation;
+            jest.restoreAllMocks();
         });
 
         it('should call captureCookies and captureQueryParams', () => {
@@ -40,13 +43,14 @@ describe('Integration Capture', () => {
             expect(integrationCapture.captureQueryParams).toHaveBeenCalled();
         });
 
-        it('should prioritize fbclid over _fbc', () => {
+        it('should pass all clickIds to clickIds object', () => {
+            jest.spyOn(Date, 'now').mockImplementation(() => 42);
 
-            const url = new URL("https://www.example.com/?fbclid=12345&");
+            const url = new URL('https://www.example.com/?fbclid=12345&');
 
             window.document.cookie = '_cookie1=1234';
             window.document.cookie = '_cookie2=39895811.9165333198';
-            window.document.cookie = '_fbc=654321';
+            window.document.cookie = '_fbp=54321';
             window.document.cookie = 'baz=qux';
 
             window.location.href = url.href;
@@ -56,12 +60,56 @@ describe('Integration Capture', () => {
             integrationCapture.capture();
 
             expect(integrationCapture.clickIds).toEqual({
-               fbclid: '12345', 
-            });
+                fbclid: 'fb.2.42.12345',
+                _fbp: '54321',
+            }); 
         });
 
         it('should format fbclid correctly', () => {
-            const url = new URL("https://www.example.com/?fbclid=fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890");
+            jest.spyOn(Date, 'now').mockImplementation(() => 42);
+
+            const url = new URL(
+                'https://www.example.com/?fbclid=AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+            );
+
+            window.document.cookie = '_cookie1=1234';
+            window.document.cookie = '_cookie2=39895811.9165333198';
+            window.document.cookie = 'baz=qux';
+
+            window.location.href = url.href;
+            window.location.search = url.search;
+
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.capture();
+
+            expect(integrationCapture.clickIds).toEqual({
+                fbclid:
+                    'fb.2.42.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+            });
+        });
+
+        it('should pass the _fbc value unaltered', () => {
+            const url = new URL('https://www.example.com/?foo=bar');
+
+            window.document.cookie = '_cookie1=1234';
+            window.document.cookie = '_cookie2=39895811.9165333198';
+            window.document.cookie =
+                '_fbc=fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+            window.document.cookie = 'baz=qux';
+
+            window.location.href = url.href;
+            window.location.search = url.search;
+
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.capture();
+
+            expect(integrationCapture.clickIds).toEqual({
+                _fbc: 'fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+            });
+        });
+
+        it('should pass the _fbp value unaltered', () => {
+            const url = new URL('https://www.example.com/?foo=bar');
 
             window.document.cookie = '_cookie1=1234';
             window.document.cookie = '_cookie2=39895811.9165333198';
@@ -75,18 +123,18 @@ describe('Integration Capture', () => {
             integrationCapture.capture();
 
             expect(integrationCapture.clickIds).toEqual({
-                fbclid: 'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-                '_fbp': '54321',
+                _fbp: '54321',
             });
         });
 
-        it('should format _fbc correctly', () => {
-            const url = new URL("https://www.example.com/?foo=bar");
+        it('should prioritize fbclid over _fbc', () => {
+            jest.spyOn(Date, 'now').mockImplementation(() => 42);
+
+            const url = new URL('https://www.example.com/?fbclid=12345&');
 
             window.document.cookie = '_cookie1=1234';
             window.document.cookie = '_cookie2=39895811.9165333198';
-            window.document.cookie = '_fbp=54321';
-            window.document.cookie = '_fbc=fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+            window.document.cookie = '_fbc=fb.1.23.654321';
             window.document.cookie = 'baz=qux';
 
             window.location.href = url.href;
@@ -96,10 +144,10 @@ describe('Integration Capture', () => {
             integrationCapture.capture();
 
             expect(integrationCapture.clickIds).toEqual({
-                '_fbc': 'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-                '_fbp': '54321',
+                fbclid: 'fb.2.42.12345',
             });
         });
+
     });
 
     describe('#captureQueryParams', () => {
@@ -118,10 +166,15 @@ describe('Integration Capture', () => {
 
         afterEach(() => {
             window.location = originalLocation;
+            jest.restoreAllMocks();
         });
 
         it('should capture specific query params into clickIds object', () => {
-            const url = new URL("https://www.example.com/?ttclid=12345&fbclid=67890&gclid=54321");
+            jest.spyOn(Date, 'now').mockImplementation(() => 42);
+
+            const url = new URL(
+                'https://www.example.com/?ttclid=12345&fbclid=67890&gclid=54321'
+            );
 
             window.location.href = url.href;
             window.location.search = url.search;
@@ -130,12 +183,14 @@ describe('Integration Capture', () => {
             const clickIds = integrationCapture.captureQueryParams();
 
             expect(clickIds).toEqual({
-                fbclid: '67890',
+                fbclid: 'fb.2.42.67890',
             });
         });
 
         it('should NOT capture query params if they are not mapped', () => {
-            const url = new URL("https://www.example.com/?invalidid=12345&foo=bar");
+            const url = new URL(
+                'https://www.example.com/?invalidid=12345&foo=bar'
+            );
 
             window.location.href = url.href;
             window.location.search = url.search;
@@ -144,6 +199,26 @@ describe('Integration Capture', () => {
             const clickIds = integrationCapture.captureQueryParams();
 
             expect(clickIds).toEqual({});
+        });
+
+        it('should format fbclid correctly with the same timestamp on subsequent captures', () => {
+            const url = new URL(
+                'https://www.example.com/?fbclid=AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+            ); 
+
+            window.location.href = url.href;
+            window.location.search = url.search;
+
+            const integrationCapture = new IntegrationCapture();
+            integrationCapture.capture();
+
+            const firstCapture = integrationCapture.captureQueryParams();
+
+            integrationCapture.capture();
+
+            const secondCapture = integrationCapture.captureQueryParams();
+
+            expect(firstCapture).toEqual(secondCapture);
         });
     });
 
@@ -162,7 +237,7 @@ describe('Integration Capture', () => {
             const clickIds = integrationCapture.captureCookies();
 
             expect(clickIds).toEqual({
-                '_fbp': '54321',
+                _fbp: '54321',
             });
         });
 
@@ -183,7 +258,7 @@ describe('Integration Capture', () => {
             const integrationCapture = new IntegrationCapture();
             integrationCapture.clickIds = {
                 fbclid: '67890',
-                '_fbp': '54321',
+                _fbp: '54321',
             };
 
             const customFlags = integrationCapture.getClickIdsAsCustomFlags();
@@ -203,33 +278,72 @@ describe('Integration Capture', () => {
     });
 
     describe('#facebookClickIdProcessor', () => {
-        it('returns a formatted clickId if it is passed in as a full click id', () => {
-            const fullClickId = 'fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
-
-            const expectedClickId = 'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
-
-            expect(facebookClickIdProcessor(fullClickId)).toEqual(expectedClickId);
-        });
-
         it('returns a formatted clickId if it is passed in as a partial click id', () => {
             const partialClickId = 'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+            const expectedClickId =
+                'fb.2.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
 
-            const expectedClickId = 'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
-
-            expect(facebookClickIdProcessor(partialClickId)).toEqual(expectedClickId);
+            expect(
+                facebookClickIdProcessor(
+                    partialClickId,
+                    'https://www.example.com/',
+                    1554763741205,
+                )
+            ).toEqual(expectedClickId);
         });
 
-        it('returns an empty string if the clickId is not valid', () => {
+        it('should start with a prefix of `fb`', () => {
+            const url = 'https://example.com/path/to/something';
+            expect(facebookClickIdProcessor('AbCdEfGhI', url, 1554763741205)).toMatch(/^fb\./);
+        });
+
+        it('should have `1` in the second portion if the host is example.com', () => {
+            const url = 'https://example.com/path/to/something';
+            const partialClickId = 'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+
+            const expectedClickId = 'fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+
+            expect(facebookClickIdProcessor(partialClickId, url, 1554763741205)).toEqual(
+                expectedClickId
+            );
+        });
+
+        it('should have `2` in the second portion if the host is www.example.com', () => {
+            const url = 'https://www.example.com/path/to/something';
+            const partialClickId = 'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+
+            const expectedClickId = 'fb.2.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+
+            expect(facebookClickIdProcessor(partialClickId, url, 1554763741205)).toEqual(
+                expectedClickId
+            );
+        });
+
+        it('should have `2` in the second portion if the host is nested subdomains', () => {
+            const url = 'https://extra.subdomain.web-3.example.com/path/to/something';
+            const partialClickId = 'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+
+            const expectedClickId = 'fb.2.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890';
+
+            expect(facebookClickIdProcessor(partialClickId, url, 1554763741205)).toEqual(
+                expectedClickId
+            );
+        });
+
+        it('returns an empty string if the clickId or url is not valid', () => {
             const expectedClickId = '';
 
-            expect(facebookClickIdProcessor(null)).toEqual(expectedClickId);
-            expect(facebookClickIdProcessor(undefined)).toEqual(expectedClickId);
-            expect(facebookClickIdProcessor('')).toEqual(expectedClickId);
-
-            // @ts-ignore
-            expect(facebookClickIdProcessor(NaN)).toEqual(expectedClickId);
-            // @ts-ignore
-            expect(facebookClickIdProcessor(0)).toEqual(expectedClickId);
+            expect(facebookClickIdProcessor(null, null)).toEqual(expectedClickId);
+            expect(facebookClickIdProcessor(undefined, undefined)).toEqual(
+                expectedClickId
+            );
+            expect(facebookClickIdProcessor('', '')).toEqual(expectedClickId);
+            expect(
+                facebookClickIdProcessor((NaN as unknown) as string, (NaN as unknown) as string)
+            ).toEqual(expectedClickId);
+            expect(facebookClickIdProcessor((0 as unknown) as string, (0 as unknown) as string)).toEqual(
+                expectedClickId
+            );
         });
     });
 });

--- a/test/jest/integration-capture.spec.ts
+++ b/test/jest/integration-capture.spec.ts
@@ -1,12 +1,5 @@
 import IntegrationCapture from "../../src/integrationCapture";
-
-function deleteAllCookies() {
-    document.cookie.split(';').forEach(cookie => {
-        const eqPos = cookie.indexOf('=');
-        const name = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
-        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    });
-}
+import { deleteAllCookies } from "./utils";
 
 describe('Integration Capture', () => {
     describe('constructor', () => {

--- a/test/jest/integration-capture.spec.ts
+++ b/test/jest/integration-capture.spec.ts
@@ -118,7 +118,7 @@ describe('Integration Capture', () => {
 
             expect(customFlags).toEqual({
                 'Facebook.ClickId': '67890',
-                'FaceBook.BrowserId': '54321',
+                'Facebook.BrowserId': '54321',
             });
         });
 

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -1,12 +1,6 @@
 import { queryStringParser, getCookies, getHref } from '../../src/utils';
+import { deleteAllCookies } from './utils';
 
-function deleteAllCookies() {
-    document.cookie.split(';').forEach(cookie => {
-        const eqPos = cookie.indexOf('=');
-        const name = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
-        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    });
-}
 
 describe('Utils', () => {
     describe('getCookies', () => {

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -16,7 +16,6 @@ describe('Utils', () => {
         });
 
         it('returns all cookies as an object', () => {
-
             const expectedResult = {
                 foo: 'bar',
                 '_cookie1': '1234',
@@ -56,31 +55,49 @@ describe('Utils', () => {
         });
     });
 
-    describe('queryyStringParser', () => {
+    describe('queryStringParser', () => {
         const url = 'https://www.example.com?q=z&foo=bar&baz=qux&narf=poit';
 
-        it('returns an object with the query string parameters that match an array of keys', () => {
-            const keys = ['foo', 'narf'];
+        describe('with URLSearchParams', () => {
+            it('returns an object with the query string parameters that match an array of keys', () => {
+                const keys = ['foo', 'narf'];
+    
+                const expectedResult = {
+                    foo: 'bar',
+                    narf: 'poit',
+                };
+    
+                expect(queryStringParser(url, keys)).toEqual(expectedResult);
+            });
+    
+            it('returns an empty object if no keys are found', () => {
+                const keys = ['quux', 'corge'];
+    
+                expect(queryStringParser(url, keys)).toEqual({});
+            });
+    
+            it('returns an empty object if the URL is empty', () => {
+                const keys = ['foo', 'narf'];
+    
+                expect(queryStringParser('', keys)).toEqual({});
+            });
+    
+            it('returns an empty object if there are no query parameters', () => {
+                expect(queryStringParser('https://www.example.com', ['foo', 'narf'])).toEqual({});
+            });
 
-            const expectedResult = {
-                foo: 'bar',
-                narf: 'poit',
-            };
+            it('returns an object with all the query string parameters if no keys are passed', () => {
+                const expectedResult = {
+                    q: 'z',
+                    foo: 'bar',
+                    baz: 'qux',
+                    narf: 'poit',
+                };
 
-            expect(queryStringParser(url, keys)).toEqual(expectedResult);
+                expect(queryStringParser(url)).toEqual(expectedResult);
+            });
         });
 
-        it('returns an empty object if no keys are found', () => {
-            const keys = ['quux', 'corge'];
-
-            expect(queryStringParser(url, keys)).toEqual({});
-        });
-
-        it('returns an empty object if the URL is empty', () => {
-            const keys = ['foo', 'narf'];
-
-            expect(queryStringParser('', keys)).toEqual({});
-        });
 
         describe('without URLSearchParams', () => {
             beforeEach(() => {
@@ -108,6 +125,21 @@ describe('Utils', () => {
                 const keys = ['foo', 'narf'];
     
                 expect(queryStringParser('', keys)).toEqual({});
+            });
+
+            it('returns an empty object if there are no query parameters', () => {
+                expect(queryStringParser('https://www.example.com', ['foo', 'narf'])).toEqual({});
+            });
+
+            it('returns an object with all the query string parameters if no keys are passed', () => {
+                const expectedResult = {
+                    q: 'z',
+                    foo: 'bar',
+                    baz: 'qux',
+                    narf: 'poit',
+                };
+
+                expect(queryStringParser(url, [])).toEqual(expectedResult);
             });
         });
     });

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -1,0 +1,120 @@
+import { queryStringParser, getCookies, getHref } from '../../src/utils';
+
+function deleteAllCookies() {
+    document.cookie.split(';').forEach(cookie => {
+        const eqPos = cookie.indexOf('=');
+        const name = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    });
+}
+
+describe('Utils', () => {
+    describe('getCookies', () => {
+        beforeEach(() => {
+            window.document.cookie = '_cookie1=1234';
+            window.document.cookie = '_cookie2=39895811.9165333198';
+            window.document.cookie = 'foo=bar';
+            window.document.cookie = 'baz=qux';
+        });
+
+        afterEach(() => {
+            deleteAllCookies();
+            console.log('window.document.cookie after', window.document.cookie);
+        });
+
+        it('returns all cookies as an object', () => {
+
+            console.log('window.document.cookie', window.document.cookie);
+
+            const expectedResult = {
+                foo: 'bar',
+                '_cookie1': '1234',
+                '_cookie2': '39895811.9165333198',
+                baz: 'qux',
+            };
+
+            expect(getCookies()).toEqual(expectedResult);
+        });
+
+        it('returns only the cookies that match the keys', () => {
+            const expectedResult = {
+                foo: 'bar',
+                baz: 'qux',
+            };
+
+            expect(getCookies(['foo', 'baz'])).toEqual(expectedResult);
+        });
+    });
+
+    describe('queryyStringParser', () => {
+        const url = 'https://www.example.com?q=z&foo=bar&baz=qux&narf=poit';
+
+        it('returns an object with the query string parameters that match an array of keys', () => {
+            const keys = ['foo', 'narf'];
+
+            const expectedResult = {
+                foo: 'bar',
+                narf: 'poit',
+            };
+
+            expect(queryStringParser(url, keys)).toEqual(expectedResult);
+        });
+
+        it('returns an empty object if no keys are found', () => {
+            const keys = ['quux', 'corge'];
+
+            expect(queryStringParser(url, keys)).toEqual({});
+        });
+
+        it('returns an empty object if the URL is empty', () => {
+            const keys = ['foo', 'narf'];
+
+            expect(queryStringParser('', keys)).toEqual({});
+        });
+
+        describe('without URLSearchParams', () => {
+            beforeEach(() => {
+                URL = undefined;
+                URLSearchParams = undefined;
+            });
+    
+            it('returns an object with the query string parameters that match an array of keys', () => {
+                const keys = ['foo', 'narf'];
+    
+                const expectedResult = {
+                    foo: 'bar',
+                    narf: 'poit',
+                };
+                expect(queryStringParser(url, keys)).toEqual(expectedResult);
+            });
+    
+            it('returns an empty object if no keys are found', () => {
+                const keys = ['quux', 'corge'];
+    
+                expect(queryStringParser(url, keys)).toEqual({});
+            });
+    
+            it('returns an empty object if the URL is empty', () => {
+                const keys = ['foo', 'narf'];
+    
+                expect(queryStringParser('', keys)).toEqual({});
+            });
+        });
+    });
+
+    describe('getHref', () => {
+        it('returns the current URL', () => {
+            expect(getHref()).toEqual(window.location.href);
+        });
+
+        it('returns an empty string if window is not defined', () => {
+            const originalWindow = global.window;
+            delete global.window;
+
+            expect(getHref()).toEqual('');
+
+            global.window = originalWindow;
+        });
+    });
+
+});

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -19,12 +19,9 @@ describe('Utils', () => {
 
         afterEach(() => {
             deleteAllCookies();
-            console.log('window.document.cookie after', window.document.cookie);
         });
 
         it('returns all cookies as an object', () => {
-
-            console.log('window.document.cookie', window.document.cookie);
 
             const expectedResult = {
                 foo: 'bar',
@@ -43,6 +40,25 @@ describe('Utils', () => {
             };
 
             expect(getCookies(['foo', 'baz'])).toEqual(expectedResult);
+        });
+
+        it('returns an empty object if no keys are found', () => {
+            expect(getCookies(['quux', 'corge'])).toEqual({});
+        });
+
+        it('returns an empty object if there are no cookies', () => {
+            deleteAllCookies();
+
+            expect(getCookies()).toEqual({});
+        });
+
+        it('returns an empty object if window is undefined', () => {
+            const originalWindow = global.window;
+            delete global.window;
+
+            expect(getCookies()).toEqual({});
+
+            global.window = originalWindow
         });
     });
 

--- a/test/jest/utils.ts
+++ b/test/jest/utils.ts
@@ -196,3 +196,11 @@ export interface IMockSideloadedKit extends MockForwarder {
 export interface IMockSideloadedKitConstructor {
     new(unregisteredKitInstance: UnregisteredKit): IMockSideloadedKit;
 }
+
+export const deleteAllCookies = ():void => {
+    document.cookie.split(';').forEach(cookie => {
+        const eqPos = cookie.indexOf('=');
+        const name = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    });
+}

--- a/test/src/_test.index.ts
+++ b/test/src/_test.index.ts
@@ -35,3 +35,4 @@ import './tests-feature-flags';
 import './tests-user';
 import './tests-legacy-alias-requests';
 import './tests-aliasRequestApiClient';
+import './tests-integration-capture';

--- a/test/src/tests-feature-flags.ts
+++ b/test/src/tests-feature-flags.ts
@@ -125,6 +125,7 @@ describe('feature-flags', function() {
             deleteAllCookies();
             sinon.restore(); // Restore all stubs and spies
 
+            deleteAllCookies();
         });
 
         it('should capture click ids when feature flag is true', () => {

--- a/test/src/tests-feature-flags.ts
+++ b/test/src/tests-feature-flags.ts
@@ -133,17 +133,17 @@ describe('feature-flags', function() {
             };
             window.mParticle._resetForTests(MPConfig);
 
-            sinon.stub(window.mParticle.getInstance()._CapturedIntegrations, 'getQueryParams').returns({
+            sinon.stub(window.mParticle.getInstance()._IntegrationCapture, 'getQueryParams').returns({
                 fbclid: '1234',
             });
 
-            const captureSpy = sinon.spy(window.mParticle.getInstance()._CapturedIntegrations, 'capture');
-            const clickIdSpy = sinon.spy(window.mParticle.getInstance()._CapturedIntegrations, 'getClickIdsAsCustomFlags');
+            const captureSpy = sinon.spy(window.mParticle.getInstance()._IntegrationCapture, 'capture');
+            const clickIdSpy = sinon.spy(window.mParticle.getInstance()._IntegrationCapture, 'getClickIdsAsCustomFlags');
 
             // initialize mParticle with feature flag 
             window.mParticle.init(apiKey, window.mParticle.config);
 
-            expect(window.mParticle.getInstance()._CapturedIntegrations.clickIds).to.deep.equal({
+            expect(window.mParticle.getInstance()._IntegrationCapture.clickIds).to.deep.equal({
                 fbclid: '1234',
                 '_fbp': '54321',
             });
@@ -157,13 +157,13 @@ describe('feature-flags', function() {
             };
             window.mParticle._resetForTests(MPConfig);
 
-            const captureSpy = sinon.spy(window.mParticle.getInstance()._CapturedIntegrations, 'capture');
-            const clickIdSpy = sinon.spy(window.mParticle.getInstance()._CapturedIntegrations, 'getClickIdsAsCustomFlags');
+            const captureSpy = sinon.spy(window.mParticle.getInstance()._IntegrationCapture, 'capture');
+            const clickIdSpy = sinon.spy(window.mParticle.getInstance()._IntegrationCapture, 'getClickIdsAsCustomFlags');
 
             // initialize mParticle with feature flag 
             window.mParticle.init(apiKey, window.mParticle.config);
 
-            expect(window.mParticle.getInstance()._CapturedIntegrations.clickIds).not.be.ok;
+            expect(window.mParticle.getInstance()._IntegrationCapture.clickIds).not.be.ok;
             expect(captureSpy.called, 'capture()').to.equal(false);
             expect(clickIdSpy.called, 'getClickIdsAsCustomFlags').to.equal(false);
         });

--- a/test/src/tests-feature-flags.ts
+++ b/test/src/tests-feature-flags.ts
@@ -124,7 +124,6 @@ describe('feature-flags', function() {
             fetchMock.restore();
             deleteAllCookies();
             sinon.restore(); // Restore all stubs and spies
-
             deleteAllCookies();
         });
 
@@ -144,8 +143,11 @@ describe('feature-flags', function() {
             // initialize mParticle with feature flag 
             window.mParticle.init(apiKey, window.mParticle.config);
 
+            const initialTimestamp = window.mParticle.getInstance()._IntegrationCapture.initialTimestamp;
+
+            expect(initialTimestamp).to.be.a('number');
             expect(window.mParticle.getInstance()._IntegrationCapture.clickIds).to.deep.equal({
-                fbclid: '1234',
+                fbclid: `fb.1.${initialTimestamp}.1234`,
                 '_fbp': '54321',
             });
             expect(captureSpy.called, 'capture()').to.equal(true);

--- a/test/src/tests-feature-flags.ts
+++ b/test/src/tests-feature-flags.ts
@@ -7,6 +7,9 @@ import { urls, apiKey,
     testMPID,
     MPConfig,
 } from './config/constants';
+import Utils from './config/utils';
+
+const { deleteAllCookies } = Utils;
 
 let mockServer;
 
@@ -14,14 +17,6 @@ declare global {
     interface Window {
         mParticle: MParticleWebSDK;
     }
-}
-
-function deleteAllCookies() {
-    document.cookie.split(';').forEach(cookie => {
-        const eqPos = cookie.indexOf('=');
-        const name = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
-        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    });
 }
 
 describe('feature-flags', function() {

--- a/test/src/tests-integration-capture.ts
+++ b/test/src/tests-integration-capture.ts
@@ -58,11 +58,13 @@ describe('Integration Capture', () => {
 
         const testEvent = findEventFromRequest(fetchMock.calls(), 'Test Event');
 
+        const initialTimestamp = window.mParticle.getInstance()._IntegrationCapture.initialTimestamp;
+
         expect(testEvent).to.have.property('data');
         expect(testEvent.data).to.have.property('event_name', 'Test Event');
         expect(testEvent.data).to.have.property('custom_flags');
         expect(testEvent.data.custom_flags).to.deep.equal({
-            'Facebook.ClickId': '1234',
+            'Facebook.ClickId': `fb.1.${initialTimestamp}.1234`,
             'Facebook.BrowserId': '54321',
         });
 

--- a/test/src/tests-integration-capture.ts
+++ b/test/src/tests-integration-capture.ts
@@ -1,0 +1,71 @@
+import sinon from 'sinon';
+import { expect}  from 'chai';
+import Utils from './config/utils';
+import fetchMock from 'fetch-mock/esm/client';
+import { urls, apiKey, testMPID, MPConfig } from "./config/constants";
+
+const findEventFromRequest = Utils.findEventFromRequest;
+const mParticle = window.mParticle;
+let mockServer;
+
+describe('Integration Capture', () => {
+    beforeEach(() => {
+        mParticle._resetForTests(MPConfig);
+        fetchMock.post(urls.events, 200);
+        delete mParticle._instances['default_instance'];
+        mockServer = sinon.createFakeServer();
+        mockServer.respondImmediately = true;
+
+        window.mParticle.config.flags = {
+            captureIntegrationSpecificIds: 'True'
+        };
+
+        mockServer.respondWith(urls.identify, [
+            200,
+            {},
+            JSON.stringify({ mpid: testMPID, is_logged_in: false }),
+        ]);
+
+        window.document.cookie = '_cookie1=234';
+        window.document.cookie = '_cookie2=39895811.9165333198';
+        window.document.cookie = 'foo=bar';
+        window.document.cookie = '_fbp=54321';
+        window.document.cookie = 'baz=qux';
+
+
+        // Mock the query params capture function because we cannot mock window.location.href
+        sinon.stub(window.mParticle.getInstance()._CapturedIntegrations, 'getQueryParams').returns({
+            fbclid: '1234',
+        });
+
+        mParticle.init(apiKey, window.mParticle.config);
+    });
+
+    afterEach(function() {
+        sinon.restore();
+        mockServer.restore();
+        fetchMock.restore();
+        mParticle._resetForTests(MPConfig);
+    });
+
+
+    it('should add captured integrations to event custom flags', (done) => {
+        window.mParticle.logEvent(
+            'Test Event',
+            mParticle.EventType.Navigation,
+            { mykey: 'myvalue' }
+        );
+
+        const testEvent = findEventFromRequest(fetchMock.calls(), 'Test Event');
+
+        expect(testEvent).to.have.property('data');
+        expect(testEvent.data).to.have.property('event_name', 'Test Event');
+        expect(testEvent.data).to.have.property('custom_flags');
+        expect(testEvent.data.custom_flags).to.deep.equal({
+            'Facebook.ClickId': '1234',
+            'Facebook.BrowserId': '54321',
+        });
+
+        done();
+    });
+});

--- a/test/src/tests-integration-capture.ts
+++ b/test/src/tests-integration-capture.ts
@@ -34,7 +34,7 @@ describe('Integration Capture', () => {
 
 
         // Mock the query params capture function because we cannot mock window.location.href
-        sinon.stub(window.mParticle.getInstance()._CapturedIntegrations, 'getQueryParams').returns({
+        sinon.stub(window.mParticle.getInstance()._IntegrationCapture, 'getQueryParams').returns({
             fbclid: '1234',
         });
 

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1239,6 +1239,7 @@ describe('Store', () => {
                     directURLRouting: 'False',
                     cacheIdentity: 'False',
                     audienceAPI: 'False',
+                    captureIntegrationSpecificIds: 'False',
                 },
             };
 
@@ -1256,6 +1257,7 @@ describe('Store', () => {
                 directURLRouting: false,
                 cacheIdentity: false,
                 audienceAPI: false,
+                captureIntegrationSpecificIds: false,
             };
 
             expect(store.SDKConfig.flags).to.deep.equal(expectedResult);
@@ -1456,6 +1458,7 @@ describe('Store', () => {
                 directURLRouting: false,
                 cacheIdentity: false,
                 audienceAPI: false,
+                captureIntegrationSpecificIds: false,
             };
 
             expect(flags).to.deep.equal(expectedResult);
@@ -1469,6 +1472,7 @@ describe('Store', () => {
                 directURLRouting: 'True',
                 cacheIdentity: 'True',
                 audienceAPI: 'True',
+                captureIntegrationSpecificIds: 'True',
             };
 
             const flags = processFlags(
@@ -1482,6 +1486,7 @@ describe('Store', () => {
                 directURLRouting: true,
                 cacheIdentity: true,
                 audienceAPI: true,
+                captureIntegrationSpecificIds: true,
             };
 
             expect(flags).to.deep.equal(expectedResult);

--- a/test/src/tests-utils.ts
+++ b/test/src/tests-utils.ts
@@ -354,6 +354,14 @@ describe('Utils', () => {
         it('returns true if object is undefined', () => {
             expect(isEmpty(undefined)).to.equal(true);
         });
+
+        it('returns true if object is an empty string', () => {
+            expect(isEmpty('')).to.equal(true);
+        });
+
+        it('returns false if object is a string', () => {
+            expect(isEmpty('string')).to.equal(false);
+        });
     });
     
     describe('#isValidCustomFlagProperty', () => {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds support to capture select Integration Ids passed as query parameters or cookies and add them to Event Custom Flags for processing.
 - Relevant Facebook Documentation: https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, pass in Facebook Click IDs via a query parameter, or Facebook Pixel ID as a cookie value and verify they appear in the Custom Flags for Events

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6806
