### PR TITLE
fix: Support capturing click ids as custom flags in commerce events

### DIFF
--- a/src/ecommerce.js
+++ b/src/ecommerce.js
@@ -540,8 +540,8 @@ export default function Ecommerce(mpInstance) {
             baseEvent.CurrencyCode = mpInstance._Store.currencyCode;
             baseEvent.ShoppingCart = [];
             baseEvent.CustomFlags = {
-                ...baseEvent.CustomFlags,
-                ...customFlags,
+                ...(baseEvent.CustomFlags || {}),
+                ...(customFlags || {}),
             };
 
             return baseEvent;

--- a/src/ecommerce.js
+++ b/src/ecommerce.js
@@ -524,7 +524,6 @@ export default function Ecommerce(mpInstance) {
     };
 
     this.createCommerceEventObject = function(customFlags, options) {
-        const { extend } = mpInstance._Helpers;
         var baseEvent;
 
         mpInstance.Logger.verbose(
@@ -540,7 +539,10 @@ export default function Ecommerce(mpInstance) {
 
             baseEvent.CurrencyCode = mpInstance._Store.currencyCode;
             baseEvent.ShoppingCart = [];
-            baseEvent.CustomFlags = extend(baseEvent.CustomFlags, customFlags);
+            baseEvent.CustomFlags = {
+                ...baseEvent.CustomFlags,
+                ...customFlags,
+            };
 
             return baseEvent;
         } else {

--- a/src/ecommerce.js
+++ b/src/ecommerce.js
@@ -524,6 +524,7 @@ export default function Ecommerce(mpInstance) {
     };
 
     this.createCommerceEventObject = function(customFlags, options) {
+        const { extend } = mpInstance._Helpers;
         var baseEvent;
 
         mpInstance.Logger.verbose(
@@ -539,7 +540,7 @@ export default function Ecommerce(mpInstance) {
 
             baseEvent.CurrencyCode = mpInstance._Store.currencyCode;
             baseEvent.ShoppingCart = [];
-            baseEvent.CustomFlags = customFlags;
+            baseEvent.CustomFlags = extend(baseEvent.CustomFlags, customFlags);
 
             return baseEvent;
         } else {

--- a/src/ecommerce.js
+++ b/src/ecommerce.js
@@ -525,6 +525,8 @@ export default function Ecommerce(mpInstance) {
 
     this.createCommerceEventObject = function(customFlags, options) {
         var baseEvent;
+        // https://go.mparticle.com/work/SQDSDKS-4801
+        var { extend } = mpInstance._Helpers;
 
         mpInstance.Logger.verbose(
             Messages.InformationMessages.StartingLogCommerceEvent
@@ -539,10 +541,7 @@ export default function Ecommerce(mpInstance) {
 
             baseEvent.CurrencyCode = mpInstance._Store.currencyCode;
             baseEvent.ShoppingCart = [];
-            baseEvent.CustomFlags = {
-                ...(baseEvent.CustomFlags || {}),
-                ...(customFlags || {}),
-            };
+            baseEvent.CustomFlags = extend(baseEvent.CustomFlags, customFlags);
 
             return baseEvent;
         } else {

--- a/test/src/config/utils.js
+++ b/test/src/config/utils.js
@@ -172,13 +172,14 @@ var pluses = /\+/g,
             return mParticle.getInstance()._Persistence.getLocalStorage();
         }
     },
+    // https://go.mparticle.com/work/SQDSDKS-6894
     findEventFromBatch = function(batch, eventName) {
         if (batch.events.length) {
             return batch.events.find(function(event) {
                 switch (event.event_type) {
                     case 'screen_view':
                         // The SDK sets "PageView" as the default for a screen_name if one is not provided
-                        return ['PageView', eventName].indexOf(event.data.screen_name) > -1;
+                        return ['PageView', eventName].includes(event.data.screen_name);
                     case 'commerce_event':
                         if (event.data.product_action) {
                             return event.data.product_action.action === eventName;

--- a/test/src/config/utils.js
+++ b/test/src/config/utils.js
@@ -176,6 +176,8 @@ var pluses = /\+/g,
         if (batch.events.length) {
             return batch.events.find(function(event) {
                 switch (event.event_type) {
+                    case 'screen_view':
+                        return event.data.screen_name === eventName;
                     case 'commerce_event':
                         if (event.data.product_action) {
                             return event.data.product_action.action === eventName;

--- a/test/src/config/utils.js
+++ b/test/src/config/utils.js
@@ -177,7 +177,8 @@ var pluses = /\+/g,
             return batch.events.find(function(event) {
                 switch (event.event_type) {
                     case 'screen_view':
-                        return event.data.screen_name === eventName;
+                        // The SDK sets "PageView" as the default for a screen_name if one is not provided
+                        return ['PageView', eventName].indexOf(event.data.screen_name) > -1;
                     case 'commerce_event':
                         if (event.data.product_action) {
                             return event.data.product_action.action === eventName;
@@ -234,7 +235,6 @@ var pluses = /\+/g,
                 return null;
             }
             var batch = JSON.parse(request[1].body);
-
             if (!batch.events) {
                 return null;
             }

--- a/test/src/tests-event-logging.js
+++ b/test/src/tests-event-logging.js
@@ -427,7 +427,7 @@ describe('event logging', function() {
 
         const pageViewEvent = findEventFromRequest(
             fetchMock.calls(),
-            'screen_view'
+            'My Page View'
         );
 
         Should(pageViewEvent).be.ok();
@@ -456,7 +456,7 @@ describe('event logging', function() {
 
         const pageViewEvent = findEventFromRequest(
             fetchMock.calls(),
-            'screen_view'
+            'test'
         );
 
         Should(pageViewEvent).be.ok();
@@ -480,7 +480,7 @@ describe('event logging', function() {
 
         const pageViewEvent = findEventFromRequest(
             fetchMock.calls(),
-            'screen_view'
+            'test bypass'
         );
 
         Should(pageViewEvent).not.be.ok();
@@ -494,7 +494,7 @@ describe('event logging', function() {
         mParticle.logPageView('test1', 'invalid', null);
         const pageViewEvent = findEventFromRequest(
             fetchMock.calls(),
-            'screen_view'
+            'test1'
         );
 
         Should(pageViewEvent).not.be.ok();
@@ -510,7 +510,7 @@ describe('event logging', function() {
 
         const pageViewEvent = findEventFromRequest(
             fetchMock.calls(),
-            'screen_view'
+            'test'
         );
         Should(pageViewEvent).not.be.ok();
 
@@ -518,7 +518,7 @@ describe('event logging', function() {
         })
     });
 
-    it('should log event with name PageView when an invalid event name is passed', function(done) {
+    it.only('should log event with name PageView when an invalid event name is passed', function(done) {
         waitForCondition(hasIdentifyReturned)
         .then(() =>  {
         fetchMock.resetHistory();

--- a/test/src/tests-event-logging.js
+++ b/test/src/tests-event-logging.js
@@ -518,7 +518,7 @@ describe('event logging', function() {
         })
     });
 
-    it.only('should log event with name PageView when an invalid event name is passed', function(done) {
+    it('should log event with name PageView when an invalid event name is passed', function(done) {
         waitForCondition(hasIdentifyReturned)
         .then(() =>  {
         fetchMock.resetHistory();

--- a/test/src/tests-integration-capture.ts
+++ b/test/src/tests-integration-capture.ts
@@ -8,7 +8,7 @@ const { waitForCondition, fetchMockSuccess, deleteAllCookies, findEventFromReque
 
 const mParticle = window.mParticle;
 
-describe('Integration Capture', () => {
+describe.only('Integration Capture', () => {
     beforeEach(() => {
         mParticle._resetForTests(MPConfig);
         fetchMock.post(urls.events, 200);
@@ -61,6 +61,208 @@ describe('Integration Capture', () => {
         expect(testEvent.data).to.have.property('custom_flags');
         expect(testEvent.data.custom_flags).to.deep.equal({
             'Facebook.ClickId': `fb.1.${initialTimestamp}.1234`,
+            'Facebook.BrowserId': '54321',
+        });
+    });
+
+    it('should add captured integrations to event custom flags, prioritizing passed in custom flags', async () => {
+        await waitForCondition(hasIdentifyReturned);
+        window.mParticle.logEvent(
+            'Test Event',
+            mParticle.EventType.Navigation,
+            { mykey: 'myvalue' },
+            {'Facebook.ClickId': 'passed-in',}
+        );
+
+        const testEvent = findEventFromRequest(fetchMock.calls(), 'Test Event');
+
+        const initialTimestamp = window.mParticle.getInstance()._IntegrationCapture.initialTimestamp;
+
+        expect(testEvent).to.have.property('data');
+        expect(testEvent.data).to.have.property('event_name', 'Test Event');
+        expect(testEvent.data).to.have.property('custom_flags');
+        expect(testEvent.data.custom_flags).to.deep.equal({
+            'Facebook.ClickId': 'passed-in',
+            'Facebook.BrowserId': '54321',
+        });
+    });
+
+    it('should add captured integrations to page view custom flags', async () => {
+        await waitForCondition(hasIdentifyReturned);
+
+        window.mParticle.logPageView(
+            'Test Page View',
+            {'foo-attr': 'bar-attr'}
+        );
+
+        const testEvent = findEventFromRequest(fetchMock.calls(), 'Test Page View');
+
+        const initialTimestamp = window.mParticle.getInstance()._IntegrationCapture.initialTimestamp;
+
+        expect(testEvent).to.have.property('data');
+        expect(testEvent.data).to.have.property('screen_name', 'Test Page View');
+        expect(testEvent.data).to.have.property('custom_flags');
+        expect(testEvent.data.custom_flags).to.deep.equal({
+            'Facebook.ClickId': `fb.1.${initialTimestamp}.1234`,
+            'Facebook.BrowserId': '54321',
+        });
+    });
+
+    it('should add captured integrations to page view custom flags, prioritizing passed in custom flags', async () => {
+        await waitForCondition(hasIdentifyReturned);
+        window.mParticle.logPageView(
+            'Test Page View',
+            {'foo-attr': 'bar-attr'},
+            {'Facebook.ClickId': 'passed-in',}
+        );
+
+        const testEvent = findEventFromRequest(fetchMock.calls(), 'Test Page View');
+
+        expect(testEvent).to.have.property('data');
+        expect(testEvent.data).to.have.property('screen_name', 'Test Page View');
+        expect(testEvent.data).to.have.property('custom_flags');
+        expect(testEvent.data.custom_flags).to.deep.equal({
+            'Facebook.ClickId': 'passed-in',
+            'Facebook.BrowserId': '54321',
+        });
+    });
+
+    it('should add captured integrations to commerce event custom flags', async () => {
+        await waitForCondition(hasIdentifyReturned);
+
+        const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
+        const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
+
+        const transactionAttributes = {
+            Id: 'foo-transaction-id',
+            Revenue: 430.00,
+            Tax: 30
+        };
+
+        const customAttributes = {sale: true};
+        const customFlags = {foo: 'bar'};
+
+        mParticle.eCommerce.logProductAction(
+            mParticle.ProductActionType.Purchase,
+            [product1, product2],
+            customAttributes,
+            customFlags,
+            transactionAttributes);
+
+        const testEvent = findEventFromRequest(fetchMock.calls(), 'purchase');
+
+        const initialTimestamp = window.mParticle.getInstance()._IntegrationCapture.initialTimestamp;
+
+        expect(testEvent.data.product_action).to.have.property('action', 'purchase');
+        expect(testEvent.data).to.have.property('custom_flags');
+        expect(testEvent.data.custom_flags).to.deep.equal({
+            foo: 'bar',
+            'Facebook.ClickId': `fb.1.${initialTimestamp}.1234`,
+            'Facebook.BrowserId': '54321',
+        });
+    });
+
+    it('should add captured integrations to commerce event custom flags, prioritizing passed in flags', async () => {
+        await waitForCondition(hasIdentifyReturned);
+
+        const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
+        const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
+
+        const transactionAttributes = {
+            Id: 'foo-transaction-id',
+            Revenue: 430.00,
+            Tax: 30
+        };
+
+        const customAttributes = {sale: true};
+        const customFlags = {
+            'Facebook.ClickId': 'passed-in'
+        };
+
+        mParticle.eCommerce.logProductAction(
+            mParticle.ProductActionType.Purchase,
+            [product1, product2],
+            customAttributes,
+            customFlags,
+            transactionAttributes);
+    
+
+        const testEvent = findEventFromRequest(fetchMock.calls(), 'purchase');
+
+        expect(testEvent.data.product_action).to.have.property('action', 'purchase');
+        expect(testEvent.data).to.have.property('custom_flags');
+        expect(testEvent.data.custom_flags).to.deep.equal({
+            'Facebook.ClickId': 'passed-in',
+            'Facebook.BrowserId': '54321',
+        });
+    });
+
+    it('should add captured integrations to commerce event custom flags', async () => {
+        await waitForCondition(hasIdentifyReturned);
+
+        const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
+        const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
+
+        const transactionAttributes = {
+            Id: 'foo-transaction-id',
+            Revenue: 430.00,
+            Tax: 30
+        };
+
+        const customAttributes = {sale: true};
+        const customFlags = {foo: 'bar'};
+
+        mParticle.eCommerce.logProductAction(
+            mParticle.ProductActionType.Purchase,
+            [product1, product2],
+            customAttributes,
+            customFlags,
+            transactionAttributes);
+
+        const testEvent = findEventFromRequest(fetchMock.calls(), 'purchase');
+
+        const initialTimestamp = window.mParticle.getInstance()._IntegrationCapture.initialTimestamp;
+
+        expect(testEvent.data.product_action).to.have.property('action', 'purchase');
+        expect(testEvent.data).to.have.property('custom_flags');
+        expect(testEvent.data.custom_flags).to.deep.equal({
+            foo: 'bar',
+            'Facebook.ClickId': `fb.1.${initialTimestamp}.1234`,
+            'Facebook.BrowserId': '54321',
+        });
+    });
+
+    it('should add captured integrations to commerce event custom flags, prioritizing passed in flags', async () => {
+        await waitForCondition(hasIdentifyReturned);
+
+        const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
+        const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
+
+        const transactionAttributes = {
+            Id: 'foo-transaction-id',
+            Revenue: 430.00,
+            Tax: 30
+        };
+
+        const customAttributes = {sale: true};
+        const customFlags = {
+            'Facebook.ClickId': 'passed-in'
+        };
+
+        mParticle.eCommerce.logProductAction(
+            mParticle.ProductActionType.Purchase,
+            [product1, product2],
+            customAttributes,
+            customFlags,
+            transactionAttributes);
+    
+
+        const testEvent = findEventFromRequest(fetchMock.calls(), 'purchase');
+
+        expect(testEvent.data.product_action).to.have.property('action', 'purchase');
+        expect(testEvent.data).to.have.property('custom_flags');
+        expect(testEvent.data.custom_flags).to.deep.equal({
+            'Facebook.ClickId': 'passed-in',
             'Facebook.BrowserId': '54321',
         });
     });

--- a/test/src/tests-integration-capture.ts
+++ b/test/src/tests-integration-capture.ts
@@ -8,7 +8,7 @@ const { waitForCondition, fetchMockSuccess, deleteAllCookies, findEventFromReque
 
 const mParticle = window.mParticle;
 
-describe.only('Integration Capture', () => {
+describe('Integration Capture', () => {
     beforeEach(() => {
         mParticle._resetForTests(MPConfig);
         fetchMock.post(urls.events, 200);
@@ -71,12 +71,11 @@ describe.only('Integration Capture', () => {
             'Test Event',
             mParticle.EventType.Navigation,
             { mykey: 'myvalue' },
-            {'Facebook.ClickId': 'passed-in',}
+            { 'Facebook.ClickId': 'passed-in' },
         );
 
         const testEvent = findEventFromRequest(fetchMock.calls(), 'Test Event');
 
-        const initialTimestamp = window.mParticle.getInstance()._IntegrationCapture.initialTimestamp;
 
         expect(testEvent).to.have.property('data');
         expect(testEvent.data).to.have.property('event_name', 'Test Event');
@@ -113,7 +112,7 @@ describe.only('Integration Capture', () => {
         window.mParticle.logPageView(
             'Test Page View',
             {'foo-attr': 'bar-attr'},
-            {'Facebook.ClickId': 'passed-in',}
+            {'Facebook.ClickId': 'passed-in'},
         );
 
         const testEvent = findEventFromRequest(fetchMock.calls(), 'Test Page View');


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- Commerce events were having the custom flags for click ids supplanted completely by custom flags that were being passed from the user. This PR fixes that. Instead we `extend` the custom flags to include both the custom flags created by `createEventObject` as well as what is passed by the user, with the flags passed by the user taken as priority.

 ## Testing Plan
Added unit tests for ecommerce and page view, as well as an additional for custom events.
Manually tested regular page events, pageViews, and commerce events with and without a custom flag of `Facebook.ClickId`.  All behavior working as expected (passed in custom flag takes priority over captured query param)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6889