### PR TITLE
feat: Add sandbox attribute depending on isDevelopmentMode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mparticle/web-sdk",
-    "version": "2.35.1",
+    "version": "2.35.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mparticle/web-sdk",
-            "version": "2.35.1",
+            "version": "2.35.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime": "^7.23.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-sdk",
-    "version": "2.35.1",
+    "version": "2.35.2",
     "description": "mParticle core SDK for web applications",
     "license": "Apache-2.0",
     "keywords": [

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -87,7 +87,7 @@ export interface IMParticleWebSDKInstance extends MParticleWebSDK {
     _Store: IStore;
     _instanceName: string;
     _preInit: IPreInit;
-    _timeOnSiteTimer: ForegroundTimer; 
+    _timeOnSiteTimer: ForegroundTimer;
 }
 
 const { Messages, HTTPCodes, FeatureFlags } = Constants;
@@ -1284,7 +1284,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
     };
     /*
         An integration delay is a workaround that prevents events from being sent when it is necessary to do so.
-        Some server side integrations require a client side value to be included in the payload to successfully 
+        Some server side integrations require a client side value to be included in the payload to successfully
         forward.  This value can only be pulled from the client side partner SDK.
 
         During the kit initialization, the kit:
@@ -1393,6 +1393,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             mpInstance._IntegrationCapture.capture();
         }
 
+        mpInstance._RoktManager.init(config);
         mpInstance._Forwarders.processForwarders(
             config,
             mpInstance._APIClient.prepareForwardingStats

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -60,7 +60,7 @@ export default class RoktManager {
                 ...options,
                 attributes: {
                     ...options.attributes,
-                    'rokt.testsession': this.config.isDevelopmentMode
+                    sandbox: this.config.isDevelopmentMode
                 }
             };
             return this.launcher.selectPlacements(enhancedOptions);

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -1,3 +1,5 @@
+import {SDKInitConfig} from "./sdkRuntimeModels";
+
 // https://docs.rokt.com/developers/integration-guides/web/library/attributes
 export interface IRoktPartnerAttributes {
     [key: string]: string | number | boolean | undefined | null;
@@ -25,12 +27,18 @@ export interface IRoktMessage {
     payload: any;
 }
 
+
 export default class RoktManager {
     public launcher: IRoktLauncher | null = null;
     private messageQueue: IRoktMessage[] = [];
+    public config: SDKInitConfig | null = null;
 
     constructor() {
         this.launcher = null;
+    }
+
+    public init(config: SDKInitConfig): void {
+        this.config = config;
     }
 
     public attachLauncher(launcher: IRoktLauncher): void {
@@ -48,7 +56,14 @@ export default class RoktManager {
         }
 
         try {
-            return this.launcher.selectPlacements(options);
+            const enhancedOptions = {
+                ...options,
+                attributes: {
+                    ...options.attributes,
+                    'rokt.testsession': this.config.isDevelopmentMode
+                }
+            };
+            return this.launcher.selectPlacements(enhancedOptions);
         } catch (error) {
             return Promise.reject(error instanceof Error ? error : new Error('Unknown error occurred'));
         }
@@ -64,7 +79,7 @@ export default class RoktManager {
             this.messageQueue = [];
         }
     }
-    
+
 
     private queueMessage(message: IRoktMessage): void {
         this.messageQueue.push(message);

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -112,8 +112,7 @@ describe('RoktManager', () => {
             expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
 
-        // New tests for the 'rokt.testsession' attribute
-        it('should add rokt.testsession with true value when isDevelopmentMode is true', () => {
+        it('should add sandbox with true value when isDevelopmentMode is true', () => {
             const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
             };
@@ -132,14 +131,14 @@ describe('RoktManager', () => {
             const expectedOptions = {
                 attributes: {
                     customAttr: 'value',
-                    'rokt.testsession': true
+                    'sandbox': true
                 }
             };
 
             expect(launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
         });
 
-        it('should add rokt.testsession with false value when isDevelopmentMode is false', () => {
+        it('should add sandbox with false value when isDevelopmentMode is false', () => {
             const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
             };
@@ -158,14 +157,14 @@ describe('RoktManager', () => {
             const expectedOptions = {
                 attributes: {
                     customAttr: 'value',
-                    'rokt.testsession': false
+                    'sandbox': false
                 }
             };
 
             expect(launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
         });
 
-        it('should preserve other option properties when adding rokt.testsession', () => {
+        it('should preserve other option properties when adding sandbox', () => {
             const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
             };
@@ -185,7 +184,7 @@ describe('RoktManager', () => {
             const expectedOptions = {
                 attributes: {
                     customAttr: 'value',
-                    'rokt.testsession': true
+                    'sandbox': true
                 },
                 identifier: 'test-identifier'
             };
@@ -193,7 +192,7 @@ describe('RoktManager', () => {
             expect(launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
         });
 
-        it('should not add rokt.testsession when config is null', () => {
+        it('should not add sandbox when config is null', () => {
             const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
             };
@@ -208,8 +207,6 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-
-            // Should pass original options without modification since config is null
             expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
     });

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -28,7 +28,7 @@ describe('RoktManager', () => {
             const launcher: IRoktLauncher = {
                 selectPlacements: jest.fn()
             };
-            
+
             roktManager.selectPlacements({} as IRoktSelectPlacementsOptions);
             roktManager.selectPlacements({} as IRoktSelectPlacementsOptions);
             roktManager.selectPlacements({} as IRoktSelectPlacementsOptions);
@@ -109,6 +109,107 @@ describe('RoktManager', () => {
             roktManager.attachLauncher(launcher);
             expect(roktManager['launcher']).not.toBeNull();
             expect(roktManager['messageQueue'].length).toBe(0);
+            expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
+        });
+
+        // New tests for the 'rokt.testsession' attribute
+        it('should add rokt.testsession with true value when isDevelopmentMode is true', () => {
+            const launcher: IRoktLauncher = {
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachLauncher(launcher);
+            roktManager.init({ isDevelopmentMode: true });
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value'
+                }
+            };
+
+            roktManager.selectPlacements(options);
+
+            const expectedOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    'rokt.testsession': true
+                }
+            };
+
+            expect(launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+        });
+
+        it('should add rokt.testsession with false value when isDevelopmentMode is false', () => {
+            const launcher: IRoktLauncher = {
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachLauncher(launcher);
+            roktManager.init({ isDevelopmentMode: false });
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value'
+                }
+            };
+
+            roktManager.selectPlacements(options);
+
+            const expectedOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    'rokt.testsession': false
+                }
+            };
+
+            expect(launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+        });
+
+        it('should preserve other option properties when adding rokt.testsession', () => {
+            const launcher: IRoktLauncher = {
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachLauncher(launcher);
+            roktManager.init({ isDevelopmentMode: true });
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value'
+                },
+                identifier: 'test-identifier'
+            };
+
+            roktManager.selectPlacements(options);
+
+            const expectedOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    'rokt.testsession': true
+                },
+                identifier: 'test-identifier'
+            };
+
+            expect(launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+        });
+
+        it('should not add rokt.testsession when config is null', () => {
+            const launcher: IRoktLauncher = {
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachLauncher(launcher);
+            // Not initializing config, so it remains null
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value'
+                }
+            };
+
+            roktManager.selectPlacements(options);
+
+            // Should pass original options without modification since config is null
             expect(launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
     });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Explicitly add sandbox attribute when calling selectPlacements depending on SDKInitConfig.isDevelopmentMode

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
