### PR TITLE
breaking: remove deprecated removeCCPAState method

### DIFF
--- a/src/consent.ts
+++ b/src/consent.ts
@@ -97,8 +97,6 @@ export interface IConsentRules {
     values: IConsentRulesValues[];
 }
 
-export interface IConsentState extends ConsentState {}
-
 // Represents Actual Interface for Consent Module
 // TODO: Should eventually consolidate with SDKConsentStateApi
 export interface IConsent {
@@ -322,7 +320,7 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
     this.createConsentState = function(
         this: ConsentState,
         consentState?: ConsentState
-    ): IConsentState {
+    ): ConsentState {
         let gdpr = {};
         let ccpa = {};
 
@@ -335,7 +333,7 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
                 consentState.getCCPAConsentState()
             );
 
-            return consentStateCopy as IConsentState;
+            return consentStateCopy as ConsentState;
         }
 
         function canonicalizeForDeduplication(purpose: string): string {

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -97,10 +97,7 @@ export interface IConsentRules {
     values: IConsentRulesValues[];
 }
 
-// TODO: Remove this if we can safely deprecate `removeCCPAState`
-export interface IConsentState extends ConsentState {
-    removeCCPAState: () => ConsentState;
-}
+export interface IConsentState extends ConsentState {}
 
 // Represents Actual Interface for Consent Module
 // TODO: Should eventually consolidate with SDKConsentStateApi
@@ -338,7 +335,6 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
                 consentState.getCCPAConsentState()
             );
 
-            // TODO: Remove casting once `removeCCPAState` is removed;
             return consentStateCopy as IConsentState;
         }
 
@@ -503,15 +499,6 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
             return this;
         }
 
-        // TODO: Can we remove this? It is deprecated.
-        function removeCCPAState(this: ConsentState) {
-            mpInstance.Logger.warning(
-                'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead'
-            );
-            // @ts-ignore
-            return removeCCPAConsentState();
-        }
-
         return {
             setGDPRConsentState,
             addGDPRConsentState,
@@ -519,7 +506,6 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
             getCCPAConsentState,
             getGDPRConsentState,
             removeGDPRConsentState,
-            removeCCPAState, // TODO: Can we remove? This is deprecated
             removeCCPAConsentState,
         };
     };

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -333,7 +333,7 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
                 consentState.getCCPAConsentState()
             );
 
-            return consentStateCopy as ConsentState;
+            return consentStateCopy;
         }
 
         function canonicalizeForDeduplication(purpose: string): string {

--- a/test/src/tests-consent.ts
+++ b/test/src/tests-consent.ts
@@ -660,39 +660,4 @@ describe('Consent', function() {
         testEvent.consent_state.gdpr['test purpose'].should.have.property('hardware_id', 'hardware');
     });
 
-    // TODO: Deprecate in next major version
-    it('Should log deprecated message when using removeCCPAState', () => {
-        const bond = sinon.spy(mParticle.getInstance().Logger, 'warning');
-        const consentState = mParticle
-            .getInstance()
-            .Consent.createConsentState();
-        expect(consentState).to.be.ok;
-
-        consentState.setCCPAConsentState(
-            mParticle.Consent.createCCPAConsent(false)
-        );
-
-        expect(consentState.getCCPAConsentState()).to.have.property(
-            'Consented'
-        );
-        expect(consentState.getCCPAConsentState()).to.have.property(
-            'ConsentDocument'
-        );
-        expect(consentState.getCCPAConsentState()).to.have.property(
-            'HardwareId'
-        );
-        expect(consentState.getCCPAConsentState()).to.have.property('Location');
-        expect(consentState.getCCPAConsentState()).to.have.property(
-            'Timestamp'
-        );
-
-        // FIXME: Remove when deprecating removeCCPAState
-        ((consentState as unknown) as any).removeCCPAState();
-        (consentState.getCCPAConsentState() === undefined).should.equal(true);
-
-        bond.called.should.eql(true);
-        bond.getCalls()[0].args[0].should.eql(
-            'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead'
-        );
-    });
 });


### PR DESCRIPTION
## Summary
- Removes the deprecated `removeCCPAState` method from the consent module. Users should use `removeCCPAConsentState` instead.
- Removes the `removeCCPAState` property from the `IConsentState` interface and associated TODO comments.
- Removes the test case that validated the deprecation warning for `removeCCPAState`.

## Breaking Change
`removeCCPAState` was deprecated in favor of `removeCCPAConsentState`. This PR completes that deprecation by removing the method entirely. Any consumers still calling `removeCCPAState` must migrate to `removeCCPAConsentState`.

## Test plan
- [ ] Verify existing consent tests pass (no test regressions from removal)
- [ ] Verify TypeScript compilation succeeds
- [ ] Confirm no remaining references to `removeCCPAState` in source (only CHANGELOG history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)