### PR TITLE
feat: Add user attribute mapping to Rokt Manager

### DIFF
--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -2,7 +2,7 @@ import { IKitConfigs } from "./configAPIClient";
 import { UserAttributeFilters  } from "./forwarders.interfaces";
 import { IMParticleUser } from "./identity-user-interfaces";
 import KitFilterHelper from "./kitFilterHelper";
-import { Dictionary, parseSettingsString } from "./utils";
+import { Dictionary, isEmpty, parseSettingsString } from "./utils";
 
 // https://docs.rokt.com/developers/integration-guides/web/library/attributes
 export interface IRoktPartnerAttributes {
@@ -37,6 +37,10 @@ export interface RoktKitFilterSettings {
     filteredUser?: IMParticleUser | null;
 }
 
+export interface IRoktKitSettings {
+    userAttributeMapping: string;
+}
+
 export interface IRoktKit  {
     filters: RoktKitFilterSettings;
     filteredUser: IMParticleUser | null;
@@ -69,7 +73,7 @@ export default class RoktManager {
 
     public init(roktConfig: IKitConfigs, filteredUser?: IMParticleUser, options?: IRoktManagerOptions): void {
         const { userAttributeFilters, settings } = roktConfig || {};
-        const { userAttributeMapping } = settings || {};
+        const { userAttributeMapping = '' } = settings as IRoktKitSettings || {};
 
         try {
             this.userAttributeMapping = parseSettingsString(userAttributeMapping);
@@ -128,9 +132,13 @@ export default class RoktManager {
     }
 
     private mapUserAttributes(attributes: IRoktPartnerAttributes, userAttributeMapping: Dictionary<string>[]): IRoktPartnerAttributes {
+        if (isEmpty(userAttributeMapping)) {
+            return attributes;
+        }
+
         const mappingLookup: { [key: string]: string } = {};
-        for (let i = 0; i < userAttributeMapping.length; i++) {
-            mappingLookup[userAttributeMapping[i].map] = userAttributeMapping[i].value;
+        for (const mapping of userAttributeMapping) {
+            mappingLookup[mapping.map] = mapping.value;
         }
     
         const mappedAttributes: IRoktPartnerAttributes = {};

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -2,7 +2,7 @@ import { IKitConfigs } from "./configAPIClient";
 import { UserAttributeFilters  } from "./forwarders.interfaces";
 import { IMParticleUser } from "./identity-user-interfaces";
 import KitFilterHelper from "./kitFilterHelper";
-import { Dictionary } from "./utils";
+import { Dictionary, parseSettingsString } from "./utils";
 
 // https://docs.rokt.com/developers/integration-guides/web/library/attributes
 export interface IRoktPartnerAttributes {
@@ -65,9 +65,17 @@ export default class RoktManager {
     private filteredUser: IMParticleUser | null = null;
     private messageQueue: IRoktMessage[] = [];
     private sandbox: boolean | null = null;
+    private userAttributeMapping: Dictionary<string>[] = [];
 
     public init(roktConfig: IKitConfigs, filteredUser?: IMParticleUser, options?: IRoktManagerOptions): void {
-        const { userAttributeFilters } = roktConfig || {};
+        const { userAttributeFilters, settings } = roktConfig || {};
+        const { userAttributeMapping } = settings || {};
+
+        try {
+            this.userAttributeMapping = parseSettingsString(userAttributeMapping);
+        } catch (error) {
+            console.error('Error parsing user attribute mapping from config', error);
+        }
 
         this.filters = {
             userAttributeFilters,
@@ -96,15 +104,17 @@ export default class RoktManager {
             const { attributes } = options;
             const sandboxValue = attributes?.sandbox ?? this.sandbox;
 
+            const mappedAttributes = this.mapUserAttributes(attributes, this.userAttributeMapping);
+
             const enrichedAttributes = {
-                ...attributes,
+                ...mappedAttributes,
                 ...(sandboxValue !== null ? { sandbox: sandboxValue } : {}),
               };
-          
-              const enrichedOptions = {
+
+            const enrichedOptions = {
                 ...options,
                 attributes: enrichedAttributes,
-              };
+            };
 
             return this.kit.selectPlacements(enrichedOptions);
         } catch (error) {
@@ -115,6 +125,22 @@ export default class RoktManager {
     private isReady(): boolean {
         // The Rokt Manager is ready when a kit is attached and has a launcher
         return Boolean(this.kit && this.kit.launcher);
+    }
+
+    private mapUserAttributes(attributes: IRoktPartnerAttributes, userAttributeMapping: Dictionary<string>[]): IRoktPartnerAttributes {
+        const mappingLookup: { [key: string]: string } = {};
+        for (let i = 0; i < userAttributeMapping.length; i++) {
+            mappingLookup[userAttributeMapping[i].map] = userAttributeMapping[i].value;
+        }
+    
+        const mappedAttributes: IRoktPartnerAttributes = {};
+        for (const key in attributes) {
+            if (attributes.hasOwnProperty(key)) {
+                const newKey = mappingLookup[key] || key;
+                mappedAttributes[newKey] = attributes[key];
+            }
+        }
+        return mappedAttributes;
     }
 
     private processMessageQueue(): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,6 +160,14 @@ const parseNumber = (value: string | number): number => {
     return isNaN(floatValue) ? 0 : floatValue;
 };
 
+const parseSettingsString = (settingsString: string): Dictionary<string>[] => {
+    try {
+        return settingsString ? JSON.parse(settingsString.replace(/&quot;/g, '"')) : [];
+    } catch (error) {
+        throw new Error('Settings string contains invalid JSON');
+    }
+};
+
 const parseStringOrNumber = (
     value: string | number
 ): string | number | null => {
@@ -412,6 +420,7 @@ export {
     isStringOrNumber,
     parseConfig,
     parseNumber,
+    parseSettingsString,
     parseStringOrNumber,
     replaceCommasWithPipes,
     replacePipesWithCommas,

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -48,6 +48,44 @@ describe('RoktManager', () => {
             roktManager.init({} as IKitConfigs, undefined, { sandbox: true });
             expect(roktManager['sandbox']).toBe(true);
         });
+
+        it('should initialize the manager with user attribute mapping from a config', () => {
+            const kitConfig: Partial<IKitConfigs> = {
+                name: 'Rokt',
+                moduleId: 181,
+                settings: {
+                    userAttributeMapping: JSON.stringify([
+                        {
+                            jsmap: null,
+                            map: 'f.name',
+                            maptype: 'UserAttributeClass.Name',
+                            value: 'firstname',
+                        },
+                        {
+                            jsmap: null,
+                            map: 'last_name',
+                            maptype: 'UserAttributeClass.Name',
+                            value: 'lastname',
+                        }
+                    ])
+                },
+            };
+            roktManager.init(kitConfig as IKitConfigs);
+            expect(roktManager['userAttributeMapping']).toEqual([
+                { 
+                    jsmap: null,
+                    map: 'f.name',
+                    maptype: 'UserAttributeClass.Name',
+                    value: 'firstname',
+                },
+                {
+                    jsmap: null,
+                    map: 'last_name', 
+                    maptype: 'UserAttributeClass.Name',
+                    value: 'lastname',
+                }
+            ]);
+        });
     });
 
     describe('#attachKit', () => {
@@ -317,7 +355,7 @@ describe('RoktManager', () => {
 
             expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
         });
-
+    
         it('should preserve other option properties when adding sandbox', () => {
             const kit: IRoktKit = {
                 launcher: {
@@ -351,7 +389,6 @@ describe('RoktManager', () => {
 
             expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
         });
-
         it('should not add sandbox when sandbox is null', () => {
             const kit: IRoktKit = {
                 launcher: {
@@ -396,6 +433,74 @@ describe('RoktManager', () => {
                     sandbox: true
                 },
                 identifier: 'test-identifier'
+            };
+
+            roktManager.selectPlacements(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+        });
+
+        it('should pass mapped attributes to kit.launcher.selectPlacements', () => {
+            const kit: Partial<IRoktKit> = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.kit = kit as IRoktKit;
+            roktManager['userAttributeMapping'] = [
+                {
+                    jsmap: null,
+                    map: 'f.name',
+                    maptype: 'UserAttributeClass.Name',
+                    value: 'firstname'
+                },
+                {
+                    jsmap: null,
+                    map: 'last_name',
+                    maptype: 'UserAttributeClass.Name',
+                    value: 'lastname'
+                }
+            ];
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    'f.name': 'John',
+                    'last_name': 'Doe',
+                    'score': 42,
+                }
+            };
+
+            const expectedOptions = {
+                attributes: {
+                    firstname: 'John',
+                    lastname: 'Doe',
+                    score: 42,
+                }
+            };
+
+            roktManager.selectPlacements(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+        });
+
+        it('should pass original attributes to kit.launcher.selectPlacements if no mapping is provided', () => {
+            const kit: Partial<IRoktKit> = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.kit = kit as IRoktKit;
+            roktManager['userAttributeMapping'] = [];
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    'f.name': 'John',
+                    'last_name': 'Doe',
+                    'score': 42,
+                    'age': 25,
+                }
             };
 
             roktManager.selectPlacements(options);

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -10,6 +10,7 @@ import {
     inArray,
     filterDictionaryWithHash,
     parseConfig,
+    parseSettingsString,
 } from '../../src/utils';
 import { deleteAllCookies } from './utils';
 
@@ -307,6 +308,26 @@ describe('Utils', () => {
 
             const result = parseConfig(config, 'Rokt', 181);
             expect(result).toBeNull();
+        });
+    });
+
+    describe('#parseSettingsString', () => {
+        it('should parse a settings string', () => {
+            const settingsString = "[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;f.name&quot;,&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;firstname&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;last_name&quot;,&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;lastname&quot;}]";
+            expect(parseSettingsString(settingsString)).toEqual([
+                { jsmap: null, map: 'f.name', maptype: 'UserAttributeClass.Name', value: 'firstname' },
+                { jsmap: null, map: 'last_name', maptype: 'UserAttributeClass.Name', value: 'lastname' },
+            ]);
+        });
+
+        it('returns an empty array if the settings string is empty', () => {
+            const settingsString = "";
+            expect(parseSettingsString(settingsString)).toEqual([]);
+        });
+
+        it('throws an error message if the settings string is not a valid JSON', () => {
+            const settingsString = "not a valid JSON";
+            expect(() => parseSettingsString(settingsString)).toThrow('Settings string contains invalid JSON');
         });
     });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Allows User Attribute Mapping via the Rokt Manager in the SDK.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Use the User Attribute Mapping via the Configuration Settings in the mParticle UI. Mapped User Attributes should appear with updated keys when making a `selectPlacements` call.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7153
