### PR TITLE
fix: Revise RoktManager promise queuing logic

### DIFF
--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -235,7 +235,7 @@ export default class RoktManager {
             return await this.kit.setExtensionData<T>(extensionData);
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            return Promise.reject(new Error('Error setting extension data: ' + errorMessage));
+            throw new Error('Error setting extension data: ' + errorMessage);
         }
     }
 

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -208,21 +208,21 @@ export default class RoktManager {
                 attributes: enrichedAttributes,
             };
 
-            return this.kit.selectPlacements(enrichedOptions);
+            return await this.kit.selectPlacements(enrichedOptions);
         } catch (error) {
-            return Promise.reject(error instanceof Error ? error : new Error('Unknown error occurred'));
+            throw error instanceof Error ? error : new Error('Unknown error occurred');
         }
     }
 
-    public hashAttributes(attributes: IRoktPartnerAttributes): Promise<Record<string, string>> {
+    public async hashAttributes(attributes: IRoktPartnerAttributes): Promise<Record<string, string>> {
         if (!this.isReady()) {
             return this.deferredCall<Record<string, string>>('hashAttributes', attributes);
         }
 
         try {
-            return this.kit.hashAttributes(attributes);
+            return await this.kit.hashAttributes(attributes);
         } catch (error) {
-            return Promise.reject(error instanceof Error ? error : new Error('Unknown error occurred'));
+            throw error instanceof Error ? error : new Error('Unknown error occurred');
         }
     }
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - When we initially implemented the Rokt Manager, we added logic to queue Rokt methods that were called before the mParticle SDK was ready.
 - In some cases, there was a race condition that would occur where the SDK was ready to queue methods (via the ready queue) but the Rokt Manager was not ready because the launcher was not attached. In this scenario, the promise would get dropped and queued asynchronous methods would not fire.
 - In some rare cases, the promise would execute the associated Rokt method, but the promise would not be returned and event listeners would not be properly invoked.
 - This new change will store queued promises as promises (rather than a simple array of method calls) and replay them when the kit is attached.
 - This change will also set a timeout value to force a lost promise to reject which should help us with troubleshooting.
 - We've also added better logging and edge case handling.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, set the SDK script tag to be deferred or introduce a setTimeout to delay the loading of the Web SDK.
 - Attempt to fire a `selectPlacement` or `hashAttributes` call.
 - The method should be queued properly and execute once the kit is attached.
 - *Note*: Using a Tag Manager like GTM or Adobe Extensions will allow easier testing by triggering a selectPlacement at the same time as the SDK initialization.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7404
