### PR TITLE
ci: Update release workflow for npm OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,6 @@ jobs:
             GIT_AUTHOR_EMAIL: developers@mparticle.com
             GIT_COMMITTER_NAME: mparticle-automation
             GIT_COMMITTER_EMAIL: developers@mparticle.com
-            # NPM_TOKEN no longer required - using OIDC trusted publishing
 
         steps:
             - name: Checkout public master branch


### PR DESCRIPTION
## Background
[npm now supports OIDC](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/) and requires an update to the release.yml to support this

## What Has Changed
* release.yml file updates
* I already updated the Trusted Publisher information on the npm package page:
<img width="757" height="394" alt="image" src="https://github.com/user-attachments/assets/eb7f4157-8ee4-48a6-9739-c7d94891d26f" />

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/SDKE-678