### PR TITLE
feat: Add listeners for signaling when kit is ready

### DIFF
--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -71,7 +71,6 @@ export default function Forwarders(mpInstance, kitBlocker) {
                     );
                     if (!forwarder.initialized) {
                         mpInstance._preInit.kitListeners[forwarder.id] = {
-                            isInitialized: true,
                             isReady: false,
                             callbackQueue: [],
                         };

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -70,6 +70,12 @@ export default function Forwarders(mpInstance, kitBlocker) {
                         forwarder.userAttributeFilters
                     );
                     if (!forwarder.initialized) {
+                        mpInstance._preInit.kitListeners[forwarder.id] = {
+                            isInitialized: true,
+                            isReady: false,
+                            callbackQueue: [],
+                        };
+
                         forwarder.logger = mpInstance.Logger;
                         forwarder.init(
                             forwarder.settings,

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -124,6 +124,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
         readyQueue: [],
         integrationDelays: {},
         forwarderConstructors: [],
+        kitListeners: {},
     };
     this._IntegrationCapture = new IntegrationCapture();
 
@@ -237,6 +238,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             pixelConfigurations: [],
             integrationDelays: {},
             forwarderConstructors: [],
+            kitListeners: {},
             isDevelopmentMode: false,
         };
     };
@@ -1267,6 +1269,31 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
         }
     };
     // Used by our forwarders
+    this.onKitReady = function(moduleId, callback) {
+        const kitListener = self._preInit.kitListeners[moduleId];
+
+        if (!kitListener) {
+            self.Logger.error('Kit listener not found for moduleId: ' + moduleId);
+            return;
+        }
+
+        kitListener.callbackQueue.push(callback);
+
+        if (kitListener.isReady) {
+            kitListener.callbackQueue.forEach(callback => callback());
+            kitListener.callbackQueue = [];
+        }
+    };
+    this.kitReady = function(moduleId) {
+        const kitListener = self._preInit.kitListeners[moduleId];
+        if (!kitListener) {
+            self.Logger.error('Kit listener not found for moduleId: ' + moduleId);
+            return;
+        }
+        kitListener.isReady = true;
+        kitListener.callbackQueue.forEach(callback => callback());
+        kitListener.callbackQueue = [];
+    };
     this.addForwarder = function(forwarder) {
         self._preInit.forwarderConstructors.push(forwarder);
     };

