### PR TITLE
Add experiments allocation function to RoktManager

### DIFF
--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -84,7 +84,6 @@ export default class RoktManager {
 
     private experimentAllocation: IRoktExperimentAllocation | null = null;
 
-
     /**
      * Initializes the RoktManager with configuration settings and user data.
      * 
@@ -139,9 +138,9 @@ export default class RoktManager {
             this.setUserAttributes(mappedAttributes);
 
             if (this.experimentAllocation) {
-                mappedAttributes['rokt.experimentid'] = this.experimentAllocation.experimentId;
-                mappedAttributes['rokt.bucketid'] = this.experimentAllocation.bucketId; 
-                mappedAttributes['rokt.userid'] = this.experimentAllocation.userId;
+                mappedAttributes['rokt.partnerexperiment.experimentid'] = this.experimentAllocation.experimentId;
+                mappedAttributes['rokt.partnerexperiment.bucketid'] = this.experimentAllocation.bucketId; 
+                mappedAttributes['rokt.partnerexperiment.userid'] = this.experimentAllocation.userId;
             }
 
             const enrichedAttributes = {


### PR DESCRIPTION
 ## Summary
 - Adding `setExperimentAllocationData` to the RoktManager for clients to save experiment allocation data
 - data will be passed down to the Rokt Kit during select placement call with specific attribute keys

 ## Testing Plan
 - [ ] TODO: Write unit tests for the new function

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
