### PR TITLE
fix: correct CaptureIntegrationSpecificIds.V2 feature flag string

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -193,7 +193,7 @@ const Constants = {
         //   - 'all'      → capture all IDs
         //   - 'none'     → capture none
         //   - 'roktonly' → capture only Rokt-related IDs
-        CaptureIntegrationSpecificIdsV2: 'captureIntegrationSpecificIdsV2',
+        CaptureIntegrationSpecificIdsV2: 'captureIntegrationSpecificIds.V2',
         AstBackgroundEvents: 'astBackgroundEvents',
     },
     DefaultInstance: 'default_instance',

--- a/src/store.ts
+++ b/src/store.ts
@@ -148,7 +148,7 @@ export interface IFeatureFlags {
     directURLRouting?: boolean;
     cacheIdentity?: boolean;
     captureIntegrationSpecificIds?: boolean;
-    captureIntegrationSpecificIdsV2?: string;
+    'captureIntegrationSpecificIds.V2'?: string;
     astBackgroundEvents?: boolean;
 }
 

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -269,7 +269,7 @@ describe('batch uploader', () => {
             };
 
             window.mParticle.config.flags.captureIntegrationSpecificIds = "False";
-            window.mParticle.config.flags.captureIntegrationSpecificIdsV2 = "roktonly";
+            window.mParticle.config.flags['captureIntegrationSpecificIds.V2'] = "roktonly";
 
             const consentState = window.mParticle.Consent.createConsentState();
             const timestamp = new Date().getTime();

--- a/test/src/tests-feature-flags.ts
+++ b/test/src/tests-feature-flags.ts
@@ -119,7 +119,7 @@ describe('feature-flags', () => {
         it('should capture click ids when feature flag is true', async () => {
             window.mParticle.config.flags = {
                 captureIntegrationSpecificIds: 'True',
-                captureIntegrationSpecificIdsV2: 'all'
+                'captureIntegrationSpecificIds.V2': 'all'
             };
 
             // initialize mParticle with feature flag 
@@ -149,7 +149,7 @@ describe('feature-flags', () => {
         it('should NOT capture click ids when feature flag is false', async () => {
             window.mParticle.config.flags = {
                 captureIntegrationSpecificIds: 'False',
-                captureIntegrationSpecificIdsV2: 'none'
+                'captureIntegrationSpecificIds.V2': 'none'
             };
 
             // initialize mParticle with feature flag 

--- a/test/src/tests-integration-capture.ts
+++ b/test/src/tests-integration-capture.ts
@@ -36,7 +36,7 @@ describe('Integration Capture', () => {
 
         window.mParticle.config.flags = {
             captureIntegrationSpecificIds: 'True',
-            captureIntegrationSpecificIdsV2: 'all'
+            'captureIntegrationSpecificIds.V2': 'all'
         };
 
         window.document.cookie = '_cookie1=234';

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1379,7 +1379,7 @@ describe('Store', () => {
                     cacheIdentity: 'False',
                     audienceAPI: 'False',
                     captureIntegrationSpecificIds: 'False',
-                    captureIntegrationSpecificIdsV2: 'none',
+                    'captureIntegrationSpecificIds.V2': 'none',
                     astBackgroundEvents: 'True',
                 },
             };
@@ -1399,7 +1399,7 @@ describe('Store', () => {
                 cacheIdentity: false,
                 audienceAPI: false,
                 captureIntegrationSpecificIds: false,
-                captureIntegrationSpecificIdsV2: 'none',
+                'captureIntegrationSpecificIds.V2': 'none',
                 astBackgroundEvents: true,
             };
 
@@ -1599,7 +1599,7 @@ describe('Store', () => {
                 cacheIdentity: false,
                 audienceAPI: false,
                 captureIntegrationSpecificIds: false,
-                captureIntegrationSpecificIdsV2: 'none',
+                'captureIntegrationSpecificIds.V2': 'none',
                 astBackgroundEvents: false,
             };
 
@@ -1615,7 +1615,7 @@ describe('Store', () => {
                 cacheIdentity: 'True',
                 audienceAPI: 'True',
                 captureIntegrationSpecificIds: 'True',
-                captureIntegrationSpecificIdsV2: 'all',
+                'captureIntegrationSpecificIds.V2': 'all',
                 astBackgroundEvents: 'True',
             };
 
@@ -1631,7 +1631,7 @@ describe('Store', () => {
                 cacheIdentity: true,
                 audienceAPI: true,
                 captureIntegrationSpecificIds: true,
-                captureIntegrationSpecificIdsV2: 'all',
+                'captureIntegrationSpecificIds.V2': 'all',
                 astBackgroundEvents: true,
             };
 


### PR DESCRIPTION
## Background
- The server sends the V2 integration capture feature flag as `captureIntegrationSpecificIds.V2` (with a dot), but the SDK constant was defined as `captureIntegrationSpecificIdsV2` (no dot)
- This key mismatch caused processFlags() in store.ts to return undefined for the V2 flag, which then defaulted to 'none' — silently disabling IntegrationCapture for any customer relying on V2                                                        
- Customers with the legacy V1 flag (captureIntegrationSpecificIds: "True") were unaffected because the V1 path bypassed V2 entirely, but they ran in 'all' mode instead of the intended 'roktonly' mode  

## What Has Changed
- Updated CaptureIntegrationSpecificIdsV2 constant in src/constants.ts from 'captureIntegrationSpecificIdsV2' to 'captureIntegrationSpecificIds.V2' to match the server-sent key and associated tests

Screenshot showing the `.` sent down from the server
<img width="512" height="230" alt="image" src="https://github.com/user-attachments/assets/747add96-1006-48ce-a4ba-33c145230a69" />


## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.