### PR TITLE
feat: disable time tracking when noTargeting is set to true

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -700,9 +700,20 @@ export default function Store(
             this.SDKConfig[baseUrlKeys] = baseUrls[baseUrlKeys];
         }
 
+        // Extract privacy flags directly from config into Store BEFORE initializing timers
+        if (config.hasOwnProperty('noFunctional')) {
+            this.setNoFunctional(config.noFunctional);
+        }
+
+        if (config.hasOwnProperty('noTargeting')) {
+            this.setNoTargeting(config.noTargeting);
+        }
+
         if (workspaceToken) {
             this.SDKConfig.workspaceToken = workspaceToken;
-            mpInstance._timeOnSiteTimer = new ForegroundTimer(workspaceToken);
+            if (!this.getNoTargeting()) {
+                mpInstance._timeOnSiteTimer = new ForegroundTimer(workspaceToken);
+            }
         } else {
             mpInstance.Logger.warning(
                 'You should have a workspaceToken on your config object for security purposes.'
@@ -711,15 +722,6 @@ export default function Store(
         // add a new function to apply items to the store that require config to be returned
         this.storageName = createMainStorageName(workspaceToken);
         this.prodStorageName = createProductStorageName(workspaceToken);
-
-        // Extract privacy flags directly from config into Store
-        if (config.hasOwnProperty('noFunctional')) {
-            this.setNoFunctional(config.noFunctional);
-        }
-
-        if (config.hasOwnProperty('noTargeting')) {
-            this.setNoTargeting(config.noTargeting);
-        }
 
         this.SDKConfig.requiredWebviewBridgeName =
             requiredWebviewBridgeName || workspaceToken;

--- a/test/jest/foregroundTimeTracker.spec.ts
+++ b/test/jest/foregroundTimeTracker.spec.ts
@@ -1,4 +1,7 @@
 import ForegroundTimeTracker from '../../src/foregroundTimeTracker';
+import Store, { IStore } from '../../src/store';
+import { SDKInitConfig } from '../../src/sdkRuntimeModels';
+import { IMParticleWebSDKInstance } from '../../src/mp-instance';
 
 describe('ForegroundTimeTracker', () => {
     let foregroundTimeTracker: ForegroundTimeTracker;
@@ -488,6 +491,71 @@ describe('ForegroundTimeTracker', () => {
 
 
             expect(updatePersistenceSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('#noTargeting', () => {
+        const workspaceToken = 'abcdef';
+        const tosKey = `mprtcl-tos-${workspaceToken}`;
+        let mockMPInstance: IMParticleWebSDKInstance;
+        let store: IStore;
+
+        beforeEach(() => {
+            jest.useFakeTimers({ now: Date.now(), advanceTimers: true });
+            localStorage.clear();
+
+            mockMPInstance = {
+                _Helpers: {
+                    createMainStorageName: () => `mprtcl-v4_${workspaceToken}`,
+                    createProductStorageName: () => `mprtcl-prodv4_${workspaceToken}`,
+                    Validators: { isFunction: () => true },
+                    extend: Object.assign,
+                },
+                _NativeSdkHelpers: { isWebviewEnabled: () => false },
+                _Persistence: {
+                    update: jest.fn(),
+                    savePersistence: jest.fn(),
+                    getPersistence: () => ({ gs: {} }),
+                },
+                Logger: { verbose: jest.fn(), warning: jest.fn(), error: jest.fn() },
+                Identity: { getCurrentUser: () => ({ getMPID: () => 'mpid' }) },
+                _timeOnSiteTimer: undefined as any,
+            } as unknown as IMParticleWebSDKInstance;
+
+            store = {} as IStore;
+            (Store as any).call(store, {} as SDKInitConfig, mockMPInstance, 'apikey');
+            mockMPInstance._Store = store;
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+            localStorage.clear();
+        });
+
+        it('should initialize timer when noTargeting is default (false)', () => {
+            store.processConfig({ workspaceToken } as SDKInitConfig);
+            expect(mockMPInstance._timeOnSiteTimer).toBeDefined();
+            if (mockMPInstance._timeOnSiteTimer) {
+                jest.advanceTimersByTime(1000);
+                mockMPInstance._timeOnSiteTimer.getTimeInForeground();
+            }
+            expect(localStorage.getItem(tosKey)).not.toBeNull();
+        });
+
+        it('should NOT initialize timer when noTargeting is true', () => {
+            store.processConfig({ workspaceToken, noTargeting: true } as SDKInitConfig);
+            expect(mockMPInstance._timeOnSiteTimer).toBeUndefined();
+            expect(localStorage.getItem(tosKey)).toBeNull();
+        });
+
+        it('should initialize timer when noTargeting is false', () => {
+            store.processConfig({ workspaceToken, noTargeting: false } as SDKInitConfig);
+            expect(mockMPInstance._timeOnSiteTimer).toBeDefined();
+            if (mockMPInstance._timeOnSiteTimer) {
+                jest.advanceTimersByTime(1000);
+                mockMPInstance._timeOnSiteTimer.getTimeInForeground();
+            }
+            expect(localStorage.getItem(tosKey)).not.toBeNull();
         });
     });
 });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Updated `store.ts` such that `_timeOnSiteTimer` is initialized only if `noTargeting` is `false`.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-90
