### PR TITLE
fix: Initialize Rokt before processing forwarders

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -1394,17 +1394,6 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             mpInstance._IntegrationCapture.capture();
         }
 
-        mpInstance._Forwarders.processForwarders(
-            config,
-            mpInstance._APIClient.prepareForwardingStats
-        );
-        mpInstance._Forwarders.processPixelConfigs(config);
-
-        // Checks if session is created, resumed, or needs to be ended
-        // Logs a session start or session end event accordingly
-        mpInstance._SessionManager.initialize();
-        mpInstance._Events.logAST();
-
         // Configure Rokt Manager with user and filtered user
         const roktConfig: IKitConfigs = parseConfig(config, 'Rokt', 181);
         if (roktConfig) {
@@ -1427,6 +1416,17 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
                 roktOptions
             );
         }
+
+        mpInstance._Forwarders.processForwarders(
+            config,
+            mpInstance._APIClient.prepareForwardingStats
+        );
+        mpInstance._Forwarders.processPixelConfigs(config);
+
+        // Checks if session is created, resumed, or needs to be ended
+        // Logs a session start or session end event accordingly
+        mpInstance._SessionManager.initialize();
+        mpInstance._Events.logAST();
 
         processIdentityCallback(
             mpInstance,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Move back Rokt init before processForwarders so that the rokt forwarder has all the appropriate parameters before being initialized

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
