### PR TITLE
fix: Fix context reference in PreInit.processPreloadedItem

### DIFF
--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -30,16 +30,21 @@ const processPreloadedItem = (readyQueueItem): void => {
 
     // if the first argument is a method on the base mParticle object, run it
     if (typeof window !== 'undefined' && window.mParticle && window.mParticle[args[0]]) {
-        window.mParticle[method].apply(this, args);
-        // otherwise, the method is on either eCommerce or Identity objects, ie. "eCommerce.setCurrencyCode", "Identity.login"
+        window.mParticle[method].apply(window.mParticle, args);
     } else {
         const methodArray = method.split('.');
         try {
             let computedMPFunction = window.mParticle;
+            let context = window.mParticle;
+            
+            // Track both the function and its context
             for (const currentMethod of methodArray) {
+                context = computedMPFunction;  // Keep track of the parent object
                 computedMPFunction = computedMPFunction[currentMethod];
             }
-            ((computedMPFunction as unknown) as Function).apply(this, args);
+            
+            // Apply the function with its proper context
+            ((computedMPFunction as unknown) as Function).apply(context, args);
         } catch (e) {
             throw new Error('Unable to compute proper mParticle function ' + e);
         }

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -31,6 +31,7 @@ const processPreloadedItem = (readyQueueItem): void => {
     // if the first argument is a method on the base mParticle object, run it
     if (typeof window !== 'undefined' && window.mParticle && window.mParticle[args[0]]) {
         window.mParticle[method].apply(window.mParticle, args);
+        // otherwise, the method is on either eCommerce or Identity objects, ie. "eCommerce.setCurrencyCode", "Identity.login"
     } else {
         const methodArray = method.split('.');
         try {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - RoktManager functions passed into `processPreloadedItem` within pre-init-utils calls RoktManager before it is initialized, and the context of `this` is the window, not the Rokt Manager.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Use a sample app with the Rokt Kit and attempt to call `mParticle.Rokt.selectPlacements()` after snippet is loaded but before `mParticle.init` fires

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
