### PR TITLE
refactor: Simplify cookie sync manager

### DIFF
--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -83,7 +83,7 @@ export default function CookieSyncManager(
             } = pixelSettings;
             const { values } = filteringConsentRuleValues || {};
 
-            if (isEmpty(pixelUrl) && isEmpty(redirectUrl)) {
+            if (isEmpty(pixelUrl)) {
                 return;
             }
 

--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -1,8 +1,7 @@
 import {
     Dictionary,
     isEmpty,
-    replaceAmpWithAmpersand,
-    combineUrlWithRedirect,
+    createCookieSyncUrl,
 } from './utils';
 import Constants from './constants';
 import { MParticleWebSDK } from './sdkRuntimeModels';
@@ -159,22 +158,5 @@ export const isLastSyncDateExpired = (
     return (
         new Date().getTime() >
         new Date(lastSyncDate).getTime() + frequencyCap * DAYS_IN_MILLISECONDS
-    );
-};
-
-export const createCookieSyncUrl = (
-    mpid: MPID,
-    pixelUrl?: string,
-    redirectUrl?: string
-): string => {
-    const modifiedPixelUrl = replaceAmpWithAmpersand(pixelUrl);
-    const modifiedDirectUrl = redirectUrl
-        ? replaceAmpWithAmpersand(redirectUrl)
-        : null;
-
-    return combineUrlWithRedirect(
-        mpid,
-        modifiedPixelUrl,
-        modifiedDirectUrl
     );
 };

--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -82,6 +82,7 @@ export default function CookieSyncManager(
                 frequencyCap,
             } = pixelSettings;
             const { values } = filteringConsentRuleValues || {};
+
             if (isEmpty(pixelUrl) && isEmpty(redirectUrl)) {
                 return;
             }

--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -72,7 +72,6 @@ export default function CookieSyncManager(
             // set requiresConsent to false to start each additional pixel configuration
             // set to true only if filteringConsenRuleValues.values.length exists
             let requiresConsent = false;
-            
             // Filtering rules as defined in UI
             const {
                 filteringConsentRuleValues,
@@ -83,7 +82,6 @@ export default function CookieSyncManager(
                 frequencyCap,
             } = pixelSettings;
             const { values } = filteringConsentRuleValues || {};
-            
             if (isEmpty(pixelUrl) && isEmpty(redirectUrl)) {
                 return;
             }

--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -98,6 +98,7 @@ export default function CookieSyncManager(
             }
 
             const { isEnabledForUserConsent } = mpInstance._Consent;
+
             if (!isEnabledForUserConsent(filteringConsentRuleValues, mpInstance.Identity.getCurrentUser())) {
                 return;
             }

--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -116,15 +116,15 @@ export default function CookieSyncManager(
             }
 
             // Url for cookie sync pixel
-            const finalPixelUrl = replaceAmpWithAmpersand(pixelUrl);
-            const finalDirectUrl = redirectUrl
+            const modifiedPixelUrl = replaceAmpWithAmpersand(pixelUrl);
+            const modifiedDirectUrl = redirectUrl
                 ? replaceAmpWithAmpersand(redirectUrl)
                 : null;
 
             const fullUrl = combineUrlWithRedirect(
                 mpid,
-                finalPixelUrl,
-                finalDirectUrl
+                modifiedPixelUrl,
+                modifiedDirectUrl
             );
 
             const cookieSyncDates: CookieSyncDates = persistence[mpid]?.csd ?? {};

--- a/src/identity.js
+++ b/src/identity.js
@@ -1230,10 +1230,7 @@ export default function Identity(mpInstance) {
                     this.getUserIdentities().userIdentities,
                     mpInstance._APIClient.prepareForwardingStats
                 );
-                mpInstance._CookieSyncManager.attemptCookieSync(
-                    null,
-                    this.getMPID()
-                );
+                mpInstance._CookieSyncManager.attemptCookieSync(this.getMPID());
             },
             isLoggedIn: function() {
                 return isLoggedIn;
@@ -1562,7 +1559,6 @@ export default function Identity(mpInstance) {
                     );
 
                     mpInstance._CookieSyncManager.attemptCookieSync(
-                        previousMPID,
                         identityApiResult.mpid,
                         mpidIsNotInCookies
                     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,6 +180,16 @@ const replaceMPID = (value: string, mpid: MPID): string => value.replace('%%mpid
 
 const replaceAmpWithAmpersand = (value: string): string => value.replace(/&amp;/g, '&');
 
+const combineUrlWithRedirect = (
+    mpid: MPID,
+    pixelUrl: string,
+    redirectUrl: string,
+): string => {
+    const url = replaceMPID(pixelUrl, mpid);
+    const redirect = redirectUrl ? replaceMPID(redirectUrl, mpid) : '';
+    return url + encodeURIComponent(redirect);
+};
+
 // FIXME: REFACTOR for V3
 // only used in store.js to sanitize server-side formatting of
 // booleans when checking for `isDevelopmentMode`
@@ -373,4 +383,5 @@ export {
     getHref,
     replaceMPID,
     replaceAmpWithAmpersand,
+    combineUrlWithRedirect,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -349,6 +349,7 @@ const getHref = (): string => {
 };
 
 export {
+    combineUrlWithRedirect,
     createCookieString,
     revertCookieString,
     valueof,
@@ -383,5 +384,4 @@ export {
     getHref,
     replaceMPID,
     replaceAmpWithAmpersand,
-    combineUrlWithRedirect,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,13 +180,20 @@ const replaceMPID = (value: string, mpid: MPID): string => value.replace('%%mpid
 
 const replaceAmpWithAmpersand = (value: string): string => value.replace(/&amp;/g, '&');
 
-const combineUrlWithRedirect = (
+const createCookieSyncUrl = (
     mpid: MPID,
     pixelUrl: string,
-    redirectUrl: string,
+    redirectUrl?: string
 ): string => {
-    const url = replaceMPID(pixelUrl, mpid);
-    const redirect = redirectUrl ? replaceMPID(redirectUrl, mpid) : '';
+    const modifiedPixelUrl = replaceAmpWithAmpersand(pixelUrl);
+    const modifiedDirectUrl = redirectUrl
+        ? replaceAmpWithAmpersand(redirectUrl)
+        : null;
+
+    const url = replaceMPID(modifiedPixelUrl, mpid);
+    const redirect = modifiedDirectUrl
+        ? replaceMPID(modifiedDirectUrl, mpid)
+        : '';
     return url + encodeURIComponent(redirect);
 };
 
@@ -349,9 +356,9 @@ const getHref = (): string => {
 };
 
 export {
-    combineUrlWithRedirect,
     createCookieString,
     revertCookieString,
+    createCookieSyncUrl,
     valueof,
     converted,
     decoded,

--- a/test/jest/cookieSyncManager.spec.ts
+++ b/test/jest/cookieSyncManager.spec.ts
@@ -412,8 +412,6 @@ describe('CookieSyncManager', () => {
                     pixelConfigurations: [pixelSettings],
                 },
                 _Persistence: {
-                    // FIXME: why is this here?  it doesn't exist in the SDK (it is used elsewhere too)
-                    setCookieSyncDates: jest.fn(),
                     getPersistence: jest.fn(),
                     saveUserCookieSyncDatesToPersistence: jest.fn(),
                 },
@@ -435,7 +433,6 @@ describe('CookieSyncManager', () => {
             jest.useFakeTimers();
 
             // Mock the Date constructor
-            // const mockDate = new Date(0); // Epoch time: 0
             const OriginalDate = global.Date;
             class MockDate extends OriginalDate {
                 constructor() {
@@ -445,9 +442,6 @@ describe('CookieSyncManager', () => {
 
             // Override global Date
             global.Date = MockDate as unknown as DateConstructor;
-
-            // Mock Date.now to always return 0
-            MockDate.now = jest.fn(() => 100);
 
             let cookieSyncDates: CookieSyncDates  = {};
             cookieSyncManager.performCookieSync(

--- a/test/jest/cookieSyncManager.spec.ts
+++ b/test/jest/cookieSyncManager.spec.ts
@@ -13,9 +13,11 @@ const pixelSettings: IPixelConfiguration = {
     isProduction: true,
     settings: {},
     frequencyCap: 14,
-    pixelUrl: '',
-    redirectUrl: '',
+    pixelUrl: 'https://test.com',
+    redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
 };
+
+const pixelUrlAndReidrectUrl = 'https://test.com%3Fredirect%3Dhttps%3A%2F%2Fredirect.com%26mpid%3DtestMPID';
 
 describe('CookieSyncManager', () => {
     describe('#attemptCookieSync', () => {
@@ -36,14 +38,13 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                '',
+                pixelUrlAndReidrectUrl,
                 '5',
                 testMPID,
                 {},
-                undefined,
                 true,
                 false, 
             );
@@ -65,7 +66,7 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, null, true);
+            cookieSyncManager.attemptCookieSync(null, true);
 
             expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
         });
@@ -86,13 +87,15 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
         });
 
         it('should toggle requiresConsent value if filtering filteringConsentRuleValues are defined', () => {
             const myPixelSettings: IPixelConfiguration = {
+                pixelUrl: 'https://test.com',
+                redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
                 filteringConsentRuleValues: {
                     values: ['test'],
                 },
@@ -113,14 +116,13 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                '',
+                pixelUrlAndReidrectUrl,
                 '5',
                 testMPID,
                 {},
-                { values: ['test'] },
                 true,
                 true, 
             );
@@ -147,105 +149,16 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                'https://test.com%3Fredirect%3Dhttps%3A%2F%2Fredirect.com%26mpid%3DtestMPID',
+                pixelUrlAndReidrectUrl,
                 '5',
                 testMPID,
                 {},
-                undefined,
                 true,
                 false, 
             );
-        });
-
-        // https://go.mparticle.com/work/SQDSDKS-6915
-        it('should call performCookieSync with mpid if previousMpid and mpid do not match', () => {
-            const mockMPInstance = ({
-                _Store: {
-                    webviewBridgeEnabled: false,
-                    pixelConfigurations: [pixelSettings],
-                },
-                _Persistence: {
-                    getPersistence: () => ({testMPID: {
-                    }}),
-                },
-            } as unknown) as MParticleWebSDK;
-
-            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
-            cookieSyncManager.performCookieSync = jest.fn();
-
-            cookieSyncManager.attemptCookieSync('other-mpid', testMPID, true);
-
-            expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                '',
-                '5',
-                testMPID,
-                {},
-                undefined,
-                true,
-                false, 
-            );
-        });
-
-        it('should include mpid AND csd when calling performCookieSync if previousMpid and mpid do not match', () => {
-            const mockMPInstance = ({
-                _Store: {
-                    webviewBridgeEnabled: false,
-                    pixelConfigurations: [pixelSettings],
-                },
-                _Persistence: {
-                    getPersistence: () => ({testMPID: {
-                        csd: { 5: 1234567890 }
-                    }}),
-                },
-            } as unknown) as MParticleWebSDK;
-
-            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
-            cookieSyncManager.performCookieSync = jest.fn();
-
-            cookieSyncManager.attemptCookieSync('other-mpid', testMPID, true);
-
-            expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                '',
-                '5',
-                testMPID,
-                {
-                    5: 1234567890
-                },
-                undefined,
-                true,
-                false, 
-            );
-        });
-
-        it('should call performCookieSync with mpid if previousMpid and mpid match', () => {
-            const mockMPInstance = ({
-                _Store: {
-                    webviewBridgeEnabled: false,
-                    pixelConfigurations: [pixelSettings],
-                },
-                _Persistence: {
-                    getPersistence: () => ({testMPID: {
-                    }}),
-                },
-            } as unknown) as MParticleWebSDK;
-
-            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
-            cookieSyncManager.performCookieSync = jest.fn();
-
-            cookieSyncManager.attemptCookieSync(testMPID, testMPID, true);
-
-            expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                '',
-                '5',
-                testMPID,
-                {},
-                undefined,
-                true,
-                false, 
-            ); 
         });
 
         it('should perform a cookie sync if lastSyncDateForModule is null', () => {
@@ -262,14 +175,13 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                '',
+                pixelUrlAndReidrectUrl,
                 '5',
                 testMPID,
                 {},
-                undefined,
                 true,
                 false, 
             );
@@ -296,16 +208,15 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                '',
+                pixelUrlAndReidrectUrl,
                 '5',
                 testMPID,
                 {
                     5: cookieSyncDateInPast 
                 },
-                undefined,
                 true,
                 false, 
             );
@@ -329,35 +240,57 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                '',
+                pixelUrlAndReidrectUrl,
                 '5',
                 testMPID,
                 {},
-                undefined,
                 true,
                 false, 
             );
         });
 
-        it('should sync cookies when there was not a previous cookie-sync', () => {
+        it.only('should sync cookies when there was not a previous cookie-sync', () => {
             const mockMPInstance = ({
                 _Store: {
                     webviewBridgeEnabled: false,
                     pixelConfigurations: [pixelSettings],
                 },
                 _Persistence: {
-                    getPersistence: () => ({}),
+                    setCookieSyncDates: jest.fn(),
+                    getPersistence: () => ({testMPID: {}}),
+                    saveUserCookieSyncDatesToPersistence: jest.fn(),
+                },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => testMPID,
+                    }),
+                },
+                Logger: {
+                    verbose: jest.fn(),
                 },
             } as unknown) as MParticleWebSDK;
 
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
+            cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, '456', true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
             expect(mockMPInstance._Store.pixelConfigurations.length).toBe(1);
             expect(mockMPInstance._Store.pixelConfigurations[0].moduleId).toBe(5);
+
+            expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
+                pixelUrlAndReidrectUrl,
+                '5',
+                testMPID,
+                {},
+                true,
+                false, 
+            );
         });
 
         it('should not perform a cookie sync if persistence is empty', () => {
@@ -374,7 +307,7 @@ describe('CookieSyncManager', () => {
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(null, testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
         });
@@ -396,6 +329,7 @@ describe('CookieSyncManager', () => {
                     pixelConfigurations: [pixelSettings],
                 },
                 _Persistence: {
+                    // FIXME: why is this here?  it doesn't exist in the SDK (it is used elsewhere too)
                     setCookieSyncDates: jest.fn(),
                     getPersistence: jest.fn(),
                     saveUserCookieSyncDatesToPersistence: jest.fn(),
@@ -421,7 +355,6 @@ describe('CookieSyncManager', () => {
                 42,
                 '1234',
                 cookieSyncDates,
-                null,
                 false,
                 false
             );
@@ -476,7 +409,6 @@ describe('CookieSyncManager', () => {
                 42,
                 '1234',
                 cookieSyncDates,
-                null,
                 false,
                 false
             );
@@ -583,7 +515,6 @@ describe('CookieSyncManager', () => {
                 42,
                 '1234',
                 cookieSyncDates,
-                null,
                 true,
                 true, 
             );
@@ -593,48 +524,6 @@ describe('CookieSyncManager', () => {
 
             expect(mockImage.src).toBe('');
             expect(cookieSyncDates[42]).toBeUndefined();
-        });
-    });
-
-    describe('#combineUrlWithRedirect', () => {
-        it('should combine a pixelUrl with a redirectUrl', () => {
-            const mockMPInstance = ({
-                _Store: {
-                    webviewBridgeEnabled: false,
-                    pixelConfigurations: [pixelSettings],
-                },
-            } as unknown) as MParticleWebSDK;
-
-            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
-
-            // Note: We expect that the input of the pixelUrl will include a `?`
-            // (ideally at the end of the string)
-            // so that the redirectUrl can be processed by the backend correctly
-            const result = cookieSyncManager.combineUrlWithRedirect(
-                '1234',
-                'https://test.com/some/path?',
-                'https://redirect.mparticle.com/v1/sync?esid=1234&amp;MPID=%%mpid%%&amp;ID=$UID&amp;Key=testMPID&amp;env=2'
-            );
-
-            expect(result).toBe('https://test.com/some/path?https%3A%2F%2Fredirect.mparticle.com%2Fv1%2Fsync%3Fesid%3D1234%26amp%3BMPID%3D1234%26amp%3BID%3D%24UID%26amp%3BKey%3DtestMPID%26amp%3Benv%3D2');
-        });
-
-        it('should return the pixelUrl if no redirectUrl is defined', () => {
-            const mockMPInstance = ({
-                _Store: {
-                    webviewBridgeEnabled: false,
-                    pixelConfigurations: [pixelSettings],
-                },
-            } as unknown) as MParticleWebSDK;
-
-            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
-
-            const result = cookieSyncManager.combineUrlWithRedirect(
-                '1234',
-                'https://test.com',
-            );
-
-            expect(result).toBe('https://test.com');
         });
     });
 });

--- a/test/jest/cookieSyncManager.spec.ts
+++ b/test/jest/cookieSyncManager.spec.ts
@@ -58,6 +58,36 @@ describe('CookieSyncManager', () => {
             );            
         });
 
+        it('should not call performCookieSync if pixelURL is empty', () => {
+            const pixelSettingsWithoutPixelUrl = {...pixelSettings, pixelUrl: ''}
+            const mockMPInstance = ({
+                _Store: {
+                    webviewBridgeEnabled: false,
+                    pixelConfigurations: [pixelSettingsWithoutPixelUrl],
+                },
+                _Persistence: {
+                    getPersistence: () => ({testMPID: {
+                        csd: {}
+                    }}),
+                },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => testMPID,
+                    }),
+                },
+            } as unknown) as MParticleWebSDK;
+
+            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
+            cookieSyncManager.performCookieSync = jest.fn();
+
+            cookieSyncManager.attemptCookieSync(testMPID, true);
+
+            expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
+        });
+
         it('should not call performCookieSync if mpid is not defined', () => {
             const mockMPInstance = ({
                 _Store: {

--- a/test/jest/cookieSyncManager.spec.ts
+++ b/test/jest/cookieSyncManager.spec.ts
@@ -1,7 +1,8 @@
 import CookieSyncManager, {
     DAYS_IN_MILLISECONDS,
     IPixelConfiguration,
-    CookieSyncDates
+    CookieSyncDates,
+    isLastSyncDateExpired
 } from '../../src/cookieSyncManager';
 import { MParticleWebSDK } from '../../src/sdkRuntimeModels';
 import { testMPID } from '../src/config/constants';
@@ -503,6 +504,23 @@ describe('CookieSyncManager', () => {
             );
 
             expect(loggerSpy).toHaveBeenCalledWith('Performing cookie sync');
+        });
+    });
+
+    describe('#isLastSyncDateExpired', () => {
+        const frequencyCap = 14; // days
+        it('should return true if there is no last sync date', () => {
+            expect(isLastSyncDateExpired(frequencyCap, null)).toBe(true);
+        });
+
+        it('should return true if lastSyncDate is beyond the frequencyCap', () => {
+            const lastSyncDate = 0;  // beginning of time
+            expect(isLastSyncDateExpired(frequencyCap, lastSyncDate)).toBe(true);
+        });
+
+        it('should return false if lastSyncDate is beyond the frequencyCap', () => {
+            const lastSyncDate = new Date().getTime();  // now
+            expect(isLastSyncDateExpired(frequencyCap, lastSyncDate)).toBe(false);
         });
     });
 });

--- a/test/jest/cookieSyncManager.spec.ts
+++ b/test/jest/cookieSyncManager.spec.ts
@@ -1,6 +1,7 @@
 import CookieSyncManager, {
     DAYS_IN_MILLISECONDS,
     IPixelConfiguration,
+    CookieSyncDates
 } from '../../src/cookieSyncManager';
 import { MParticleWebSDK } from '../../src/sdkRuntimeModels';
 import { testMPID } from '../src/config/constants';
@@ -17,7 +18,7 @@ const pixelSettings: IPixelConfiguration = {
     redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
 };
 
-const pixelUrlAndReidrectUrl = 'https://test.com%3Fredirect%3Dhttps%3A%2F%2Fredirect.com%26mpid%3DtestMPID';
+const pixelUrlAndRedirectUrl = 'https://test.com%3Fredirect%3Dhttps%3A%2F%2Fredirect.com%26mpid%3DtestMPID';
 
 describe('CookieSyncManager', () => {
     describe('#attemptCookieSync', () => {
@@ -33,6 +34,14 @@ describe('CookieSyncManager', () => {
                         csd: {}
                     }}),
                 },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => testMPID,
+                    }),
+                },
             } as unknown) as MParticleWebSDK;
 
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
@@ -41,16 +50,14 @@ describe('CookieSyncManager', () => {
             cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                pixelUrlAndReidrectUrl,
+                pixelUrlAndRedirectUrl,
                 '5',
                 testMPID,
                 {},
-                true,
-                false, 
-            );
+            );            
         });
 
-        it('should return early if mpid is not defined', () => {
+        it('should not call performCookieSync if mpid is not defined', () => {
             const mockMPInstance = ({
                 _Store: {
                     webviewBridgeEnabled: false,
@@ -71,7 +78,7 @@ describe('CookieSyncManager', () => {
             expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
         });
 
-        it('should return early if webviewBridgeEnabled is true', () => {
+        it('should not call performCookieSync if webviewBridgeEnabled is true', () => {
             const mockMPInstance = ({
                 _Store: {
                     webviewBridgeEnabled: true,
@@ -92,9 +99,10 @@ describe('CookieSyncManager', () => {
             expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
         });
 
-        it('should toggle requiresConsent value if filtering filteringConsentRuleValues are defined', () => {
+        it('should call performCookieSync when there are filteringConsentRuleValues and mpidIsNotInCookies = false', () => {
             const myPixelSettings: IPixelConfiguration = {
                 pixelUrl: 'https://test.com',
+                moduleId: 5,
                 redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
                 filteringConsentRuleValues: {
                     values: ['test'],
@@ -104,31 +112,37 @@ describe('CookieSyncManager', () => {
             const mockMPInstance = ({
                 _Store: {
                     webviewBridgeEnabled: false,
-                    pixelConfigurations: [{...pixelSettings, ...myPixelSettings}],
+                    pixelConfigurations: [myPixelSettings],
                 },
                 _Persistence: {
                     getPersistence: () => ({testMPID: {
                         csd: {}
                     }}),
                 },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => testMPID,
+                    }),
+                },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                },
             } as unknown) as MParticleWebSDK;
 
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
             cookieSyncManager.performCookieSync = jest.fn();
 
-            cookieSyncManager.attemptCookieSync(testMPID, true);
+            cookieSyncManager.attemptCookieSync(testMPID, false);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                pixelUrlAndReidrectUrl,
+                pixelUrlAndRedirectUrl,
                 '5',
                 testMPID,
                 {},
-                true,
-                true, 
             );
         });
 
-        it('should update the urlWithRedirect if a redirectUrl is defined', () => {
+        it('should update the cookie sync url if a redirectUrl is defined', () => {
             const myPixelSettings: IPixelConfiguration = {
                 pixelUrl: 'https://test.com',
                 redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
@@ -144,6 +158,14 @@ describe('CookieSyncManager', () => {
                         csd: {}
                     }}),
                 },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => testMPID,
+                    }),
+                },
             } as unknown) as MParticleWebSDK;
 
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
@@ -152,16 +174,14 @@ describe('CookieSyncManager', () => {
             cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                pixelUrlAndReidrectUrl,
+                pixelUrlAndRedirectUrl,
                 '5',
                 testMPID,
                 {},
-                true,
-                false, 
             );
         });
 
-        it('should perform a cookie sync if lastSyncDateForModule is null', () => {
+        it('should call performCookieSync if lastSyncDateForModule is null', () => {
             const mockMPInstance = ({
                 _Store: {
                     webviewBridgeEnabled: false,
@@ -170,6 +190,14 @@ describe('CookieSyncManager', () => {
                 _Persistence: {
                     getPersistence: () => ({testMPID: {}}),
                 },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => testMPID,
+                    }),
+                },
             } as unknown) as MParticleWebSDK;
 
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
@@ -178,16 +206,14 @@ describe('CookieSyncManager', () => {
             cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                pixelUrlAndReidrectUrl,
+                pixelUrlAndRedirectUrl,
                 '5',
                 testMPID,
                 {},
-                true,
-                false, 
             );
         });
 
-        it('should perform a cookie sync if lastSyncDateForModule has passed the frequency cap', () => {
+        it('should call performCookieSync if lastSyncDateForModule has passed the frequency cap', () => {
             const now = new Date().getTime();
 
             // Rev the date by one
@@ -203,6 +229,14 @@ describe('CookieSyncManager', () => {
                         csd: { 5: cookieSyncDateInPast }
                     }}),
                 },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => testMPID,
+                    }),
+                },
             } as unknown) as MParticleWebSDK;
 
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
@@ -211,57 +245,23 @@ describe('CookieSyncManager', () => {
             cookieSyncManager.attemptCookieSync(testMPID, true);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                pixelUrlAndReidrectUrl,
+                pixelUrlAndRedirectUrl,
                 '5',
                 testMPID,
                 {
                     5: cookieSyncDateInPast 
                 },
-                true,
-                false, 
             );
         });
 
-        it('should perform a cookie sync if lastSyncDateForModule is past the frequency cap even if csd is empty', () => {
-            const now = new Date().getTime();
-
+        it('should call performCookieSync when there was not a previous cookie-sync', () => {
             const mockMPInstance = ({
                 _Store: {
                     webviewBridgeEnabled: false,
                     pixelConfigurations: [pixelSettings],
                 },
                 _Persistence: {
-                    // This will make lastSyncDateForModule undefined, which bypasses the
-                    // actual time check, but still performs a cookie sync
                     getPersistence: () => ({testMPID: {}}),
-                },
-            } as unknown) as MParticleWebSDK;
-
-            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
-            cookieSyncManager.performCookieSync = jest.fn();
-
-            cookieSyncManager.attemptCookieSync(testMPID, true);
-
-            expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                pixelUrlAndReidrectUrl,
-                '5',
-                testMPID,
-                {},
-                true,
-                false, 
-            );
-        });
-
-        it.only('should sync cookies when there was not a previous cookie-sync', () => {
-            const mockMPInstance = ({
-                _Store: {
-                    webviewBridgeEnabled: false,
-                    pixelConfigurations: [pixelSettings],
-                },
-                _Persistence: {
-                    setCookieSyncDates: jest.fn(),
-                    getPersistence: () => ({testMPID: {}}),
-                    saveUserCookieSyncDatesToPersistence: jest.fn(),
                 },
                 _Consent: {
                     isEnabledForUserConsent: jest.fn().mockReturnValue(true),
@@ -280,20 +280,16 @@ describe('CookieSyncManager', () => {
             cookieSyncManager.performCookieSync = jest.fn();
 
             cookieSyncManager.attemptCookieSync(testMPID, true);
-            expect(mockMPInstance._Store.pixelConfigurations.length).toBe(1);
-            expect(mockMPInstance._Store.pixelConfigurations[0].moduleId).toBe(5);
 
             expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                pixelUrlAndReidrectUrl,
+                pixelUrlAndRedirectUrl,
                 '5',
-                testMPID,
+                testMPID, 
                 {},
-                true,
-                false, 
             );
         });
 
-        it('should not perform a cookie sync if persistence is empty', () => {
+        it('should not call performCookieSync if persistence is empty', () => {
             const mockMPInstance = ({
                 _Store: {
                     webviewBridgeEnabled: false,
@@ -311,10 +307,97 @@ describe('CookieSyncManager', () => {
 
             expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
         });
+
+        it('should not call performCookieSync if the user has not consented to the cookie sync', () => {
+            const loggerSpy = jest.fn();
+            const myPixelSettings: IPixelConfiguration = {
+                pixelUrl: 'https://test.com',
+                redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
+                filteringConsentRuleValues: {
+                    values: ['test'],
+                },
+            } as unknown as IPixelConfiguration;   
+
+            const mockMPInstance = ({
+                _Store: {
+                    webviewBridgeEnabled: false,
+                    pixelConfigurations: [myPixelSettings],
+                },
+                _Persistence: {
+                    getPersistence: () => ({testMPID: {
+                        csd: {}
+                    }}),
+                },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(false),
+                },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => '123',
+                    }),
+                },
+                Logger: {
+                    verbose: loggerSpy,
+                },
+            } as unknown) as MParticleWebSDK;
+
+            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
+            cookieSyncManager.performCookieSync = jest.fn();
+
+            cookieSyncManager.attemptCookieSync(
+                '123',
+                false,
+            );
+
+            expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
+        });
+
+        it('should return early if requiresConsent and mpidIsNotInCookies are both true', () => {
+            const myPixelSettings: IPixelConfiguration = {
+                pixelUrl: 'https://test.com',
+                redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
+                filteringConsentRuleValues: {
+                    values: ['test'],
+                },
+            } as unknown as IPixelConfiguration;            const loggerSpy = jest.fn();
+
+            const mockMPInstance = ({
+                _Store: {
+                    webviewBridgeEnabled: false,
+                    pixelConfigurations: [myPixelSettings], // empty values will make require consent to be true
+                },
+                _Persistence: {
+                    getPersistence: () => ({testMPID: {
+                        csd: {}
+                    }}),
+                },
+                _Consent: {
+                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                },
+                Identity: {
+                    getCurrentUser: jest.fn().mockReturnValue({
+                        getMPID: () => '123',
+                    }),
+                },
+                Logger: {
+                    verbose: loggerSpy,
+                },
+            } as unknown) as MParticleWebSDK;
+
+            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
+            cookieSyncManager.performCookieSync = jest.fn();
+
+            cookieSyncManager.attemptCookieSync(
+                '123',
+                true
+            );
+
+            expect(cookieSyncManager.performCookieSync).not.toHaveBeenCalled();
+        });
     });
 
     describe('#performCookieSync', () => {
-        it('should add cookie sync dates to a tracking pixel', () => {
+        it('should add cookie sync data to a tracking pixel', () => {
             const mockImage = {
                 onload: jest.fn(),
                 src: '',
@@ -349,14 +432,29 @@ describe('CookieSyncManager', () => {
 
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
 
-            let cookieSyncDates = [];
+            jest.useFakeTimers();
+
+            // Mock the Date constructor
+            // const mockDate = new Date(0); // Epoch time: 0
+            const OriginalDate = global.Date;
+            class MockDate extends OriginalDate {
+                constructor() {
+                    super(100); // Always return 100 as the date
+                }
+            }
+
+            // Override global Date
+            global.Date = MockDate as unknown as DateConstructor;
+
+            // Mock Date.now to always return 0
+            MockDate.now = jest.fn(() => 100);
+
+            let cookieSyncDates: CookieSyncDates  = {};
             cookieSyncManager.performCookieSync(
                 'https://test.com',
                 42,
                 '1234',
                 cookieSyncDates,
-                false,
-                false
             );
 
             // Simulate image load
@@ -364,18 +462,17 @@ describe('CookieSyncManager', () => {
 
             expect(mockImage.src).toBe('https://test.com');
             expect(cookieSyncDates[42]).toBeDefined();
-            expect(cookieSyncDates[42]).toBeGreaterThan(0);
+            expect(cookieSyncDates[42]).toBe(100)
+
+            expect(mockMPInstance._Persistence.saveUserCookieSyncDatesToPersistence).toBeCalledWith(
+                '1234', {42: 100}
+            );
+
+            global.Date = OriginalDate;
+            jest.useRealTimers();
         });
 
         it('should log a verbose message when a cookie sync is performed', () => {
-            const mockImage = {
-                onload: jest.fn(),
-                src: '',
-            };
-            jest.spyOn(document, 'createElement').mockReturnValue(
-                (mockImage as unknown) as HTMLImageElement
-            );
-
             const loggerSpy = jest.fn();
 
             const mockMPInstance = ({
@@ -384,9 +481,9 @@ describe('CookieSyncManager', () => {
                     pixelConfigurations: [pixelSettings],
                 },
                 _Persistence: {
-                    setCookieSyncDates: jest.fn(),
-                    getPersistence: jest.fn(),
-                    saveUserCookieSyncDatesToPersistence: jest.fn(),
+                    getPersistence: () => ({testMPID: {
+                        csd: {}
+                    }}),
                 },
                 _Consent: {
                     isEnabledForUserConsent: jest.fn().mockReturnValue(true),
@@ -403,127 +500,15 @@ describe('CookieSyncManager', () => {
 
             const cookieSyncManager = new CookieSyncManager(mockMPInstance);
 
-            let cookieSyncDates = [];
+            let cookieSyncDates = {};
             cookieSyncManager.performCookieSync(
                 'https://test.com',
                 42,
                 '1234',
                 cookieSyncDates,
-                false,
-                false
             );
-
-            // Simulate image load
-            mockImage.onload();
 
             expect(loggerSpy).toHaveBeenCalledWith('Performing cookie sync');
-        });
-
-        it('should return early if the user has not consented to the cookie sync', () => {
-            const mockImage = {
-                onload: jest.fn(),
-                src: '',
-            };
-            jest.spyOn(document, 'createElement').mockReturnValue(
-                (mockImage as unknown) as HTMLImageElement
-            );
-
-            const loggerSpy = jest.fn();
-
-            const mockMPInstance = ({
-                _Store: {
-                    webviewBridgeEnabled: false,
-                    pixelConfigurations: [pixelSettings],
-                },
-                _Persistence: {
-                    setCookieSyncDates: jest.fn(),
-                    getPersistence: jest.fn(),
-                    saveUserCookieSyncDatesToPersistence: jest.fn(),
-                },
-                _Consent: {
-                    isEnabledForUserConsent: jest.fn().mockReturnValue(false),
-                },
-                Identity: {
-                    getCurrentUser: jest.fn().mockReturnValue({
-                        getMPID: () => '123',
-                    }),
-                },
-                Logger: {
-                    verbose: loggerSpy,
-                },
-            } as unknown) as MParticleWebSDK;
-
-            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
-
-            let cookieSyncDates = [];
-            cookieSyncManager.performCookieSync(
-                'https://test.com',
-                42,
-                '1234',
-                cookieSyncDates,
-                null,
-                false,
-                false, 
-            );
-
-            // Simulate image load
-            mockImage.onload();
-
-            expect(mockImage.src).toBe('');
-            expect(cookieSyncDates[42]).toBeUndefined();
-        });
-
-        it('should return early if requiresConsent and mpidIsNotInCookies are both true', () => {
-            const mockImage = {
-                onload: jest.fn(),
-                src: '',
-            };
-            jest.spyOn(document, 'createElement').mockReturnValue(
-                (mockImage as unknown) as HTMLImageElement
-            );
-
-            const loggerSpy = jest.fn();
-
-            const mockMPInstance = ({
-                _Store: {
-                    webviewBridgeEnabled: false,
-                    pixelConfigurations: [pixelSettings],
-                },
-                _Persistence: {
-                    setCookieSyncDates: jest.fn(),
-                    getPersistence: jest.fn(),
-                    saveUserCookieSyncDatesToPersistence: jest.fn(),
-                },
-                _Consent: {
-                    isEnabledForUserConsent: jest.fn().mockReturnValue(true),
-                },
-                Identity: {
-                    getCurrentUser: jest.fn().mockReturnValue({
-                        getMPID: () => '123',
-                    }),
-                },
-                Logger: {
-                    verbose: loggerSpy,
-                },
-            } as unknown) as MParticleWebSDK;
-
-            const cookieSyncManager = new CookieSyncManager(mockMPInstance);
-
-            let cookieSyncDates = [];
-            cookieSyncManager.performCookieSync(
-                'https://test.com',
-                42,
-                '1234',
-                cookieSyncDates,
-                true,
-                true, 
-            );
-
-            // Simulate image load
-            mockImage.onload();
-
-            expect(mockImage.src).toBe('');
-            expect(cookieSyncDates[42]).toBeUndefined();
         });
     });
 });

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -4,7 +4,7 @@ import {
     getHref,
     replaceMPID,
     replaceAmpWithAmpersand,
-    combineUrlWithRedirect,
+    createCookieSyncUrl,
 } from '../../src/utils';
 import { deleteAllCookies } from './utils';
 
@@ -185,20 +185,16 @@ describe('Utils', () => {
         });
     });
 
-    describe('#combineUrlWithRedirect', () => {
-        const pixelUrl: string = "https://abc.abcdex.net/ibs:exampleid=12345&amp;exampleuuid=%%mpid%%&amp;redir=";
-        const redirectUrl: string = "https://cookiesync.mparticle.com/v1/sync?esid=123456&amp;MPID=%%mpid%%&amp;ID=${DD_UUID}&amp;Key=mpApiKey&amp;env=2"
+    describe('#createCookieSyncUrl', () => {
+        const pixelUrl: string = 'https://abc.abcdex.net/ibs:exampleid=12345&amp;exampleuuid=%%mpid%%&amp;redir=';
+        const redirectUrl: string = 'https://cookiesync.mparticle.com/v1/sync?esid=123456&amp;MPID=%%mpid%%&amp;ID=${DD_UUID}&amp;Key=mpApiKey&amp;env=2';
 
-        it('should properly combine data from a pixelUrl, redirectUrl, and mpid when everything is defined', () => {
-            expect(combineUrlWithRedirect('testMPID', pixelUrl, redirectUrl)).toEqual(
-                'https://abc.abcdex.net/ibs:exampleid=12345&amp;exampleuuid=testMPID&amp;redir=https%3A%2F%2Fcookiesync.mparticle.com%2Fv1%2Fsync%3Fesid%3D123456%26amp%3BMPID%3DtestMPID%26amp%3BID%3D%24%7BDD_UUID%7D%26amp%3BKey%3DmpApiKey%26amp%3Benv%3D2'
-            );
+        it('should return a cookieSyncUrl when both pixelUrl and redirectUrl are not null', () => {
+            expect(createCookieSyncUrl('testMPID', pixelUrl, redirectUrl)).toBe('https://abc.abcdex.net/ibs:exampleid=12345&exampleuuid=testMPID&redir=https%3A%2F%2Fcookiesync.mparticle.com%2Fv1%2Fsync%3Fesid%3D123456%26MPID%3DtestMPID%26ID%3D%24%7BDD_UUID%7D%26Key%3DmpApiKey%26env%3D2');
         });
 
-        it('should return the pixelUrl with MPID if no redirectUrl is defined', () => {
-            expect(combineUrlWithRedirect('testMPID', pixelUrl, '')).toEqual(
-                'https://abc.abcdex.net/ibs:exampleid=12345&amp;exampleuuid=testMPID&amp;redir='
-            );
+        it('should return a cookieSyncUrl when pixelUrl is not null but redirectUrl is null', () => {
+            expect(createCookieSyncUrl('testMPID', pixelUrl, null)).toBe('https://abc.abcdex.net/ibs:exampleid=12345&exampleuuid=testMPID&redir=');
         });
     });
 });

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -4,6 +4,7 @@ import {
     getHref,
     replaceMPID,
     replaceAmpWithAmpersand,
+    combineUrlWithRedirect,
 } from '../../src/utils';
 import { deleteAllCookies } from './utils';
 
@@ -180,6 +181,23 @@ describe('Utils', () => {
 
             expect(replaceAmpWithAmpersand(string)).toEqual(
                 'https://www.google.com?mpid=%%mpid%%&foo=bar'
+            );
+        });
+    });
+
+    describe('#combineUrlWithRedirect', () => {
+        const pixelUrl: string = "https://abc.abcdex.net/ibs:exampleid=12345&amp;exampleuuid=%%mpid%%&amp;redir=";
+        const redirectUrl: string = "https://cookiesync.mparticle.com/v1/sync?esid=123456&amp;MPID=%%mpid%%&amp;ID=${DD_UUID}&amp;Key=mpApiKey&amp;env=2"
+
+        it('should properly combine data from a pixelUrl, redirectUrl, and mpid when everything is defined', () => {
+            expect(combineUrlWithRedirect('testMPID', pixelUrl, redirectUrl)).toEqual(
+                'https://abc.abcdex.net/ibs:exampleid=12345&amp;exampleuuid=testMPID&amp;redir=https%3A%2F%2Fcookiesync.mparticle.com%2Fv1%2Fsync%3Fesid%3D123456%26amp%3BMPID%3DtestMPID%26amp%3BID%3D%24%7BDD_UUID%7D%26amp%3BKey%3DmpApiKey%26amp%3Benv%3D2'
+            );
+        });
+
+        it('should return the pixelUrl with MPID if no redirectUrl is defined', () => {
+            expect(combineUrlWithRedirect('testMPID', pixelUrl, '')).toEqual(
+                'https://abc.abcdex.net/ibs:exampleid=12345&amp;exampleuuid=testMPID&amp;redir='
             );
         });
     });

--- a/test/src/tests-cookie-syncing.ts
+++ b/test/src/tests-cookie-syncing.ts
@@ -18,8 +18,8 @@ const pixelSettings: IPixelConfiguration = {
     isProduction: true,
     settings: {},
     frequencyCap: 14,
-    pixelUrl: '',
-    redirectUrl: '',
+    pixelUrl: 'https://test.com',
+    redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
 };
 
 declare global {
@@ -277,8 +277,8 @@ describe('cookie syncing', function() {
                     isProduction: true,
                     settings: {},
                     frequencyCap: 14,
-                    pixelUrl: '',
-                    redirectUrl: '',
+                    pixelUrl: 'https://test.com',
+                    redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
                 },
             ],
         };
@@ -1222,8 +1222,8 @@ describe('cookie syncing', function() {
             isProduction: true,
             settings: {},
             frequencyCap: 14,
-            pixelUrl: '',
-            redirectUrl: '',
+            pixelUrl: 'https://test.com',
+            redirectUrl: '?redirect=https://redirect.com&mpid=%%mpid%%',
         };
 
         pixelSettings1.filteringConsentRuleValues = {
@@ -1247,8 +1247,8 @@ describe('cookie syncing', function() {
             isProduction: true,
             settings: {},
             frequencyCap: 14,
-            pixelUrl: '',
-            redirectUrl: '',
+            pixelUrl: 'https://test2.com',
+            redirectUrl: '?redirect=https://redirect2.com&mpid=%%mpid%%',
         };
 
         window.mParticle.config.pixelConfigs = [pixelSettings1, pixelSettings2];

--- a/test/src/tests-cookie-syncing.ts
+++ b/test/src/tests-cookie-syncing.ts
@@ -31,7 +31,7 @@ declare global {
 
 const mParticle = window.mParticle;
 
-describe('cookie syncing', function() {
+describe.only('cookie syncing', function() {
     const timeout = 100;
     // Have a reference to createElement function to reset after all cookie sync
     // tests have run

--- a/test/src/tests-cookie-syncing.ts
+++ b/test/src/tests-cookie-syncing.ts
@@ -31,7 +31,7 @@ declare global {
 
 const mParticle = window.mParticle;
 
-describe.only('cookie syncing', function() {
+describe('cookie syncing', function() {
     const timeout = 100;
     // Have a reference to createElement function to reset after all cookie sync
     // tests have run


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
This PR makes the cookie sync manager less cognitively complex by:
1. Not triggering cookie sync when `pixelUrl` is empty
2. Removing the logic between previousMPID and current mpid.  To simplify, we always test to see if the new mpid has a last sync date that has expired or not
3. Simplify `performCookieSync` by removing a lot of logic from it to `attemptCookieSync`
4. Reduce nested if statements throughout `attemptCookieSync`.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
Unit tests continue to run successfully.  Additional tests added to the jest tests, as well as removing any tests that dealt with previous MPID.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6915
