### PR TITLE
fix: fire identify call if config identities differ from current user

### DIFF
--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -13,7 +13,6 @@ import {
     IIdentityResponse,
     IMParticleUser,
 } from './identity-user-interfaces';
-import { IMParticleWebSDKInstance } from './mp-instance';
 
 const { Identify, Modify, Login, Logout } = Constants.IdentityMethods;
 export const CACHE_HEADER = 'x-mp-max-age' as const;

--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -7,10 +7,11 @@ import {
     UserIdentities,
     IdentityCallback,
 } from '@mparticle/web-sdk';
-import { IdentityAPIMethod } from './identity.interfaces';
+import { IdentityAPIMethod, IIdentityRequest } from './identity.interfaces';
 import {
     IdentityResultBody,
     IIdentityResponse,
+    IMParticleUser,
 } from './identity-user-interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
 
@@ -282,17 +283,10 @@ const parseIdentityResponse = (responseText: string): IdentityResultBody =>
     responseText ? JSON.parse(responseText) : ({} as IdentityResultBody);
 
 export const hasIdentityRequestChanged = (
-    mpInstance: IMParticleWebSDKInstance
+    currentUser: IMParticleUser,
+    newIdentityRequest: IdentityApiData
 ): boolean => {
-    const currentUser = mpInstance.Identity.getCurrentUser();
-
-    const newIdentityRequest = mpInstance._Store.SDKConfig.identifyRequest;
-
-    if (
-        !currentUser ||
-        !newIdentityRequest ||
-        !newIdentityRequest.userIdentities
-    ) {
+    if (!currentUser || !newIdentityRequest?.userIdentities) {
         return false;
     }
 

--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -12,6 +12,7 @@ import {
     IdentityResultBody,
     IIdentityResponse,
 } from './identity-user-interfaces';
+import { IMParticleWebSDKInstance } from './mp-instance';
 
 const { Identify, Modify, Login, Logout } = Constants.IdentityMethods;
 export const CACHE_HEADER = 'x-mp-max-age' as const;
@@ -279,3 +280,28 @@ const getExpireTimestamp = (maxAge: number = ONE_DAY_IN_SECONDS): number =>
 
 const parseIdentityResponse = (responseText: string): IdentityResultBody =>
     responseText ? JSON.parse(responseText) : ({} as IdentityResultBody);
+
+export const hasIdentityRequestChanged = (
+    mpInstance: IMParticleWebSDKInstance
+): boolean => {
+    const currentUser = mpInstance.Identity.getCurrentUser();
+
+    const newIdentityRequest = mpInstance._Store.SDKConfig.identifyRequest;
+
+    if (
+        !currentUser ||
+        !newIdentityRequest ||
+        !newIdentityRequest.userIdentities
+    ) {
+        return false;
+    }
+
+    const currentUserIdentities =
+        currentUser.getUserIdentities().userIdentities;
+
+    const newIdentities = newIdentityRequest.userIdentities;
+
+    return (
+        JSON.stringify(currentUserIdentities) !== JSON.stringify(newIdentities)
+    );
+};

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -48,7 +48,13 @@ export default function SessionManager(
             } else {
                 // https://go.mparticle.com/work/SQDSDKS-6045
                 // https://go.mparticle.com/work/SQDSDKS-6323
-                if (hasIdentityRequestChanged(mpInstance)) {
+                const currentUser = mpInstance.Identity.getCurrentUser();
+                const sdkIdentityRequest =
+                    mpInstance._Store.SDKConfig.identifyRequest;
+
+                if (
+                    hasIdentityRequestChanged(currentUser, sdkIdentityRequest)
+                ) {
                     mpInstance.Identity.identify(
                         mpInstance._Store.SDKConfig.identifyRequest,
                         mpInstance._Store.SDKConfig.identityCallback

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -48,26 +48,14 @@ export default function SessionManager(
                 self.startNewSession();
             } else {
                 // https://go.mparticle.com/work/SQDSDKS-6045
-                const persistence: IPersistenceMinified =
-                    mpInstance._Persistence.getPersistence();
-                if (persistence && !persistence.cu) {
-                    // https://go.mparticle.com/work/SQDSDKS-6323
+                // https://go.mparticle.com/work/SQDSDKS-6323
+                if (self.hasIdentityRequestChanged()) {
                     mpInstance.Identity.identify(
                         mpInstance._Store.SDKConfig.identifyRequest,
                         mpInstance._Store.SDKConfig.identityCallback
                     );
                     mpInstance._Store.identifyCalled = true;
                     mpInstance._Store.SDKConfig.identityCallback = null;
-                } else if (persistence && persistence.cu) {
-                    // Check if the identity request differs from current user identities
-                    if (self.hasIdentityRequestChanged()) {
-                        mpInstance.Identity.identify(
-                            mpInstance._Store.SDKConfig.identifyRequest,
-                            mpInstance._Store.SDKConfig.identityCallback
-                        );
-                        mpInstance._Store.identifyCalled = true;
-                        mpInstance._Store.SDKConfig.identityCallback = null;
-                    }
                 }
             }
         } else {
@@ -75,7 +63,7 @@ export default function SessionManager(
         }
     };
 
-    this.hasIdentityRequestChanged = function (): boolean {
+    this.hasIdentityRequestChanged = (): boolean => {
         const currentUser = mpInstance.Identity.getCurrentUser();
         if (!currentUser) {
             return false;

--- a/test/src/config/utils.js
+++ b/test/src/config/utils.js
@@ -631,8 +631,8 @@ var pluses = /\+/g,
             { overwriteRoutes: true }
         );
     },
-    hasIdentifyReturned = () => {
-        return window.mParticle.Identity.getCurrentUser()?.getMPID() === testMPID;
+    hasIdentifyReturned = (mpid = testMPID) => {
+        return window.mParticle.Identity.getCurrentUser()?.getMPID() === mpid;
     },
     hasIdentityCallInflightReturned = () => !mParticle.getInstance()?._Store?.identityCallInFlight,
     hasConfigurationReturned = () => !!mParticle.getInstance()?._Store?.configurationLoaded;

--- a/test/src/config/utils.js
+++ b/test/src/config/utils.js
@@ -631,8 +631,8 @@ var pluses = /\+/g,
             { overwriteRoutes: true }
         );
     },
-    hasIdentifyReturned = (mpid = testMPID) => {
-        return window.mParticle.Identity.getCurrentUser()?.getMPID() === mpid;
+    hasIdentifyReturned = (_mpid = testMPID) => {
+        return window.mParticle.Identity.getCurrentUser()?.getMPID() === _mpid;
     },
     hasIdentityCallInflightReturned = () => !mParticle.getInstance()?._Store?.identityCallInFlight,
     hasConfigurationReturned = () => !!mParticle.getInstance()?._Store?.configurationLoaded;

--- a/test/src/tests-identity-utils.ts
+++ b/test/src/tests-identity-utils.ts
@@ -555,30 +555,14 @@ describe('identity-utils', () => {
                     email: 'different@email.com',
                 };
 
-                // Create a mock mpInstance
-                const mockMPInstance = {
-                    Identity: {
-                        getCurrentUser: () => ({
-                            getMPID: () => 'test-mpid',
-                            getUserIdentities: () => ({
-                                userIdentities: userIdentities,
-                            }),
-                            getAllUserAttributes: () => ({}),
-                            setUserTag: () => {},
-                            setUserAttribute: () => {},
-                            getCart: () => ({}),
-                        }),
-                    },
-                    _Store: {
-                        SDKConfig: {
-                            identifyRequest: {
-                                userIdentities: newIdentities,
-                            },
-                        },
-                    },
+                // Create a mock current user
+                const mockCurrentUser = {
+                    getUserIdentities: () => ({
+                        userIdentities: userIdentities,
+                    }),
                 } as any;
 
-                const result = hasIdentityRequestChanged(mockMPInstance);
+                const result = hasIdentityRequestChanged(mockCurrentUser, { userIdentities: newIdentities });
                 expect(result).to.equal(true);
             });
 
@@ -588,79 +572,35 @@ describe('identity-utils', () => {
                     email: 'same@email.com',
                 };
 
-                // Create a mock mpInstance
-                const mockMPInstance = {
-                    Identity: {
-                        getCurrentUser: () => ({
-                            getMPID: () => 'test-mpid',
-                            getUserIdentities: () => ({
-                                userIdentities: userIdentities,
-                            }),
-                            getAllUserAttributes: () => ({}),
-                            setUserTag: () => {},
-                            setUserAttribute: () => {},
-                            getCart: () => ({}),
-                        }),
-                    },
-                    _Store: {
-                        SDKConfig: {
-                            identifyRequest: {
-                                userIdentities: userIdentities,
-                            },
-                        },
-                    },
+                // Create a mock current user
+                const mockCurrentUser = {
+                    getUserIdentities: () => ({
+                        userIdentities: userIdentities,
+                    }),
                 } as any;
 
-                const result = hasIdentityRequestChanged(mockMPInstance);
+                const result = hasIdentityRequestChanged(mockCurrentUser, { userIdentities: userIdentities });
                 expect(result).to.equal(false);
             });
 
             it('returns false when getCurrentUser() is null', () => {
-                // Create a mock mpInstance with no current user
-                const mockMPInstance = {
-                    Identity: {
-                        getCurrentUser: () => null,
-                    },
-                    _Store: {
-                        SDKConfig: {
-                            identifyRequest: {
-                                userIdentities: {
-                                    customerid: 'some-customer-id',
-                                },
-                            },
-                        },
-                    },
-                } as any;
-
-                const result = hasIdentityRequestChanged(mockMPInstance);
+                const result = hasIdentityRequestChanged(null, { 
+                    userIdentities: { customerid: 'some-customer-id' } 
+                });
                 expect(result).to.equal(false);
             });
 
-            it('returns false when  SDKConfig.identifyRequest is null', () => {
-                // Create a mock mpInstance with current user but no identifyRequest
-                const mockMPInstance = {
-                    Identity: {
-                        getCurrentUser: () => ({
-                            getMPID: () => 'test-mpid',
-                            getUserIdentities: () => ({
-                                userIdentities: {
-                                    customerid: 'current-customer-id',
-                                },
-                            }),
-                            getAllUserAttributes: () => ({}),
-                            setUserTag: () => {},
-                            setUserAttribute: () => {},
-                            getCart: () => ({}),
-                        }),
-                    },
-                    _Store: {
-                        SDKConfig: {
-                            identifyRequest: null,
+            it('returns false when SDKConfig.identifyRequest is null', () => {
+                // Create a mock current user
+                const mockCurrentUser = {
+                    getUserIdentities: () => ({
+                        userIdentities: {
+                            customerid: 'current-customer-id',
                         },
-                    },
+                    }),
                 } as any;
 
-                const result = hasIdentityRequestChanged(mockMPInstance);
+                const result = hasIdentityRequestChanged(mockCurrentUser, null);
                 expect(result).to.equal(false);
             });
         });

--- a/test/src/tests-identity.ts
+++ b/test/src/tests-identity.ts
@@ -1951,7 +1951,7 @@ describe('identity', function() {
         products2.testMPID.cp[0].should.have.property('Quantity', 2);
     });
 
-    it('should maintain cookie structure when initializing multiple identity requests, and reinitializing with a previous one will keep the last MPID ', async () => {
+    it('should maintain cookie structure when initializing multiple identity requests, and reinitializing with a previous identity within the same session will return the correct mpid ', async () => {
         mParticle._resetForTests(MPConfig);
 
         const user1 = {
@@ -2017,7 +2017,6 @@ describe('identity', function() {
             is_logged_in: true,
         });
 
-
         mParticle.Identity.login(user4);
 
         await waitForCondition(hasIdentityCallInflightReturned)
@@ -2035,12 +2034,12 @@ describe('identity', function() {
         await waitForCondition(hasIdentityCallInflightReturned)
 
         const user5 = mParticle.Identity.getCurrentUser();
-        user5.getUserIdentities().userIdentities.customerid.should.equal('4');
-        user5.getMPID().should.equal('mpid4');
+        user5.getUserIdentities().userIdentities.customerid.should.equal('1');
+        user5.getMPID().should.equal('testMPID');
 
         const data = mParticle.getInstance()._Persistence.getLocalStorage();
 
-        data.cu.should.equal('mpid4');
+        data.cu.should.equal('testMPID');
         data.testMPID.ui[1].should.equal('1');
         data.mpid2.ui[1].should.equal('2');
         data.mpid3.ui[1].should.equal('3');

--- a/test/src/tests-identity.ts
+++ b/test/src/tests-identity.ts
@@ -1951,7 +1951,7 @@ describe('identity', function() {
         products2.testMPID.cp[0].should.have.property('Quantity', 2);
     });
 
-    it('should maintain cookie structure when initializing multiple identity requests, and reinitializing with a previous identity within the same session will return the correct mpid ', async () => {
+    it('should add new MPIDs to cookie structure when initializing new identity requests, returning an existing mpid when reinitializing with a previous identity', async () => {
         mParticle._resetForTests(MPConfig);
 
         const user1 = {

--- a/test/src/tests-session-manager.ts
+++ b/test/src/tests-session-manager.ts
@@ -850,154 +850,6 @@ describe('SessionManager', () => {
                 expect(startNewSessionSpy.called).to.equal(false);
             });
         });
-
-        describe('#hasIdentityRequestChanged', () => {
-            it('should return true when identifyRequest differs from current user identities', () => {
-                mParticle.init(apiKey, window.mParticle.config);
-                const mpInstance = mParticle.getInstance();
-
-                // Mock current user with specific identities
-                const mockCurrentUser = {
-                    getMPID: () => 'test-mpid',
-                    getUserIdentities: () => ({
-                        userIdentities: {
-                            customerid: 'current-customer-id',
-                            email: 'current@email.com',
-                        },
-                    }),
-                    getAllUserAttributes: () => ({}),
-                    setUserTag: () => {},
-                    setUserAttribute: () => {},
-                    getCart: () => ({}),
-                } as any;
-
-                mpInstance.Identity.getCurrentUser = () => mockCurrentUser;
-
-                // Set different identifyRequest
-                mpInstance._Store.SDKConfig.identifyRequest = {
-                    userIdentities: {
-                        customerid: 'different-customer-id',
-                        email: 'different@email.com',
-                    },
-                };
-
-                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
-                expect(result).to.equal(true);
-            });
-
-            it('should return false when identifyRequest matches current user identities', () => {
-                mParticle.init(apiKey, window.mParticle.config);
-                const mpInstance = mParticle.getInstance();
-
-                // Mock current user with specific identities
-                const mockCurrentUser = {
-                    getMPID: () => 'test-mpid',
-                    getUserIdentities: () => ({
-                        userIdentities: {
-                            customerid: 'same-customer-id',
-                            email: 'same@email.com',
-                        },
-                    }),
-                    getAllUserAttributes: () => ({}),
-                    setUserTag: () => {},
-                    setUserAttribute: () => {},
-                    getCart: () => ({}),
-                } as any;
-
-                mpInstance.Identity.getCurrentUser = () => mockCurrentUser;
-
-                // Set same identifyRequest
-                mpInstance._Store.SDKConfig.identifyRequest = {
-                    userIdentities: {
-                        customerid: 'same-customer-id',
-                        email: 'same@email.com',
-                    },
-                };
-
-                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
-                expect(result).to.equal(false);
-            });
-
-            it('should return false when no current user exists', () => {
-                mParticle.init(apiKey, window.mParticle.config);
-                const mpInstance = mParticle.getInstance();
-
-                // Mock no current user
-                mpInstance.Identity.getCurrentUser = () => null;
-
-                // Set identifyRequest
-                mpInstance._Store.SDKConfig.identifyRequest = {
-                    userIdentities: {
-                        customerid: 'some-customer-id',
-                    },
-                };
-
-                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
-                expect(result).to.equal(false);
-            });
-
-            it('should return false when no identifyRequest exists', () => {
-                mParticle.init(apiKey, window.mParticle.config);
-                const mpInstance = mParticle.getInstance();
-
-                // Mock current user
-                const mockCurrentUser = {
-                    getMPID: () => 'test-mpid',
-                    getUserIdentities: () => ({
-                        userIdentities: {
-                            customerid: 'current-customer-id',
-                        },
-                    }),
-                    getAllUserAttributes: () => ({}),
-                    setUserTag: () => {},
-                    setUserAttribute: () => {},
-                    getCart: () => ({}),
-                } as any;
-
-                mpInstance.Identity.getCurrentUser = () => mockCurrentUser;
-
-                // No identifyRequest
-                mpInstance._Store.SDKConfig.identifyRequest = null;
-
-                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
-                expect(result).to.equal(false);
-            });
-
-            it('should handle partial identity differences correctly', () => {
-                mParticle.init(apiKey, window.mParticle.config);
-                const mpInstance = mParticle.getInstance();
-
-                // Mock current user with multiple identities
-                const mockCurrentUser = {
-                    getMPID: () => 'test-mpid',
-                    getUserIdentities: () => ({
-                        userIdentities: {
-                            customerid: 'same-customer-id',
-                            email: 'current@email.com',
-                            other: 'same-value',
-                        },
-                    }),
-                    getAllUserAttributes: () => ({}),
-                    setUserTag: () => {},
-                    setUserAttribute: () => {},
-                    getCart: () => ({}),
-                } as any;
-
-                mpInstance.Identity.getCurrentUser = () => mockCurrentUser;
-
-                // Set identifyRequest with different email but same customerid
-                mpInstance._Store.SDKConfig.identifyRequest = {
-                    userIdentities: {
-                        customerid: 'same-customer-id',
-                        email: 'different@email.com',
-                        other: 'same-value',
-                    },
-                };
-
-                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
-                expect(result).to.equal(true);
-            });
-        });
     });
 
     describe('Integration Tests', () => {
@@ -1011,7 +863,7 @@ describe('SessionManager', () => {
                 'generateUniqueId'
             );
             generateUniqueIdSpy.returns('test-unique-id');
-            
+
             const now = new Date();
             clock = sinon.useFakeTimers(now.getTime());
 
@@ -1048,7 +900,7 @@ describe('SessionManager', () => {
             clock.restore();
         });
 
-        it('should call identify when identity request differs from current user identities on page refresh', async () => {
+        it('should call identify when SDKConfig.identifyRequest differs from getCurrentUser().userIdentities on page refresh', async () => {
                 // First initialization with initial identity request
                 const initialIdentityApiData: IdentityApiData = {
                     userIdentities: {
@@ -1099,7 +951,7 @@ describe('SessionManager', () => {
                 expect(identifySpy.getCall(0).args[0]).to.eql(newIdentityApiData);
             });
 
-            it('should NOT call identify when identity request matches current user identities on page refresh', async () => {
+            it('should NOT call identify when SDKConfig.identifyRequest matches getCurrentUser().userIdentities on page refresh', async () => {
                 // First initialization with initial identity request
                 const initialIdentityApiData: IdentityApiData = {
                     userIdentities: {

--- a/test/src/tests-session-manager.ts
+++ b/test/src/tests-session-manager.ts
@@ -850,6 +850,154 @@ describe('SessionManager', () => {
                 expect(startNewSessionSpy.called).to.equal(false);
             });
         });
+
+        describe('#hasIdentityRequestChanged', () => {
+            it('should return true when identifyRequest differs from current user identities', () => {
+                mParticle.init(apiKey, window.mParticle.config);
+                const mpInstance = mParticle.getInstance();
+
+                // Mock current user with specific identities
+                const mockCurrentUser = {
+                    getMPID: () => 'test-mpid',
+                    getUserIdentities: () => ({
+                        userIdentities: {
+                            customerid: 'current-customer-id',
+                            email: 'current@email.com',
+                        },
+                    }),
+                    getAllUserAttributes: () => ({}),
+                    setUserTag: () => {},
+                    setUserAttribute: () => {},
+                    getCart: () => ({}),
+                } as any;
+
+                mpInstance.Identity.getCurrentUser = () => mockCurrentUser;
+
+                // Set different identifyRequest
+                mpInstance._Store.SDKConfig.identifyRequest = {
+                    userIdentities: {
+                        customerid: 'different-customer-id',
+                        email: 'different@email.com',
+                    },
+                };
+
+                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
+                expect(result).to.equal(true);
+            });
+
+            it('should return false when identifyRequest matches current user identities', () => {
+                mParticle.init(apiKey, window.mParticle.config);
+                const mpInstance = mParticle.getInstance();
+
+                // Mock current user with specific identities
+                const mockCurrentUser = {
+                    getMPID: () => 'test-mpid',
+                    getUserIdentities: () => ({
+                        userIdentities: {
+                            customerid: 'same-customer-id',
+                            email: 'same@email.com',
+                        },
+                    }),
+                    getAllUserAttributes: () => ({}),
+                    setUserTag: () => {},
+                    setUserAttribute: () => {},
+                    getCart: () => ({}),
+                } as any;
+
+                mpInstance.Identity.getCurrentUser = () => mockCurrentUser;
+
+                // Set same identifyRequest
+                mpInstance._Store.SDKConfig.identifyRequest = {
+                    userIdentities: {
+                        customerid: 'same-customer-id',
+                        email: 'same@email.com',
+                    },
+                };
+
+                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
+                expect(result).to.equal(false);
+            });
+
+            it('should return false when no current user exists', () => {
+                mParticle.init(apiKey, window.mParticle.config);
+                const mpInstance = mParticle.getInstance();
+
+                // Mock no current user
+                mpInstance.Identity.getCurrentUser = () => null;
+
+                // Set identifyRequest
+                mpInstance._Store.SDKConfig.identifyRequest = {
+                    userIdentities: {
+                        customerid: 'some-customer-id',
+                    },
+                };
+
+                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
+                expect(result).to.equal(false);
+            });
+
+            it('should return false when no identifyRequest exists', () => {
+                mParticle.init(apiKey, window.mParticle.config);
+                const mpInstance = mParticle.getInstance();
+
+                // Mock current user
+                const mockCurrentUser = {
+                    getMPID: () => 'test-mpid',
+                    getUserIdentities: () => ({
+                        userIdentities: {
+                            customerid: 'current-customer-id',
+                        },
+                    }),
+                    getAllUserAttributes: () => ({}),
+                    setUserTag: () => {},
+                    setUserAttribute: () => {},
+                    getCart: () => ({}),
+                } as any;
+
+                mpInstance.Identity.getCurrentUser = () => mockCurrentUser;
+
+                // No identifyRequest
+                mpInstance._Store.SDKConfig.identifyRequest = null;
+
+                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
+                expect(result).to.equal(false);
+            });
+
+            it('should handle partial identity differences correctly', () => {
+                mParticle.init(apiKey, window.mParticle.config);
+                const mpInstance = mParticle.getInstance();
+
+                // Mock current user with multiple identities
+                const mockCurrentUser = {
+                    getMPID: () => 'test-mpid',
+                    getUserIdentities: () => ({
+                        userIdentities: {
+                            customerid: 'same-customer-id',
+                            email: 'current@email.com',
+                            other: 'same-value',
+                        },
+                    }),
+                    getAllUserAttributes: () => ({}),
+                    setUserTag: () => {},
+                    setUserAttribute: () => {},
+                    getCart: () => ({}),
+                } as any;
+
+                mpInstance.Identity.getCurrentUser = () => mockCurrentUser;
+
+                // Set identifyRequest with different email but same customerid
+                mpInstance._Store.SDKConfig.identifyRequest = {
+                    userIdentities: {
+                        customerid: 'same-customer-id',
+                        email: 'different@email.com',
+                        other: 'same-value',
+                    },
+                };
+
+                const result = mpInstance._SessionManager.hasIdentityRequestChanged();
+                expect(result).to.equal(true);
+            });
+        });
     });
 
     describe('Integration Tests', () => {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Current user flow for an MPA:
* Developer initializes MP with no identities.  identify request is called
* Developer then adds a known identity to the mp initialization script.  When the page reloads, an identify request is not called because the SDK only looks to see if there is an existing session
New behavior:
* When a new identity is added to the initialization script, we check to see if there is any difference between the current user's identities.  If so, make an identify call.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - Added integration tests and local tests

Videos are below of before and after behavior

1. [Previous behavior](https://share.zight.com/4guEDjxq) (identify call only made on the initial page load, not after a page refresh with new identities in the initialization script0
2. [New behavior](https://share.zight.com/4guEDjyq) (identify calls are made on the initial page load, then after identities are changed in the initialization script0

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7504