### PR TITLE
feat: Add domain to RoktManager to support CNAME for Rokt

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -1406,6 +1406,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             const roktOptions: IRoktOptions = {
                 sandbox: config?.isDevelopmentMode,
                 launcherOptions: config?.launcherOptions,
+                domain: config?.domain,
             };
             // https://go.mparticle.com/work/SQDSDKS-7339
             mpInstance._RoktManager.init(

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -58,6 +58,7 @@ export interface IRoktKit {
 export interface IRoktOptions {
     sandbox?: boolean;
     launcherOptions?: IRoktLauncherOptions;
+    domain?: string;
 }
 
 export type IRoktLauncherOptions = Dictionary<any>;
@@ -81,6 +82,7 @@ export default class RoktManager {
     private identityService: SDKIdentityApi;
     private launcherOptions?: IRoktLauncherOptions;
     private logger: SDKLoggerApi;
+    private domain?: string;
     /**
      * Initializes the RoktManager with configuration settings and user data.
      * 
@@ -126,6 +128,8 @@ export default class RoktManager {
         // Launcher options are set here for the kit to pick up and pass through
         // to the Rokt Launcher.
         this.launcherOptions = { sandbox, ...options?.launcherOptions };
+
+        this.domain = options?.domain;
     }
 
     public attachKit(kit: IRoktKit): void {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -129,7 +129,9 @@ export default class RoktManager {
         // to the Rokt Launcher.
         this.launcherOptions = { sandbox, ...options?.launcherOptions };
 
-        this.domain = options?.domain;
+        if (options?.domain) {
+            this.domain = options.domain;
+        }
     }
 
     public attachKit(kit: IRoktKit): void {

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -308,6 +308,20 @@ describe('RoktManager', () => {
 
             expect(roktManager['launcherOptions']).toEqual(expectedOptions);
         });
+
+        it('should set the domain property when passed in options', () => {
+            const domain = 'custom.domain.com';
+            roktManager.init(
+                {} as IKitConfigs,
+                undefined,
+                mockMPInstance.Identity,
+                mockMPInstance.Logger,
+                {
+                    domain,
+                }
+            );
+            expect(roktManager['domain']).toBe(domain);
+        });
     });
 
     describe('#attachKit', () => {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
This PR supports CNAME-ing for Rokt by adding this to the RoktManager.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Locally tested with a CNAME and building the kit  - PR for kit here - https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/pull/34

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7387