### PR TITLE
feat: Add base64-encoded MPID query parameter for Google Marketing Pl…

### DIFF
--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -137,8 +137,11 @@ export default function CookieSyncManager(
             // It is optional but to simplify the code, we add it for all Trade
             // // Desk cookie syncs.
             const domain = moduleId === PARTNER_MODULE_IDS.TradeDesk ? window.location.hostname : undefined;
-            // Add domain parameter for Trade Desk
-            const fullUrl = createCookieSyncUrl(mpid, pixelUrl, redirectUrl, domain);
+
+            // Google Marketing Platform requires a base64-encoded MPID query parameter
+            const base64Mpid = moduleId === PARTNER_MODULE_IDS.DoubleclickDFP ? btoa(mpid) : undefined;
+
+            const fullUrl = createCookieSyncUrl(mpid, pixelUrl, redirectUrl, domain, base64Mpid);
 
             self.performCookieSync(
                 fullUrl,

--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -2,6 +2,7 @@ import {
     Dictionary,
     isEmpty,
     createCookieSyncUrl,
+    toWebSafeBase64,
 } from './utils';
 import Constants from './constants';
 import { MPID } from '@mparticle/web-sdk';
@@ -95,6 +96,7 @@ export default function CookieSyncManager(
                 pixelUrl,
                 redirectUrl,
                 moduleId,
+                settings,
                 // Tells you how often we should do a cookie sync (in days)
                 frequencyCap,
             } = pixelSettings;
@@ -138,8 +140,16 @@ export default function CookieSyncManager(
             // // Desk cookie syncs.
             const domain = moduleId === PARTNER_MODULE_IDS.TradeDesk ? window.location.hostname : undefined;
 
-            // Google Marketing Platform requires a base64-encoded MPID query parameter
-            const base64Mpid = moduleId === PARTNER_MODULE_IDS.DoubleclickDFP ? btoa(mpid) : undefined;
+            // Google Marketing Platform accepts a web-safe base64-encoded MPID via the
+            // `google_hm` query parameter, but only for accounts provisioned for Google
+            // Hosted Matching — Google returns errors otherwise. It is therefore gated
+            // behind the opt-in `enableHmTag` setting (off by default), which the server
+            // delivers as the string 'True' when the UI toggle is enabled.
+            const enableHmTag = settings?.enableHmTag?.toLowerCase() === 'true';
+            const base64Mpid =
+                moduleId === PARTNER_MODULE_IDS.DoubleclickDFP && enableHmTag
+                    ? toWebSafeBase64(mpid)
+                    : undefined;
 
             const fullUrl = createCookieSyncUrl(mpid, pixelUrl, redirectUrl, domain, base64Mpid);
 

--- a/src/cookieSyncManager.ts
+++ b/src/cookieSyncManager.ts
@@ -146,10 +146,8 @@ export default function CookieSyncManager(
             // behind the opt-in `enableHmTag` setting (off by default), which the server
             // delivers as the string 'True' when the UI toggle is enabled.
             const enableHmTag = settings?.enableHmTag?.toLowerCase() === 'true';
-            const base64Mpid =
-                moduleId === PARTNER_MODULE_IDS.DoubleclickDFP && enableHmTag
-                    ? toWebSafeBase64(mpid)
-                    : undefined;
+            const isDoubleClickModule = moduleId === PARTNER_MODULE_IDS.DoubleclickDFP;
+            const base64Mpid = isDoubleClickModule && enableHmTag ? toWebSafeBase64(mpid) : undefined;
 
             const fullUrl = createCookieSyncUrl(mpid, pixelUrl, redirectUrl, domain, base64Mpid);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,7 +207,8 @@ const createCookieSyncUrl = (
     mpid: MPID,
     pixelUrl: string,
     redirectUrl?: string,
-    domain?: string
+    domain?: string,
+    base64Mpid?: string
 ): string => {
     const modifiedPixelUrl = replaceAmpWithAmpersand(pixelUrl);
     const modifiedDirectUrl = redirectUrl
@@ -215,18 +216,23 @@ const createCookieSyncUrl = (
         : null;
 
     let url = replaceMPID(modifiedPixelUrl, mpid);
-    
+
     const redirect = modifiedDirectUrl
         ? replaceMPID(modifiedDirectUrl, mpid)
         : '';
-    
+
     let fullUrl = url + encodeURIComponent(redirect);
-    
+
     if (domain) {
         const separator = fullUrl.includes('?') ? '&' : '?';
         fullUrl += `${separator}domain=${domain}`;
     }
-    
+
+    if (base64Mpid) {
+        const separator = fullUrl.includes('?') ? '&' : '?';
+        fullUrl += `${separator}google_hm=${base64Mpid}`;
+    }
+
     return fullUrl;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -236,6 +236,19 @@ const createCookieSyncUrl = (
     return fullUrl;
 };
 
+// Google's cookie matching service requires `google_hm` values to be web-safe
+// base64 (RFC 4648 §5) without padding, otherwise the write to the hosted
+// match table fails: https://developers.google.com/authorized-buyers/rtb/cookie-guide
+// (String#replaceAll is not available in our ES5 browser targets.)
+const WEB_SAFE_BASE64_REPLACEMENTS: Dictionary<string> = {
+    '+': '-',
+    '/': '_',
+    '=': '',
+};
+
+const toWebSafeBase64 = (value: string): string =>
+    btoa(value).replace(/[+/=]/g, c => WEB_SAFE_BASE64_REPLACEMENTS[c]);
+
 // FIXME: REFACTOR for V3
 // only used in store.js to sanitize server-side formatting of
 // booleans when checking for `isDevelopmentMode`
@@ -501,6 +514,7 @@ export {
     createCookieString,
     revertCookieString,
     createCookieSyncUrl,
+    toWebSafeBase64,
     valueof,
     AttributeValue,
     converted,

--- a/test/jest/cookieSyncManager.spec.ts
+++ b/test/jest/cookieSyncManager.spec.ts
@@ -776,6 +776,92 @@ describe('CookieSyncManager', () => {
                 );
             });
         });
+
+        describe('Google Marketing Platform (DoubleclickDFP) base64 MPID', () => {
+            it('should add base64-encoded MPID parameter for DoubleclickDFP (module ID 41)', () => {
+                const gmpPixelSettings: IPixelConfiguration = {
+                    ...pixelSettings,
+                    moduleId: PARTNER_MODULE_IDS.DoubleclickDFP, // 41
+                    pixelUrl: 'https://cm.g.doubleclick.net/pixel?google_nid=abc123',
+                    redirectUrl: '',
+                };
+
+                const mockMPInstance = ({
+                    _Store: {
+                        webviewBridgeEnabled: false,
+                        pixelConfigurations: [gmpPixelSettings],
+                    },
+                    _CookieConsentManager: { getNoFunctional: jest.fn().mockReturnValue(false) },
+                    _Persistence: {
+                        getPersistence: () => ({testMPID: {
+                            csd: {}
+                        }}),
+                    },
+                    _Consent: {
+                        isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                    },
+                    Identity: {
+                        getCurrentUser: jest.fn().mockReturnValue({
+                            getMPID: () => testMPID,
+                        }),
+                    },
+                } as unknown) as IMParticleWebSDKInstance;
+
+                const cookieSyncManager = new CookieSyncManager(mockMPInstance);
+                cookieSyncManager.performCookieSync = jest.fn();
+
+                cookieSyncManager.attemptCookieSync(testMPID, true);
+
+                expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
+                    `https://cm.g.doubleclick.net/pixel?google_nid=abc123&google_hm=${btoa(testMPID)}`,
+                    '41',
+                    testMPID,
+                    {},
+                );
+            });
+
+            it('should not add base64 MPID parameter for non-DoubleclickDFP partners', () => {
+                const appNexusPixelSettings: IPixelConfiguration = {
+                    ...pixelSettings,
+                    moduleId: PARTNER_MODULE_IDS.AppNexus, // 50
+                    pixelUrl: 'https://ib.adnxs.com/cookie_sync?adv=abc123',
+                    redirectUrl: '',
+                };
+
+                const mockMPInstance = ({
+                    _Store: {
+                        webviewBridgeEnabled: false,
+                        pixelConfigurations: [appNexusPixelSettings],
+                    },
+                    _CookieConsentManager: { getNoFunctional: jest.fn().mockReturnValue(false) },
+                    _Persistence: {
+                        getPersistence: () => ({testMPID: {
+                            csd: {}
+                        }}),
+                    },
+                    _Consent: {
+                        isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                    },
+                    Identity: {
+                        getCurrentUser: jest.fn().mockReturnValue({
+                            getMPID: () => testMPID,
+                        }),
+                    },
+                } as unknown) as IMParticleWebSDKInstance;
+
+                const cookieSyncManager = new CookieSyncManager(mockMPInstance);
+                cookieSyncManager.performCookieSync = jest.fn();
+
+                cookieSyncManager.attemptCookieSync(testMPID, true);
+
+                expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
+                    'https://ib.adnxs.com/cookie_sync?adv=abc123',
+                    '50',
+                    testMPID,
+                    {},
+                );
+            });
+        });
     });
 
     describe('PARTNER_MODULE_IDS', () => {

--- a/test/jest/cookieSyncManager.spec.ts
+++ b/test/jest/cookieSyncManager.spec.ts
@@ -778,10 +778,11 @@ describe('CookieSyncManager', () => {
         });
 
         describe('Google Marketing Platform (DoubleclickDFP) base64 MPID', () => {
-            it('should add base64-encoded MPID parameter for DoubleclickDFP (module ID 41)', () => {
+            it('should add a web-safe base64-encoded MPID parameter for DoubleclickDFP (module ID 41) when enableHmTag is enabled', () => {
                 const gmpPixelSettings: IPixelConfiguration = {
                     ...pixelSettings,
                     moduleId: PARTNER_MODULE_IDS.DoubleclickDFP, // 41
+                    settings: { enableHmTag: 'True' },
                     pixelUrl: 'https://cm.g.doubleclick.net/pixel?google_nid=abc123',
                     redirectUrl: '',
                 };
@@ -813,17 +814,20 @@ describe('CookieSyncManager', () => {
                 cookieSyncManager.attemptCookieSync(testMPID, true);
 
                 expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
-                    `https://cm.g.doubleclick.net/pixel?google_nid=abc123&google_hm=${btoa(testMPID)}`,
+                    // btoa('testMPID') is 'dGVzdE1QSUQ=' — google_hm must be the
+                    // web-safe, unpadded form per Google's cookie matching spec
+                    'https://cm.g.doubleclick.net/pixel?google_nid=abc123&google_hm=dGVzdE1QSUQ',
                     '41',
                     testMPID,
                     {},
                 );
             });
 
-            it('should not add base64 MPID parameter for non-DoubleclickDFP partners', () => {
+            it('should not add base64 MPID parameter for non-DoubleclickDFP partners even when enableHmTag is enabled', () => {
                 const appNexusPixelSettings: IPixelConfiguration = {
                     ...pixelSettings,
                     moduleId: PARTNER_MODULE_IDS.AppNexus, // 50
+                    settings: { enableHmTag: 'True' },
                     pixelUrl: 'https://ib.adnxs.com/cookie_sync?adv=abc123',
                     redirectUrl: '',
                 };
@@ -858,6 +862,122 @@ describe('CookieSyncManager', () => {
                     'https://ib.adnxs.com/cookie_sync?adv=abc123',
                     '50',
                     testMPID,
+                    {},
+                );
+            });
+
+            it.each([
+                [
+                    'is absent',
+                    {},
+                    'https://cm.g.doubleclick.net/pixel?google_nid=abc123',
+                ],
+                [
+                    "is 'False'",
+                    { enableHmTag: 'False' },
+                    'https://cm.g.doubleclick.net/pixel?google_nid=abc123',
+                ],
+                [
+                    "is 'True' (server contract)",
+                    { enableHmTag: 'True' },
+                    'https://cm.g.doubleclick.net/pixel?google_nid=abc123&google_hm=dGVzdE1QSUQ',
+                ],
+                [
+                    "is 'true' (case-insensitive)",
+                    { enableHmTag: 'true' },
+                    'https://cm.g.doubleclick.net/pixel?google_nid=abc123&google_hm=dGVzdE1QSUQ',
+                ],
+            ] as Array<[string, Record<string, string>, string]>)(
+                'should gate google_hm on the enableHmTag setting when it %s',
+                (_description, settings, expectedUrl) => {
+                    const gmpPixelSettings: IPixelConfiguration = {
+                        ...pixelSettings,
+                        moduleId: PARTNER_MODULE_IDS.DoubleclickDFP, // 41
+                        settings,
+                        pixelUrl: 'https://cm.g.doubleclick.net/pixel?google_nid=abc123',
+                        redirectUrl: '',
+                    };
+
+                    const mockMPInstance = ({
+                        _Store: {
+                            webviewBridgeEnabled: false,
+                            pixelConfigurations: [gmpPixelSettings],
+                        },
+                        _CookieConsentManager: { getNoFunctional: jest.fn().mockReturnValue(false) },
+                        _Persistence: {
+                            getPersistence: () => ({testMPID: {
+                                csd: {}
+                            }}),
+                        },
+                        _Consent: {
+                            isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                        },
+                        Identity: {
+                            getCurrentUser: jest.fn().mockReturnValue({
+                                getMPID: () => testMPID,
+                            }),
+                        },
+                    } as unknown) as IMParticleWebSDKInstance;
+
+                    const cookieSyncManager = new CookieSyncManager(mockMPInstance);
+                    cookieSyncManager.performCookieSync = jest.fn();
+
+                    cookieSyncManager.attemptCookieSync(testMPID, true);
+
+                    expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
+                        expectedUrl,
+                        '41',
+                        testMPID,
+                        {},
+                    );
+                }
+            );
+
+            it('should strip base64 padding from the google_hm value', () => {
+                // Realistic MPIDs are signed 64-bit integers whose base64 form
+                // always carries `=` padding, which Google rejects
+                const paddedMpid = '-1234567890123456789';
+
+                const gmpPixelSettings: IPixelConfiguration = {
+                    ...pixelSettings,
+                    moduleId: PARTNER_MODULE_IDS.DoubleclickDFP, // 41
+                    settings: { enableHmTag: 'True' },
+                    pixelUrl: 'https://cm.g.doubleclick.net/pixel?google_nid=abc123',
+                    redirectUrl: '',
+                };
+
+                const mockMPInstance = ({
+                    _Store: {
+                        webviewBridgeEnabled: false,
+                        pixelConfigurations: [gmpPixelSettings],
+                    },
+                    _CookieConsentManager: { getNoFunctional: jest.fn().mockReturnValue(false) },
+                    _Persistence: {
+                        getPersistence: () => ({testMPID: {
+                            csd: {}
+                        }}),
+                    },
+                    _Consent: {
+                        isEnabledForUserConsent: jest.fn().mockReturnValue(true),
+                    },
+                    Identity: {
+                        getCurrentUser: jest.fn().mockReturnValue({
+                            getMPID: () => paddedMpid,
+                        }),
+                    },
+                } as unknown) as IMParticleWebSDKInstance;
+
+                const cookieSyncManager = new CookieSyncManager(mockMPInstance);
+                cookieSyncManager.performCookieSync = jest.fn();
+
+                cookieSyncManager.attemptCookieSync(paddedMpid, true);
+
+                expect(cookieSyncManager.performCookieSync).toHaveBeenCalledWith(
+                    // btoa(paddedMpid) is 'LTEyMzQ1Njc4OTAxMjM0NTY3ODk=' — the
+                    // trailing padding must be stripped
+                    'https://cm.g.doubleclick.net/pixel?google_nid=abc123&google_hm=LTEyMzQ1Njc4OTAxMjM0NTY3ODk',
+                    '41',
+                    paddedMpid,
                     {},
                 );
             });

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -7,6 +7,7 @@ import {
     replaceMPID,
     replaceAmpWithAmpersand,
     createCookieSyncUrl,
+    toWebSafeBase64,
     inArray,
     filterDictionaryWithHash,
     parseConfig,
@@ -267,6 +268,26 @@ describe('Utils', () => {
         it('should not add domain parameter when domain is empty string', () => {
             const simplePixelUrl = 'https://test.com/pixel';
             expect(createCookieSyncUrl('testMPID', simplePixelUrl, null, '')).toBe('https://test.com/pixel');
+        });
+    });
+
+    describe('#toWebSafeBase64', () => {
+        it('should strip base64 padding', () => {
+            // btoa values are 'dGVzdE1QSUQ=' and 'LTEyMzQ1Njc4OTAxMjM0NTY3ODk=' respectively
+            expect(toWebSafeBase64('testMPID')).toBe('dGVzdE1QSUQ');
+            expect(toWebSafeBase64('-1234567890123456789')).toBe(
+                'LTEyMzQ1Njc4OTAxMjM0NTY3ODk'
+            );
+        });
+
+        it('should replace + and / with web-safe - and _', () => {
+            // btoa value is '+/AA'
+            expect(toWebSafeBase64(String.fromCharCode(0xfb, 0xf0, 0x00))).toBe('-_AA');
+        });
+
+        it('should leave already web-safe values unchanged', () => {
+            // btoa('123456') === 'MTIzNDU2' — Google's documented example
+            expect(toWebSafeBase64('123456')).toBe('MTIzNDU2');
         });
     });
 


### PR DESCRIPTION
When the cookie sync partner is Google Marketing Platform (DoubleclickDFP, module ID 41) **and the customer has opted into Google Hosted Matching**, append a `google_hm` query parameter containing the **web-safe base64-encoded MPID** to the cookie sync URL.

## Summary
- `google_hm` is only sent when the pixel config delivers the `enableHmTag` setting as `'True'` (the "Enable google_hm" UI toggle shipped in mPServer #42288, [CORECDP-3674]). Google returns errors for accounts not provisioned for Hosted Matching, so the default is off; the check is case-insensitive and treats absent/`'False'`/anything-else as off.
- The value is **web-safe unpadded base64** (RFC 4648 §5). Numeric MPIDs always produce `=` padding under plain `btoa`, which Google's [cookie matching spec](https://developers.google.com/authorized-buyers/rtb/cookie-guide) rejects (their example is unpadded `MTIzNDU2`).
- Wire contract verified against a live prod config (`.../js/v2/e207c24e.../config`), which delivers `"settings": { "enableHmTag": "True" }` on the GMP pixel config when the toggle is on.

## What Has Changed
- **`src/cookieSyncManager.ts`**: when `moduleId` equals `PARTNER_MODULE_IDS.DoubleclickDFP` (41) and `settings.enableHmTag` is `'true'` (case-insensitive), computes the web-safe base64 MPID and passes it as `base64Mpid` to `createCookieSyncUrl`
- **`src/utils.ts`**: `createCookieSyncUrl` accepts a new optional `base64Mpid` parameter and appends `google_hm=<base64Mpid>` when provided; new `toWebSafeBase64` helper (single-pass replace: `+`→`-`, `/`→`_`, `=` stripped)
- **`test/jest/cookieSyncManager.spec.ts`**: gate matrix (setting absent / `'False'` / `'True'` / lowercase `'true'`), padded-MPID case asserting the unpadded value, non-GMP partners unaffected even with the setting present
- **`test/jest/utils.spec.ts`**: unit tests for `toWebSafeBase64`

## Tested Locally
Opt-in ON (`enableHmTag: 'True'`): pixel fires with `google_hm` = unpadded web-safe base64 of the MPID:
<img width="800" height="600" alt="hm_on_result" src="https://github.com/user-attachments/assets/d79b295f-c4a3-4327-8d0e-8f44e00a52c0" />
Opt-in OFF (setting absent): cookie sync fires normally with the same URL and no `google_hm`:
<img width="800" height="600" alt="hm_off_result" src="https://github.com/user-attachments/assets/da80ee5f-324e-4382-ac96-f34bb2fbcfd0" />

HAR capture of the ON flow against Google's live endpoint confirms the full exchange: the pixel 302s with `google_hm` decoding exactly to the MPID, **no `google_error`** anywhere in the redirect chain (per Google's spec, a rejected hosted-match-table write is signaled as `google_error=1-5`), and Google hands its encrypted user ID back to `cookiesync.mparticle.com` (204). Both directions of the match are verified, with the existing `GOOGLE_USER_ID`-as-Partner-ID behavior intact.

## Note on the BrowserStack check
The "BrowserStack Test" failure is pre-existing on this repo (identical legacy Edge 15 consent-test failures on master's May 26 run, which pre-dates this branch); all modern browsers pass 1041/1051 with these changes. Details in #1318.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.