### PR TITLE
refactor: Add Type interfaces for identity api client

### DIFF
--- a/src/aliasRequestApiClient.ts
+++ b/src/aliasRequestApiClient.ts
@@ -3,6 +3,7 @@ import { MParticleWebSDK } from "./sdkRuntimeModels";
 import Constants from './constants';
 import { FetchUploader, XHRUploader } from './uploaders';
 import { HTTP_ACCEPTED, HTTP_OK } from "./constants";
+import { IIdentityApiClientSendAliasRequest } from "./identityApiClient.interfaces";
 
 
 const { HTTPCodes, Messages } = Constants;
@@ -11,7 +12,7 @@ interface IAliasResponseBody {
     message?: string
 }
 
-export async function sendAliasRequest (mpInstance: MParticleWebSDK, aliasRequest: IAliasRequest, aliasCallback: IAliasCallback) {
+export const sendAliasRequest: IIdentityApiClientSendAliasRequest = async function  (mpInstance: MParticleWebSDK, aliasRequest: IAliasRequest, aliasCallback: IAliasCallback): Promise<void> {
         const { verbose, error } = mpInstance.Logger;
         const { invokeAliasCallback } = mpInstance._Helpers;
         const { aliasUrl } = mpInstance._Store.SDKConfig;

--- a/src/identityApiClient.interfaces.ts
+++ b/src/identityApiClient.interfaces.ts
@@ -1,0 +1,46 @@
+import { IdentityApiData, MPID, UserIdentities } from '@mparticle/web-sdk';
+import {
+    IdentityCallback,
+    IIdentityResponse,
+} from './identity-user-interfaces';
+import {
+    IAliasRequest,
+    IAliasCallback,
+    IIdentityRequest,
+    IdentityAPIMethod,
+    IIdentity,
+} from './identity.interfaces';
+import { MParticleWebSDK } from './sdkRuntimeModels';
+
+export interface IIdentityApiClient {
+    sendAliasRequest: (
+        aliasRequest: IAliasRequest,
+        aliasCallback: IAliasCallback
+    ) => Promise<void>;
+    sendIdentityRequest: (
+        identityApiRequest: IIdentityRequest,
+        method: IdentityAPIMethod,
+        callback: IdentityCallback,
+        originalIdentityApiData: IdentityApiData,
+        parseIdentityResponse: IIdentity['parseIdentityResponse'],
+        mpid: MPID,
+        knownIdentities: UserIdentities
+    ) => Promise<void>;
+    getUploadUrl: (method: IdentityAPIMethod, mpid: MPID) => string;
+    getIdentityResponseFromFetch: (
+        response: Response,
+        responseBody: string
+    ) => IIdentityResponse;
+    getIdentityResponseFromXHR: (response: Response) => IIdentityResponse;
+}
+
+// https://go.mparticle.com/work/SQDSDKS-6568
+// https://go.mparticle.com/work/SQDSDKS-6679
+// Combine with `sendIdentityRequest` above once module is fully migrated
+export interface IIdentityApiClientSendAliasRequest {
+    (
+        mpInstance: MParticleWebSDK,
+        aliasRequest: IAliasRequest,
+        aliasCallback: IAliasCallback
+    ): Promise<void>;
+}

--- a/src/identityApiClient.interfaces.ts
+++ b/src/identityApiClient.interfaces.ts
@@ -22,7 +22,7 @@ export interface IIdentityApiClient {
         method: IdentityAPIMethod,
         callback: IdentityCallback,
         originalIdentityApiData: IdentityApiData,
-        parseIdentityResponse: IIdentity['parseIdentityResponse'],
+        parseIdentityResponse: Pick<IIdentity, 'parseIdentityResponse'>,
         mpid: MPID,
         knownIdentities: UserIdentities
     ) => Promise<void>;

--- a/src/identityApiClient.interfaces.ts
+++ b/src/identityApiClient.interfaces.ts
@@ -22,7 +22,7 @@ export interface IIdentityApiClient {
         method: IdentityAPIMethod,
         callback: IdentityCallback,
         originalIdentityApiData: IdentityApiData,
-        parseIdentityResponse: Pick<IIdentity, 'parseIdentityResponse'>,
+        parseIdentityResponse: IIdentity['parseIdentityResponse'],
         mpid: MPID,
         knownIdentities: UserIdentities
     ) => Promise<void>;

--- a/src/identityApiClient.interfaces.ts
+++ b/src/identityApiClient.interfaces.ts
@@ -37,10 +37,8 @@ export interface IIdentityApiClient {
 // https://go.mparticle.com/work/SQDSDKS-6568
 // https://go.mparticle.com/work/SQDSDKS-6679
 // Combine with `sendIdentityRequest` above once module is fully migrated
-export interface IIdentityApiClientSendAliasRequest {
-    (
-        mpInstance: MParticleWebSDK,
-        aliasRequest: IAliasRequest,
-        aliasCallback: IAliasCallback
-    ): Promise<void>;
-}
+export type IIdentityApiClientSendAliasRequest = (
+    mpInstance: MParticleWebSDK,
+    aliasRequest: IAliasRequest,
+    aliasCallback: IAliasCallback
+) => Promise<void>;

--- a/test/src/tests-aliasRequestApiClient.ts
+++ b/test/src/tests-aliasRequestApiClient.ts
@@ -4,7 +4,7 @@ import { urls, apiKey, MPConfig, testMPID } from './config/constants';
 import { MParticleWebSDK } from '../../src/sdkRuntimeModels';
 import { expect } from 'chai';
 import { sendAliasRequest } from '../../src/aliasRequestApiClient';
-import { IAliasCallback, IAliasRequest } from '../../src/identity.interfaces';
+import { IAliasRequest } from '../../src/identity.interfaces';
 import { HTTP_ACCEPTED, HTTP_BAD_REQUEST, HTTP_FORBIDDEN, HTTP_OK } from '../../src/constants';
 
 declare global {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Create Type Interfaces for Identity API Client

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - N/A - Defines new type interfaces but they will not be used until we refactor api client

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6678
