### PR TITLE
docs: Update link to Web SDK docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Hello! This is the public repo of the mParticle Web SDK. We've built the mPartic
 
 ## Documentation
 
-Fully detailed documentation and other information about mParticle web SDK can be found at our doc site [here](https://docs.mparticle.com/developers/sdk/web/getting-started)
+Fully detailed documentation and other information about mParticle web SDK can be found at our doc site [here](https://docs.mparticle.com/developers/sdk/web/initialization/)
 
 ## Include and Initialize the SDK
 


### PR DESCRIPTION
## Summary
 - Current link to Web SDK docs results in a 404. This PR updates link to Web SDK documentation on docs.mparticle.com to point to the current web SDK reference

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Small fix, I just tested the URL to make sure it was correct.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
