### PR TITLE
fix: Add app name, version, package to AST background event

### DIFF
--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -151,6 +151,9 @@ export class BatchUploader {
         const { getCurrentUser } = Identity;
 
         const event = {
+            AppName: SDKConfig.appName,
+            AppVersion: SDKConfig.appVersion,
+            Package: SDKConfig.package,
             EventDataType: MessageType.AppStateTransition,
             Timestamp: now,
             SessionId: sessionId,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Because the AST background event is added as the last event in the batch, and the batch converter takes values from the last event to append to the batch, we need to ensure the AST background event has ALL of the keys that the batch needs to prevent any batch that includes this AST from having a blank key that should be populated.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Added unit tests and did local testing to confirm all values come abck

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7145