### PR TITLE
feat: Add method for logProductActionV2

### DIFF
--- a/src/ecommerce.interfaces.ts
+++ b/src/ecommerce.interfaces.ts
@@ -84,6 +84,16 @@ export interface SDKECommerceAPI extends IECommerceShared {
         transactionAttributes?: TransactionAttributes,
         eventOptions?: SDKEventOptions
     ): void;
+    logProductActionV2(
+        productActionType: valueof<typeof ProductActionType>,
+        product: SDKProduct | SDKProduct[],
+        options?: {
+            attrs?: SDKEventAttrs;
+            customFlags?: SDKEventCustomFlags;
+            transactionAttributes?: TransactionAttributes;
+            eventOptions?: SDKEventOptions;
+        }
+    ): void;
     logPromotion(
         type: valueof<typeof PromotionActionType>,
         promotion: SDKPromotion,

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -944,6 +944,36 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             );
         },
         /**
+         * Logs a product action with optional parameters in an optional dictionary
+         * @for mParticle.eCommerce
+         * @method logProductActionV2
+         * @param {Number} productActionType product action type as found [here](https://github.com/mParticle/mparticle-sdk-javascript/blob/master-v2/src/types.js#L206-L218)
+         * @param {Object} product the product for which you are creating the product action
+         * @param {Object} [options] options object containing attrs, customFlags, transactionAttributes, and eventOptions
+         */
+        logProductActionV2: function(
+            productActionType,
+            product,
+            options = {}
+        ) {
+            const {
+                attrs = {},
+                customFlags = {},
+                transactionAttributes,
+                eventOptions
+            } = options;
+
+            this.logProductAction(
+                productActionType,
+                product,
+                attrs,
+                customFlags,
+                transactionAttributes,
+                eventOptions
+            );
+        },
+
+        /**
          * Logs a product purchase
          * @for mParticle.eCommerce
          * @method logPurchase

--- a/src/mparticle-instance-manager.ts
+++ b/src/mparticle-instance-manager.ts
@@ -284,13 +284,24 @@ function mParticleInstanceManager(this: IMParticleInstanceManager) {
             transactionAttributes,
             eventOptions
         ) {
-            self.getInstance().eCommerce.logProductAction(
+            return self.getInstance().eCommerce.logProductAction(
                 productActionType,
                 product,
                 attrs,
                 customFlags,
                 transactionAttributes,
                 eventOptions
+            );
+        },
+        logProductActionV2: function(
+            productActionType,
+            product,
+            options = {}
+        ) {
+            self.getInstance().eCommerce.logProductActionV2(
+                productActionType,
+                product,
+                options
             );
         },
         logPurchase: function(

--- a/test/src/tests-eCommerce.js
+++ b/test/src/tests-eCommerce.js
@@ -1670,6 +1670,75 @@ describe('eCommerce', function() {
         done();
     })
     });
+
+    it('should call logProductAction with same arguments when using logProductActionV2', function(done) {
+        const logProductActionSpy = sinon.spy(mParticle.getInstance().eCommerce, 'logProductAction');
+
+        const product = mParticle.eCommerce.createProduct(
+            'iPhone',
+            '12345',
+            400,
+            2,
+            'Plus',
+            'Phones',
+            'Apple',
+            1,
+            'my-coupon-code',
+            { customkey: 'customvalue' }
+        );
+
+        const transactionAttributes = mParticle.eCommerce.createTransactionAttributes(
+            '12345',
+            'test-affiliation',
+            'coupon-code',
+            44334,
+            600,
+            200
+        );
+
+        const eventAttributes = {
+            customAttr1: 'value1',
+            customAttr2: 'value2'
+        };
+
+        const customFlags = {
+            flag1: 'value1',
+            flag2: 'value2'
+        };
+
+        const eventOptions = {
+            option1: 'value1',
+            option2: 'value2'
+        };
+
+        // Call logProductActionV2
+
+        mParticle.eCommerce.logProductActionV2(
+            mParticle.ProductActionType.Purchase, 
+            product,
+            {
+                attrs: eventAttributes,
+                customFlags: customFlags,
+                transactionAttributes: transactionAttributes,
+                eventOptions: eventOptions
+            }
+        );
+
+        // Verify logProductAction was called with the same arguments
+        logProductActionSpy.calledOnce.should.be.true;
+
+        const args = logProductActionSpy.firstCall.args;
+        args[0].should.equal(mParticle.ProductActionType.Purchase);
+        args[1].should.equal(product);
+        args[2].should.equal(eventAttributes);
+        args[3].should.equal(customFlags);
+        args[4].should.equal(transactionAttributes);
+        args[5].should.equal(eventOptions);
+
+        logProductActionSpy.restore();
+        done();
+    });
+
     describe('Cart', function() {
         afterEach(function() {
             sinon.restore();

--- a/test/src/tests-mparticle-instance-manager.ts
+++ b/test/src/tests-mparticle-instance-manager.ts
@@ -143,6 +143,7 @@ describe('mParticle instance manager', () => {
             'createTransactionAttributes',
             'logCheckout',
             'logProductAction',
+            'logProductActionV2',
             'logPurchase',
             'logPromotion',
             'logImpression',


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
`logProductAction` currently has a suboptimail signature because `transactionAttributes` comes after `customFlags` which can often be `null`.  This exists from 5 years ago when we deprecated [logCheckout/logPurchase/logRefund](https://github.com/mParticle/mparticle-web-sdk/commit/5ba57a3760667e875fc209806661db14b25df178) in favor of using logProductAction, but `logProductAction` didn't take TA at the time which the deprecated methods did, and so we had to add it to the tail end of the method signature.

This PR attempts to resolve this by allowing anything optional to be put in a single options object via `logProductActionV2`.  [Amplitude does something similar](https://amplitude.com/docs/sdks/analytics/browser/javascript-sdk#track-revenue) with `logRevenueV2`.  I have no issue changing this to a brand new method name.

 ## Testing Plan
 - [X] Was this tested locally? 
Tested in a test app locally - See screenshot below
![image](https://github.com/user-attachments/assets/db0bc4f5-9e22-41a5-9766-d54d8f22e70f)


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7237