### PR TITLE
feat: Add User Filtering for Rokt Wrapper

### DIFF
--- a/src/forwarders.interfaces.ts
+++ b/src/forwarders.interfaces.ts
@@ -1,7 +1,7 @@
 import { SDKEvent, SDKEventCustomFlags } from './sdkRuntimeModels';
 import { Dictionary } from './utils';
 import { IKitConfigs, IKitFilterSettings } from './configAPIClient';
-import { IdentityApiData } from '@mparticle/web-sdk';
+import { IdentityApiData, IdentityType } from '@mparticle/web-sdk';
 import {
     IMParticleUser,
     ISDKUserIdentity,
@@ -12,16 +12,27 @@ import {
 export type MPForwarder = Dictionary;
 
 // The state of the kit when accessed via window.KitName via CDN
-// or imported as an NPM package
+// or imported as an NPM package but before it goes through the registration process
+// This also applies to sideloaded kits which have not yet been registered
 export interface UnregisteredKit {
     constructor: () => void;
     register(config: KitRegistrationConfig): void;
     name: string;
+
+
+    // Optional Attributes that are not used for sideloaded kits
+
+    // Module ID is used for kits that are provided via CDN or NPM
+    moduleId?: number;
+
+    // Suffix is used for kits that are provided via CDN or NPM
+    // and is used for version pinning of the SDK
     suffix?: string;
 }
 
 // The state of the kit after being added to forwarderConstructors in the CDN
 // or after registered to SDKConfig.kits via NPM
+// Sideloaded Kits would also be considered registere
 export interface RegisteredKit {
     constructor: () => void;
 
@@ -81,6 +92,8 @@ export interface ConfiguredKit
 
 export type UserIdentityId = string;
 export type UserIdentityType = number;
+export type UserAttributeFilters = number[];
+export type UserIdentityFilters = typeof IdentityType[];
 
 export type forwardingStatsCallback = (
     forwarder: ConfiguredKit,

--- a/src/forwarders.interfaces.ts
+++ b/src/forwarders.interfaces.ts
@@ -19,7 +19,6 @@ export interface UnregisteredKit {
     register(config: KitRegistrationConfig): void;
     name: string;
 
-
     // Optional Attributes that are not used for sideloaded kits
 
     // Module ID is used for kits that are provided via CDN or NPM
@@ -32,7 +31,7 @@ export interface UnregisteredKit {
 
 // The state of the kit after being added to forwarderConstructors in the CDN
 // or after registered to SDKConfig.kits via NPM
-// Sideloaded Kits would also be considered registere
+// Sideloaded Kits would also be considered registered
 export interface RegisteredKit {
     constructor: () => void;
 

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -417,7 +417,7 @@ export default function Forwarders(mpInstance, kitBlocker) {
             const forwarderFunction = forwarder[functionNameKey];
             if (
                 !forwarderFunction ||
-                mpInstance._Helpers.isFilteredUserAttribute(
+                KitFilterHelper.isFilteredUserAttribute(
                     key,
                     forwarder.userAttributeFilters
                 )

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -304,55 +304,9 @@ export default function Helpers(mpInstance) {
         return filteredUserIdentities;
     };
 
-    this.filterUserIdentitiesForForwarders = function(
-        userIdentitiesObject,
-        filterList
-    ) {
-        const filteredUserIdentities = {};
-
-        if (userIdentitiesObject && Object.keys(userIdentitiesObject).length) {
-            for (const userIdentityName in userIdentitiesObject) {
-                if (userIdentitiesObject.hasOwnProperty(userIdentityName)) {
-                    const userIdentityType = KitFilterHelper.hashUserIdentity(
-                        Types.IdentityType.getIdentityType(userIdentityName)
-                    );
-                    if (!self.inArray(filterList, userIdentityType)) {
-                        filteredUserIdentities[userIdentityName] =
-                            userIdentitiesObject[userIdentityName];
-                    }
-                }
-            }
-        }
-
-        return filteredUserIdentities;
-    };
-
-    this.filterUserAttributes = function(userAttributes, filterList) {
-        var filteredUserAttributes = {};
-
-        if (userAttributes && Object.keys(userAttributes).length) {
-            for (var userAttribute in userAttributes) {
-                if (userAttributes.hasOwnProperty(userAttribute)) {
-                    const hashedUserAttribute = KitFilterHelper.hashUserAttribute(
-                        userAttribute
-                    );
-                    if (!self.inArray(filterList, hashedUserAttribute)) {
-                        filteredUserAttributes[userAttribute] =
-                            userAttributes[userAttribute];
-                    }
-                }
-            }
-        }
-
-        return filteredUserAttributes;
-    };
-
-    this.isFilteredUserAttribute = function(userAttributeKey, filterList) {
-        const hashedUserAttribute = KitFilterHelper.hashUserAttribute(
-            userAttributeKey
-        );
-        return filterList && self.inArray(filterList, hashedUserAttribute);
-    };
+    this.filterUserIdentitiesForForwarders =
+        KitFilterHelper.filterUserIdentities;
+    this.filterUserAttributes = KitFilterHelper.filterUserAttributes;
 
     this.isEventType = function(type) {
         for (var prop in Types.EventType) {

--- a/src/kitFilterHelper.ts
+++ b/src/kitFilterHelper.ts
@@ -1,4 +1,4 @@
-import { generateHash, valueof } from "./utils";
+import { Dictionary, generateHash, inArray, valueof, filterDictionaryWithHash } from "./utils";
 // TODO: https://mparticle-eng.atlassian.net/browse/SQDSDKS-5381
 import { EventType, IdentityType } from "./types";
 
@@ -43,4 +43,20 @@ export default class KitFilterHelper {
     static hashConsentPurposeConditionalForwarding(prefix: string, purpose: string): string {
         return this.hashConsentPurpose(prefix, purpose).toString();
     }
+
+    static readonly filterUserAttributes = (userAttributes: Dictionary<string>, filterList: number[]): Dictionary<string> => {
+        return filterDictionaryWithHash(userAttributes, filterList, (key: string) => this.hashUserAttribute(key));
+    }
+
+    static readonly filterUserIdentities = (userIdentities: Dictionary<string>, filterList: number[]): Dictionary<string> => {
+        return filterDictionaryWithHash(userIdentities, filterList, (key: string) => this.hashUserIdentity(
+            IdentityType.getIdentityType(key)
+        ));
+    }
+    
+    static readonly isFilteredUserAttribute = (userAttributeKey: string, filterList: number[]): boolean => {
+        const hashedUserAttribute = this.hashUserAttribute(userAttributeKey);
+        return filterList && inArray(filterList, hashedUserAttribute);
+    }
+        
 }

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -36,7 +36,7 @@ import Consent, { IConsent } from './consent';
 import KitBlocker from './kitBlocking';
 import ConfigAPIClient, { IKitConfigs } from './configAPIClient';
 import IdentityAPIClient from './identityApiClient';
-import { isFunction } from './utils';
+import { isFunction, parseConfig } from './utils';
 import { LocalStorageVault } from './vault';
 import { removeExpiredIdentityCacheDates } from './identity-utils';
 import IntegrationCapture from './integrationCapture';
@@ -1395,7 +1395,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
         }
 
         // Configure Rokt Manager with filtered user
-        const roktConfig = parseConfig(config, 'Rokt', 181);
+        const roktConfig: IKitConfigs = parseConfig(config, 'Rokt', 181);
         if (roktConfig) {
             const { userAttributeFilters } = roktConfig;
             const roktFilteredUser = filteredMparticleUser(
@@ -1586,12 +1586,5 @@ function queueIfNotInitialized(func, self) {
         return true;
     }
     return false;
-}
-
-function parseConfig(config: SDKInitConfig, moduleName: string, moduleId: number): IKitConfigs {
-    return config.kitConfigs?.find((kitConfig: IKitConfigs) => 
-        kitConfig.name === moduleName && 
-        kitConfig.moduleId === moduleId
-    ) || null;
 }
 

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -34,14 +34,14 @@ import ForwardingStatsUploader from './forwardingStatsUploader';
 import Identity from './identity';
 import Consent, { IConsent } from './consent';
 import KitBlocker from './kitBlocking';
-import ConfigAPIClient from './configAPIClient';
+import ConfigAPIClient, { IKitConfigs } from './configAPIClient';
 import IdentityAPIClient from './identityApiClient';
-import { isFunction, valueof } from './utils';
+import { isFunction } from './utils';
 import { LocalStorageVault } from './vault';
 import { removeExpiredIdentityCacheDates } from './identity-utils';
 import IntegrationCapture from './integrationCapture';
 import { IPreInit, processReadyQueue } from './pre-init-utils';
-import { BaseEvent, MParticleWebSDK, SDKHelpersApi } from './sdkRuntimeModels';
+import { BaseEvent, MParticleWebSDK, SDKHelpersApi, SDKInitConfig } from './sdkRuntimeModels';
 import { Dictionary, SDKEventAttrs } from '@mparticle/web-sdk';
 import { IIdentity } from './identity.interfaces';
 import { IEvents } from './events.interfaces';
@@ -1395,7 +1395,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
         }
 
         // Configure Rokt Manager with filtered user
-        const roktConfig = mpInstance._RoktManager.parseConfig(config);
+        const roktConfig = parseConfig(config, 'Rokt', 181);
         if (roktConfig) {
             const { userAttributeFilters } = roktConfig;
             const roktFilteredUser = filteredMparticleUser(
@@ -1403,7 +1403,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
                 { userAttributeFilters },
                 mpInstance
             );
-            mpInstance._RoktManager.init(config, roktFilteredUser);
+            mpInstance._RoktManager.init(roktConfig, roktFilteredUser);
         }
 
         mpInstance._Forwarders.processForwarders(
@@ -1586,5 +1586,12 @@ function queueIfNotInitialized(func, self) {
         return true;
     }
     return false;
+}
+
+function parseConfig(config: SDKInitConfig, moduleName: string, moduleId: number): IKitConfigs {
+    return config.kitConfigs?.find((kitConfig: IKitConfigs) => 
+        kitConfig.name === moduleName && 
+        kitConfig.moduleId === moduleId
+    ) || null;
 }
 

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -41,7 +41,7 @@ import { LocalStorageVault } from './vault';
 import { removeExpiredIdentityCacheDates } from './identity-utils';
 import IntegrationCapture from './integrationCapture';
 import { IPreInit, processReadyQueue } from './pre-init-utils';
-import { BaseEvent, MParticleWebSDK, SDKHelpersApi, SDKInitConfig } from './sdkRuntimeModels';
+import { BaseEvent, MParticleWebSDK, SDKHelpersApi } from './sdkRuntimeModels';
 import { Dictionary, SDKEventAttrs } from '@mparticle/web-sdk';
 import { IIdentity } from './identity.interfaces';
 import { IEvents } from './events.interfaces';

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -50,6 +50,7 @@ import { INativeSdkHelpers } from './nativeSdkHelpers.interfaces';
 import { IPersistence } from './persistence.interfaces';
 import ForegroundTimer from './foregroundTimeTracker';
 import RoktManager from './roktManager';
+import filteredMparticleUser from './filteredMparticleUser';
 
 export interface IErrorLogMessage {
     message?: string;
@@ -1393,6 +1394,18 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             mpInstance._IntegrationCapture.capture();
         }
 
+        // Configure Rokt Manager with filtered user
+        const roktConfig = mpInstance._RoktManager.parseConfig(config);
+        if (roktConfig) {
+            const { userAttributeFilters } = roktConfig;
+            const roktFilteredUser = filteredMparticleUser(
+                currentUserMPID,
+                { userAttributeFilters },
+                mpInstance
+            );
+            mpInstance._RoktManager.init(config, roktFilteredUser);
+        }
+
         mpInstance._Forwarders.processForwarders(
             config,
             mpInstance._APIClient.prepareForwardingStats
@@ -1574,3 +1587,4 @@ function queueIfNotInitialized(func, self) {
     }
     return false;
 }
+

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -35,6 +35,7 @@ export interface IRoktMessage {
 export interface RoktKitFilterSettings {
     userAttributeFilters?: UserAttributeFilters;
     filterUserAttributes?: (userAttributes: Dictionary<string>, filterList: number[]) => Dictionary<string>;
+    filteredUser?: IMParticleUser | null;
 }
 
 export interface IRoktKit  {
@@ -68,9 +69,8 @@ export default class RoktManager {
         this.filters = {
             userAttributeFilters,
             filterUserAttributes: KitFilterHelper.filterUserAttributes,
+            filteredUser: filteredUser,
         };
-
-        this.filteredUser = filteredUser;
     }
 
     public attachKit(kit: IRoktKit): void {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -61,7 +61,7 @@ export default class RoktManager {
     private filteredUser: IMParticleUser | null = null;
     private messageQueue: IRoktMessage[] = [];
 
-    public init(config: IKitConfigs, filteredUser?: IMParticleUser): void {
+    public init(roktConfig: IKitConfigs, filteredUser?: IMParticleUser): void {
         const { userAttributeFilters } = config || {};
 
         this.filters = {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -56,7 +56,6 @@ export interface IRoktKit  {
 //
 // https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt
 export default class RoktManager {
-    public config: SDKInitConfig | null = null;
     public kit: IRoktKit = null;
     public filters: RoktKitFilterSettings = {};
 

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -88,7 +88,7 @@ export default class RoktManager {
         }
 
         try {
-            return this.kit.launcher.selectPlacements(options);
+            return this.kit.selectPlacements(options);
         } catch (error) {
             return Promise.reject(error instanceof Error ? error : new Error('Unknown error occurred'));
         }

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -44,6 +44,15 @@ export interface IRoktKit  {
     selectPlacements: (options: IRoktSelectPlacementsOptions) => Promise<IRoktSelection>;
 }
 
+// The purpose of this class is to create a link between the Core mParticle SDK and the
+// Rokt Web SDK via a Web Kit.
+// The Rokt Manager should load before the Web Kit and stubs out many of the
+// Rokt Web SDK functions with an internal message queue in case a Rokt function
+// is requested before the Rokt Web Kit or SDK is finished loaded.
+// Once the Rokt Kit is attached to the Rokt Manager, we can consider the
+// Rokt Manager in a "ready" state and it can begin sending data to the kit.
+//
+// https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt
 export default class RoktManager {
     public config: SDKInitConfig | null = null;
     public kit: IRoktKit = null;
@@ -52,15 +61,8 @@ export default class RoktManager {
     private filteredUser: IMParticleUser | null = null;
     private messageQueue: IRoktMessage[] = [];
 
-    constructor() {
-        this.kit = null;
-        this.filters = {};
-        this.filteredUser = null;
-    }
-
-    public init(config: SDKInitConfig, filteredUser?: IMParticleUser): void {
-        const roktConfig = this.parseConfig(config);
-        const { userAttributeFilters } = roktConfig || {};
+    public init(config: IKitConfigs, filteredUser?: IMParticleUser): void {
+        const { userAttributeFilters } = config || {};
 
         this.filters = {
             userAttributeFilters,
@@ -68,13 +70,6 @@ export default class RoktManager {
         };
 
         this.filteredUser = filteredUser;
-    }
-
-    public parseConfig(config: SDKInitConfig): IKitConfigs | null {
-        return config.kitConfigs?.find((kitConfig: IKitConfigs) => 
-            kitConfig.name === 'Rokt' && 
-            kitConfig.moduleId === 181
-        ) || null;
     }
 
     public attachKit(kit: IRoktKit): void {
@@ -99,6 +94,7 @@ export default class RoktManager {
     }
 
     private isReady(): boolean {
+        // The Rokt Manager is ready when a kit is attached
         return Boolean(this.kit);
     }
 

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -62,7 +62,7 @@ export default class RoktManager {
     private messageQueue: IRoktMessage[] = [];
 
     public init(roktConfig: IKitConfigs, filteredUser?: IMParticleUser): void {
-        const { userAttributeFilters } = config || {};
+        const { userAttributeFilters } = roktConfig || {};
 
         this.filters = {
             userAttributeFilters,

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -40,6 +40,7 @@ export interface RoktKitFilterSettings {
 export interface IRoktKit  {
     filters: RoktKitFilterSettings;
     filteredUser: IMParticleUser | null;
+    launcher: IRoktLauncher | null;
     userAttributes: Dictionary<string>;
     selectPlacements: (options: IRoktSelectPlacementsOptions) => Promise<IRoktSelection>;
 }
@@ -87,15 +88,15 @@ export default class RoktManager {
         }
 
         try {
-            return this.kit.selectPlacements(options);
+            return this.kit.launcher.selectPlacements(options);
         } catch (error) {
             return Promise.reject(error instanceof Error ? error : new Error('Unknown error occurred'));
         }
     }
 
     private isReady(): boolean {
-        // The Rokt Manager is ready when a kit is attached
-        return Boolean(this.kit);
+        // The Rokt Manager is ready when a kit is attached and has a launcher
+        return Boolean(this.kit && this.kit.launcher);
     }
 
     private processMessageQueue(): void {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -2,7 +2,6 @@ import { IKitConfigs } from "./configAPIClient";
 import { UserAttributeFilters  } from "./forwarders.interfaces";
 import { IMParticleUser } from "./identity-user-interfaces";
 import KitFilterHelper from "./kitFilterHelper";
-import { SDKInitConfig } from "./sdkRuntimeModels";
 import { Dictionary } from "./utils";
 
 // https://docs.rokt.com/developers/integration-guides/web/library/attributes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { MPID } from '@mparticle/web-sdk';
 import Constants from './constants';
+import { SDKInitConfig } from './sdkRuntimeModels';
+import { IKitConfigs } from './configAPIClient';
 
 const { Messages } = Constants;
 
@@ -385,6 +387,13 @@ const filterDictionaryWithHash = <T>(
     return filtered;
 }
 
+const parseConfig = (config: SDKInitConfig, moduleName: string, moduleId: number): IKitConfigs | null => {
+    return config.kitConfigs?.find((kitConfig: IKitConfigs) => 
+        kitConfig.name === moduleName && 
+        kitConfig.moduleId === moduleId
+    ) || null;
+}
+
 export {
     createCookieString,
     revertCookieString,
@@ -401,6 +410,7 @@ export {
     inArray,
     isObject,
     isStringOrNumber,
+    parseConfig,
     parseNumber,
     parseStringOrNumber,
     replaceCommasWithPipes,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,11 @@ const createCookieString = (value: string): string =>
 const revertCookieString = (value: string): string =>
     replacePipesWithCommas(replaceApostrophesWithQuotes(value));
 
-const inArray = (items: any[], name: string): boolean => {
+const inArray = (items: any[], name: any): boolean => {
+    if (!items) {
+        return false;
+    }
+
     let i = 0;
 
     if (Array.prototype.indexOf) {
@@ -360,6 +364,27 @@ const getHref = (): string => {
         : '';
 };
 
+const filterDictionaryWithHash = <T>(
+    dictionary: Dictionary<T>,
+    filterList: any[],
+    hashFn: (key: string) => any
+): Dictionary<T> => {
+    const filtered = {};
+
+    if (!isEmpty(dictionary)) {
+        for (const key in dictionary) {
+            if (dictionary.hasOwnProperty(key)) {
+                const hashedKey = hashFn(key);
+                if (!inArray(filterList, hashedKey)) {
+                    filtered[key] = dictionary[key];
+                }
+            }
+        }
+    }
+
+    return filtered;
+}
+
 export {
     createCookieString,
     revertCookieString,
@@ -367,6 +392,7 @@ export {
     valueof,
     converted,
     decoded,
+    filterDictionaryWithHash,
     findKeyInObject,
     generateDeprecationMessage,
     generateHash,

--- a/test/jest/kitFilterHelper.spec.ts
+++ b/test/jest/kitFilterHelper.spec.ts
@@ -184,7 +184,7 @@ describe('FilterHashingUtilities', () => {
 
     describe('#hashUserAttribute', () => {
         it('should hash user attributey', () => {
-            const userAttribute :string = 'foo-value';
+            const userAttribute: string = 'foo-value';
 
             const resultHash = KitFilterHelper.hashUserAttribute(userAttribute);
 
@@ -384,6 +384,94 @@ describe('FilterHashingUtilities', () => {
             const expectedHash = "-575335347";
 
             expect(resultHash).toBe(expectedHash);
+        });
+    });
+
+    describe('#filterUserAttributes', () => {
+        it('should return the original user attributes if no filter list is provided', () => {
+            const userAttributes = {
+                'foo-key': 'foo-value',
+                'bar-key': 'bar-value',
+                'baz-key': 'baz-value',
+            };
+
+            const result = KitFilterHelper.filterUserAttributes(userAttributes, []);
+
+            expect(result).toEqual(userAttributes);
+        });
+
+        it('should filter user attributes', () => {
+            const userAttributes = {
+                'foo-key': 'foo-value',
+                'bar-key': 'bar-value',
+                'baz-key': 'baz-value',
+            };
+
+            const fooFilter = KitFilterHelper.hashUserAttribute('foo-key');
+            const barFilter = KitFilterHelper.hashUserAttribute('bar-key');
+
+            const result = KitFilterHelper.filterUserAttributes(userAttributes, [
+                fooFilter,
+                barFilter,
+            ]);
+
+            expect(result).toEqual({
+                'baz-key': 'baz-value',
+            });
+        });
+    });
+
+    describe('#filterUserIdentities', () => {
+        it('should return the original user identities if no filter list is provided', () => {
+            const userIdentities = {
+                'other': 'foo-value',
+                'customerid': 'bar-value',
+                'facebook': 'baz-value',
+            };
+
+            const result = KitFilterHelper.filterUserIdentities(userIdentities, []);
+
+            expect(result).toEqual(userIdentities);
+        });
+
+        it('should filter user identities', () => {
+            const userIdentities = {
+                'other': 'foo-value',
+                'customerid': 'bar-value',
+                'facebook': 'baz-value',
+            };
+
+            const fooFilter = KitFilterHelper.hashUserIdentity(IdentityType.Other);
+            const barFilter = KitFilterHelper.hashUserIdentity(IdentityType.CustomerId);
+
+            const result = KitFilterHelper.filterUserIdentities(userIdentities, [
+                fooFilter,
+                barFilter,
+            ]);
+
+            expect(result).toEqual({
+                'facebook': 'baz-value',
+            });
+        });
+    });
+
+    describe('#isFilteredUserAttribute', () => {
+        it('should return true if the user attribute is filtered', () => {
+            const userAttributeKey = 'foo-key';
+            const filterList = [KitFilterHelper.hashUserAttribute(userAttributeKey)];
+
+            const result = KitFilterHelper.isFilteredUserAttribute(userAttributeKey, filterList);
+
+            expect(result).toBe(true);
+        });
+
+        it('should return false if the user attribute is not filtered', () => {
+            const userAttributeKey = 'foo-key';
+            const filterList = [];
+
+            const result = KitFilterHelper.isFilteredUserAttribute(userAttributeKey, filterList);
+
+            expect(result).toBe(false);
         });
     });
 });

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -25,8 +25,8 @@ describe('RoktManager', () => {
             expect(roktManager['filters']).toEqual({
                 userAttributeFilters: undefined,
                 filterUserAttributes: expect.any(Function),
+                filteredUser: undefined,
             });
-            expect(roktManager['filteredUser']).toBeUndefined();
             expect(roktManager['kit']).toBeNull();
         });
 

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -21,7 +21,7 @@ describe('RoktManager', () => {
 
     describe('#init', () => {
         it('should initialize the manager with defaults when no config is provided', () => {
-            roktManager.init({} as SDKInitConfig);
+            roktManager.init({} as IKitConfigs);
             expect(roktManager['kit']).toBeNull();
             expect(roktManager['filters']).toEqual({
                 userAttributeFilters: undefined,
@@ -30,6 +30,7 @@ describe('RoktManager', () => {
             expect(roktManager['filteredUser']).toBeUndefined();
             expect(roktManager['kit']).toBeNull();
         });
+
         it('should initialize the manager with user attribute filters from a config', () => {
             const kitConfig: Partial<IKitConfigs> = {
                 name: 'Rokt',
@@ -37,45 +38,11 @@ describe('RoktManager', () => {
                 userAttributeFilters: [816506310, 1463937872, 36300687],
             };
 
-            const config: SDKInitConfig = {
-                kitConfigs: [kitConfig as IKitConfigs],
-            };
-
-            roktManager.init(config);
+            roktManager.init(kitConfig as IKitConfigs);
             expect(roktManager['filters']).toEqual({
                 userAttributeFilters: [816506310, 1463937872, 36300687],
                 filterUserAttributes: expect.any(Function),
             });
-        });
-    });
-
-    describe('#parseConfig', () => {
-        it('should ONLY return the kit config for Rokt', () => {
-            const roktKitConfig: Partial<IKitConfigs> = {
-                name: 'Rokt',
-                moduleId: 181,
-            };
-
-            const otherKitConfig: Partial<IKitConfigs> = {
-                name: 'Other Kit',
-                moduleId: 42,
-            };
-
-            const config: SDKInitConfig = {
-                kitConfigs: [roktKitConfig as IKitConfigs, otherKitConfig as IKitConfigs],
-            };
-
-            const result = roktManager.parseConfig(config);
-            expect(result).toEqual(roktKitConfig);
-        });
-
-        it('should return null if no kit config is found', () => {
-            const config: SDKInitConfig = {
-                kitConfigs: [],
-            };
-
-            const result = roktManager.parseConfig(config);
-            expect(result).toBeNull();
         });
     });
 

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -92,7 +92,7 @@ describe('RoktManager', () => {
     });
 
     describe('#selectPlacements', () => {
-        it('should call kit.launcher.selectPlacements with empty attributes', () => {
+        it('should call kit.selectPlacements with empty attributes', () => {
             const kit: IRoktKit = {
                 launcher: {
                     selectPlacements: jest.fn()
@@ -110,10 +110,10 @@ describe('RoktManager', () => {
             } as IRoktSelectPlacementsOptions;
 
             roktManager.selectPlacements(options);
-            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
 
-        it('should call kit.launcher.selectPlacements with passed in attributes', () => {
+        it('should call kit.selectPlacements with passed in attributes', () => {
             const kit: IRoktKit = {
                 launcher: {
                     selectPlacements: jest.fn()
@@ -137,7 +137,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should queue the selectPlacements method if no launcher or kit is attached', () => {
@@ -161,14 +161,7 @@ describe('RoktManager', () => {
                 filters: undefined,
                 filteredUser: undefined,
                 userAttributes: undefined,
-
-                // We are mocking the selectPlacements method to return the
-                // launcher's selectPlacements method and verify that the
-                // both the kit's and the launcher's selectPlacements methods
-                // are called with the correct options
-                selectPlacements: jest.fn().mockImplementation((options) => {
-                    return kit.launcher.selectPlacements(options);
-                })
+                selectPlacements: jest.fn()
             };
 
             const options = {
@@ -184,6 +177,41 @@ describe('RoktManager', () => {
             roktManager.attachKit(kit);
             expect(roktManager['kit']).not.toBeNull();
             expect(roktManager['messageQueue'].length).toBe(0);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+        });
+
+        it('should pass through the correct attributes to kit.launcher.selectPlacements', () => {
+            const kit: IRoktKit = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                filters: undefined,
+                filteredUser: undefined,
+                userAttributes: undefined,
+
+                // We are mocking the selectPlacements method to return the
+                // launcher's selectPlacements method and verify that
+                // both the kit's and the launcher's selectPlacements methods
+                // are called with the correct options
+                // This will happen through the Web Kit's selectPlacements method
+                selectPlacements: jest.fn().mockImplementation((options) => {
+                    return kit.launcher.selectPlacements(options);
+                })
+            };
+
+            roktManager.attachKit(kit);
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    age: 25,
+                    score: 100.5,
+                    isSubscribed: true,
+                    isActive: false,
+                    interests: 'sports,music,books'
+                }
+            };
+
+            roktManager.selectPlacements(options);
             expect(kit.selectPlacements).toHaveBeenCalledWith(options);
             expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
         });

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -48,6 +48,9 @@ describe('RoktManager', () => {
     describe('#attachKit', () => {
         it('should attach a kit', () => {
             const kit: IRoktKit = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
                 filters: undefined,
                 filteredUser: undefined,
                 userAttributes: undefined,
@@ -62,8 +65,11 @@ describe('RoktManager', () => {
     describe('#processMessageQueue', () => {
         it('should process the message queue if a launcher and kit are attached', () => {
             const kit: IRoktKit = {
-                selectPlacements: jest.fn(),
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
                 filters: undefined,
+                selectPlacements: jest.fn(),
                 filteredUser: undefined,
                 userAttributes: undefined
             };
@@ -86,12 +92,15 @@ describe('RoktManager', () => {
     });
 
     describe('#selectPlacements', () => {
-        it('should call kit.selectPlacements with empty attributes', () => {
+        it('should call kit.launcher.selectPlacements with empty attributes', () => {
             const kit: IRoktKit = {
-                selectPlacements: jest.fn(),
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
                 filters: undefined,
                 filteredUser: undefined,
-                userAttributes: undefined
+                userAttributes: undefined,
+                selectPlacements: jest.fn()
             };
 
             roktManager.attachKit(kit);
@@ -101,15 +110,18 @@ describe('RoktManager', () => {
             } as IRoktSelectPlacementsOptions;
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
 
-        it('should call kit.selectPlacements with passed in attributes', () => {
+        it('should call kit.launcher.selectPlacements with passed in attributes', () => {
             const kit: IRoktKit = {
-                selectPlacements: jest.fn(),
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
                 filters: undefined,
                 filteredUser: undefined,
-                userAttributes: undefined
+                userAttributes: undefined,
+                selectPlacements: jest.fn()
             };
 
             roktManager.attachKit(kit);
@@ -125,7 +137,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should queue the selectPlacements method if no launcher or kit is attached', () => {
@@ -141,12 +153,22 @@ describe('RoktManager', () => {
             expect(roktManager['messageQueue'][0].payload).toBe(options);
         });
 
-        it('should process queued selectPlacements calls once the launcher and kit are attached', () => {
+        it('should process queued selectPlacements calls once the launcher and kit are attached', async () => {
             const kit: IRoktKit = {
-                selectPlacements: jest.fn(),
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
                 filters: undefined,
                 filteredUser: undefined,
-                userAttributes: undefined
+                userAttributes: undefined,
+
+                // We are mocking the selectPlacements method to return the
+                // launcher's selectPlacements method and verify that the
+                // both the kit's and the launcher's selectPlacements methods
+                // are called with the correct options
+                selectPlacements: jest.fn().mockImplementation((options) => {
+                    return kit.launcher.selectPlacements(options);
+                })
             };
 
             const options = {
@@ -163,6 +185,7 @@ describe('RoktManager', () => {
             expect(roktManager['kit']).not.toBeNull();
             expect(roktManager['messageQueue'].length).toBe(0);
             expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
     });
 });

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -1,6 +1,5 @@
 import { IKitConfigs } from "../../src/configAPIClient";
 import RoktManager, { IRoktKit, IRoktSelectPlacementsOptions } from "../../src/roktManager";
-import { SDKInitConfig } from "../../src/sdkRuntimeModels";
 
 describe('RoktManager', () => {
     let roktManager: RoktManager;

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -1,3 +1,5 @@
+import { IKitConfigs } from '../../src/configAPIClient';
+import { SDKInitConfig } from '../../src/sdkRuntimeModels';
 import {
     queryStringParser,
     getCookies,
@@ -7,6 +9,7 @@ import {
     createCookieSyncUrl,
     inArray,
     filterDictionaryWithHash,
+    parseConfig,
 } from '../../src/utils';
 import { deleteAllCookies } from './utils';
 
@@ -274,6 +277,36 @@ describe('Utils', () => {
             expect(filtered).toEqual({
                 'quux': 'corge',
             });
+        });
+    });
+
+    describe('#parseConfig', () => {
+        it('should ONLY return the kit config for Rokt', () => {
+            const roktKitConfig: Partial<IKitConfigs> = {
+                name: 'Rokt',
+                moduleId: 181,
+            };
+
+            const otherKitConfig: Partial<IKitConfigs> = {
+                name: 'Other Kit',
+                moduleId: 42,
+            };
+
+            const config: SDKInitConfig = {
+                kitConfigs: [roktKitConfig as IKitConfigs, otherKitConfig as IKitConfigs],
+            };
+
+            const result = parseConfig(config, 'Rokt', 181);
+            expect(result).toEqual(roktKitConfig);
+        });
+
+        it('should return null if no kit config is found', () => {
+            const config: SDKInitConfig = {
+                kitConfigs: [],
+            };
+
+            const result = parseConfig(config, 'Rokt', 181);
+            expect(result).toBeNull();
         });
     });
 });

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -5,6 +5,8 @@ import {
     replaceMPID,
     replaceAmpWithAmpersand,
     createCookieSyncUrl,
+    inArray,
+    filterDictionaryWithHash,
 } from '../../src/utils';
 import { deleteAllCookies } from './utils';
 
@@ -216,6 +218,60 @@ describe('Utils', () => {
 
         it('should return a cookieSyncUrl when pixelUrl is not null but redirectUrl is null', () => {
             expect(createCookieSyncUrl('testMPID', pixelUrl, null)).toBe('https://abc.abcdex.net/ibs:exampleid=12345&exampleuuid=testMPID&redir=');
+        });
+    });
+
+    describe('#inArray', () => {
+        it('returns true if the item is in the array', () => {
+            expect(inArray(['foo', 'bar', 'baz'], 'bar')).toBe(true);
+        });
+
+        it('returns false if the item is not in the array', () => {
+            expect(inArray(['foo', 'bar', 'baz'], 'qux')).toBe(false);
+        });
+
+        it('returns false if the array is empty', () => {
+            expect(inArray([], 'foo')).toBe(false);
+        });
+
+        it('returns false if the array is null', () => {
+            expect(inArray(null, 'foo')).toBe(false);
+        });
+
+        it('returns false if the array is undefined', () => {
+            expect(inArray(undefined, 'foo')).toBe(false);
+        });
+
+        it('should support different types of arrays', () => {
+            expect(inArray([1, 2, 3], 2)).toBe(true);
+            expect(inArray([1, 2, 3], '2')).toBe(false);
+            expect(inArray([1, 2, 3], 4)).toBe(false);
+            expect(inArray([1, 2, 3], NaN)).toBe(false);
+            expect(inArray([1, 2, 3], null)).toBe(false);
+            expect(inArray([1, 2, 3], undefined)).toBe(false);
+        });
+    });
+
+    describe('#filterDictionaryWithHash', () => {
+        it('should filter a dictionary based on a hash function and filter list', () => {
+            const dictionary = {
+                'foo': 'bar',
+                'bar': 'baz',
+                'baz': 'qux',
+                'quux': 'corge',
+            };
+    
+            const filterList = [
+                98, // charCode for 'b'
+                102, // charCode for 'f'
+            ];
+            const hashFn = (key: string): number => key.charCodeAt(0);
+
+            const filtered = filterDictionaryWithHash(dictionary, filterList, hashFn);
+
+            expect(filtered).toEqual({
+                'quux': 'corge',
+            });
         });
     });
 });

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -242,13 +242,15 @@ describe('Utils', () => {
             expect(inArray(undefined, 'foo')).toBe(false);
         });
 
-        it('should support different types of arrays', () => {
+        it('should handle type-sensitive array membership checks', () => {
             expect(inArray([1, 2, 3], 2)).toBe(true);
+            expect(inArray([1, '2', 3], 2)).toBe(false);
             expect(inArray([1, 2, 3], '2')).toBe(false);
+            expect(inArray([1, '2', 3], '2')).toBe(true);
             expect(inArray([1, 2, 3], 4)).toBe(false);
-            expect(inArray([1, 2, 3], NaN)).toBe(false);
-            expect(inArray([1, 2, 3], null)).toBe(false);
-            expect(inArray([1, 2, 3], undefined)).toBe(false);
+            expect(inArray([1, 2, '', 3], NaN)).toBe(false);
+            expect(inArray([1, 2, '', 3], null)).toBe(false);
+            expect(inArray([1, 2, '', 3], undefined)).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Exposes User Filtering Logic to Rokt Web Kit

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample a with the latest version of the Rokt Kit, verify that filtered user attribute are not passed into the `selectPlacements` call

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7162
