### PR TITLE
refactor: remove duplicate session methods from instance-manager

### DIFF
--- a/src/mparticle-instance-manager.ts
+++ b/src/mparticle-instance-manager.ts
@@ -158,12 +158,6 @@ function mParticleInstanceManager(this: IMParticleInstanceManager) {
     this.setPosition = function(lat, lng) {
         self.getInstance().setPosition(lat, lng);
     };
-    this.startNewSession = function() {
-        self.getInstance().startNewSession();
-    };
-    this.endSession = function() {
-        self.getInstance().endSession();
-    };
     this.logBaseEvent = function(event, eventOptions) {
         self.getInstance().logBaseEvent(event, eventOptions);
     };


### PR DESCRIPTION
## Background
- We have duplicate methods - `startNewSession` and `endSession` in `mparticle-instance-manager`

## What Has Changed
- Removed duplicate `startNewSession` and `endSession` methods

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://rokt.atlassian.net/browse/SDKE-375
