### PR TITLE
feat: support batch forwarding in kits

### DIFF
--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -333,6 +333,19 @@ export class BatchUploader {
                     entry[1],
                     mpInstance
                 );
+
+                if (uploadBatchObject) {
+                    try {
+                        mpInstance._Forwarders.sendBatchToForwarders(
+                            uploadBatchObject
+                        );
+                    } catch (e) {
+                        mpInstance.Logger.error(
+                            `Error forwarding batch to kits. ${e}`
+                        );
+                    }
+                }
+
                 const onCreateBatchCallback =
                     mpInstance._Store.SDKConfig.onCreateBatch;
 

--- a/src/forwarders.interfaces.ts
+++ b/src/forwarders.interfaces.ts
@@ -1,4 +1,3 @@
-import { Batch } from '@mparticle/event-models';
 import { SDKEvent, SDKEventCustomFlags } from './sdkRuntimeModels';
 import { Dictionary } from './utils';
 import { IKitConfigs, IKitFilterSettings } from './configAPIClient';
@@ -82,7 +81,6 @@ export interface ConfiguredKit
     ): string;
     onUserIdentified(user: IMParticleUser): string;
     process(event: SDKEvent): string;
-    processBatch?(batch: Batch): string;
     setOptOut(isOptingOut: boolean): string;
     removeUserAttribute(key: string): string;
     setUserAttribute(key: string, value: string): string;

--- a/src/forwarders.interfaces.ts
+++ b/src/forwarders.interfaces.ts
@@ -1,3 +1,4 @@
+import { Batch } from '@mparticle/event-models';
 import { SDKEvent, SDKEventCustomFlags } from './sdkRuntimeModels';
 import { Dictionary } from './utils';
 import { IKitConfigs, IKitFilterSettings } from './configAPIClient';
@@ -81,6 +82,7 @@ export interface ConfiguredKit
     ): string;
     onUserIdentified(user: IMParticleUser): string;
     process(event: SDKEvent): string;
+    processBatch?(batch: Batch): string;
     setOptOut(isOptingOut: boolean): string;
     removeUserAttribute(key: string): string;
     setUserAttribute(key: string, value: string): string;

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -413,13 +413,15 @@ export default function Forwarders(mpInstance, kitBlocker) {
             return;
         }
 
