### PR TITLE
refactor: Create Distinct Kit Interfaces

### DIFF
--- a/src/forwarders.interfaces.ts
+++ b/src/forwarders.interfaces.ts
@@ -26,7 +26,7 @@ export interface RegisteredKit {
     constructor: () => void;
 
     // Applies to sideloaded kits only
-    filters: IKitFilterSettings;
+    filters?: IKitFilterSettings;
 }
 
 // This is the subset of the SDKConfig.kits object that is used to register kits.
@@ -38,6 +38,7 @@ export interface KitRegistrationConfig {
 export interface ConfiguredKit
     extends Omit<IKitConfigs, 'isDebugString' | 'hasDebugString'> {
     common: Dictionary<unknown>;
+    id: number;
     init(
         settings: Dictionary<unknown>,
         service: forwardingStatsCallback,

--- a/src/forwarders.interfaces.ts
+++ b/src/forwarders.interfaces.ts
@@ -1,6 +1,6 @@
 import { SDKEvent, SDKEventCustomFlags } from './sdkRuntimeModels';
 import { Dictionary } from './utils';
-import { IKitConfigs } from './configAPIClient';
+import { IKitConfigs, IKitFilterSettings } from './configAPIClient';
 import { IdentityApiData } from '@mparticle/web-sdk';
 import {
     IMParticleUser,
@@ -8,22 +8,30 @@ import {
     UserAttributes,
 } from './identity-user-interfaces';
 
-// TODO: https://go.mparticle.com/work/SQDSDKS-6035
-export type Kit = Dictionary;
+// TODO: https://go.mparticle.com/work/SQDSDKS-4475
 export type MPForwarder = Dictionary;
 
 // The state of the kit when accessed via window.KitName via CDN
 // or imported as an NPM package
 export interface UnregisteredKit {
-    register(config): void;
+    constructor: () => void;
+    register(config: KitRegistrationConfig): void;
+    name: string;
+    suffix?: string;
 }
 
 // The state of the kit after being added to forwarderConstructors in the CDN
 // or after registered to SDKConfig.kits via NPM
 export interface RegisteredKit {
-    constructor(): void;
-    name: string;
-    getId(): number;
+    constructor: () => void;
+
+    // Applies to sideloaded kits only
+    filters: IKitFilterSettings;
+}
+
+// This is the subset of the SDKConfig.kits object that is used to register kits.
+export interface KitRegistrationConfig {
+    kits: Dictionary<RegisteredKit>;
 }
 
 // The state of the kit after being configured. This is what the kit looks like when acted on.
@@ -45,22 +53,22 @@ export interface ConfiguredKit
     onIdentifyComplete(
         user: IMParticleUser,
         filteredIdentityRequest: IdentityApiData
-    ): string | KitMappedMethodFailure;
+    ): string;
     onLoginComplete(
         user: IMParticleUser,
         filteredIdentityRequest: IdentityApiData
-    ): string | KitMappedMethodFailure;
+    ): string;
     onLogoutComplete(
         user: IMParticleUser,
         filteredIdentityRequest: IdentityApiData
-    ): string | KitMappedMethodFailure;
+    ): string;
     onModifyComplete(
         user: IMParticleUser,
         filteredIdentityRequest: IdentityApiData
-    ): string | KitMappedMethodFailure;
-    onUserIdentified(user: IMParticleUser): string | KitMappedMethodFailure;
+    ): string;
+    onUserIdentified(user: IMParticleUser): string;
     process(event: SDKEvent): string;
-    setOptOut(isOptingOut: boolean): string | KitMappedMethodFailure;
+    setOptOut(isOptingOut: boolean): string;
     removeUserAttribute(key: string): string;
     setUserAttribute(key: string, value: string): string;
     setUserIdentity(id: UserIdentityId, type: UserIdentityType): void;
@@ -68,9 +76,6 @@ export interface ConfiguredKit
     // TODO: https://go.mparticle.com/work/SQDSDKS-5156
     isSandbox: boolean;
     hasSandbox: boolean;
-}
-export interface KitMappedMethodFailure {
-    error: string;
 }
 
 export type UserIdentityId = string;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -14,7 +14,7 @@ import { IKitConfigs } from './configAPIClient';
 import { SDKConsentApi, SDKConsentState } from './consent';
 import MPSideloadedKit from './sideloadedKit';
 import { ISessionManager } from './sessionManager';
