### PR TITLE
fix: prevent error when forwarding user attributes to kits while kit …

### DIFF
--- a/src/kitBlocking.ts
+++ b/src/kitBlocking.ts
@@ -460,7 +460,7 @@ export default class KitBlocker {
         if (!this.blockUserAttributes) {
             return false
         }
-        var matchedAttributes = this.dataPlanMatchLookups['user_attributes'];
+        const matchedAttributes = this.dataPlanMatchLookups['user_attributes'];
 
         // When additionalProperties is set to true, matchedAttributes 
         // will be a boolean, otherwise it will return an object
@@ -468,7 +468,7 @@ export default class KitBlocker {
             return false
         }
 
-        if (this.blockUserAttributes && typeof matchedAttributes === "object") {
+        if (typeof matchedAttributes === "object") {
             if (matchedAttributes[key] === true) {
                 return false;
             } else {

--- a/src/kitBlocking.ts
+++ b/src/kitBlocking.ts
@@ -476,6 +476,8 @@ export default class KitBlocker {
             }
         }
 
+        // When block unplanned user attributess is enabled and allow unplanned user
+        // attributes is also enabled, allowing unplanned user attribues will be prioritized
         return false;
     }
 

--- a/src/kitBlocking.ts
+++ b/src/kitBlocking.ts
@@ -460,17 +460,23 @@ export default class KitBlocker {
         if (!this.blockUserAttributes) {
             return false
         }
-        if (this.blockUserAttributes) {
-            const matchedAttributes = this.dataPlanMatchLookups['user_attributes'];
-            if (matchedAttributes === true) {
-                return false
-            }
-            if (!matchedAttributes[key]) {
-                return true
+        var matchedAttributes = this.dataPlanMatchLookups['user_attributes'];
+
+        // When additionalProperties is set to true, matchedAttributes 
+        // will be a boolean, otherwise it will return an object
+        if (typeof matchedAttributes === 'boolean' && matchedAttributes) {
+            return false
+        }
+
+        if (this.blockUserAttributes && typeof matchedAttributes === "object") {
+            if (matchedAttributes[key] === true) {
+                return false;
+            } else {
+                return true;
             }
         }
 
-        return false
+        return false;
     }
 
     isIdentityBlocked(key: string) {

--- a/src/kitBlocking.ts
+++ b/src/kitBlocking.ts
@@ -476,8 +476,8 @@ export default class KitBlocker {
             }
         }
 
-        // When block unplanned user attributess is enabled and allow unplanned user
-        // attributes is also enabled, allowing unplanned user attribues will be prioritized
+        // When "Block unplanned user attributes" is enabled and "Allow unplanned user
+        // attributes" is also enabled in the UI, allowing unplanned user attributes will be prioritized
         return false;
     }
 

--- a/test/src/tests-kit-blocking.ts
+++ b/test/src/tests-kit-blocking.ts
@@ -628,7 +628,7 @@ describe('kit blocking', () => {
             let kitBlocker = new KitBlocker(kitBlockerDataPlan, window.mParticle.getInstance());
 
             expect(() => { kitBlocker.isAttributeKeyBlocked('unplannedAttr') }).to.not.throw(TypeError, /Cannot read properties of undefined \(reading 'unplannedAttr'\)/)
-            // allow unplanned user attributes is prioritized when blocking unplanned attributes is also enabled, hence the expected value is false
+            // "Allow unplanned user attributes" is prioritized when blocking unplanned attributes is also enabled, hence the expected value is false
             expect(kitBlocker.isAttributeKeyBlocked('unplannedAttr')).to.equal(false)
             // reset data points
             dataPlan.dtpn.vers.version_document.data_points = oldDataPoints;

--- a/test/src/tests-kit-blocking.ts
+++ b/test/src/tests-kit-blocking.ts
@@ -621,14 +621,16 @@ describe('kit blocking', () => {
             window.mParticle.config.kitConfigs.push(forwarderDefaultConfiguration('MockForwarder'));
             window.mParticle.init(apiKey, window.mParticle.config);
             
-            //save old data points for reset later
+            // save old data points for reset later
             const oldDataPoints = dataPlan.dtpn.vers.version_document.data_points;
+            // when allow unplanned user attributes is enabled, the data points returned is an empty array
             dataPlan.dtpn.vers.version_document.data_points = [];
             let kitBlocker = new KitBlocker(kitBlockerDataPlan, window.mParticle.getInstance());
 
             expect(() => { kitBlocker.isAttributeKeyBlocked('unplannedAttr') }).to.not.throw(TypeError, /Cannot read properties of undefined \(reading 'unplannedAttr'\)/)
-            
-            //reset data points
+            // allow unplanned user attributes is prioritized when blocking unplanned attributes is also enabled, hence the expected value is false
+            expect(kitBlocker.isAttributeKeyBlocked('unplannedAttr')).to.equal(false)
+            // reset data points
             dataPlan.dtpn.vers.version_document.data_points = oldDataPoints;
 
             done();

--- a/test/src/tests-kit-blocking.ts
+++ b/test/src/tests-kit-blocking.ts
@@ -623,7 +623,7 @@ describe('kit blocking', () => {
             
             // save old data points for reset later
             const oldDataPoints = dataPlan.dtpn.vers.version_document.data_points;
-            // when allow unplanned user attributes is enabled, the data points returned is an empty array
+            // when "Allow unplanned user attributes" is enabled, the data points returned is an empty array
             dataPlan.dtpn.vers.version_document.data_points = [];
             let kitBlocker = new KitBlocker(kitBlockerDataPlan, window.mParticle.getInstance());
 

--- a/test/src/tests-kit-blocking.ts
+++ b/test/src/tests-kit-blocking.ts
@@ -7,6 +7,7 @@ import KitBlocker from '../../src/kitBlocking';
 import Types from '../../src/types';
 import { DataPlanVersion } from '@mparticle/data-planning-models';
 import fetchMock from 'fetch-mock/esm/client';
+import { expect } from 'chai'
 const { findBatch, waitForCondition, fetchMockSuccess, hasIdentifyReturned } = Utils;
 
 let forwarderDefaultConfiguration = Utils.forwarderDefaultConfiguration,
@@ -614,6 +615,24 @@ describe('kit blocking', () => {
 
             done();
             })
+        });
+
+        it('integration test - should not throw an error when unplanned user attributes are allowed and block.ua = true', function(done) {
+            window.mParticle.config.kitConfigs.push(forwarderDefaultConfiguration('MockForwarder'));
+            window.mParticle.init(apiKey, window.mParticle.config);
+            
+            //save old data points for reset later
+            const oldDataPoints = dataPlan.dtpn.vers.version_document.data_points;
+            dataPlan.dtpn.vers.version_document.data_points = [];
+            let kitBlocker = new KitBlocker(kitBlockerDataPlan, window.mParticle.getInstance());
+
+            expect(() => { kitBlocker.isAttributeKeyBlocked('unplannedAttr') }).to.not.throw(TypeError, /Cannot read properties of undefined \(reading 'unplannedAttr'\)/)
+            
+            //reset data points
+            dataPlan.dtpn.vers.version_document.data_points = oldDataPoints;
+
+            done();
+            
         });
 
         it('integration test - should allow an unplanned attribute to be set on forwarder if additionalProperties = true and blok.ua = true', function(done) {


### PR DESCRIPTION
…blocking enabled and unplanned UAs are allowed

 ## Summary
 - A customer provided that an error is thrown when enabling kit blocking or user attributes in the UI and having unplanned user attributes to be allowed, this result in a conflict where dataPointMatchLookUps for user_attributes will be null since and thus when we try to look into a key of null, the error is thrown.

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Unit tests did not fail and E2E tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6391
