### PR TITLE
feat: Add support for sandbox mode via selectPlacements

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -49,7 +49,7 @@ import { IECommerce } from './ecommerce.interfaces';
 import { INativeSdkHelpers } from './nativeSdkHelpers.interfaces';
 import { IPersistence } from './persistence.interfaces';
 import ForegroundTimer from './foregroundTimeTracker';
-import RoktManager from './roktManager';
+import RoktManager, { IRoktManagerOptions } from './roktManager';
 import filteredMparticleUser from './filteredMparticleUser';
 
 export interface IErrorLogMessage {
@@ -1403,7 +1403,10 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
                 { userAttributeFilters },
                 mpInstance
             );
-            mpInstance._RoktManager.init(roktConfig, roktFilteredUser);
+            const roktOptions: IRoktManagerOptions = {
+                sandbox: config.isDevelopmentMode,
+            };
+            mpInstance._RoktManager.init(roktConfig, roktFilteredUser, roktOptions);
         }
 
         mpInstance._Forwarders.processForwarders(

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -92,21 +92,19 @@ export default class RoktManager {
             return Promise.resolve({} as IRoktSelection);
         }
 
-        debugger;
-
         try {
-            let enrichedOptions = options;
             const { attributes } = options;
-            const sandbox = attributes?.sandbox ?? this.sandbox;
+            const sandboxValue = attributes?.sandbox ?? this.sandbox;
 
-            if (sandbox !== null) {
-                attributes['sandbox'] = sandbox;
-            }
-
-            enrichedOptions = {
+            const enrichedAttributes = {
+                ...attributes,
+                ...(sandboxValue !== null ? { sandbox: sandboxValue } : {}),
+              };
+          
+              const enrichedOptions = {
                 ...options,
-                attributes,
-            }
+                attributes: enrichedAttributes,
+              };
 
             return this.kit.selectPlacements(enrichedOptions);
         } catch (error) {

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -43,6 +43,11 @@ describe('RoktManager', () => {
                 filterUserAttributes: expect.any(Function),
             });
         });
+
+        it('should initialize the manager with sandbox from options', () => {
+            roktManager.init({} as IKitConfigs, undefined, { sandbox: true });
+            expect(roktManager['sandbox']).toBe(true);
+        });
     });
 
     describe('#attachKit', () => {
@@ -214,6 +219,196 @@ describe('RoktManager', () => {
             roktManager.selectPlacements(options);
             expect(kit.selectPlacements).toHaveBeenCalledWith(options);
             expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
+        });
+
+        it('should set sandbox to false in placement attributes when initialized as true', () => {
+            const kit: IRoktKit = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                filters: undefined,
+                filteredUser: undefined,
+                userAttributes: undefined,
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachKit(kit);
+            roktManager['sandbox'] = true;
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value'
+                }
+            };
+
+            roktManager.selectPlacements(options);
+
+            const expectedOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    'sandbox': true
+                }
+            };
+
+            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+        });
+
+        it('should set sandbox to false in placement attributes when initialized as false', () => {
+            const kit: IRoktKit = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                filters: undefined,
+                filteredUser: undefined,
+                userAttributes: undefined,
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachKit(kit);
+            roktManager['sandbox'] = false;
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value'
+                }
+            };
+
+            roktManager.selectPlacements(options);
+
+            const expectedOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    'sandbox': false
+                }
+            };
+
+            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+        });
+
+        it('should override sandbox to false in placement attributes when initialized as true', () => {
+            const kit: IRoktKit = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                filters: undefined,
+                filteredUser: undefined,
+                userAttributes: undefined,
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachKit(kit);
+            roktManager['sandbox'] = true;
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    sandbox: false
+                }
+            };
+
+            roktManager.selectPlacements(options);
+
+            const expectedOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    sandbox: false
+                }
+            };
+
+            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+        });
+
+        it('should preserve other option properties when adding sandbox', () => {
+            const kit: IRoktKit = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                filters: undefined,
+                filteredUser: undefined,
+                userAttributes: undefined,
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachKit(kit);
+            roktManager['sandbox'] = true;
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value'
+                },
+                identifier: 'test-identifier'
+            };
+
+            roktManager.selectPlacements(options);
+
+            const expectedOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    'sandbox': true
+                },
+                identifier: 'test-identifier'
+            };
+
+            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+        });
+
+        it('should not add sandbox when sandbox is null', () => {
+            const kit: IRoktKit = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                filters: undefined,
+                filteredUser: undefined,
+                userAttributes: undefined,
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachKit(kit);
+            // Not initializing sandbox, so it remains null 
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value'
+                }
+            };
+
+            roktManager.selectPlacements(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+        });
+
+        it('should set sandbox in placement attributes when not initialized', () => {
+            const kit: IRoktKit = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                filters: undefined,
+                filteredUser: undefined,
+                userAttributes: undefined,
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.attachKit(kit);
+            // Not initializing sandbox, so it remains null
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    sandbox: true
+                },
+                identifier: 'test-identifier'
+            };
+
+            roktManager.selectPlacements(options);
+
+            const expectedOptions = {
+                attributes: {
+                    customAttr: 'value',
+                    'sandbox': true
+                },
+                identifier: 'test-identifier'
+            };
+
+            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
         });
     });
 });

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -221,7 +221,7 @@ describe('RoktManager', () => {
             expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
 
-        it('should set sandbox to false in placement attributes when initialized as true', () => {
+        it('should set sandbox to true in placement attributes when initialized as true', () => {
             const kit: IRoktKit = {
                 launcher: {
                     selectPlacements: jest.fn()
@@ -399,16 +399,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-
-            const expectedOptions = {
-                attributes: {
-                    customAttr: 'value',
-                    'sandbox': true
-                },
-                identifier: 'test-identifier'
-            };
-
-            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
     });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Explicitly adds sandbox attribute when calling selectPlacements as an override while also supporting sandbox via RoktManager init
 - Replaces #1013

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Attempt to send `selectPlacement` with a sandbox mode that is different than the default config.isDevelopmentMode setting.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7182