--- a/src/mparticle-instance-manager.ts
+++ b/src/mparticle-instance-manager.ts
@@ -121,6 +121,12 @@ function mParticleInstanceManager(this: IMParticleInstanceManager) {
     this.setLogLevel = function(newLogLevel) {
         self.getInstance().setLogLevel(newLogLevel);
     };
+    this.onKitReady = function(moduleId, callback) {
+        self.getInstance().onKitReady(moduleId, callback);
+    };
+    this.kitReady = function(moduleId) {
+        self.getInstance().kitReady(moduleId);
+    };
     this.ready = function(argument) {
         self.getInstance().ready(argument);
     };

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -5,7 +5,6 @@ import { isEmpty, isFunction } from './utils';
 
 export interface KitListener {
     isReady: boolean;
-    isInitialized: boolean;
     callbackQueue: Function[];
 }
 

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -3,12 +3,19 @@ import { MPForwarder } from './forwarders.interfaces';
 import { IntegrationDelays } from './mp-instance';
 import { isEmpty, isFunction } from './utils';
 
+export interface KitListener {
+    isReady: boolean;
+    isInitialized: boolean;
+    callbackQueue: Function[];
+}
+
 export interface IPreInit {
     readyQueue: Function[] | any[];
     integrationDelays: IntegrationDelays;
     forwarderConstructors: MPForwarder[];
     pixelConfigurations?: IPixelConfiguration[];
     isDevelopmentMode?: boolean;
+    kitListeners: Record<string, KitListener>;
 }
 
 export const processReadyQueue = (readyQueue): Function[] => {

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -226,6 +226,9 @@ export interface MParticleWebSDK {
     generateHash(value: string): string;
     setIntegrationAttribute(integrationModuleId: number, attrs: IntegrationAttribute): void;
     getIntegrationAttributes(integrationModuleId: number): IntegrationAttribute;
+
+    onKitReady(moduleId: number, callback: Callback): void;
+    kitReady(moduleId: number): void;
 }
 
 // https://go.mparticle.com/work/SQDSDKS-4805

--- a/test/src/tests-core-sdk.js
+++ b/test/src/tests-core-sdk.js
@@ -142,6 +142,14 @@ describe('core SDK', function() {
         expect(readyFuncCalled).equal(true);
     });
 
+    it('should initialize kit listeners when initialized', async () => {
+        mParticle.init(apiKey, window.mParticle.config);
+
+        await waitForCondition(hasIdentityCallInflightReturned);
+
+        expect(mParticle.getInstance()._preInit.kitListeners).eqls({});
+    });
+
     it('should set app version on the payload', function(done) {
         waitForCondition(hasIdentifyReturned)
         .then(() => {

--- a/test/src/tests-forwarders.ts
+++ b/test/src/tests-forwarders.ts
@@ -85,7 +85,7 @@ const mParticle = window.mParticle as unknown as MockMParticleForForwarders;
 
 let mockServer;
 
-describe.only('forwarders', function() {
+describe('forwarders', function() {
     beforeEach(function() {
         mParticle._resetForTests(MPConfig);
         delete mParticle._instances['default_instance'];
@@ -2948,7 +2948,6 @@ describe.only('forwarders', function() {
 
             expect(mParticle.getInstance()._preInit.kitListeners).to.have.key('1');
             expect(mParticle.getInstance()._preInit.kitListeners).eqls({ '1': {
-                isInitialized: true,
                 isReady: false,
                 callbackQueue: [],
             } });
@@ -2967,7 +2966,6 @@ describe.only('forwarders', function() {
 
             expect(mParticle.getInstance()._preInit.kitListeners).to.have.key('1');
             expect(mParticle.getInstance()._preInit.kitListeners).eqls({ '1': {
-                isInitialized: true,
                 isReady: false,
                 callbackQueue: [],
             } });
@@ -2975,7 +2973,6 @@ describe.only('forwarders', function() {
             mParticle.getInstance().kitReady(1);
 
             expect(mParticle.getInstance()._preInit.kitListeners).eqls({ '1': {
-                isInitialized: true,
                 isReady: true,
                 callbackQueue: [],
             } });
@@ -2998,7 +2995,6 @@ describe.only('forwarders', function() {
 
             const kitListeners = mParticle.getInstance()._preInit.kitListeners;
             expect(kitListeners).to.have.property('1');
-            expect(kitListeners['1'].isInitialized, 'isInitialized').to.be.true;
             expect(kitListeners['1'].isReady, 'isReady').to.be.false;
             expect(kitListeners['1'].callbackQueue, 'callbackQueue').to.eql([callback]);
 

--- a/test/src/tests-mparticle-instance-manager.ts
+++ b/test/src/tests-mparticle-instance-manager.ts
@@ -213,6 +213,8 @@ describe('mParticle instance manager', () => {
             'isInitialized',
             'getEnvironment',
             'upload',
+            'onKitReady',
+            'kitReady',
         ]);
     });
 

--- a/test/src/tests-queue-public-methods.js
+++ b/test/src/tests-queue-public-methods.js
@@ -1,6 +1,8 @@
 import { apiKey, MPConfig, testMPID, urls } from './config/constants';
 import { SDKProductActionType } from  '../../src/sdkRuntimeModels';
 import Utils from './config/utils';
+import sinon from 'sinon';
+import { expect } from 'chai';
 
 const { waitForCondition, fetchMockSuccess, hasIdentityCallInflightReturned } = Utils;
 
@@ -319,5 +321,27 @@ describe('Queue Public Methods', function () {
                 mParticle.getInstance()._preInit.readyQueue.length.should.equal(0);
             });
         });	
+
+        describe('#onKitReady', function () {
+            it('should queue if not initialized', function () {
+                mParticle.getInstance()._preInit.readyQueue.length.should.equal(0);
+                const callback = sinon.spy();
+                mParticle.onKitReady(1, callback);
+                expect(callback.called).to.be.false;
+                mParticle.getInstance()._preInit.readyQueue.length.should.equal(1);
+            });
+
+            it.only('should process queue after initialization', async function () {
+                mParticle.getInstance()._preInit.readyQueue.length.should.equal(0);
+                const callback = sinon.spy();
+                mParticle.onKitReady(1, callback);
+                expect(callback.called).to.be.false;
+                mParticle.getInstance()._preInit.readyQueue.length.should.equal(1);
+                mParticle.init(apiKey, window.mParticle.config);
+                await waitForCondition(hasIdentityCallInflightReturned)
+                expect(callback.called).to.be.true;
+                mParticle.getInstance()._preInit.readyQueue.length.should.equal(0);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds a listener to Core SDK that kits can use to publish their ready status for subscribers.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Use a sample app (Ideally React or an SPA) to publish and subscribe ready status.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7130
