### PR TITLE
refactor: remove falsey values in identity requests

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -34,17 +34,15 @@ export default function Identity(mpInstance) {
             );
 
             // First, remove any falsy identity values and warn about them
-            const cleanedIdentityApiData =
-                mpInstance._Helpers.Validators.removeFalsyIdentityValues(
-                    identityApiData,
-                    mpInstance.Logger
-                );
+            const cleanedIdentityApiData = mpInstance._Helpers.Validators.removeFalsyIdentityValues(
+                identityApiData,
+                mpInstance.Logger
+            );
 
-            var identityValidationResult =
-                mpInstance._Helpers.Validators.validateIdentities(
-                    cleanedIdentityApiData,
-                    method
-                );
+            var identityValidationResult = mpInstance._Helpers.Validators.validateIdentities(
+                cleanedIdentityApiData,
+                method
+            );
 
             if (!identityValidationResult.valid) {
                 mpInstance.Logger.error(
@@ -245,16 +243,15 @@ export default function Identity(mpInstance) {
             }
 
             if (preProcessResult.valid) {
-                var identityApiRequest =
-                    mpInstance._Identity.IdentityRequest.createIdentityRequest(
-                        preProcessResult.cleanedIdentities,
-                        Constants.platform,
-                        Constants.sdkVendor,
-                        Constants.sdkVersion,
-                        mpInstance._Store.deviceId,
-                        mpInstance._Store.context,
-                        mpid
-                    );
+                var identityApiRequest = mpInstance._Identity.IdentityRequest.createIdentityRequest(
+                    preProcessResult.cleanedIdentities,
+                    Constants.platform,
+                    Constants.sdkVendor,
+                    Constants.sdkVersion,
+                    mpInstance._Store.deviceId,
+                    mpInstance._Store.context,
+                    mpid
+                );
                 if (
                     mpInstance._Helpers.getFeatureFlag(
                         Constants.FeatureFlags.CacheIdentity

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -40,7 +40,37 @@ const Validators = {
         );
     },
 
-    validateIdentities: function(
+    removeFalsyIdentityValues: function (
+        identityApiData: IdentityApiData,
+        logger: any
+    ): IdentityApiData {
+        if (!identityApiData || !identityApiData.userIdentities) {
+            return identityApiData;
+        }
+
+        const cleanedData = {} as IdentityApiData;
+        const cleanedUserIdentities = { ...identityApiData.userIdentities };
+
+        for (const identityType in identityApiData.userIdentities) {
+            if (identityApiData.userIdentities.hasOwnProperty(identityType)) {
+                const value = identityApiData.userIdentities[identityType];
+
+                // Check if value is falsy (undefined, false, 0, '', etc.) but not null
+                if (value !== null && !value) {
+                    logger.warning(
+                        `Identity value for '${identityType}' is falsy (${value}). This value will be removed from the request.`
+                    );
+                    delete cleanedUserIdentities[identityType];
+                }
+            }
+        }
+
+        cleanedData.userIdentities = cleanedUserIdentities;
+
+        return cleanedData;
+    },
+
+    validateIdentities: function (
         identityApiData: IdentityApiData,
         method?: IdentityAPIMethod
     ): ValidationIdentitiesReturn {

--- a/test/src/tests-identity-utils.ts
+++ b/test/src/tests-identity-utils.ts
@@ -590,14 +590,15 @@ describe('identity-utils', () => {
                 expect(result).to.equal(false);
             });
 
+
             it('returns false when SDKConfig.identifyRequest is null', () => {
                 // Create a mock current user
                 const mockCurrentUser = {
                     getUserIdentities: () => ({
                         userIdentities: {
-                            customerid: 'current-customer-id',
-                        },
-                    }),
+                            customerid: 'current-customer-id'
+                        }
+                    })
                 } as any;
 
                 const result = hasIdentityRequestChanged(mockCurrentUser, null);

--- a/test/src/tests-identity.ts
+++ b/test/src/tests-identity.ts
@@ -410,6 +410,236 @@ describe('identity', function() {
             );
         });
 
+        it('should strip falsey values from identify request', async () => {
+            await waitForCondition(hasIdentifyReturned)
+
+            const identityApiData = {
+                userIdentities: {
+                    customerid: 'valid-customer-id',
+                    email: undefined,
+                    facebook: false,
+                    twitter: '',
+                    google: 0,
+                    microsoft: null, // null should be preserved
+                },
+            };
+
+            fetchMock.resetHistory();
+
+            mParticle.Identity.identify(identityApiData as unknown as IdentityApiData);
+
+            await waitForCondition(hasIdentifyReturned)
+
+            const firstCall = fetchMock.calls()[0];
+            expect(firstCall[0].split('/')[4]).to.equal('identify');
+
+            const data = JSON.parse(firstCall[1].body as unknown as string) as IIdentityAPIRequestData;
+
+            expect(data).to.have.keys(
+                'client_sdk',
+                'environment',
+                'known_identities',
+                'previous_mpid',
+                'request_id',
+                'request_timestamp_ms',
+                'context'
+            );
+
+            expect(data.known_identities).to.have.property(
+                'device_application_stamp',
+            );
+            expect(data.known_identities).to.have.property(
+                'customerid',
+            );
+            expect(data.known_identities).to.have.property(
+                'microsoft',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'email',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'facebook',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'twitter',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'google',
+            );
+        });
+
+        it('should strip falsey values from login request', async () => {
+            await waitForCondition(hasIdentifyReturned)
+
+            const identityApiData = {
+                    userIdentities: {
+                    customerid: 'valid-customer-id',
+                    email: undefined,
+                    facebook: false,
+                    twitter: '',
+                    google: 0,
+                    microsoft: null, // null should be preserved
+                },
+            };
+
+            fetchMockSuccess(urls.login, {
+                context: null,
+                matched_identities: {
+                    device_application_stamp: 'my-das',
+                },
+                is_ephemeral: true,
+                mpid: testMPID,
+                is_logged_in: false,
+            });
+
+            fetchMock.resetHistory();
+
+            mParticle.Identity.login(identityApiData as unknown as IdentityApiData);
+
+            await waitForCondition(hasIdentityCallInflightReturned)
+
+            const firstCall = fetchMock.calls()[0];
+            expect(firstCall[0].split('/')[4]).to.equal('login');
+
+            const data = JSON.parse(firstCall[1].body as unknown as string) as IIdentityAPIRequestData;
+
+            expect(data.known_identities).to.have.property(
+                'device_application_stamp',
+            );
+            expect(data.known_identities).to.have.property(
+                'customerid',
+            );
+            expect(data.known_identities).to.have.property(
+                'microsoft',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'email',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'facebook',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'twitter',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'google',
+            );
+        });
+
+        it('should strip falsey values from logout request', async () => {
+            await waitForCondition(hasIdentifyReturned)
+
+            const identityApiData = {
+                    userIdentities: {
+                    customerid: 'valid-customer-id',
+                    email: undefined,
+                    facebook: false,
+                    twitter: '',
+                    google: 0,
+                    microsoft: null, // null should be preserved
+                },
+            };
+
+            fetchMockSuccess(urls.logout, {
+                context: null,
+                matched_identities: {
+                    device_application_stamp: 'my-das',
+                },
+                is_ephemeral: true,
+                mpid: testMPID,
+                is_logged_in: false,
+            });
+
+            fetchMock.resetHistory();
+
+            mParticle.Identity.logout(identityApiData as unknown as IdentityApiData);
+
+            await waitForCondition(hasIdentityCallInflightReturned)
+
+            const firstCall = fetchMock.calls()[0];
+            expect(firstCall[0].split('/')[4]).to.equal('logout');
+
+            const data = JSON.parse(firstCall[1].body as unknown as string) as IIdentityAPIRequestData;
+
+            expect(data.known_identities).to.have.property(
+                'device_application_stamp',
+            );
+            expect(data.known_identities).to.have.property(
+                'customerid',
+            );
+            expect(data.known_identities).to.have.property(
+                'microsoft',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'email',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'facebook',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'twitter',
+            );
+            expect(data.known_identities).to.not.have.property(
+                'google',
+            );
+        });
+
+        it('should strip falsey values from modify request', async () => {
+            await waitForCondition(hasIdentifyReturned)
+
+            const identityApiData = {
+                    userIdentities: {
+                    customerid: 'valid-customer-id',
+                    email: undefined,
+                    facebook: false,
+                    twitter: '',
+                    google: 0,
+                    microsoft: null, // null should be preserved
+                },
+            };
+
+            fetchMock.resetHistory();
+
+            fetchMockSuccess(urls.modify, {
+                change_results: [
+                    {
+                        identity_type: 'email',
+                        modified_mpid: testMPID,
+                    },
+                ],
+            });
+
+            mParticle.Identity.modify(identityApiData as unknown as IdentityApiData);
+
+            await waitForCondition(hasIdentityCallInflightReturned)
+
+            const firstCall = fetchMock.calls()[0];
+            debugger
+            expect(firstCall[0].split('/')[5]).to.equal('modify');
+
+            const data = JSON.parse(firstCall[1].body as unknown as string) as IIdentityAPIModifyRequestData;
+
+            expect(data).to.have.keys(
+                'client_sdk',
+                'environment',
+                'identity_changes',
+                'request_id',
+                'request_timestamp_ms',
+                'context'
+            );
+
+            // For modify requests, we check identity_changes instead of known_identities
+            expect(data.identity_changes).to.be.an('array');
+            expect(data.identity_changes).to.have.length(2); // customerid and microsoft (null preserved)
+
+            const identityTypes = data.identity_changes.map(change => change.identity_type);
+            expect(identityTypes).to.include('customerid');
+            expect(identityTypes).to.include('microsoft');
+            expect(identityTypes).to.not.include('email');
+            expect(identityTypes).to.not.include('facebook');
+            expect(identityTypes).to.not.include('twitter');
+            expect(identityTypes).to.not.include('google');
+        });
     });
 
     // https://go.mparticle.com/work/SQDSDKS-6849
@@ -1234,6 +1464,7 @@ describe('identity', function() {
 
     it('should not make a request when an invalid request is sent as a string', async () => {
         const identityAPIRequest = BAD_USER_IDENTITIES_AS_STRING;
+        debugger
         mParticle.Identity.modify(identityAPIRequest);
 
         await waitForCondition(hasIdentityCallInflightReturned)

--- a/test/src/tests-validators.ts
+++ b/test/src/tests-validators.ts
@@ -1,5 +1,7 @@
+import { IdentityApiData } from '@mparticle/web-sdk';
 import Validators from '../../src/validators';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 describe('Validators', () => {
     it('#isValidAttributeValue should correctly validate an attribute value', ()=> {
@@ -128,5 +130,44 @@ describe('Validators', () => {
 
         expect(Validators.isFunction(function (){})).to.eq(true);
         expect(Validators.isFunction(() => {})).to.eq(true);
+    });
+
+    it('#removeFalsyIdentityValues should remove falsy identity values', () => {
+        const mockLogger = {
+            warning: sinon.spy(),
+        };
+
+        const identityApiData = {
+            userIdentities: {
+                customerid: 'valid-customer-id',
+                email: undefined,
+                facebook: false,
+                twitter: '',
+                google: 0,
+                microsoft: null, // null should be preserved
+            },
+        };
+
+        const result = Validators.removeFalsyIdentityValues(identityApiData as unknown as IdentityApiData, mockLogger);
+
+        // Should warn about each falsy value
+        expect(mockLogger.warning.calledWith(
+            "Identity value for 'email' is falsy (undefined). This value will be removed from the request."
+        )).to.be.true;
+        expect(mockLogger.warning.calledWith(
+            "Identity value for 'facebook' is falsy (false). This value will be removed from the request."
+        )).to.be.true;
+        expect(mockLogger.warning.calledWith(
+            "Identity value for 'twitter' is falsy (). This value will be removed from the request."
+        )).to.be.true;
+        expect(mockLogger.warning.calledWith(
+            "Identity value for 'google' is falsy (0). This value will be removed from the request."
+        )).to.be.true;
+
+        // Should preserve valid values and null
+        expect(result.userIdentities).to.deep.equal({
+            customerid: 'valid-customer-id',
+            microsoft: null,
+        });
     });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Previously we accepted a value of `null` to be sent to our identity servers. Any other falsey value would prevent an identity request from going through.  Now, any other falsey value will just be stripped from the identity request.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7519