-        for (var i = 0; i < mpInstance._Store.activeForwarders.length; i++) {
-            var forwarder = mpInstance._Store.activeForwarders[i];
-
+        for (const forwarder of mpInstance._Store.activeForwarders) {
             if (forwarder.processBatch) {
                 try {
-                    var batchCopy = mpInstance._Helpers.extend(true, {}, batch);
-                    var result = forwarder.processBatch(batchCopy);
+                    const batchCopy = mpInstance._Helpers.extend(
+                        true,
+                        {},
+                        batch
+                    );
+                    const result = forwarder.processBatch(batchCopy);
 
                     if (result) {
                         mpInstance.Logger.verbose(result);

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -418,7 +418,8 @@ export default function Forwarders(mpInstance, kitBlocker) {
 
             if (forwarder.processBatch) {
                 try {
-                    var result = forwarder.processBatch(batch);
+                    var batchCopy = mpInstance._Helpers.extend(true, {}, batch);
+                    var result = forwarder.processBatch(batchCopy);
 
                     if (result) {
                         mpInstance.Logger.verbose(result);

--- a/src/forwarders.js
+++ b/src/forwarders.js
@@ -405,6 +405,31 @@ export default function Forwarders(mpInstance, kitBlocker) {
         }
     };
 
+    this.sendBatchToForwarders = function(batch) {
+        if (
+            mpInstance._Store.webviewBridgeEnabled ||
+            !mpInstance._Store.activeForwarders
+        ) {
+            return;
+        }
+
+        for (var i = 0; i < mpInstance._Store.activeForwarders.length; i++) {
+            var forwarder = mpInstance._Store.activeForwarders[i];
+
+            if (forwarder.processBatch) {
+                try {
+                    var result = forwarder.processBatch(batch);
+
+                    if (result) {
+                        mpInstance.Logger.verbose(result);
+                    }
+                } catch (e) {
+                    mpInstance.Logger.verbose(e);
+                }
+            }
+        }
+    };
+
     this.handleForwarderUserAttributes = function(functionNameKey, key, value) {
         if (
             (kitBlocker && kitBlocker.isAttributeKeyBlocked(key)) ||
@@ -747,7 +772,6 @@ export default function Forwarders(mpInstance, kitBlocker) {
             config.filteringConsentRuleValues || {};
         newForwarder.excludeAnonymousUser =
             config.excludeAnonymousUser || false;
-
         return newForwarder;
     };
 

--- a/test/jest/batchUploader.spec.ts
+++ b/test/jest/batchUploader.spec.ts
@@ -170,7 +170,7 @@ describe('BatchUploader', () => {
                 mockMPInstance
             );
 
-            expect(forwardedEventCount).toBeGreaterThan(0);
+            expect(forwardedEventCount).toBe(1);
         });
 
         it('should forward batch even when onCreateBatch drops it', () => {

--- a/test/jest/batchUploader.spec.ts
+++ b/test/jest/batchUploader.spec.ts
@@ -5,6 +5,7 @@ describe('BatchUploader', () => {
     let batchUploader: BatchUploader;
     let mockMPInstance: IMParticleWebSDKInstance;
     let originalFetch: typeof global.fetch;
+    let mockSendBatchToForwarders: jest.Mock;
 
     beforeEach(() => {
         const now = Date.now();
@@ -16,21 +17,36 @@ describe('BatchUploader', () => {
         global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
 
         // Create a mock mParticle instance with mocked methods for instantiating a BatchUploader
+        mockSendBatchToForwarders = jest.fn();
         mockMPInstance = {
             _Store: {
                 SDKConfig: {
-                    flags: {}
-                }
+                    flags: {},
+                },
+                sideloadedKitsCount: 0,
             },
             _Helpers: {
                 getFeatureFlag: jest.fn().mockReturnValue(false),
                 createServiceUrl: jest.fn().mockReturnValue('https://mock-url.com'),
+                generateUniqueId: jest.fn().mockReturnValue('mock-uuid'),
+            },
+            _Forwarders: {
+                sendBatchToForwarders: mockSendBatchToForwarders,
             },
             Identity: {
                 getCurrentUser: jest.fn().mockReturnValue({
-                    getMPID: () => 'test-mpid'
-                })
-            }
+                    getMPID: () => 'test-mpid',
+                    getConsentState: () => null,
+                    getUserIdentities: () => ({ userIdentities: {} }),
+                    getAllUserAttributes: () => ({}),
+                }),
+            },
+            Logger: {
+                error: jest.fn(),
+                warning: jest.fn(),
+                verbose: jest.fn(),
+                isVerbose: jest.fn().mockReturnValue(false),
+            },
         } as unknown as IMParticleWebSDKInstance;
 
         batchUploader = new BatchUploader(mockMPInstance, 1000);
@@ -39,6 +55,227 @@ describe('BatchUploader', () => {
     afterEach(() => {
         jest.useRealTimers();
         global.fetch = originalFetch;
+    });
+
+    describe('batch forwarding to kits', () => {
+        it('should call sendBatchToForwarders for each new batch in createNewBatches', () => {
+            const mockEvents = [
+                {
+                    EventName: 'Test Event',
+                    EventDataType: 4,
+                    MPID: 'test-mpid',
+                    SessionId: 'session-1',
+                    EventCategory: 1,
+                    Timestamp: Date.now(),
+                },
+            ];
+
+            const mockUser = {
+                getMPID: () => 'test-mpid',
+                getConsentState: () => null,
+                getUserIdentities: () => ({ userIdentities: {} }),
+                getAllUserAttributes: () => ({}),
+            };
+
+            BatchUploader['createNewBatches'](
+                mockEvents as any,
+                mockUser as any,
+                mockMPInstance
+            );
+
+            expect(mockSendBatchToForwarders).toHaveBeenCalledTimes(1);
+            expect(mockSendBatchToForwarders).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    mpid: 'test-mpid',
+                })
+            );
+        });
+
+        it('should call sendBatchToForwarders before onCreateBatch', () => {
+            const callOrder: string[] = [];
+
+            mockSendBatchToForwarders.mockImplementation(() => {
+                callOrder.push('sendBatchToForwarders');
+            });
+
+            mockMPInstance._Store.SDKConfig.onCreateBatch = (batch) => {
+                callOrder.push('onCreateBatch');
+                return batch;
+            };
+
+            const mockEvents = [
+                {
+                    EventName: 'Test Event',
+                    EventDataType: 4,
+                    MPID: 'test-mpid',
+                    SessionId: 'session-1',
+                    EventCategory: 1,
+                    Timestamp: Date.now(),
+                },
+            ];
+
+            const mockUser = {
+                getMPID: () => 'test-mpid',
+                getConsentState: () => null,
+                getUserIdentities: () => ({ userIdentities: {} }),
+                getAllUserAttributes: () => ({}),
+            };
+
+            BatchUploader['createNewBatches'](
+                mockEvents as any,
+                mockUser as any,
+                mockMPInstance
+            );
+
+            expect(callOrder).toEqual([
+                'sendBatchToForwarders',
+                'onCreateBatch',
+            ]);
+        });
+
+        it('should forward batch before onCreateBatch can modify it', () => {
+            let forwardedEventCount = 0;
+
+            mockSendBatchToForwarders.mockImplementation((batch) => {
+                forwardedEventCount = batch.events.length;
+            });
+
+            mockMPInstance._Store.SDKConfig.onCreateBatch = (batch) => {
+                batch.modified = true;
+                batch.events = [];
+                return batch;
+            };
+
+            const mockEvents = [
+                {
+                    EventName: 'Test Event',
+                    EventDataType: 4,
+                    MPID: 'test-mpid',
+                    SessionId: 'session-1',
+                    EventCategory: 1,
+                    Timestamp: Date.now(),
+                },
+            ];
+
+            const mockUser = {
+                getMPID: () => 'test-mpid',
+                getConsentState: () => null,
+                getUserIdentities: () => ({ userIdentities: {} }),
+                getAllUserAttributes: () => ({}),
+            };
+
+            BatchUploader['createNewBatches'](
+                mockEvents as any,
+                mockUser as any,
+                mockMPInstance
+            );
+
+            expect(forwardedEventCount).toBeGreaterThan(0);
+        });
+
+        it('should forward batch even when onCreateBatch drops it', () => {
+            mockMPInstance._Store.SDKConfig.onCreateBatch = () => {
+                return null;
+            };
+
+            (mockMPInstance.Logger as any).warning = jest.fn();
+
+            const mockEvents = [
+                {
+                    EventName: 'Test Event',
+                    EventDataType: 4,
+                    MPID: 'test-mpid',
+                    SessionId: 'session-1',
+                    EventCategory: 1,
+                    Timestamp: Date.now(),
+                },
+            ];
+
+            const mockUser = {
+                getMPID: () => 'test-mpid',
+                getConsentState: () => null,
+                getUserIdentities: () => ({ userIdentities: {} }),
+                getAllUserAttributes: () => ({}),
+            };
+
+            BatchUploader['createNewBatches'](
+                mockEvents as any,
+                mockUser as any,
+                mockMPInstance
+            );
+
+            expect(mockSendBatchToForwarders).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not throw if sendBatchToForwarders errors', () => {
+            mockSendBatchToForwarders.mockImplementation(() => {
+                throw new Error('Kit failure');
+            });
+
+            const mockEvents = [
+                {
+                    EventName: 'Test Event',
+                    EventDataType: 4,
+                    MPID: 'test-mpid',
+                    SessionId: 'session-1',
+                    EventCategory: 1,
+                    Timestamp: Date.now(),
+                },
+            ];
+
+            const mockUser = {
+                getMPID: () => 'test-mpid',
+                getConsentState: () => null,
+                getUserIdentities: () => ({ userIdentities: {} }),
+                getAllUserAttributes: () => ({}),
+            };
+
+            expect(() => {
+                BatchUploader['createNewBatches'](
+                    mockEvents as any,
+                    mockUser as any,
+                    mockMPInstance
+                );
+            }).not.toThrow();
+
+            expect(mockMPInstance.Logger.error).toHaveBeenCalled();
+        });
+
+        it('should create separate batches per MPID and forward each', () => {
+            const mockEvents = [
+                {
+                    EventName: 'Event User A',
+                    EventDataType: 4,
+                    MPID: 'mpid-a',
+                    SessionId: 'session-1',
+                    EventCategory: 1,
+                    Timestamp: Date.now(),
+                },
+                {
+                    EventName: 'Event User B',
+                    EventDataType: 4,
+                    MPID: 'mpid-b',
+                    SessionId: 'session-1',
+                    EventCategory: 1,
+                    Timestamp: Date.now(),
+                },
+            ];
+
+            const mockUser = {
+                getMPID: () => 'mpid-a',
+                getConsentState: () => null,
+                getUserIdentities: () => ({ userIdentities: {} }),
+                getAllUserAttributes: () => ({}),
+            };
+
+            BatchUploader['createNewBatches'](
+                mockEvents as any,
+                mockUser as any,
+                mockMPInstance
+            );
+
+            expect(mockSendBatchToForwarders).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('shouldDebounceAST', () => {

--- a/test/src/tests-forwarders.ts
+++ b/test/src/tests-forwarders.ts
@@ -50,6 +50,8 @@ interface IMockForwarderInstance {
     onModifyCompleteUser?: IMParticleUser;
     onUserIdentifiedCalled?: boolean;
     onUserIdentifiedUser?: IMParticleUser;
+    processBatch?: (batch: unknown) => void;
+    processCalled?: boolean;
     receivedEvent?: SDKEvent;
     receivedEvents?: SDKEvent[];
     removeUserAttributeCalled?: boolean;
@@ -4014,6 +4016,149 @@ describe('forwarders', function() {
                     true
                 );
             });
+        });
+    });
+
+    describe('batch forwarding', () => {
+        it('should call processBatch on forwarders that implement it', async () => {
+            const mockForwarder = new MockForwarder();
+            mockForwarder.register(window.mParticle.config);
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('MockForwarder')
+            );
+
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const forwarderInstance = window.MockForwarder1.instance;
+            let receivedBatch = null;
+            forwarderInstance.processBatch = function(batch) {
+                receivedBatch = batch;
+            };
+
+            const fakeBatch = {
+                events: [{ event_type: 'custom_event' }],
+                mpid: testMPID,
+            };
+
+            mParticle
+                .getInstance()
+                ._Forwarders.sendBatchToForwarders(fakeBatch);
+
+            expect(receivedBatch).to.be.ok;
+            expect(receivedBatch.events.length).to.equal(1);
+            expect(receivedBatch.events[0].event_type).to.equal(
+                'custom_event'
+            );
+        });
+
+        it('should not call processBatch on forwarders that do not implement it', async () => {
+            const mockForwarder = new MockForwarder();
+            mockForwarder.register(window.mParticle.config);
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('MockForwarder')
+            );
+
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const fakeBatch = {
+                events: [{ event_type: 'custom_event' }],
+                mpid: testMPID,
+            };
+
+            // Should not throw when forwarder lacks processBatch
+            mParticle
+                .getInstance()
+                ._Forwarders.sendBatchToForwarders(fakeBatch);
+
+            // process() should not have been called by sendBatchToForwarders
+            const forwarderInstance = window.MockForwarder1.instance;
+            expect(forwarderInstance.receivedEvent).to.equal(null);
+        });
+
+        it('should still send individual events via process() regardless of processBatch', async () => {
+            const mockForwarder = new MockForwarder();
+            mockForwarder.register(window.mParticle.config);
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('MockForwarder')
+            );
+
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const forwarderInstance = window.MockForwarder1.instance;
+            let batchReceived = false;
+            forwarderInstance.processBatch = function() {
+                batchReceived = true;
+            };
+
+            mParticle.logEvent('Test Event');
+
+            // Individual event should still arrive via process()
+            expect(forwarderInstance.processCalled).to.equal(true);
+            expect(forwarderInstance.receivedEvent).to.be.ok;
+            expect(forwarderInstance.receivedEvent.EventName).to.equal(
+                'Test Event'
+            );
+        });
+
+        it('should not send batches to forwarders when webviewBridgeEnabled is true', async () => {
+            const mockForwarder = new MockForwarder();
+            mockForwarder.register(window.mParticle.config);
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('MockForwarder')
+            );
+
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const forwarderInstance = window.MockForwarder1.instance;
+            let batchReceived = false;
+            forwarderInstance.processBatch = function() {
+                batchReceived = true;
+            };
+
+            mParticle.getInstance()._Store.webviewBridgeEnabled = true;
+
+            const fakeBatch = {
+                events: [{ event_type: 'custom_event' }],
+                mpid: testMPID,
+            };
+
+            mParticle
+                .getInstance()
+                ._Forwarders.sendBatchToForwarders(fakeBatch);
+
+            expect(batchReceived).to.equal(false);
+
+            mParticle.getInstance()._Store.webviewBridgeEnabled = false;
+        });
+
+        it('should handle errors in processBatch gracefully', async () => {
+            const mockForwarder = new MockForwarder();
+            mockForwarder.register(window.mParticle.config);
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('MockForwarder')
+            );
+
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const forwarderInstance = window.MockForwarder1.instance;
+            forwarderInstance.processBatch = function() {
+                throw new Error('Kit error');
+            };
+
+            const fakeBatch = {
+                events: [{ event_type: 'custom_event' }],
+                mpid: testMPID,
+            };
+
+            // Should not throw
+            mParticle
+                .getInstance()
+                ._Forwarders.sendBatchToForwarders(fakeBatch);
         });
     });
 });

--- a/test/src/tests-forwarders.ts
+++ b/test/src/tests-forwarders.ts
@@ -4062,19 +4062,19 @@ describe('forwarders', function() {
             mParticle.init(apiKey, window.mParticle.config);
             await waitForCondition(hasIdentifyReturned);
 
+            const forwarderInstance = window.MockForwarder1.instance;
+            expect(forwarderInstance.processBatch).to.not.be.ok;
+
             const fakeBatch = {
                 events: [{ event_type: 'custom_event' }],
                 mpid: testMPID,
             };
 
-            // Should not throw when forwarder lacks processBatch
-            mParticle
-                .getInstance()
-                ._Forwarders.sendBatchToForwarders(fakeBatch);
-
-            // process() should not have been called by sendBatchToForwarders
-            const forwarderInstance = window.MockForwarder1.instance;
-            expect(forwarderInstance.receivedEvent).to.equal(null);
+            expect(() => {
+                mParticle
+                    .getInstance()
+                    ._Forwarders.sendBatchToForwarders(fakeBatch);
+            }).to.not.throw();
         });
 
         it('should still send individual events via process() regardless of processBatch', async () => {

--- a/test/src/tests-forwarders.ts
+++ b/test/src/tests-forwarders.ts
@@ -4155,10 +4155,11 @@ describe('forwarders', function() {
                 mpid: testMPID,
             };
 
-            // Should not throw
-            mParticle
-                .getInstance()
-                ._Forwarders.sendBatchToForwarders(fakeBatch);
+            expect(() => {
+                mParticle
+                    .getInstance()
+                    ._Forwarders.sendBatchToForwarders(fakeBatch);
+            }).to.not.throw();
         });
 
         it('should deep-clone the batch so kit mutations do not corrupt the original', async () => {

--- a/test/src/tests-forwarders.ts
+++ b/test/src/tests-forwarders.ts
@@ -4160,5 +4160,34 @@ describe('forwarders', function() {
                 .getInstance()
                 ._Forwarders.sendBatchToForwarders(fakeBatch);
         });
+
+        it('should deep-clone the batch so kit mutations do not corrupt the original', async () => {
+            const mockForwarder = new MockForwarder();
+            mockForwarder.register(window.mParticle.config);
+            window.mParticle.config.kitConfigs.push(
+                forwarderDefaultConfiguration('MockForwarder')
+            );
+
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const forwarderInstance = window.MockForwarder1.instance;
+            forwarderInstance.processBatch = function(batch: any) {
+                batch.events = [];
+                batch.mpid = 'mutated';
+            };
+
+            const fakeBatch = {
+                events: [{ event_type: 'custom_event' }],
+                mpid: testMPID,
+            };
+
+            mParticle
+                .getInstance()
+                ._Forwarders.sendBatchToForwarders(fakeBatch);
+
+            expect(fakeBatch.events.length).to.equal(1);
+            expect(fakeBatch.mpid).to.equal(testMPID);
+        });
     });
 });


### PR DESCRIPTION
## Background
- Kits currently only receive individual events via forwarder.process(event). Some kits need access to the full batch object (grouped by MPID and session, in Events API format) to support batch-level processing.

## What Has Changed
- Added optional `processBatch(batch)` method to the ConfiguredKit interface, kits that implement it receive batches, others are unaffected
- Added `sendBatchToForwarders(batch)` in `forwarders.js` to route batches to opted-in kits
- Wired batch forwarding into `createNewBatches` in `batchUploader.ts`, after `convertEvents` but before `onCreateBatch`, so kits get the unmodified batch


## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes NA  
