### PR TITLE
feat: SDKE-221 Support hashedEmailUserIdentityType for "other" identity type

### DIFF
--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -203,9 +203,9 @@ export default class RoktManager {
                 newHashedEmail = mappedAttributes['emailsha256'] as string || undefined;
             }
 
-            const emailChanged = !!(newEmail && (!currentEmail || currentEmail !== newEmail));
-            const hashedEmailChanged = !!(newHashedEmail && (!currentHashedEmail || currentHashedEmail !== newHashedEmail));
-            // https://go.mparticle.com/work/SQDSDKS-7338
+            const emailChanged = this.hasIdentityChanged(currentEmail, newEmail);
+            const hashedEmailChanged = this.hasIdentityChanged(currentHashedEmail, newHashedEmail);
+
             const newIdentities: UserIdentities = {};
             if (emailChanged) {
                 newIdentities.email = newEmail;
@@ -218,6 +218,7 @@ export default class RoktManager {
                 newIdentities[normalizedHashedEmailUserIdentityType] = newHashedEmail;
                 this.logger.warning(`emailsha256 mismatch detected. Current mParticle ${normalizedHashedEmailUserIdentityType} identity, ${currentHashedEmail}, differs from from 'emailsha256' passed to selectPlacements call, ${newHashedEmail}. Proceeding to call identify with ${normalizedHashedEmailUserIdentityType} set to ${newHashedEmail}. Please verify your implementation`);
             }
+
             if (!isEmpty(newIdentities)) {
                 // Call identify with the new user identities
                 try {
@@ -399,5 +400,28 @@ export default class RoktManager {
         }
         
         this.messageQueue.delete(messageId);
+    }
+
+    /**
+     * Checks if an identity value has changed by comparing current and new values
+     * 
+     * @param {string | undefined} currentValue - The current identity value
+     * @param {string | undefined} newValue - The new identity value to compare against
+     * @returns {boolean} True if the identity has changed (new value exists and differs from current), false otherwise
+     */
+    private hasIdentityChanged(currentValue: string | undefined, newValue: string | undefined): boolean {
+        if (!newValue) {
+            return false;
+        }
+        
+        if (!currentValue) {
+            return true; // New value exists but no current value
+        }
+        
+        if (currentValue !== newValue) {
+            return true; // Values are different
+        }
+        
+        return false; // Values are the same
     }
 }

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -197,7 +197,7 @@ export default class RoktManager {
             // Hashed email identity is valid if it is set to Other-Other10
             if(this.mappedEmailShaIdentityType && IdentityType.getIdentityType(this.mappedEmailShaIdentityType) !== false) {
                 currentHashedEmail = currentUserIdentities[this.mappedEmailShaIdentityType];
-                newHashedEmail = mappedAttributes['emailsha256'] as string || undefined;
+                newHashedEmail = mappedAttributes['emailsha256'] as string || mappedAttributes[this.mappedEmailShaIdentityType] as string || undefined;
             }
 
             const emailChanged = this.hasIdentityChanged(currentEmail, newEmail);
@@ -346,6 +346,7 @@ export default class RoktManager {
         this.messageQueue.forEach((message) => {
             if(!(message.methodName in this) || !isFunction(this[message.methodName])) {
                 this.logger?.error(`RoktManager: Method ${message.methodName} not found`);
+
                 return;
             }
 

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -99,7 +99,7 @@ export default class RoktManager {
     private launcherOptions?: IRoktLauncherOptions;
     private logger: SDKLoggerApi;
     private domain?: string;
-    private normalizedHashedEmailUserIdentityType?: string  | null;
+    private mappedEmailShaIdentityType?: string  | null;
     /**
      * Initializes the RoktManager with configuration settings and user data.
      * 
@@ -121,7 +121,7 @@ export default class RoktManager {
     ): void {
         const { userAttributeFilters, settings } = roktConfig || {};
         const { placementAttributesMapping, hashedEmailUserIdentityType } = settings || {};
-        this.normalizedHashedEmailUserIdentityType = hashedEmailUserIdentityType?.toLowerCase() ?? null;
+        this.mappedEmailShaIdentityType = hashedEmailUserIdentityType?.toLowerCase() ?? null;
 
         this.identityService = identityService;
         this.store = store;
@@ -190,15 +190,14 @@ export default class RoktManager {
 
             const currentEmail = currentUserIdentities.email;
             const newEmail = mappedAttributes.email as string;
-            const mappedEmailShaIdentityType = this.normalizedHashedEmailUserIdentityType;
 
             let currentHashedEmail: string | undefined;
             let newHashedEmail: string | undefined;
             
             // Hashed email identity is valid if it is set to Other-Other10
 
-            if(mappedEmailShaIdentityType && IdentityType.getIdentityType(mappedEmailShaIdentityType) !== false) {
-                currentHashedEmail = currentUserIdentities[mappedEmailShaIdentityType];
+            if(this.mappedEmailShaIdentityType && IdentityType.getIdentityType(this.mappedEmailShaIdentityType) !== false) {
+                currentHashedEmail = currentUserIdentities[this.mappedEmailShaIdentityType];
                 newHashedEmail = mappedAttributes['emailsha256'] as string || undefined;
             }
 
@@ -214,8 +213,8 @@ export default class RoktManager {
             }
 
             if (hashedEmailChanged) {
-                newIdentities[mappedEmailShaIdentityType] = newHashedEmail;
-                this.logger.warning(`emailsha256 mismatch detected. Current mParticle ${mappedEmailShaIdentityType} identity, ${currentHashedEmail}, differs from 'emailsha256' passed to selectPlacements call, ${newHashedEmail}. Proceeding to call identify with ${mappedEmailShaIdentityType} set to ${newHashedEmail}. Please verify your implementation`);
+                newIdentities[this.mappedEmailShaIdentityType] = newHashedEmail;
+                this.logger.warning(`emailsha256 mismatch detected. Current mParticle ${this.mappedEmailShaIdentityType} identity, ${currentHashedEmail}, differs from 'emailsha256' passed to selectPlacements call, ${newHashedEmail}. Proceeding to call identify with ${this.mappedEmailShaIdentityType} set to ${newHashedEmail}. Please verify your implementation`);
             }
 
             if (!isEmpty(newIdentities)) {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -195,7 +195,6 @@ export default class RoktManager {
             let newHashedEmail: string | undefined;
             
             // Hashed email identity is valid if it is set to Other-Other10
-
             if(this.mappedEmailShaIdentityType && IdentityType.getIdentityType(this.mappedEmailShaIdentityType) !== false) {
                 currentHashedEmail = currentUserIdentities[this.mappedEmailShaIdentityType];
                 newHashedEmail = mappedAttributes['emailsha256'] as string || undefined;

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -99,7 +99,7 @@ export default class RoktManager {
     private launcherOptions?: IRoktLauncherOptions;
     private logger: SDKLoggerApi;
     private domain?: string;
-    private configSettings: Dictionary<string> = {};
+    private hashedEmailUserIdentityType?: string  | null;
     /**
      * Initializes the RoktManager with configuration settings and user data.
      * 
@@ -120,8 +120,8 @@ export default class RoktManager {
         options?: IRoktOptions
     ): void {
         const { userAttributeFilters, settings } = roktConfig || {};
-        const { placementAttributesMapping } = settings || {};
-        this.configSettings = settings;
+        const { placementAttributesMapping, configSettings } = settings || {};
+        this.hashedEmailUserIdentityType = configSettings?.hashedEmailUserIdentityType;
 
         this.identityService = identityService;
         this.store = store;
@@ -183,9 +183,8 @@ export default class RoktManager {
             const { attributes } = options;
             const sandboxValue = attributes?.sandbox || null;
             const mappedAttributes = this.mapPlacementAttributes(attributes, this.placementAttributesMapping);
-            const { hashedEmailUserIdentityType = null } = this.configSettings || {};
 
-            const normalizedHashedEmailUserIdentityType = hashedEmailUserIdentityType?.toLowerCase() || null;
+            const normalizedHashedEmailUserIdentityType = this.hashedEmailUserIdentityType?.toLowerCase() || null;
 
             // Get current user identities
             this.currentUser = this.identityService.getCurrentUser();

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -209,6 +209,32 @@ export default class RoktManager {
                 }
             }
 
+            // Handle emailsha256 mapping to 'other' identity
+            const newEmailSha256 = options.attributes.emailsha256;
+            const currentOther = currentUserIdentities.other;
+            
+            if (newEmailSha256 && (!currentOther || currentOther !== newEmailSha256)) {
+                if (currentOther && currentOther !== newEmailSha256) {
+                    this.logger.warning(`emailsha256 identity mismatch detected. Current mParticle 'other' identity, ${currentOther} differs from emailsha256 passed to selectPlacements call, ${newEmailSha256}. Proceeding to call identify with 'other' set to ${newEmailSha256}. Please verify your implementation.`);
+                }
+
+                // Call identify with the new 'other' identity mapped from emailsha256
+                try {
+                    await new Promise<void>((resolve, reject) => {
+                        this.identityService.identify({
+                            userIdentities: {
+                                ...currentUserIdentities,
+                                other: newEmailSha256 as string
+                            }
+                        }, () => {
+                            resolve();
+                        });
+                    });
+                } catch (error) {
+                    this.logger.error('Failed to identify user with new emailsha256 mapped to other identity: ' + JSON.stringify(error));
+                }
+            }
+
             this.setUserAttributes(mappedAttributes);
 
             const enrichedAttributes = {

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -1118,7 +1118,8 @@ describe('RoktManager', () => {
             const kit: Partial<IRoktKit> = {
                 launcher: {
                     selectPlacements: jest.fn(),
-                    hashAttributes: jest.fn()
+                    hashAttributes: jest.fn(),
+                    use: jest.fn(),
                 },
                 selectPlacements: jest.fn(),
                 hashAttributes: jest.fn(),
@@ -1163,7 +1164,8 @@ describe('RoktManager', () => {
             const kit: Partial<IRoktKit> = {
                 launcher: {
                     selectPlacements: jest.fn(),
-                    hashAttributes: jest.fn()
+                    hashAttributes: jest.fn(),
+                    use: jest.fn(),
                 },
                 selectPlacements: jest.fn().mockResolvedValue({}),
                 hashAttributes: jest.fn(),
@@ -1218,7 +1220,8 @@ describe('RoktManager', () => {
             const kit: Partial<IRoktKit> = {
                 launcher: {
                     selectPlacements: jest.fn(),
-                    hashAttributes: jest.fn()
+                    hashAttributes: jest.fn(),
+                    use: jest.fn(),
                 },
                 selectPlacements: jest.fn(),
                 hashAttributes: jest.fn(),
@@ -1261,7 +1264,8 @@ describe('RoktManager', () => {
             const kit: Partial<IRoktKit> = {
                 launcher: {
                     selectPlacements: jest.fn(),
-                    hashAttributes: jest.fn()
+                    hashAttributes: jest.fn(),
+                    use: jest.fn(),
                 },
                 selectPlacements: jest.fn(),
                 hashAttributes: jest.fn(),
@@ -1313,7 +1317,8 @@ describe('RoktManager', () => {
             const kit: Partial<IRoktKit> = {
                 launcher: {
                     selectPlacements: jest.fn(),
-                    hashAttributes: jest.fn()
+                    hashAttributes: jest.fn(),
+                    use: jest.fn(),
                 },
                 selectPlacements: jest.fn(),
                 hashAttributes: jest.fn(),

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -7,7 +7,7 @@ import { testMPID } from '../src/config/constants';
 
 const resolvePromise = () => new Promise(resolve => setTimeout(resolve, 0));
 
-describe.only('RoktManager', () => {
+describe('RoktManager', () => {
     let roktManager: RoktManager;
     let currentUser: IMParticleUser;
 

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -1127,7 +1127,6 @@ describe('RoktManager', () => {
             };
             
             roktManager['placementAttributesMapping'] = [];
-            roktManager['configSettings'] = {};
             roktManager.kit = kit as IRoktKit;
 
             const mockIdentity = {
@@ -1173,9 +1172,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['configSettings'] = {
-                hashedEmailUserIdentityType: 'Other5'
-            };
+            roktManager['hashedEmailUserIdentityType'] ='Other5';
 
             // Set up fresh mocks for this test
             const mockIdentity = {
@@ -1229,9 +1226,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['configSettings'] = {
-                hashedEmailUserIdentityType: 'Other5'
-            };
+            roktManager['hashedEmailUserIdentityType'] = 'Other5';
 
             // Set up fresh mocks for this test
             const mockIdentity = {
@@ -1273,9 +1268,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['configSettings'] = {
-                hashedEmailUserIdentityType: 'Other'
-            };
+            roktManager['hashedEmailUserIdentityType'] = 'Other';
 
             const mockIdentity = {
                 getCurrentUser: jest.fn().mockReturnValue({
@@ -1326,9 +1319,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['configSettings'] = {
-                hashedEmailUserIdentityType: 'Other'
-            };
+            roktManager['hashedEmailUserIdentityType'] = 'Other';
 
             // Set up fresh mocks for this test
             const mockIdentity = {

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -365,7 +365,7 @@ describe('RoktManager', () => {
             expect(roktManager['domain']).toBe(domain);
         });
         
-        it('should set normalizedHashedEmailUserIdentityType as a lowercase hashedEmailUserIdentityType when passed as a setting', () => {
+        it('should set mappedEmailShaIdentityType as a lowercase hashedEmailUserIdentityType when passed as a setting', () => {
             roktManager.init(
                 {settings: {hashedEmailUserIdentityType: 'Other5'}} as unknown as IKitConfigs,
                 undefined,
@@ -373,7 +373,7 @@ describe('RoktManager', () => {
                 mockMPInstance._Store,
                 mockMPInstance.Logger,
             );
-            expect(roktManager['normalizedHashedEmailUserIdentityType']).toBe('other5');
+            expect(roktManager['mappedEmailShaIdentityType']).toBe('other5');
         });
     });
 
@@ -1183,7 +1183,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['normalizedHashedEmailUserIdentityType'] ='other5';
+            roktManager['mappedEmailShaIdentityType'] ='other5';
 
             // Set up fresh mocks for this test
             const mockIdentity = {
@@ -1237,7 +1237,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['normalizedHashedEmailUserIdentityType'] = 'other5';
+            roktManager['mappedEmailShaIdentityType'] = 'other5';
 
             // Set up fresh mocks for this test
             const mockIdentity = {
@@ -1279,7 +1279,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['normalizedHashedEmailUserIdentityType'] = 'other';
+            roktManager['mappedEmailShaIdentityType'] = 'other';
 
             const mockIdentity = {
                 getCurrentUser: jest.fn().mockReturnValue({

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -364,6 +364,17 @@ describe('RoktManager', () => {
             );
             expect(roktManager['domain']).toBe(domain);
         });
+        
+        it('should set normalizedHashedEmailUserIdentityType as a lowercase hashedEmailUserIdentityType when passed as a setting', () => {
+            roktManager.init(
+                {settings: {hashedEmailUserIdentityType: 'Other5'}} as unknown as IKitConfigs,
+                undefined,
+                mockMPInstance.Identity,
+                mockMPInstance._Store,
+                mockMPInstance.Logger,
+            );
+            expect(roktManager['normalizedHashedEmailUserIdentityType']).toBe('other5');
+        });
     });
 
     describe('#attachKit', () => {
@@ -1172,7 +1183,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['hashedEmailUserIdentityType'] ='Other5';
+            roktManager['normalizedHashedEmailUserIdentityType'] ='other5';
 
             // Set up fresh mocks for this test
             const mockIdentity = {
@@ -1206,7 +1217,7 @@ describe('RoktManager', () => {
                 }
             }, expect.any(Function));
             expect(mockMPInstance.Logger.warning).toHaveBeenCalledWith(
-                "emailsha256 mismatch detected. Current mParticle other5 identity, old-other-value, differs from from 'emailsha256' passed to selectPlacements call, new-emailsha256-value. Proceeding to call identify with other5 set to new-emailsha256-value. Please verify your implementation"
+                "emailsha256 mismatch detected. Current mParticle other5 identity, old-other-value, differs from 'emailsha256' passed to selectPlacements call, new-emailsha256-value. Proceeding to call identify with other5 set to new-emailsha256-value. Please verify your implementation"
             );
         });
 
@@ -1226,7 +1237,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['hashedEmailUserIdentityType'] = 'Other5';
+            roktManager['normalizedHashedEmailUserIdentityType'] = 'other5';
 
             // Set up fresh mocks for this test
             const mockIdentity = {
@@ -1268,7 +1279,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.kit = kit as IRoktKit;
-            roktManager['hashedEmailUserIdentityType'] = 'Other';
+            roktManager['normalizedHashedEmailUserIdentityType'] = 'other';
 
             const mockIdentity = {
                 getCurrentUser: jest.fn().mockReturnValue({
@@ -1299,7 +1310,7 @@ describe('RoktManager', () => {
                 }
             }, expect.any(Function));
             expect(mockMPInstance.Logger.warning).toHaveBeenCalledWith(
-                "emailsha256 mismatch detected. Current mParticle other identity, undefined, differs from from 'emailsha256' passed to selectPlacements call, new-emailsha256-value. Proceeding to call identify with other set to new-emailsha256-value. Please verify your implementation"
+                "emailsha256 mismatch detected. Current mParticle other identity, undefined, differs from 'emailsha256' passed to selectPlacements call, new-emailsha256-value. Proceeding to call identify with other set to new-emailsha256-value. Please verify your implementation"
             );
         });
 

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -1222,9 +1222,6 @@ describe('RoktManager', () => {
         });
 
         it('should not call identify when emailsha256 matches current user other5 identity', () => {
-            // Reset mocks
-            jest.clearAllMocks();
-            
             const kit: Partial<IRoktKit> = {
                 launcher: {
                     selectPlacements: jest.fn(),
@@ -1315,9 +1312,6 @@ describe('RoktManager', () => {
         });
 
         it('should not call identify when current user has other identity but emailsha256 is null', () => {
-            // Reset mocks
-            jest.clearAllMocks();
-            
             const kit: Partial<IRoktKit> = {
                 launcher: {
                     selectPlacements: jest.fn(),

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -1702,4 +1702,70 @@ describe('RoktManager', () => {
         });
     });
 
+    describe('#hasIdentityChanged', () => {
+        it('should return false when newValue is null', () => {
+            const result = roktManager['hasIdentityChanged']('current@example.com', null);
+            expect(result).toBe(false);
+        });
+
+        it('should return false when newValue is undefined', () => {
+            const result = roktManager['hasIdentityChanged']('current@example.com', undefined);
+            expect(result).toBe(false);
+        });
+
+        it('should return false when newValue is empty string', () => {
+            const result = roktManager['hasIdentityChanged']('current@example.com', '');
+            expect(result).toBe(false);
+        });
+
+        it('should return true when currentValue is null and newValue exists', () => {
+            const result = roktManager['hasIdentityChanged'](null, 'new@example.com');
+            expect(result).toBe(true);
+        });
+
+        it('should return true when currentValue is undefined and newValue exists', () => {
+            const result = roktManager['hasIdentityChanged'](undefined, 'new@example.com');
+            expect(result).toBe(true);
+        });
+
+        it('should return true when currentValue is empty string and newValue exists', () => {
+            const result = roktManager['hasIdentityChanged']('', 'new@example.com');
+            expect(result).toBe(true);
+        });
+
+        it('should return true when currentValue and newValue are different', () => {
+            const result = roktManager['hasIdentityChanged']('old@example.com', 'new@example.com');
+            expect(result).toBe(true);
+        });
+
+        it('should return false when currentValue and newValue are the same', () => {
+            const result = roktManager['hasIdentityChanged']('same@example.com', 'same@example.com');
+            expect(result).toBe(false);
+        });
+
+        it('should return false when both currentValue and newValue are null', () => {
+            const result = roktManager['hasIdentityChanged'](null, null);
+            expect(result).toBe(false);
+        });
+
+        it('should return false when both currentValue and newValue are undefined', () => {
+            const result = roktManager['hasIdentityChanged'](undefined, undefined);
+            expect(result).toBe(false);
+        });
+
+        it('should return false when both currentValue and newValue are empty strings', () => {
+            const result = roktManager['hasIdentityChanged']('', '');
+            expect(result).toBe(false);
+        });
+
+        it('should handle whitespace-only strings as valid values', () => {
+            const result = roktManager['hasIdentityChanged']('old@example.com', '   ');
+            expect(result).toBe(true);
+        });
+
+        it('should be case sensitive', () => {
+            const result = roktManager['hasIdentityChanged']('test@example.com', 'TEST@EXAMPLE.COM');
+            expect(result).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
In this PR, we make an identify call if `emailsha256` passed to `selectPlacement` differs from the `other` identity value.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Integration tests and tested in an app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7619