### PR TITLE
chore: remove main branch push from staging step 3 workflow

### DIFF
--- a/.github/workflows/staging-step-3.yml
+++ b/.github/workflows/staging-step-3.yml
@@ -27,11 +27,10 @@ jobs:
           run: |
             git push origin HEAD:development
         
-        # We will eventually replace master with main
-        - name: Push release commits to main and master
+        # We will eventually migrate from master to main
+        - name: Push release commits to master
           run: |
             git push origin HEAD:master
-            git push origin HEAD:main
 
         - name: Push release commits to Release Order Branches
           run: |


### PR DESCRIPTION
## Background
- The staging step 3 workflow currently pushes release commits to both `master` and `main`, but main has diverged from main as we transition to using the main branch as the production branch.

## What Has Changed
- Removed `git push origin HEAD:main` from the staging step 3 synchronization workflow
- Updated the comment to note that we will eventually migrate from `master` to `main`

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- NO JIRA