### PR TITLE
test: Remove set timeouts from tests and other cleanup

### DIFF
--- a/test/src/config/utils.js
+++ b/test/src/config/utils.js
@@ -635,7 +635,7 @@ var pluses = /\+/g,
         return window.mParticle.Identity.getCurrentUser()?.getMPID() === testMPID;
     },
     hasIdentityCallInflightReturned = () => !mParticle.getInstance()?._Store?.identityCallInFlight,
-    hasConfigLoaded = () => !!mParticle.getInstance()?._Store?.configurationLoaded
+    hasConfigurationReturned = () => !!mParticle.getInstance()?._Store?.configurationLoaded;
 
 var TestsCore = {
     getLocalStorageProducts: getLocalStorageProducts,
@@ -664,7 +664,7 @@ var TestsCore = {
     fetchMockSuccess: fetchMockSuccess,
     hasIdentifyReturned: hasIdentifyReturned,
     hasIdentityCallInflightReturned,
-    hasConfigLoaded,
+    hasConfigurationReturned,
 };
 
 export default TestsCore;

--- a/test/src/tests-batchUploader_3.ts
+++ b/test/src/tests-batchUploader_3.ts
@@ -234,7 +234,7 @@ describe('batch uploader', () => {
             })
         });
 
-        it('should call the identity callback after a session ends if user is returning to the page after a long period of time', async function() {
+        it('should call the identity callback after a session ends if user is returning to the page after a long period of time', async () => {
             // Background of bug that this test fixes:
             // User navigates away from page and returns after some time
             // and the session should end.  There is a UAC firing inside of

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -17,7 +17,7 @@ const {
     fetchMockSuccess,
     hasIdentifyReturned,
     hasIdentityCallInflightReturned,
-    hasConfigLoaded,
+    hasConfigurationReturned
 } = Utils;
 
 describe('core SDK', function() {
@@ -128,7 +128,7 @@ describe('core SDK', function() {
         });
     });
 
-    it('should process ready queue when initialized', async function() {
+    it('should process ready queue when initialized', async () => {
         let readyFuncCalled = false;
 
         mParticle._resetForTests(MPConfig);
@@ -156,7 +156,7 @@ describe('core SDK', function() {
         })
     });
 
-    it('should get app version', async function() {
+    it('should get app version', async () => {
         await waitForCondition(hasIdentityCallInflightReturned);
         mParticle.setAppVersion('2.0');
 
@@ -1100,7 +1100,7 @@ describe('core SDK', function() {
     });
 
     // TODO - there are no actual tests here....what's going on?
-    it('should fetch from /config and keep everything properly on the store', function(done) {
+    it('should fetch from /config and keep everything properly on the store', async () => {
         mParticle._resetForTests(MPConfig);
         const config = {
             appName: 'appNameTest',
@@ -1116,23 +1116,15 @@ describe('core SDK', function() {
         window.mParticle.config.requestConfig = true;
         mParticle.init(apiKey, window.mParticle.config);
 
-        waitForCondition(() => {
-            return (
-                mParticle.getInstance()._Store.configurationLoaded === true
-            );
-        })
-        .then(() => {
+        await waitForCondition(hasConfigurationReturned);
         mParticle.getInstance()._Store.SDKConfig.appName = config.appName;
         mParticle.getInstance()._Store.SDKConfig.minWebviewBridgeVersion =
             config.minWebviewBridgeVersion;
         mParticle.getInstance()._Store.SDKConfig.workspaceToken = config.workspaceToken;
         localStorage.removeItem(config.workspaceToken);
-
-        done();
-        })
     });
 
-    it('should initialize and log events even with a failed /config fetch and empty config',  async () => {
+    it('should initialize and log events even with a failed /config fetch and empty config', async () => {
         // this instance occurs when self hosting and the user only passes an object into init
         mParticle._resetForTests(MPConfig);
 
@@ -1158,7 +1150,7 @@ describe('core SDK', function() {
 
         mParticle.init(apiKey, window.mParticle.config);
 
-        await waitForCondition(hasConfigLoaded);
+        await waitForCondition(hasConfigurationReturned);
         // fetching the config is async and we need to wait for it to finish
         mParticle.getInstance()._Store.isInitialized.should.equal(true);
 
@@ -1183,7 +1175,7 @@ describe('core SDK', function() {
         testEvent.should.be.ok();
     });
 
-    it('should initialize without a config object passed to init', async function() {
+    it('should initialize without a config object passed to init', async () => {
         // this instance occurs when self hosting and the user only passes an object into init
         mParticle._resetForTests(MPConfig);
 
@@ -1253,7 +1245,7 @@ describe('core SDK', function() {
         done();
     });
 
-    it('should set a device id when calling setDeviceId', async function() {
+    it('should set a device id when calling setDeviceId', async () => {
         mParticle._resetForTests(MPConfig);
         
         mParticle.init(apiKey, window.mParticle.config);
@@ -1300,7 +1292,7 @@ describe('core SDK', function() {
         done();
     });
 
-    it('should set the wrapper sdk info in Store when mParticle._setWrapperSDKInfo() method is called after init is called', async function() {
+    it('should set the wrapper sdk info in Store when mParticle._setWrapperSDKInfo() method is called after init is called', async () => {
         mParticle._resetForTests(MPConfig);
 
         mParticle._setWrapperSDKInfo('flutter', '1.0.3');
@@ -1313,7 +1305,7 @@ describe('core SDK', function() {
         mParticle.getInstance()._Store.wrapperSDKInfo.isInfoSet.should.equal(true);
     });
 
-    it('should not set the wrapper sdk info in Store after it has previously been set', async function() {
+    it('should not set the wrapper sdk info in Store after it has previously been set', async () => {
         mParticle._resetForTests(MPConfig);
 
         mParticle._setWrapperSDKInfo('flutter', '1.0.3');

--- a/test/src/tests-forwarders.js
+++ b/test/src/tests-forwarders.js
@@ -1118,7 +1118,7 @@ describe('forwarders', function() {
         done();
     });
 
-    it('should invoke forwarder opt out', async function() {
+    it('should invoke forwarder opt out', async () => {
         mParticle._resetForTests(MPConfig);
         const mockForwarder = new MockForwarder();
 
@@ -2698,7 +2698,7 @@ describe('forwarders', function() {
         done();
     });
 
-    it('should set integration attributes on forwarders', async function() {
+    it('should set integration attributes on forwarders', async () => {
         mParticle.init(apiKey, window.mParticle.config)
 
         await waitForCondition(hasIdentityCallInflightReturned);
@@ -2710,7 +2710,7 @@ describe('forwarders', function() {
         adobeIntegrationAttributes.MCID.should.equal('abcdefg');
     });
 
-    it('should clear integration attributes when an empty object or a null is passed', async function() {
+    it('should clear integration attributes when an empty object or a null is passed', async () => {
         mParticle.init(apiKey, window.mParticle.config)
         await waitForCondition(hasIdentityCallInflightReturned);
 
@@ -2733,7 +2733,7 @@ describe('forwarders', function() {
         Object.keys(adobeIntegrationAttributes).length.should.equal(0);
     });
 
-    it('should set only strings as integration attributes', async function() {
+    it('should set only strings as integration attributes', async () => {
         mParticle.init(apiKey, window.mParticle.config)
         await waitForCondition(hasIdentityCallInflightReturned);
 
@@ -3060,7 +3060,7 @@ describe('forwarders', function() {
 
     
     // This will pass when we add mpInstance._Store.isInitialized = true; to mp-instance before `processIdentityCallback`
-    it('configures forwarders before events are logged via identify callback', async function() {
+    it('configures forwarders before events are logged via identify callback', async () => {
         mParticle._resetForTests(MPConfig);
         window.mParticle.config.identifyRequest = {
             userIdentities: {

--- a/test/src/tests-helpers.js
+++ b/test/src/tests-helpers.js
@@ -56,7 +56,7 @@ describe('helpers', function() {
         done();
     });
 
-    it('should return event name in warning when sanitizing invalid attributes', async function() {
+    it('should return event name in warning when sanitizing invalid attributes', async () => {
         await waitForCondition(hasIdentityCallInflightReturned);
         const bond = sinon.spy(mParticle.getInstance().Logger, 'warning');
         mParticle.logEvent('eventName', mParticle.EventType.Location, {invalidValue: {}});
@@ -93,7 +93,7 @@ describe('helpers', function() {
         done();
     });
 
-    it('should return commerce event name in warning when sanitizing invalid attributes', async function() {
+    it('should return commerce event name in warning when sanitizing invalid attributes', async () => {
         await waitForCondition(hasIdentityCallInflightReturned);
 
         const bond = sinon.spy(mParticle.getInstance().Logger, 'warning');

--- a/test/src/tests-kit-blocking.ts
+++ b/test/src/tests-kit-blocking.ts
@@ -1403,7 +1403,7 @@ describe('kit blocking', () => {
                 fetchMock.restore();
             });
 
-            it('should create a proper kitblocker on a self hosted set up', function(done) {
+            it('should create a proper kitblocker on a self hosted set up', async () => {
                 fetchMock.get(`${urls.config}&plan_id=robs_plan&plan_version=1`, {
                     status: 200,
                     body: JSON.stringify({ dataPlanResult: dataPlan }),
@@ -1424,21 +1424,17 @@ describe('kit blocking', () => {
                 window.mParticle.config.kitConfigs.push(forwarderDefaultConfiguration('MockForwarder'));
                 window.mParticle.init(apiKey, window.mParticle.config);
 
+                await waitForCondition(hasIdentifyReturned)
+
                 window.mParticle.logEvent('Blocked event');
 
-                setTimeout(() => {
-                    let event = window.MockForwarder1.instance.receivedEvent;
-                    (event === null).should.equal(true);
-                    
-                    window.mParticle.config.requestConfig = false;
-    
-                    done();
-                    
-                }, 50);
-
+                let event = window.MockForwarder1.instance.receivedEvent;
+                (event === null).should.equal(true);
+                
+                window.mParticle.config.requestConfig = false;
             });
 
-            it('should log an error if the data plan has an error on it', function(done) {
+            it('should log an error if the data plan has an error on it', async () => {
                 const errorMessage = 'This is an error';
 
                 fetchMock.get(`${urls.config}&plan_id=robs_plan&plan_version=1`, {
@@ -1470,12 +1466,10 @@ describe('kit blocking', () => {
                 }
 
                 window.mParticle.init(apiKey, window.mParticle.config);
-                setTimeout(() => {
-                    errorMessages[0].should.equal(errorMessage);
-                    window.mParticle.config.requestConfig = false;
-    
-                    done();
-                }, 50);
+                await waitForCondition(hasIdentifyReturned)
+
+                errorMessages[0].should.equal(errorMessage);
+                window.mParticle.config.requestConfig = false;
             });
         })
     });

--- a/test/src/tests-mparticle-instance-manager.ts
+++ b/test/src/tests-mparticle-instance-manager.ts
@@ -4,10 +4,11 @@ import { expect } from 'chai';
 import { urls, MPConfig } from './config/constants';
 import Utils from './config/utils';
 import { MParticleWebSDK } from '../../src/sdkRuntimeModels';
-const {
+const { 
     findEventFromRequest,
     waitForCondition,
     fetchMockSuccess,
+    hasConfigurationReturned
 } = Utils;
 
 declare global {
@@ -291,29 +292,18 @@ describe('mParticle instance manager', () => {
             fetchMock.restore();
         });
 
-        it('creates multiple instances with their own cookies', done => {
-            // setTimeout to allow config to come back from the beforeEach initialization
-            setTimeout(() => {
-                const cookies1 = window.localStorage.getItem(
-                    'mprtcl-v4_wtTest1'
-                );
-                const cookies2 = window.localStorage.getItem(
-                    'mprtcl-v4_wtTest2'
-                );
-                const cookies3 = window.localStorage.getItem(
-                    'mprtcl-v4_wtTest3'
-                );
+        it('creates multiple instances with their own cookies', async () => {
+            await waitForCondition(hasConfigurationReturned);
+            const cookies1 = window.localStorage.getItem('mprtcl-v4_wtTest1');
+            const cookies2 = window.localStorage.getItem('mprtcl-v4_wtTest2');
+            const cookies3 = window.localStorage.getItem('mprtcl-v4_wtTest3');
 
-                cookies1.includes('apiKey1').should.equal(true);
-                cookies2.includes('apiKey2').should.equal(true);
-                cookies3.includes('apiKey3').should.equal(true);
-
-                done();
-            }, 50);
+            cookies1.includes('apiKey1').should.equal(true);
+            cookies2.includes('apiKey2').should.equal(true);
+            cookies3.includes('apiKey3').should.equal(true);
         });
 
         it('logs events to their own instances', async () => {
-            // setTimeout to allow config to come back from the beforeEach initialization
             await waitForCondition(() => {
                 return (
                     mParticle.getInstance('default_instance')._Store
@@ -323,31 +313,31 @@ describe('mParticle instance manager', () => {
                     mParticle.getInstance('instance3')._Store
                         .configurationLoaded === true
                 );
-            });
+            })
             mParticle.getInstance('default_instance').logEvent('hi1');
             mParticle.getInstance('instance2').logEvent('hi2');
             mParticle.getInstance('instance3').logEvent('hi3');
-
+            
             const instance1Event = returnEventForMPInstance(
                 fetchMock.calls(),
                 'apiKey1',
                 'hi1'
             );
-            instance1Event.should.be.ok();
+            expect(instance1Event).to.be.ok;
 
             const instance2Event = returnEventForMPInstance(
                 fetchMock.calls(),
                 'apiKey2',
                 'hi2'
             );
-            instance2Event.should.be.ok();
+            expect(instance2Event).to.be.ok;
 
             const instance3Event = returnEventForMPInstance(
                 fetchMock.calls(),
                 'apiKey3',
                 'hi3'
             );
-            instance3Event.should.be.ok();
+            expect(instance3Event).to.be.ok;
 
             const instance1EventsFail1 = returnEventForMPInstance(
                 fetchMock.calls(),
@@ -355,45 +345,45 @@ describe('mParticle instance manager', () => {
                 'hi2'
             );
 
-            expect(instance1EventsFail1).not.be.ok;
+            expect(instance1EventsFail1).to.not.be.ok;
 
             const instance1EventsFail2 = returnEventForMPInstance(
                 fetchMock.calls(),
                 'apiKey1',
                 'hi3'
             );
-            expect(instance1EventsFail2).not.be.ok;
+            expect(instance1EventsFail2).to.not.be.ok;
 
             const instance2EventsFail1 = returnEventForMPInstance(
                 fetchMock.calls(),
                 'apiKey2',
                 'hi1'
             );
-            expect(instance2EventsFail1).not.be.ok;
+            expect(instance2EventsFail1).to.not.be.ok;
 
             const instance2EventsFail2 = returnEventForMPInstance(
                 fetchMock.calls(),
                 'apiKey2',
                 'hi3'
             );
-            expect(instance2EventsFail2).not.be.ok;
+            expect(instance2EventsFail2).to.not.be.ok;
 
             const instance3EventsFail1 = returnEventForMPInstance(
                 fetchMock.calls(),
                 'apiKey3',
                 'hi1'
             );
-            expect(instance3EventsFail1).not.be.ok;
+            expect(instance3EventsFail1).to.not.be.ok;
 
             const instance3EventsFail2 = returnEventForMPInstance(
                 fetchMock.calls(),
                 'apiKey3',
                 'hi2'
             );
-            expect(instance3EventsFail2).not.be.ok;
+            expect(instance3EventsFail2).to.not.be.ok;
         });
 
-        it('logs purchase events to their own instances', done => {
+        it('logs purchase events to their own instances', async () => {
             const prodattr1 = {
                 journeyType: 'testjourneytype1',
                 eventMetric1: 'metric2',
@@ -437,74 +427,59 @@ describe('mParticle instance manager', () => {
                 5
             );
 
-            // setTimeout to allow config to come back from the beforeEach initialization
+            await waitForCondition(hasConfigurationReturned);
             mParticle
                 .getInstance()
                 .eCommerce.logPurchase(ta, [product1, product2]);
-            setTimeout(() => {
-                const instance1Event = returnEventForMPInstance(
-                    fetchMock.calls(),
-                    'apiKey1',
-                    'purchase'
-                );
-                let instance2Event = returnEventForMPInstance(
-                    fetchMock.calls(),
-                    'apiKey2',
-                    'purchase'
-                );
-                let instance3Event = returnEventForMPInstance(
-                    fetchMock.calls(),
-                    'apiKey3',
-                    'purchase'
-                );
-                expect(instance1Event).be.ok;
-                expect(instance2Event).not.be.ok;
-                expect(instance3Event).not.be.ok;
 
-                mParticle
-                    .getInstance('instance2')
-                    .eCommerce.logPurchase(
-                        ta,
-                        [product1, product2],
-                        false,
-                        {},
-                        {}
-                    );
+            const instance1Event = returnEventForMPInstance(
+                fetchMock.calls(),
+                'apiKey1',
+                'purchase'
+            );
+            let instance2Event = returnEventForMPInstance(
+                fetchMock.calls(),
+                'apiKey2',
+                'purchase'
+            );
+            let instance3Event = returnEventForMPInstance(
+                fetchMock.calls(),
+                'apiKey3',
+                'purchase'
+            );
+            instance1Event.should.be.ok();
+            expect(instance2Event).to.not.be.ok;
+            expect(instance3Event).to.not.be.ok;
 
-                instance2Event = returnEventForMPInstance(
-                    fetchMock.calls(),
-                    'apiKey2',
-                    'purchase'
-                );
-                instance3Event = returnEventForMPInstance(
-                    fetchMock.calls(),
-                    'apiKey3',
-                    'purchase'
-                );
+            mParticle
+                .getInstance('instance2')
+                .eCommerce.logPurchase(ta, [product1, product2]);
 
-                instance2Event.should.be.ok();
-                expect(instance3Event).not.be.ok;
+            instance2Event = returnEventForMPInstance(
+                fetchMock.calls(),
+                'apiKey2',
+                'purchase'
+            );
+            instance3Event = returnEventForMPInstance(
+                fetchMock.calls(),
+                'apiKey3',
+                'purchase'
+            );
 
-                mParticle
-                    .getInstance('instance3')
-                    .eCommerce.logPurchase(
-                        ta,
-                        [product1, product2],
-                        false,
-                        {},
-                        {}
-                    );
+            expect(instance2Event).to.be.ok;
+            expect(instance3Event).to.not.be.ok;
 
-                instance3Event = returnEventForMPInstance(
-                    fetchMock.calls(),
-                    'apiKey3',
-                    'purchase'
-                );
+            mParticle
+                .getInstance('instance3')
+                .eCommerce.logPurchase(ta, [product1, product2]);
 
-                instance3Event.should.be.ok();
+            instance3Event = returnEventForMPInstance(
+                fetchMock.calls(),
+                'apiKey3',
+                'purchase'
+            );
 
-                done();
-            }, 50);
+            expect(instance3Event).to.be.ok;
         });
     });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
In this PR, there is a lot of cleanup
* The main refactor is in cookie sync.  I removed the `setTimeout` from the mock for `onload` and have it immediately call the callback, to avoid having setTImeout elsewhere in the cookie sync manager which has historically been very flakey. 
* removed `Should` and replaced with `expect`
* used `hasConfigurationReturned` from Utils to keep things DRY
* cleaned up function() {} to () => {} in some places

There is plenty more to do, but I was already going beyond the scope of this jira ticket.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6916