### PR TITLE
fix: prevent crash when calling upload() early

### DIFF
--- a/src/mp-instance.js
+++ b/src/mp-instance.js
@@ -590,7 +590,7 @@ export default function mParticleInstance(instanceName) {
                     Constants.NativeSdkPaths.Upload
                 );
             } else {
-                self._APIClient.uploader.prepareAndUpload(false, false);
+                self._APIClient.uploader?.prepareAndUpload(false, false);
             }
         }
     };


### PR DESCRIPTION
 ## Summary
 - github issue with description [here](https://github.com/mParticle/mparticle-web-sdk/issues/840)

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Tested with local overrides

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6164