### PR TITLE
refactor: Replace usages of Object.entries

### DIFF
--- a/src/integrationCapture.ts
+++ b/src/integrationCapture.ts
@@ -190,10 +190,13 @@ export default class IntegrationCapture {
             return mappedClickIds;
         }
 
-        for (const [key, value] of Object.entries(clickIds)) {
+        for (const key in clickIds) {
+            if (clickIds.hasOwnProperty(key)) {
+            const value = clickIds[key];
             const mappedKey = mappingList[key]?.mappedKey;
-            if (!isEmpty(mappedKey)) {
-                mappedClickIds[mappedKey] = value;
+                if (!isEmpty(mappedKey)) {
+                    mappedClickIds[mappedKey] = value;
+                }
             }
         }
 
@@ -207,12 +210,11 @@ export default class IntegrationCapture {
     ): Dictionary<string> {
         const processedClickIds: Dictionary<string> = {};
 
-        for (const [key, value] of Object.entries(clickIds)) {
-            const processor = integrationMapping[key]?.processor;
-            if (processor) {
-                processedClickIds[key] = processor(value, url, timestamp);
-            } else {
-                processedClickIds[key] = value;
+        for (const key in clickIds) {
+            if (clickIds.hasOwnProperty(key)) {
+                const value = clickIds[key];
+                const processor = integrationMapping[key]?.processor;
+                processedClickIds[key] = processor ? processor(value, url, timestamp) : value;
             }
         }
 

--- a/src/uploaders.ts
+++ b/src/uploaders.ts
@@ -75,9 +75,11 @@ export class XHRUploader extends AsyncUploader {
 
             xhr.open(method, url);
 
-            Object.entries(headers).forEach(([key, value]) => {
-                xhr.setRequestHeader(key, value);
-            });
+            for (const key in headers) {
+                if (headers.hasOwnProperty(key)) {
+                    xhr.setRequestHeader(key, headers[key]);
+                }
+            }
 
             xhr.send(data);
         });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Replaces usage of `Object.entries` which isn't supported by older browsers and doesn't transpile successfully.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Run automated tests
 - Manually test web sdk, specifically Integration Capture workflow

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7065
