### PR TITLE
feat: Add Rokt Wrapper

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -49,6 +49,7 @@ import { IECommerce } from './ecommerce.interfaces';
 import { INativeSdkHelpers } from './nativeSdkHelpers.interfaces';
 import { IPersistence } from './persistence.interfaces';
 import ForegroundTimer from './foregroundTimeTracker';
+import RoktManager from './roktManager';
 
 export interface IErrorLogMessage {
     message?: string;
@@ -80,6 +81,7 @@ export interface IMParticleWebSDKInstance extends MParticleWebSDK {
     _IntegrationCapture: IntegrationCapture;
     _NativeSdkHelpers: INativeSdkHelpers;
     _Persistence: IPersistence;
+    _RoktManager: RoktManager;
     _SessionManager: ISessionManager;
     _ServerModel: IServerModel;
     _Store: IStore;
@@ -126,6 +128,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
         forwarderConstructors: [],
     };
     this._IntegrationCapture = new IntegrationCapture();
+    this._RoktManager = new RoktManager();
 
     // required for forwarders once they reference the mparticle instance
     this.IdentityType = IdentityType;

--- a/src/mparticle-instance-manager.ts
+++ b/src/mparticle-instance-manager.ts
@@ -103,6 +103,9 @@ function mParticleInstanceManager(this: IMParticleInstanceManager) {
             return client;
         }
     };
+
+    this.Rokt = self.getInstance()._RoktManager;
+
     this.getDeviceId = function() {
         return self.getInstance().getDeviceId();
     };

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -33,19 +33,9 @@ export default class RoktManager {
         this.launcher = null;
     }
 
