### PR TITLE
fix: Revise sandbox setting

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -49,7 +49,7 @@ import { IECommerce } from './ecommerce.interfaces';
 import { INativeSdkHelpers } from './nativeSdkHelpers.interfaces';
 import { IPersistence } from './persistence.interfaces';
 import ForegroundTimer from './foregroundTimeTracker';
-import RoktManager, { IRoktManagerOptions, IRoktOptions } from './roktManager';
+import RoktManager, { IRoktOptions } from './roktManager';
 import filteredMparticleUser from './filteredMparticleUser';
 
 export interface IErrorLogMessage {
@@ -1404,9 +1404,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
                 mpInstance
             );
             const roktOptions: IRoktOptions = {
-                managerOptions: {
-                    sandbox: config.isDevelopmentMode,
-                },
+                sandbox: config?.isDevelopmentMode,
                 launcherOptions: config?.launcherOptions,
             };
             // https://go.mparticle.com/work/SQDSDKS-7339

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -56,14 +56,11 @@ export interface IRoktKit {
 }
 
 export interface IRoktOptions {
-    managerOptions?: IRoktManagerOptions;
+    sandbox?: boolean;
     launcherOptions?: IRoktLauncherOptions;
 }
 
 export type IRoktLauncherOptions = Dictionary<any>;
-export type IRoktManagerOptions = {
-    sandbox?: boolean;
-};
 
 // The purpose of this class is to create a link between the Core mParticle SDK and the
 // Rokt Web SDK via a Web Kit.
@@ -124,11 +121,11 @@ export default class RoktManager {
         // It is set here and passed in to the createLauncher method in the Rokt Kit
         // This is not to be confused for the `sandbox` flag in the selectPlacements attributes
         // as that is independent of this setting, though they share the same name.
-        this.sandbox = options?.managerOptions?.sandbox;
+        const sandbox = options?.sandbox || false;
 
         // Launcher options are set here for the kit to pick up and pass through
         // to the Rokt Launcher.
-        this.launcherOptions = options?.launcherOptions;
+        this.launcherOptions = { sandbox, ...options?.launcherOptions };
     }
 
     public attachKit(kit: IRoktKit): void {

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -217,17 +217,17 @@ describe('RoktManager', () => {
             });
         });
 
-        it('should initialize the manager with sandbox from options', () => {
+        it('should initialize the manager with sandbox from options as launcherOptions', () => {
             roktManager.init(
                 {} as IKitConfigs,
                 undefined,
                 mockMPInstance.Identity,
                 undefined,
                 {
-                    managerOptions: { sandbox: true },
+                    sandbox: true,
                 }
             );
-            expect(roktManager['sandbox']).toBe(true);
+            expect(roktManager['launcherOptions']).toEqual({ sandbox: true });
         });
 
         it('should initialize the manager with placement attributes mapping from a config', () => {
@@ -281,26 +281,32 @@ describe('RoktManager', () => {
                 mockMPInstance.Identity,
                 mockMPInstance.Logger,
                 {
-                    managerOptions: { sandbox: true },
                     launcherOptions
                 }
             );
 
-            expect(roktManager['launcherOptions']).toEqual(launcherOptions);
+            const expectedOptions = {
+                sandbox: false,
+                ...launcherOptions
+            };
+
+            expect(roktManager['launcherOptions']).toEqual(expectedOptions);
         });
 
-        it('should initialize the manager with launcher options as undefined when not provided', () => {
+        it('should initialize the manager with default launcher options not provided', () => {
             roktManager.init(
                 {} as IKitConfigs,
                 undefined,
                 mockMPInstance.Identity,
                 mockMPInstance.Logger,
-                {
-                    managerOptions: { sandbox: true }
-                }
+                undefined,
             );
 
-            expect(roktManager['launcherOptions']).toEqual(undefined);
+            const expectedOptions = {
+                sandbox: false,
+            };
+
+            expect(roktManager['launcherOptions']).toEqual(expectedOptions);
         });
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fixes implementation of `isDevelopmentMode` in the Rokt Manager.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, verify that `window.mParticle.config.isDevelopmentMode = true` enables `sandbox = true` in the Rokt Web SDK

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7361
