### PR TITLE
feat: Add hashSha256 method for SHA-256 hashing

### DIFF
--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -344,7 +344,7 @@ export default class RoktManager {
             return await this.sha256Hex(normalizedValue);
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            this.logger.error(`Failed to hashSha256 and returning undefined: ${errorMessage}`);
+            this.logger.error(`Failed to hashSha256, returning undefined: ${errorMessage}`);
             return undefined;
         }
     }

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -224,7 +224,7 @@ describe('RoktManager', () => {
             
             expect(result).toBeUndefined();
             expect(mockMPInstance.Logger.error).toHaveBeenCalledWith(
-                expect.stringContaining('Failed to hashSha256 and returning undefined: Hash failed')
+                expect.stringContaining('Failed to hashSha256, returning undefined: Hash failed')
             );
         });
 


### PR DESCRIPTION
## Background
- Added `hashSha256` method and related helpers to provide SHA-256 hashing functionality for advertisers using the mParticle Web SDK without requiring the Rokt Kit dependency.
- Code reference: [attribute-service](https://github.com/ROKT/sdk-web/blob/main/packages/web-sdk/controller/src/controller/platform/services/attributes/attributes-service.ts#L65C16-L65C20) , [hash-string](https://github.com/ROKT/sdk-web/blob/main/packages/web-sdk/integrations/src/controller/hash-string/hash-string.ts
), [rokt-docs](https://docs.rokt.com/developers/integration-guides/data-and-security/hash-identifiers)

## What Has Changed
- Added `hashSha256` method
- Added unit tests for hashing. Referred the same test cases from [sdk-web](https://github.com/ROKT/sdk-web/blob/main/packages/testing/testing-integration-tests-playwright/src/tests/integration-launcher/interface/hash-attributes.spec.ts)to compare the hashed values 

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/SDKE-452
