### PR TITLE
fix: Add try/catch logic for getCookie to prevent crashes on web exte…

### DIFF
--- a/src/persistence.js
+++ b/src/persistence.js
@@ -467,7 +467,7 @@ export default function _Persistence(mpInstance) {
     };
 
     this.getCookie = function() {
-        var cookies = window.document.cookie.split('; '),
+        var cookies,
             key = mpInstance._Store.storageName,
             i,
             l,
@@ -477,6 +477,13 @@ export default function _Persistence(mpInstance) {
             result = key ? undefined : {};
 
         mpInstance.Logger.verbose(Messages.InformationMessages.CookieSearch);
+
+        try {
+            cookies = window.document.cookie.split('; ');
+        } catch (e) {
+            mpInstance.Logger.verbose('Unable to parse undefined cookie');
+            return null;
+        }
 
         for (i = 0, l = cookies.length; i < l; i++) {
             try {


### PR DESCRIPTION
…nsions

 ## Summary
 - we have customers including the web sdk on web extensions they built with service workers where cookies don't exist, we check for window.document.cookie without checking if it exist which is what causing the crashes for the customer. with this PR added a try/catch error to prevent the crashes

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7201