-    public attachLauncher(launcher: IRoktLauncher): Promise<void> {
-        return new Promise<void>((resolve) => {
-            if (!launcher) {
-                this.queueMessage({
-                    methodName: 'attachLauncher',
-                    payload: launcher,
-                });
-            } else {
-                this.setLauncher(launcher);
-                this.processMessageQueue();
-            }
-            resolve();
-        });
+    public attachLauncher(launcher: IRoktLauncher): void {
+        this.setLauncher(launcher);
+        this.processMessageQueue();
     }
 
     public selectPlacements(options: IRoktSelectPlacementsOptions): Promise<IRoktSelection> {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -4,19 +4,20 @@ export interface IRoktPartnerAttributes {
 }
 
 // https://docs.rokt.com/developers/integration-guides/web/library/select-placements-options
-export interface ISelectPlacementsOptions {
+export interface IRoktSelectPlacementsOptions {
     attributes: IRoktPartnerAttributes;
     identifier?: string;
 }
 
-export interface ISelection {
-    placementId?: string;
-    status?: string;
-    error?: string;
+interface IRoktPlacement {}
+
+export interface IRoktSelection {
+    close: () => void;
+    getPlacements: () => Promise<IRoktPlacement[]>;
 }
 
 export interface IRoktLauncher {
-    selectPlacements: (options: ISelectPlacementsOptions) => Promise<ISelection>;
+    selectPlacements: (options: IRoktSelectPlacementsOptions) => Promise<IRoktSelection>;
 }
 
 export interface IRoktMessage {
@@ -25,7 +26,7 @@ export interface IRoktMessage {
 }
 
 export default class RoktManager {
-    private launcher: IRoktLauncher | null = null;
+    public launcher: IRoktLauncher | null = null;
     private messageQueue: IRoktMessage[] = [];
 
     constructor() {
@@ -47,13 +48,13 @@ export default class RoktManager {
         });
     }
 
-    public selectPlacements(options: ISelectPlacementsOptions): Promise<ISelection> {
+    public selectPlacements(options: IRoktSelectPlacementsOptions): Promise<IRoktSelection> {
         if (!this.launcher) {
             this.queueMessage({
                 methodName: 'selectPlacements',
                 payload: options,
             });
-            return Promise.resolve({});
+            return Promise.resolve({} as IRoktSelection);
         }
 
         try {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -1,7 +1,9 @@
+// https://docs.rokt.com/developers/integration-guides/web/library/attributes
 export interface IRoktPartnerAttributes {
     [key: string]: string | number | boolean | undefined | null;
 }
 
+// https://docs.rokt.com/developers/integration-guides/web/library/select-placements-options
 export interface ISelectPlacementsOptions {
     attributes: IRoktPartnerAttributes;
     identifier?: string;

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -1,0 +1,83 @@
+export interface IRoktPartnerAttributes {
+    [key: string]: string | number | boolean | undefined | null;
+}
+
+export interface ISelectPlacementsOptions {
+    attributes: IRoktPartnerAttributes;
+    identifier?: string;
+}
+
+export interface ISelection {
+    placementId?: string;
+    status?: string;
+    error?: string;
+}
+
+export interface IRoktLauncher {
+    selectPlacements: (options: ISelectPlacementsOptions) => Promise<ISelection>;
+}
+
+export interface IRoktMessage {
+    methodName: string;
+    payload: any;
+}
+
+export default class RoktManager {
+    private launcher: IRoktLauncher | null = null;
+    private messageQueue: IRoktMessage[] = [];
+
+    constructor() {
+        this.launcher = null;
+    }
+
+    public attachLauncher(launcher: IRoktLauncher): Promise<void> {
+        return new Promise<void>((resolve) => {
+            if (!launcher) {
+                this.queueMessage({
+                    methodName: 'attachLauncher',
+                    payload: launcher,
+                });
+            } else {
+                this.setLauncher(launcher);
+                this.processMessageQueue();
+            }
+            resolve();
+        });
+    }
+
+    public selectPlacements(options: ISelectPlacementsOptions): Promise<ISelection> {
+        if (!this.launcher) {
+            this.queueMessage({
+                methodName: 'selectPlacements',
+                payload: options,
+            });
+            return Promise.resolve({});
+        }
+
+        try {
+            return this.launcher.selectPlacements(options);
+        } catch (error) {
+            return Promise.reject(error instanceof Error ? error : new Error('Unknown error occurred'));
+        }
+    }
+
+    private processMessageQueue(): void {
+        if (this.messageQueue.length > 0) {
+            this.messageQueue.forEach(async (message) => {
+                if (this.launcher && message.methodName in this.launcher) {
+                    await (this.launcher[message.methodName] as Function)(message.payload);
+                }
+            });
+            this.messageQueue = [];
+        }
+    }
+    
+
+    private queueMessage(message: IRoktMessage): void {
+        this.messageQueue.push(message);
+    }
+
+    private setLauncher(launcher: IRoktLauncher): void {
+        this.launcher = launcher;
+    }
+}

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -39,6 +39,7 @@ import _BatchValidator from './mockBatchCreator';
 import {  SDKECommerceAPI } from './ecommerce.interfaces';
 import { IErrorLogMessage, IMParticleWebSDKInstance, IntegrationDelays } from './mp-instance';
 import Constants from './constants';
+import RoktManager from './roktManager';
 
 // TODO: Resolve this with version in @mparticle/web-sdk
 export type SDKEventCustomFlags = Dictionary<any>;
@@ -242,6 +243,7 @@ export interface IMParticleInstanceManager extends MParticleWebSDK {
     config: SDKInitConfig;
     isIOS?: boolean;
     MPSideloadedKit: typeof MPSideloadedKit;
+    Rokt: RoktManager;
     // https://go.mparticle.com/work/SQDSDKS-7060
     sessionManager: Pick<ISessionManager, 'getSession'>; 
     Store: IStore;

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -24,26 +24,21 @@ describe('RoktManager', () => {
             expect(roktManager['launcher']).not.toBeNull();
         });
 
-        it('should queue the launcher method if no launcher is attached', () => {
-            roktManager.attachLauncher(null);
-            expect(roktManager['launcher']).toBeNull();
-            expect(roktManager['messageQueue'].length).toBe(1);
-            expect(roktManager['messageQueue'][0].methodName).toBe('attachLauncher');
-            expect(roktManager['messageQueue'][0].payload).toBe(null);
-        });
-
         it('should process the message queue if a launcher is attached', () => {
-            const launcher = jest.fn() as unknown as IRoktLauncher;
+            const launcher = {
+                selectPlacements: jest.fn()
+            } as unknown as IRoktLauncher;
+            
+            roktManager.selectPlacements({} as IRoktSelectPlacementsOptions);
+            roktManager.selectPlacements({} as IRoktSelectPlacementsOptions);
+            roktManager.selectPlacements({} as IRoktSelectPlacementsOptions);
 
-            roktManager.attachLauncher(null);
-            expect(roktManager['launcher']).toBeNull();
-            expect(roktManager['messageQueue'].length).toBe(1);
-            expect(roktManager['messageQueue'][0].methodName).toBe('attachLauncher');
-            expect(roktManager['messageQueue'][0].payload).toBe(null);
+            expect(roktManager['messageQueue'].length).toBe(3);
 
             roktManager.attachLauncher(launcher);
             expect(roktManager['launcher']).not.toBeNull();
             expect(roktManager['messageQueue'].length).toBe(0);
+            expect(launcher.selectPlacements).toHaveBeenCalledTimes(3);
         });
     });
 

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -1,4 +1,4 @@
-import RoktManager, { IRoktLauncher, ISelectPlacementsOptions } from "../../src/roktManager";
+import RoktManager, { IRoktLauncher, IRoktSelectPlacementsOptions } from "../../src/roktManager";
 
 describe('RoktManager', () => {
     let roktManager: RoktManager;
@@ -56,7 +56,7 @@ describe('RoktManager', () => {
             roktManager.attachLauncher(launcher);
             const options = {
                 attributes: {}
-            } as ISelectPlacementsOptions;
+            } as IRoktSelectPlacementsOptions;
 
             roktManager.selectPlacements(options);
             expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
@@ -69,7 +69,7 @@ describe('RoktManager', () => {
 
             roktManager.attachLauncher(launcher);
 
-            const options: ISelectPlacementsOptions = {
+            const options: IRoktSelectPlacementsOptions = {
                 attributes: {
                     age: 25,
                     score: 100.5,
@@ -86,7 +86,7 @@ describe('RoktManager', () => {
         it('should queue the selectPlacements method if no launcher is attached', () => {
             const options = {
                 attributes: {}
-            } as ISelectPlacementsOptions;
+            } as IRoktSelectPlacementsOptions;
 
             roktManager.selectPlacements(options);
 
@@ -103,7 +103,7 @@ describe('RoktManager', () => {
 
             const options = {
                 attributes: {}
-            } as ISelectPlacementsOptions;
+            } as IRoktSelectPlacementsOptions;
 
             roktManager.selectPlacements(options);
             expect(roktManager['launcher']).toBeNull();

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -11,6 +11,7 @@ describe('RoktManager', () => {
         it('should be initialized', () => {
             expect(roktManager).toBeDefined();
         });
+
         it('should have a null launcher', () => {
             expect(roktManager['launcher']).toBeNull();
         });

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -48,10 +48,10 @@ describe('RoktManager', () => {
     });
 
     describe('#selectPlacements', () => {
-        it('should call selectPlacements', () => {
-            const launcher = {
+        it('should call launcher.selectPlacements with empty attributes', () => {
+            const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
-            } as unknown as IRoktLauncher;
+            };
 
             roktManager.attachLauncher(launcher);
             const options = {
@@ -62,10 +62,10 @@ describe('RoktManager', () => {
             expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
 
-        it('should call selectPlacements with any passed in attributes', () => {
-            const launcher = {
+        it('should call launcher.selectPlacements with passed in attributes', () => {
+            const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
-            } as unknown as IRoktLauncher;
+            };
 
             roktManager.attachLauncher(launcher);
 
@@ -97,9 +97,9 @@ describe('RoktManager', () => {
         });
 
         it('should process queued selectPlacements calls once the launcher is attached', () => {
-            const launcher = {
+            const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
-            } as unknown as IRoktLauncher;
+            };
 
             const options = {
                 attributes: {}

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -25,9 +25,9 @@ describe('RoktManager', () => {
         });
 
         it('should process the message queue if a launcher is attached', () => {
-            const launcher = {
+            const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
-            } as unknown as IRoktLauncher;
+            };
             
             roktManager.selectPlacements({} as IRoktSelectPlacementsOptions);
             roktManager.selectPlacements({} as IRoktSelectPlacementsOptions);

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -1,0 +1,119 @@
+import RoktManager, { IRoktLauncher, ISelectPlacementsOptions } from "../../src/roktManager";
+
+describe('RoktManager', () => {
+    let roktManager: RoktManager;
+
+    beforeEach(() => {
+        roktManager = new RoktManager();
+    });
+
+    describe('constructor', () => {
+        it('should be initialized', () => {
+            expect(roktManager).toBeDefined();
+        });
+        it('should have a null launcher', () => {
+            expect(roktManager['launcher']).toBeNull();
+        });
+    });
+
+    describe('#attachLauncher', () => {
+        it('should attach a launcher', () => {
+            const launcher = {} as IRoktLauncher;
+            roktManager.attachLauncher(launcher);
+            expect(roktManager['launcher']).not.toBeNull();
+        });
+
+        it('should queue the launcher method if no launcher is attached', () => {
+            roktManager.attachLauncher(null);
+            expect(roktManager['launcher']).toBeNull();
+            expect(roktManager['messageQueue'].length).toBe(1);
+            expect(roktManager['messageQueue'][0].methodName).toBe('attachLauncher');
+            expect(roktManager['messageQueue'][0].payload).toBe(null);
+        });
+
+        it('should process the message queue if a launcher is attached', () => {
+            const launcher = jest.fn() as unknown as IRoktLauncher;
+
+            roktManager.attachLauncher(null);
+            expect(roktManager['launcher']).toBeNull();
+            expect(roktManager['messageQueue'].length).toBe(1);
+            expect(roktManager['messageQueue'][0].methodName).toBe('attachLauncher');
+            expect(roktManager['messageQueue'][0].payload).toBe(null);
+
+            roktManager.attachLauncher(launcher);
+            expect(roktManager['launcher']).not.toBeNull();
+            expect(roktManager['messageQueue'].length).toBe(0);
+        });
+    });
+
+    describe('#selectPlacements', () => {
+        it('should call selectPlacements', () => {
+            const launcher = {
+                selectPlacements: jest.fn()
+            } as unknown as IRoktLauncher;
+
+            roktManager.attachLauncher(launcher);
+            const options = {
+                attributes: {}
+            } as ISelectPlacementsOptions;
+
+            roktManager.selectPlacements(options);
+            expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
+        });
+
+        it('should call selectPlacements with any passed in attributes', () => {
+            const launcher = {
+                selectPlacements: jest.fn()
+            } as unknown as IRoktLauncher;
+
+            roktManager.attachLauncher(launcher);
+
+            const options: ISelectPlacementsOptions = {
+                attributes: {
+                    age: 25,
+                    score: 100.5,
+                    isSubscribed: true,
+                    isActive: false,
+                    interests: 'sports,music,books'
+                }
+            };
+
+            roktManager.selectPlacements(options);
+            expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
+        });
+
+        it('should queue the selectPlacements method if no launcher is attached', () => {
+            const options = {
+                attributes: {}
+            } as ISelectPlacementsOptions;
+
+            roktManager.selectPlacements(options);
+
+            expect(roktManager['launcher']).toBeNull();
+            expect(roktManager['messageQueue'].length).toBe(1);
+            expect(roktManager['messageQueue'][0].methodName).toBe('selectPlacements');
+            expect(roktManager['messageQueue'][0].payload).toBe(options);
+        });
+
+        it('should process queued selectPlacements calls once the launcher is attached', () => {
+            const launcher = {
+                selectPlacements: jest.fn()
+            } as unknown as IRoktLauncher;
+
+            const options = {
+                attributes: {}
+            } as ISelectPlacementsOptions;
+
+            roktManager.selectPlacements(options);
+            expect(roktManager['launcher']).toBeNull();
+            expect(roktManager['messageQueue'].length).toBe(1);
+            expect(roktManager['messageQueue'][0].methodName).toBe('selectPlacements');
+            expect(roktManager['messageQueue'][0].payload).toBe(options);
+
+            roktManager.attachLauncher(launcher);
+            expect(roktManager['launcher']).not.toBeNull();
+            expect(roktManager['messageQueue'].length).toBe(0);
+            expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
+        });
+    });
+});

--- a/test/src/tests-mparticle-instance-manager.ts
+++ b/test/src/tests-mparticle-instance-manager.ts
@@ -213,6 +213,7 @@ describe('mParticle instance manager', () => {
             'isInitialized',
             'getEnvironment',
             'upload',
+            'Rokt',
         ]);
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Introduces a wrapper class for the Rokt SDK to allow integrations and partners to access Rokt functionality via the mParticle Web SDK.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, attempt to access the `window.mParticle.Rokt.selectPlacements()` method.
 - Add the [Rokt Web SDK](https://docs.rokt.com/developers/integration-guides/web/best-practices/) to your sample app and attempt to attach the launcher through `window.mParticle.Rokt.attachLauncher()`.
 - `selectPlacement` requests should be queued until the launcher is attached, which will then trigger Rokt's `selectPlacements` logic.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
