### PR TITLE
feat: Expose config.domain for easier CNAME configuration

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -139,6 +139,15 @@ const Constants = {
         aliasUrl: 'jssdks.mparticle.com/v1/identity/',
         userAudienceUrl: 'nativesdks.mparticle.com/v1/',
     },
+    // These are the paths that are used to construct the CNAME urls
+    CNAMEUrlPaths: {
+        v1SecureServiceUrl: '/webevents/v1/JS/',
+        v2SecureServiceUrl: '/webevents/v2/JS/',
+        v3SecureServiceUrl: '/webevents/v3/JS/',
+        configUrl: '/tags/JS/v2/',
+        identityUrl: '/identity/v1/',
+        aliasUrl: '/webevents/v1/identity/',
+    },
     Base64CookieKeys: {
         csm: 1,
         sa: 1,

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -294,6 +294,7 @@ export interface SDKInitConfig
     v1SecureServiceUrl?: string;
     v2SecureServiceUrl?: string;
     v3SecureServiceUrl?: string;
+    domain?: string;
 
     workspaceToken?: string;
     isDevelopmentMode?: boolean;

--- a/src/store.ts
+++ b/src/store.ts
@@ -765,8 +765,15 @@ export function processBaseUrls(
 function processCustomBaseUrls(config: SDKInitConfig): Dictionary<string> {
     const defaultBaseUrls: Dictionary<string> = Constants.DefaultBaseUrls;
     const CNAMEUrlPaths: Dictionary<string> = Constants.CNAMEUrlPaths;
+
+    // newBaseUrls are default if the customer is not using a CNAME
+    // If a customer passes either config.domain or config.v3SecureServiceUrl,
+    // config.identityUrl, etc, the customer is using a CNAME.
+    // config.domain will take priority if a customer passes both.
     const newBaseUrls: Dictionary<string> = {};
-    // If config.domain exists, the customer is using a CNAME, and we append the url paths to the domain
+    // If config.domain exists, the customer is using a CNAME.  We append the url paths to the provided domain.
+    // This flag is set on the Rokt/MP snippet (starting at version 2.6), meaning config.domain will alwys be empty
+    // if a customer is using a snippet prior to 2.6.
     if (!isEmpty(config.domain)) {
         for (let pathKey in CNAMEUrlPaths) {
             newBaseUrls[pathKey] = `${config.domain}${CNAMEUrlPaths[pathKey]}`;

--- a/src/store.ts
+++ b/src/store.ts
@@ -764,9 +764,17 @@ export function processBaseUrls(
 
 function processCustomBaseUrls(config: SDKInitConfig): Dictionary<string> {
     const defaultBaseUrls: Dictionary<string> = Constants.DefaultBaseUrls;
+    const CNAMEUrlPaths: Dictionary<string> = Constants.CNAMEUrlPaths;
     const newBaseUrls: Dictionary<string> = {};
+    // If config.domain exists, the customer is using a CNAME, and we append the url paths to the domain
+    if (!isEmpty(config.domain)) {
+        for (let pathKey in CNAMEUrlPaths) {
+            newBaseUrls[pathKey] = `${config.domain}${CNAMEUrlPaths[pathKey]}`;
+        }
 
-    // If there is no custo base url, we use the default base url
+        return newBaseUrls;
+    }
+
     for (let baseUrlKey in defaultBaseUrls) {
         newBaseUrls[baseUrlKey] =
             config[baseUrlKey] || defaultBaseUrls[baseUrlKey];

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1568,6 +1568,8 @@ describe('Store', () => {
             it('should prioritize domain over custom baseUrls when both are set', () => {
                 const config = {
                     domain: 'custom.domain.com',
+                    v1SecureServiceUrl: 'foo.customer.mp.com/v1/JS/',
+                    v2SecureServiceUrl: 'foo.customer.mp.com/v2/JS/',
                     v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
                     configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
                     identityUrl: 'foo-identity.customer.mp.com/',

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1530,13 +1530,13 @@ describe('Store', () => {
                 );
 
                 const expectedResult = {
-                    v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
                     configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
                     identityUrl: 'foo-identity.customer.mp.com/',
                     userAudienceUrl: 'foo-user-segment.customer.mp.com/',
                     aliasUrl: 'foo-alias.customer.mp.com/',
                     v1SecureServiceUrl: 'jssdks.mparticle.com/v1/JS/',
                     v2SecureServiceUrl: 'jssdks.mparticle.com/v2/JS/',
+                    v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
                 };
 
                 expect(result).to.deep.equal(expectedResult);
@@ -1554,12 +1554,12 @@ describe('Store', () => {
                 );
 
                 const expectedResult = {
-                    v3SecureServiceUrl: 'custom.domain.com/webevents/v3/JS/',
                     configUrl: 'custom.domain.com/tags/JS/v2/',
                     identityUrl: 'custom.domain.com/identity/v1/',
                     aliasUrl: 'custom.domain.com/webevents/v1/identity/',
                     v1SecureServiceUrl: 'custom.domain.com/webevents/v1/JS/',
                     v2SecureServiceUrl: 'custom.domain.com/webevents/v2/JS/',
+                    v3SecureServiceUrl: 'custom.domain.com/webevents/v3/JS/',
                 };
 
                 expect(result).to.deep.equal(expectedResult);
@@ -1581,12 +1581,12 @@ describe('Store', () => {
                 );
 
                 const expectedResult = {
-                    v3SecureServiceUrl: 'custom.domain.com/webevents/v3/JS/',
                     configUrl: 'custom.domain.com/tags/JS/v2/',
                     identityUrl: 'custom.domain.com/identity/v1/',
                     aliasUrl: 'custom.domain.com/webevents/v1/identity/',
                     v1SecureServiceUrl: 'custom.domain.com/webevents/v1/JS/',
                     v2SecureServiceUrl: 'custom.domain.com/webevents/v2/JS/',
+                    v3SecureServiceUrl: 'custom.domain.com/webevents/v3/JS/',
                 };
 
                 expect(result).to.deep.equal(expectedResult);
@@ -1644,13 +1644,13 @@ describe('Store', () => {
                 );
 
                 const expectedResult = {
-                    v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
                     configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
                     identityUrl: 'foo-identity.customer.mp.com/',
                     userAudienceUrl: 'foo-user-segment.customer.mp.com/',
                     aliasUrl: 'foo-alias.customer.mp.com/',
                     v1SecureServiceUrl: 'jssdks.us1.mparticle.com/v1/JS/',
                     v2SecureServiceUrl: 'jssdks.us1.mparticle.com/v2/JS/',
+                    v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
                 };
 
                 expect(result).to.deep.equal(expectedResult);

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1541,6 +1541,56 @@ describe('Store', () => {
 
                 expect(result).to.deep.equal(expectedResult);
             });
+
+            it('should append url paths to domain when config.domain is set', () => {
+                const config = {
+                    domain: 'custom.domain.com'
+                };
+
+                const result = processBaseUrls(
+                    (config as unknown) as SDKInitConfig,
+                    (featureFlags as unknown) as IFeatureFlags,
+                    'apikey'
+                );
+
+                const expectedResult = {
+                    v3SecureServiceUrl: 'custom.domain.com/webevents/v3/JS/',
+                    configUrl: 'custom.domain.com/tags/JS/v2/',
+                    identityUrl: 'custom.domain.com/identity/v1/',
+                    aliasUrl: 'custom.domain.com/webevents/v1/identity/',
+                    v1SecureServiceUrl: 'custom.domain.com/webevents/v1/JS/',
+                    v2SecureServiceUrl: 'custom.domain.com/webevents/v2/JS/',
+                };
+
+                expect(result).to.deep.equal(expectedResult);
+            });
+
+            it('should prioritize domain over custom baseUrls when both are set', () => {
+                const config = {
+                    domain: 'custom.domain.com',
+                    v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
+                    configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
+                    identityUrl: 'foo-identity.customer.mp.com/',
+                    aliasUrl: 'foo-alias.customer.mp.com/',
+                };
+
+                const result = processBaseUrls(
+                    (config as unknown) as SDKInitConfig,
+                    (featureFlags as unknown) as IFeatureFlags,
+                    'apikey'
+                );
+
+                const expectedResult = {
+                    v3SecureServiceUrl: 'custom.domain.com/webevents/v3/JS/',
+                    configUrl: 'custom.domain.com/tags/JS/v2/',
+                    identityUrl: 'custom.domain.com/identity/v1/',
+                    aliasUrl: 'custom.domain.com/webevents/v1/identity/',
+                    v1SecureServiceUrl: 'custom.domain.com/webevents/v1/JS/',
+                    v2SecureServiceUrl: 'custom.domain.com/webevents/v2/JS/',
+                };
+
+                expect(result).to.deep.equal(expectedResult);
+            });
         });
 
         describe('directURLRouting === true', () => {

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1543,6 +1543,8 @@ describe('Store', () => {
             });
 
             it('should append url paths to domain when config.domain is set', () => {
+                // This example assumes only the domain is set, and not any of the 
+                // configurable URLs
                 const config = {
                     domain: 'custom.domain.com'
                 };
@@ -1566,6 +1568,9 @@ describe('Store', () => {
             });
 
             it('should prioritize domain over custom baseUrls when both are set', () => {
+                // If both the domain and other configurable URLs are set, then 
+                // we use the domain.  A customer should not be passing in both, as
+                // that would be an implementation error.
                 const config = {
                     domain: 'custom.domain.com',
                     v1SecureServiceUrl: 'foo.customer.mp.com/v1/JS/',


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
A new config.domain will be added to the snippet.  When this happens, we will create the CNAME urls automatically as opposed to requiring a customer pass specific URLs to us, which is cumbersome.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - Tested on Rokt customer site to use new snippet and confirmed URLs are mapped correctly
 - Tested locally pulling down app.js using the default `https://apps.rokt-api.com/` URL.  works correctly
 - Tested on other customer sites using our CURRENT snippet to ensure that data flows properly.  Confirmed on 1 site that has their own CNAME, 1 site that does not have a CNAME, 
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7366