### PR TITLE
feat: Add select placement attributes to current user

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -1394,7 +1394,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             mpInstance._IntegrationCapture.capture();
         }
 
-        // Configure Rokt Manager with filtered user
+        // Configure Rokt Manager with user and filtered user
         const roktConfig: IKitConfigs = parseConfig(config, 'Rokt', 181);
         if (roktConfig) {
             const { userAttributeFilters } = roktConfig;
@@ -1406,7 +1406,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             const roktOptions: IRoktManagerOptions = {
                 sandbox: config.isDevelopmentMode,
             };
-            mpInstance._RoktManager.init(roktConfig, roktFilteredUser, roktOptions);
+            mpInstance._RoktManager.init(roktConfig, roktFilteredUser, currentUser, roktOptions);
         }
 
         mpInstance._Forwarders.processForwarders(

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -145,7 +145,7 @@ export default class RoktManager {
         const reservedAttributes = ['sandbox'];
         const filteredAttributes = {};
         
-        for (var key in attributes) {
+        for (const key in attributes) {
             if (attributes.hasOwnProperty(key) && reservedAttributes.indexOf(key) === -1) {
                 filteredAttributes[key] = attributes[key];
             }
@@ -160,8 +160,8 @@ export default class RoktManager {
 
     private mapUserAttributes(attributes: IRoktPartnerAttributes, userAttributeMapping: Dictionary<string>[]): IRoktPartnerAttributes {
         const mappingLookup: { [key: string]: string } = {};
-        for (let i = 0; i < userAttributeMapping.length; i++) {
-            mappingLookup[userAttributeMapping[i].map] = userAttributeMapping[i].value;
+        for (const mapping of userAttributeMapping) {
+            mappingLookup[mapping.map] = mapping.value;
         }
     
         const mappedAttributes: IRoktPartnerAttributes = {};

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -107,7 +107,6 @@ export default class RoktManager {
         try {
             const { attributes } = options;
             const sandboxValue = attributes?.sandbox ?? this.sandbox;
-
             const mappedAttributes = this.mapUserAttributes(attributes, this.userAttributeMapping);
 
             const enrichedAttributes = {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -66,12 +66,13 @@ export default class RoktManager {
     public kit: IRoktKit = null;
     public filters: RoktKitFilterSettings = {};
 
+    private currentUser: IMParticleUser | null = null;
     private filteredUser: IMParticleUser | null = null;
     private messageQueue: IRoktMessage[] = [];
     private sandbox: boolean | null = null;
     private userAttributeMapping: Dictionary<string>[] = [];
 
-    public init(roktConfig: IKitConfigs, filteredUser?: IMParticleUser, options?: IRoktManagerOptions): void {
+    public init(roktConfig: IKitConfigs, filteredUser: IMParticleUser, currentUser: IMParticleUser, options?: IRoktManagerOptions): void {
         const { userAttributeFilters, settings } = roktConfig || {};
         const { userAttributeMapping = '' } = settings as IRoktKitSettings || {};
 
@@ -80,6 +81,8 @@ export default class RoktManager {
         } catch (error) {
             console.error('Error parsing user attribute mapping from config', error);
         }
+
+        this.currentUser = currentUser;
 
         this.filters = {
             userAttributeFilters,
@@ -108,6 +111,8 @@ export default class RoktManager {
             const { attributes } = options;
             const sandboxValue = attributes?.sandbox ?? this.sandbox;
             const mappedAttributes = this.mapUserAttributes(attributes, this.userAttributeMapping);
+
+            this.currentUser?.setUserAttributes(mappedAttributes);
 
             const enrichedAttributes = {
                 ...mappedAttributes,

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -2,7 +2,7 @@ import { IKitConfigs } from "./configAPIClient";
 import { UserAttributeFilters  } from "./forwarders.interfaces";
 import { IMParticleUser } from "./identity-user-interfaces";
 import KitFilterHelper from "./kitFilterHelper";
-import { Dictionary, isEmpty, parseSettingsString } from "./utils";
+import { Dictionary, parseSettingsString } from "./utils";
 
 // https://docs.rokt.com/developers/integration-guides/web/library/attributes
 export interface IRoktPartnerAttributes {
@@ -37,10 +37,6 @@ export interface RoktKitFilterSettings {
     filteredUser?: IMParticleUser | null;
 }
 
-export interface IRoktKitSettings {
-    userAttributeMapping: string;
-}
-
 export interface IRoktKit  {
     filters: RoktKitFilterSettings;
     filteredUser: IMParticleUser | null;
@@ -70,7 +66,7 @@ export default class RoktManager {
     private filteredUser: IMParticleUser | null = null;
     private messageQueue: IRoktMessage[] = [];
     private sandbox: boolean | null = null;
-    private userAttributeMapping: Dictionary<string>[] | null = null;
+    private userAttributeMapping: Dictionary<string>[] = [];
 
     /**
      * Initializes the RoktManager with configuration settings and user data.
@@ -84,7 +80,7 @@ export default class RoktManager {
      */
     public init(roktConfig: IKitConfigs, filteredUser: IMParticleUser, currentUser: IMParticleUser, options?: IRoktManagerOptions): void {
         const { userAttributeFilters, settings } = roktConfig || {};
-        const { userAttributeMapping = '' } = settings as IRoktKitSettings || {};
+        const { userAttributeMapping } = settings || {};
 
         try {
             this.userAttributeMapping = parseSettingsString(userAttributeMapping);
@@ -150,13 +146,9 @@ export default class RoktManager {
     }
 
     private mapUserAttributes(attributes: IRoktPartnerAttributes, userAttributeMapping: Dictionary<string>[]): IRoktPartnerAttributes {
-        if (isEmpty(userAttributeMapping)) {
-            return attributes;
-        }
-
         const mappingLookup: { [key: string]: string } = {};
-        for (const mapping of userAttributeMapping) {
-            mappingLookup[mapping.map] = mapping.value;
+        for (let i = 0; i < userAttributeMapping.length; i++) {
+            mappingLookup[userAttributeMapping[i].map] = userAttributeMapping[i].value;
         }
     
         const mappedAttributes: IRoktPartnerAttributes = {};

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -72,6 +72,16 @@ export default class RoktManager {
     private sandbox: boolean | null = null;
     private userAttributeMapping: Dictionary<string>[] = [];
 
+    /**
+     * Initializes the RoktManager with configuration settings and user data.
+     * 
+     * @param {IKitConfigs} roktConfig - Configuration object containing user attribute filters and settings
+     * @param {IMParticleUser} filteredUser - User object with filtered attributes
+     * @param {IMParticleUser} currentUser - Current mParticle user object
+     * @param {IRoktManagerOptions} options - Options for the RoktManager
+     * 
+     * @throws Logs error to console if userAttributeMapping parsing fails
+     */
     public init(roktConfig: IKitConfigs, filteredUser: IMParticleUser, currentUser: IMParticleUser, options?: IRoktManagerOptions): void {
         const { userAttributeFilters, settings } = roktConfig || {};
         const { userAttributeMapping = '' } = settings as IRoktKitSettings || {};

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -122,7 +122,11 @@ export default class RoktManager {
             const sandboxValue = attributes?.sandbox ?? this.sandbox;
             const mappedAttributes = this.mapUserAttributes(attributes, this.userAttributeMapping);
 
-            this.currentUser?.setUserAttributes(mappedAttributes);
+            try {
+                this.currentUser.setUserAttributes(mappedAttributes);
+            } catch (error) {
+                console.error('Error setting user attributes', error);
+            }
 
             const enrichedAttributes = {
                 ...mappedAttributes,

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -118,11 +118,7 @@ export default class RoktManager {
             const sandboxValue = attributes?.sandbox ?? this.sandbox;
             const mappedAttributes = this.mapUserAttributes(attributes, this.userAttributeMapping);
 
-            try {
-                this.currentUser.setUserAttributes(mappedAttributes);
-            } catch (error) {
-                console.error('Error setting user attributes', error);
-            }
+            this.setUserAttributes(mappedAttributes);
 
             const enrichedAttributes = {
                 ...mappedAttributes,
@@ -143,6 +139,23 @@ export default class RoktManager {
     private isReady(): boolean {
         // The Rokt Manager is ready when a kit is attached and has a launcher
         return Boolean(this.kit && this.kit.launcher);
+    }
+
+    private setUserAttributes(attributes: IRoktPartnerAttributes): void {
+        const reservedAttributes = ['sandbox'];
+        const filteredAttributes = {};
+        
+        for (var key in attributes) {
+            if (attributes.hasOwnProperty(key) && reservedAttributes.indexOf(key) === -1) {
+                filteredAttributes[key] = attributes[key];
+            }
+        }
+
+        try {
+            this.currentUser.setUserAttributes(filteredAttributes);
+        } catch (error) {
+            console.error('Error setting user attributes', error);
+        }
     }
 
     private mapUserAttributes(attributes: IRoktPartnerAttributes, userAttributeMapping: Dictionary<string>[]): IRoktPartnerAttributes {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -70,7 +70,7 @@ export default class RoktManager {
     private filteredUser: IMParticleUser | null = null;
     private messageQueue: IRoktMessage[] = [];
     private sandbox: boolean | null = null;
-    private userAttributeMapping: Dictionary<string>[] = [];
+    private userAttributeMapping: Dictionary<string>[] | null = null;
 
     /**
      * Initializes the RoktManager with configuration settings and user data.

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -4,9 +4,13 @@ import RoktManager, { IRoktKit, IRoktSelectPlacementsOptions } from "../../src/r
 
 describe('RoktManager', () => {
     let roktManager: RoktManager;
+    let currentUser: IMParticleUser;
 
     beforeEach(() => {
         roktManager = new RoktManager();
+        currentUser = {
+            setUserAttributes: jest.fn()
+        } as unknown as IMParticleUser;
     });
 
     describe('constructor', () => {
@@ -21,7 +25,7 @@ describe('RoktManager', () => {
 
     describe('#init', () => {
         it('should initialize the manager with defaults when no config is provided', () => {
-            roktManager.init({} as IKitConfigs, {} as IMParticleUser, {} as IMParticleUser);
+            roktManager.init({} as IKitConfigs, {} as IMParticleUser, currentUser);
             expect(roktManager['kit']).toBeNull();
             expect(roktManager['filters']).toEqual({
                 userAttributeFilters: undefined,
@@ -29,7 +33,7 @@ describe('RoktManager', () => {
                 filteredUser: {},
             });
             expect(roktManager['kit']).toBeNull();
-            expect(roktManager['currentUser']).toEqual({});
+            expect(roktManager['currentUser']).toEqual(currentUser);
         });
 
         it('should initialize the manager with user attribute filters from a config', () => {
@@ -39,7 +43,7 @@ describe('RoktManager', () => {
                 userAttributeFilters: [816506310, 1463937872, 36300687],
             };
 
-            roktManager.init(kitConfig as IKitConfigs, {} as IMParticleUser, {} as IMParticleUser);
+            roktManager.init(kitConfig as IKitConfigs, {} as IMParticleUser, currentUser);
             expect(roktManager['filters']).toEqual({
                 userAttributeFilters: [816506310, 1463937872, 36300687],
                 filterUserAttributes: expect.any(Function),
@@ -73,7 +77,7 @@ describe('RoktManager', () => {
                     ])
                 },
             };
-            roktManager.init(kitConfig as IKitConfigs, {} as IMParticleUser, {} as IMParticleUser);
+            roktManager.init(kitConfig as IKitConfigs, {} as IMParticleUser, currentUser);
             expect(roktManager['userAttributeMapping']).toEqual([
                 { 
                     jsmap: null,
@@ -138,6 +142,10 @@ describe('RoktManager', () => {
     });
 
     describe('#selectPlacements', () => {
+        beforeEach(() => {
+            roktManager['currentUser'] = currentUser;
+        });
+
         it('should call kit.selectPlacements with empty attributes', () => {
             const kit: IRoktKit = {
                 launcher: {

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -389,6 +389,7 @@ describe('RoktManager', () => {
 
             expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
         });
+
         it('should not add sandbox when sandbox is null', () => {
             const kit: IRoktKit = {
                 launcher: {

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -52,7 +52,12 @@ describe('RoktManager', () => {
         });
 
         it('should initialize the manager with sandbox from options', () => {
-            roktManager.init({} as IKitConfigs, undefined, { sandbox: true });
+            roktManager.init(
+                {} as IKitConfigs,
+                undefined,
+                currentUser,
+                { sandbox: true }
+            );
             expect(roktManager['sandbox']).toBe(true);
         });
 
@@ -562,6 +567,32 @@ describe('RoktManager', () => {
                 lastname: 'Doe',
                 age: 25,
                 score: 42,
+            });
+        });
+
+        it('should not set reserved attributes on the current user', () => {
+            const kit: Partial<IRoktKit> = {
+                launcher: {
+                    selectPlacements: jest.fn()
+                },
+                selectPlacements: jest.fn()
+            };
+
+            roktManager.kit = kit as IRoktKit;
+            roktManager['currentUser'] = {
+                setUserAttributes: jest.fn()
+            } as unknown as IMParticleUser;
+
+            const options: IRoktSelectPlacementsOptions = {
+                attributes: {
+                    'sandbox': true
+                }
+            };
+
+            roktManager.selectPlacements(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(roktManager['currentUser'].setUserAttributes).not.toHaveBeenCalledWith({
+                sandbox: true
             });
         });
     });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds selectPlacement Attributes to Current User Attributes


 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Verify that any select placement attributes appear within the current user's attributes
 - Should also trigger a user attribute change event if an attribute changes

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7175
 - Depends on #1018 to be merged in first