### PR TITLE
fix: Handle cases where window.screen is unavailable

### DIFF
--- a/src/sdkToEventsApiConverter.ts
+++ b/src/sdkToEventsApiConverter.ts
@@ -77,8 +77,8 @@ export function convertEvents(
 
         device_info: {
             platform: EventsApi.DeviceInformationPlatformEnum.web,
-            screen_width: window.screen.width,
-            screen_height: window.screen.height,
+            screen_width: typeof window !== 'undefined' ? window.screen.width : 0,
+            screen_height: typeof window !== 'undefined' ? window.screen.height : 0,
         },
         user_attributes: lastEvent.UserAttributes,
         user_identities: convertUserIdentities(lastEvent.UserIdentities),


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - When customers use the Web SDK in an environment that does not support `window`, such as in a service worker, batch creation will throw an exception when trying to detect the screen size.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Attempt to run Web SDK in a service worker

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6847