-import { Kit, MPForwarder } from './forwarders.interfaces';
+import { ConfiguredKit, MPForwarder, UnregisteredKit } from './forwarders.interfaces';
 import {
     SDKIdentityApi,
     IAliasCallback,
@@ -164,7 +164,7 @@ export interface SDKProduct {
 
 // https://go.mparticle.com/work/SQDSDKS-6949
 export interface MParticleWebSDK {
-    addForwarder(mockForwarder: MPForwarder): void;
+    addForwarder(forwarder: UnregisteredKit): void;
     IdentityType: typeof IdentityType;
     CommerceEventType: typeof CommerceEventType;
     EventType: typeof EventType;
@@ -181,7 +181,7 @@ export interface MParticleWebSDK {
     configurePixel(config: IPixelConfiguration): void;
     endSession(): void;
     init(apiKey: string, config: SDKInitConfig, instanceName?: string): void;
-    _getActiveForwarders(): MPForwarder[];
+    _getActiveForwarders(): ConfiguredKit[];
     _getIntegrationDelays(): IntegrationDelays;
     _setIntegrationDelay(module: number, shouldDelayIntegration: boolean): void;
     _setWrapperSDKInfo(name: WrapperSDKTypes, version: string): void;
@@ -271,7 +271,7 @@ export interface SDKInitConfig
     logLevel?: LogLevelType;
 
     kitConfigs?: IKitConfigs[];
-    kits?: Dictionary<Kit>;
+    kits?: Dictionary<UnregisteredKit>;
     sideloadedKits?: MPForwarder[];
     dataPlanOptions?: KitBlockerOptions;
     flags?: Dictionary;

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,7 +30,7 @@ import {
     returnConvertedBoolean,
 } from './utils';
 import { IMinifiedConsentJSONObject, SDKConsentState } from './consent';
-import { Kit, MPForwarder } from './forwarders.interfaces';
+import { ConfiguredKit, MPForwarder, UnregisteredKit } from './forwarders.interfaces';
 import { IdentityCallback, UserAttributes } from './identity-user-interfaces';
 import {
     IGlobalStoreV2MinifiedKeys,
@@ -61,7 +61,7 @@ export interface SDKConfig {
     package?: string;
     flags?: IFeatureFlags;
     kitConfigs: IKitConfigs[];
-    kits: Dictionary<Kit>;
+    kits: Dictionary<UnregisteredKit>;
     logLevel?: LogLevelType;
     cookieDomain?: string;
     maxCookieSize?: number | undefined;
@@ -176,7 +176,7 @@ export interface IStore {
     isLocalStorageAvailable: boolean | null;
     storageName: string | null;
     prodStorageName: string | null;
-    activeForwarders: MPForwarder[];
+    activeForwarders: ConfiguredKit[];
     kits: Dictionary<MPForwarder>;
     sideloadedKits: MPForwarder[];
     configuredForwarders: MPForwarder[];

--- a/test/jest/sideloadedKit.spec.ts
+++ b/test/jest/sideloadedKit.spec.ts
@@ -5,7 +5,9 @@ import { UnregisteredKit } from '../../src/forwarders.interfaces';
 import { IKitFilterSettings } from '../../src/configAPIClient';
 
 const mockKitInstance: UnregisteredKit = {
-    register: function() {}
+    register: function() {},
+    name: 'mock-kit',
+    constructor: function() {},
 };
 
 describe('MPSideloadedKit', () => {

--- a/test/jest/utils.ts
+++ b/test/jest/utils.ts
@@ -1,5 +1,4 @@
-import { ConfiguredKit, KitRegistrationConfig, RegisteredKit, UnregisteredKit } from "../../src/forwarders.interfaces";
-import { SDKInitConfig } from "../../src/sdkRuntimeModels";
+import { KitRegistrationConfig, RegisteredKit, UnregisteredKit } from "../../src/forwarders.interfaces";
 
 // export interface IMockForwarder {
 

--- a/test/jest/utils.ts
+++ b/test/jest/utils.ts
@@ -41,7 +41,7 @@ export class MockForwarder {
         if (config.kits) {
             config.kits[this.name] = {
                 constructor: this.constructor as () => RegisteredKit,
-            } as unknown as RegisteredKit;
+            };
         }
     }
 

--- a/test/jest/utils.ts
+++ b/test/jest/utils.ts
@@ -1,4 +1,4 @@
-import { UnregisteredKit } from "../../src/forwarders.interfaces";
+import { ConfiguredKit, KitRegistrationConfig, RegisteredKit, UnregisteredKit } from "../../src/forwarders.interfaces";
 import { SDKInitConfig } from "../../src/sdkRuntimeModels";
 
 // export interface IMockForwarder {
@@ -37,11 +37,11 @@ export class MockForwarder {
         this.moduleId = id || 1;
     }
 
-    public register = (config: SDKInitConfig): void => {
+    public register = (config: KitRegistrationConfig): void => {
         if (config.kits) {
             config.kits[this.name] = {
-                constructor: this.constructor,
-            };
+                constructor: this.constructor as () => RegisteredKit,
+            } as unknown as RegisteredKit;
         }
     }
 

--- a/test/jest/utils.ts
+++ b/test/jest/utils.ts
@@ -1,13 +1,5 @@
 import { KitRegistrationConfig, RegisteredKit, UnregisteredKit } from "../../src/forwarders.interfaces";
 
-// export interface IMockForwarder {
-
-// }
-
-// export interface IMockForwarderConstructor {
-//     new(unregisteredKitInstance: MockForwarder): IMockForwarder;
-// }
-
 export class MockForwarder {
     public name: string;
     public moduleId: number;
@@ -68,129 +60,12 @@ export class MockForwarder {
         this.appName = appName;
         this.settings = settings;
         this.testMode = testMode;
-        // mParticle.userAttributesFilterOnInitTest = userAttributes;
-        // mParticle.userIdentitiesFilterOnInitTest = userIdentities;
     })
 }
 
-// export const MockForwarder = function(forwarderName, forwarderId) {
-        // var constructor = function() {
-        //     var self = this;
-        //     this.id = forwarderId || 1;
-        //     this.initCalled = false;
-        //     this.processCalled = false;
-        //     this.setUserIdentityCalled = false;
-        //     this.onUserIdentifiedCalled = false;
-        //     this.setOptOutCalled = false;
-        //     this.setUserAttributeCalled = false;
-        //     this.reportingService = null;
-        //     this.name = forwarderName || 'MockForwarder';
-        //     this.userAttributeFilters = [];
-        //     this.setUserIdentityCalled = false;
-        //     this.removeUserAttributeCalled = false;
-        //     this.receivedEvent = null;
-        //     this.isVisible = false;
-        //     this.logOutCalled = false;
-
-        //     this.trackerId = null;
-        //     this.userAttributes = {};
-        //     this.userIdentities = null;
-        //     this.appVersion = null;
-        //     this.appName = null;
-
-        //     this.logOut = function() {
-        //         this.logOutCalled = true;
-        //     };
-
-        //     this.init = function(
-        //         settings,
-        //         reportingService,
-        //         testMode,
-        //         id,
-        //         userAttributes,
-        //         userIdentities,
-        //         appVersion,
-        //         appName
-        //     ) {
-        //         self.reportingService = reportingService;
-        //         self.initCalled = true;
-
-        //         self.trackerId = id;
-        //         self.userAttributes = userAttributes;
-        //         mParticle.userAttributesFilterOnInitTest = userAttributes;
-        //         mParticle.userIdentitiesFilterOnInitTest = userIdentities;
-        //         self.userIdentities = userIdentities;
-        //         self.appVersion = appVersion;
-        //         self.appName = appName;
-        //         self.settings = settings;
-        //         self.testMode = testMode;
-        //     };
-
-        //     this.process = function(event) {
-        //         self.processCalled = true;
-        //         this.receivedEvent = event;
-        //         self.reportingService(self, event);
-        //         self.logger.verbose(event.EventName + ' sent');
-        //     };
-
-        //     this.setUserIdentity = function(a, b) {
-        //         this.userIdentities = {};
-        //         this.userIdentities[b] = a;
-        //         self.setUserIdentityCalled = true;
-        //     };
-
-        //     this.settings = {
-        //         PriorityValue: 1,
-        //     };
-
-        //     this.setOptOut = function() {
-        //         this.setOptOutCalled = true;
-        //     };
-
-        //     this.onUserIdentified = function(user) {
-        //         this.onUserIdentifiedCalled = true;
-        //         this.onUserIdentifiedUser = user;
-        //     };
-
-        //     this.onIdentifyComplete = function(user) {
-        //         this.onIdentifyCompleteCalled = true;gs
-        //         this.onIdentifyCompleteUser = user;
-        //     };
-
-        //     this.onLoginComplete = function(user) {
-        //         this.onLoginCompleteCalled = true;
-        //         this.onLoginCompleteUser = user;
-        //     };
-
-        //     this.onLogoutComplete = function(user) {
-        //         this.onLogoutCompleteCalled = true;
-        //         this.onLogoutCompleteUser = user;
-        //     };
-
-        //     this.onModifyComplete = function(user) {
-        //         this.onModifyCompleteCalled = true;
-        //         this.onModifyCompleteUser = user;
-        //     };
-
-        //     this.setUserAttribute = function(key, value) {
-        //         this.setUserAttributeCalled = true;
-        //         this.userAttributes[key] = value;
-        //     };
-
-        //     this.removeUserAttribute = function(key) {
-        //         this.removeUserAttributeCalled = true;
-        //         delete this.userAttributes[key]
-        //     };
-
-        //     window[this.name + this.id] = {
-        //         instance: this,
-        //     };
-        // };
 export const MockSideloadedKit = MockForwarder;
 
-export interface IMockSideloadedKit extends MockForwarder {
-
-}
+export interface IMockSideloadedKit extends MockForwarder {}
 
 export interface IMockSideloadedKitConstructor {
     new(unregisteredKitInstance: UnregisteredKit): IMockSideloadedKit;


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Defines specific interfaces for Kits:
 - UnregisteredKit - The state of a kit when imported via a kit config via NPM/CDN
 - RegisteredKit - A kit that has a constructor and is assigned to the forwarderConstructors data structure and can be configured
 - ConfiguredKit - the "final" state of a kit where it can be acted upon by the SDK

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - N/A - this just changes kit interfaces within the SDK

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6035
