### PR TITLE
fix: Append domain query parameter to Trade Desk cookie syncs

### DIFF
--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -13,6 +13,16 @@ const { InformationMessages } = Messages;
 
 export const DAYS_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
+// Partner module IDs for cookie sync configurations
+export const PARTNER_MODULE_IDS = {
+    AdobeEventForwarder: 11,
+    DoubleclickDFP: 41,
+    AppNexus: 50,
+    Lotame: 58,
+    TradeDesk: 103,
+    VerizonMedia: 155,
+} as const;
+
 export type CookieSyncDates = Dictionary<number>; 
 
 export interface IPixelConfiguration {
@@ -112,7 +122,9 @@ export default function CookieSyncManager(
             }
 
             // Url for cookie sync pixel
-            const fullUrl = createCookieSyncUrl(mpid, pixelUrl, redirectUrl)
+            // Add domain parameter for Trade Desk
+            const domain = moduleId === PARTNER_MODULE_IDS.TradeDesk ? window.location.hostname : undefined;
+            const fullUrl = createCookieSyncUrl(mpid, pixelUrl, redirectUrl, domain);
 
             self.performCookieSync(
                 fullUrl,

--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -121,9 +121,11 @@ export default function CookieSyncManager(
                 return;
             }
 
-            // Url for cookie sync pixel
-            // Add domain parameter for Trade Desk
+            // The Trade Desk requires a URL parameter for GDPR enabled users.
+            // It is optional but to simplify the code, we add it for all Trade
+            // // Desk cookie syncs.
             const domain = moduleId === PARTNER_MODULE_IDS.TradeDesk ? window.location.hostname : undefined;
+            // Add domain parameter for Trade Desk
             const fullUrl = createCookieSyncUrl(mpid, pixelUrl, redirectUrl, domain);
 
             self.performCookieSync(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -206,18 +206,28 @@ const replaceAmpWithAmpersand = (value: string): string => value.replace(/&amp;/
 const createCookieSyncUrl = (
     mpid: MPID,
     pixelUrl: string,
-    redirectUrl?: string
+    redirectUrl?: string,
+    domain?: string
 ): string => {
     const modifiedPixelUrl = replaceAmpWithAmpersand(pixelUrl);
     const modifiedDirectUrl = redirectUrl
         ? replaceAmpWithAmpersand(redirectUrl)
         : null;
 
-    const url = replaceMPID(modifiedPixelUrl, mpid);
+    let url = replaceMPID(modifiedPixelUrl, mpid);
+    
     const redirect = modifiedDirectUrl
         ? replaceMPID(modifiedDirectUrl, mpid)
         : '';
-    return url + encodeURIComponent(redirect);
+    
+    let fullUrl = url + encodeURIComponent(redirect);
+    
+    if (domain) {
+        const separator = fullUrl.includes('?') ? '&' : '?';
+        fullUrl += `${separator}domain=${domain}`;
+    }
+    
+    return fullUrl;
 };
 
 // FIXME: REFACTOR for V3

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -240,6 +240,32 @@ describe('Utils', () => {
         it('should return a cookieSyncUrl when pixelUrl is not null but redirectUrl is null', () => {
             expect(createCookieSyncUrl('testMPID', pixelUrl, null)).toBe('https://abc.abcdex.net/ibs:exampleid=12345&exampleuuid=testMPID&redir=');
         });
+
+        it('should add domain parameter when provided', () => {
+            const simplePixelUrl = 'https://test.com/pixel';
+            expect(createCookieSyncUrl('testMPID', simplePixelUrl, null, 'example.com')).toBe('https://test.com/pixel?domain=example.com');
+        });
+
+        it('should handle domain parameter with hyphens and dots', () => {
+            const simplePixelUrl = 'https://test.com/pixel';
+            expect(createCookieSyncUrl('testMPID', simplePixelUrl, null, 'sub-domain.example.com')).toBe('https://test.com/pixel?domain=sub-domain.example.com');
+        });
+
+        it('should handle domain parameter with redirect URL', () => {
+            const simplePixelUrl = 'https://test.com/pixel';
+            const simpleRedirectUrl = 'https://redirect.com/callback';
+            expect(createCookieSyncUrl('testMPID', simplePixelUrl, simpleRedirectUrl, 'example.com')).toBe('https://test.com/pixelhttps%3A%2F%2Fredirect.com%2Fcallback?domain=example.com');
+        });
+
+        it('should not add domain parameter when domain is undefined', () => {
+            const simplePixelUrl = 'https://test.com/pixel';
+            expect(createCookieSyncUrl('testMPID', simplePixelUrl, null, undefined)).toBe('https://test.com/pixel');
+        });
+
+        it('should not add domain parameter when domain is empty string', () => {
+            const simplePixelUrl = 'https://test.com/pixel';
+            expect(createCookieSyncUrl('testMPID', simplePixelUrl, null, '')).toBe('https://test.com/pixel');
+        });
     });
 
     describe('#inArray', () => {


### PR DESCRIPTION
## Background
Our cookie sync builds a url by appending settings from the pixel configuration.  It was discovered that The Trade Desk (TTD) requires a `domain` parameter when a user is subject to GDPR (ie. user accesses the internet from the UK). 

The parameter is optional, but to keep things simple, we will be adding it to each time a TTD pixel needs to be fired. 

## What Has Changed
This PR adds updates to:
* Cookie sync manager - added constants for each potential cookie sync partner we have (you can reference the moduleIds and names from this [config endpoint](https://jssdkcdns.mparticle.com/js/v2/e207c24e36a7a8478ba0fcb3707a616b/config) which contains all of them - it is pretty printed below as well), adds a check for TTD and adds the domain if so
* Utils - update the cookie sync manager's URL creation by adding an optional domain parameter

## Screenshots/Video
Pretty printed config:
<img width="590" height="1248" alt="image" src="https://github.com/user-attachments/assets/527fce8b-38da-49f7-950f-60c8c85f7368" />

<img width="1611" height="149" alt="image" src="https://github.com/user-attachments/assets/4f54f7a0-c6f5-49c6-8587-44e4ad7ce1cd" />

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/SDKE-335
