### PR TITLE
fix: Add failsafes for queryStringParser

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -292,14 +292,19 @@ interface URLSearchParamsFallback {
 }
 
 const queryStringParserFallback = (url: string): URLSearchParamsFallback => {
-    let params: Dictionary<string> = {};
+    const params: Dictionary<string> = {};
     const queryString = url.split('?')[1] || '';
     const pairs = queryString.split('&');
 
     pairs.forEach(pair => {
-        var [key, value] = pair.split('=');
-        if (key && value) {
-            params[key] = decodeURIComponent(value || '');
+        const [key, ...valueParts] = pair.split('=');
+        const value = valueParts.join('=');
+        if (key && value !== undefined) {
+            try {
+                params[key] = decodeURIComponent(value || '');
+            } catch (e) {
+                console.error(`Failed to decode value for key ${key}: ${e}`);
+            }
         }
     });
 

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -148,7 +148,7 @@ describe('Utils', () => {
             });
 
             it('should handle non-standard characters or malformed urls', () => {
-                const malformedUrl = 'https://www.example.com?foo=bar&baz=qux&narf=poit&param0=你好&*;<script>alert("hi")</script>&http://a.com/?c=7&d=8#!/asd+/%^^%zz%%%world你好&param1&param2=&param3=%E0%A4%A&param4=value1=value2';
+                const malformedUrl = 'https://www.example.com?foo=bar&baz=qux&mal=%E0%A4%A&narf=poit&param0=你好&*;<script>alert("hi")</script>&http://a.com/?c=7&d=8#!/asd+/%^^%zz%%%world你好&param1&param2=&param3=%E0%A4%A&param4=value1=value2&param5=a%AFc';
                 const keys = [
                     'foo',
                     'narf',

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -146,6 +146,27 @@ describe('Utils', () => {
 
                 expect(queryStringParser(url, [])).toEqual(expectedResult);
             });
+
+            it('should handle non-standard characters or malformed urls', () => {
+                const malformedUrl = 'https://www.example.com?foo=bar&baz=qux&narf=poit&param0=你好&*;<script>alert("hi")</script>&http://a.com/?c=7&d=8#!/asd+/%^^%zz%%%world你好&param1&param2=&param3=%E0%A4%A&param4=value1=value2';
+                const keys = [
+                    'foo',
+                    'narf',
+                    'param0',
+                    'param1',
+                    'param2',
+                    'param3',
+                    'param4'
+                ];
+
+                const expectedResult = {
+                    foo: 'bar',
+                    narf: 'poit',
+                    param0: '你好',
+                };
+
+                expect(queryStringParser(malformedUrl, keys)).toEqual(expectedResult);
+            });
         });
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds handlers to catch potentially malformed urls in `queryStringParser` fallback

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Run automated tests
 - Set up sample app and pass in malformed strings into url as query parameter

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6989
