### PR TITLE
fix: resolve Android bridge test failures

### DIFF
--- a/.github/workflows/android-bridge-tests.yml
+++ b/.github/workflows/android-bridge-tests.yml
@@ -12,7 +12,7 @@ jobs:
               uses: actions/checkout@v6
               with:
                 repository: mParticle/mparticle-android-sdk
-                ref: main
+                ref: fix/increase-mplatch-timeout
                 path: mparticle-android-sdk
             - name: "Install JDK 17"
               uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary
- Points the Android bridge tests workflow at the `fix/increase-mplatch-timeout` branch in `mparticle-android-sdk`, which increases the `MPLatch` timeout from 5s to 30s
- The Android bridge tests have been consistently failing since **March 12, 2026** due to a GitHub Actions runner image update (`ubuntu24/20260309.50`) that slowed WebView/JS initialization beyond the 5-second timeout
- **No code changes** in either the web SDK or Android SDK caused the regression — it was purely environmental

## Root cause investigation
We verified the following:
- Same web SDK code (identical `mparticle.js`) passes on runner image `20260302.42`, fails on `20260309.50`
- Same Android SDK commit in both passing and failing runs
- Downgrading platform-tools from 37.0.0 to 36.0.2 does **not** fix it
- Bumping emulator API level from 29 to 34 reduces failures but doesn't eliminate them
- Increasing the `MPLatch` timeout from 5s to 30s **fixes it** (verified: https://github.com/mParticle/mparticle-web-sdk/actions/runs/24104711064)

## Dependencies
- Depends on [mparticle-android-sdk#695](https://github.com/mParticle/mparticle-android-sdk/pull/695)
- Once that PR is merged, the `ref` in this workflow should be switched back from `fix/increase-mplatch-timeout` to `main`

## Test plan
- [x] Verified Android bridge tests pass with the timeout fix ([run](https://github.com/mParticle/mparticle-web-sdk/actions/runs/24104711064))
- [ ] Merge mparticle-android-sdk#695 first
- [ ] Update ref back to `main` before merging this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)