### PR TITLE
fix: Clean up BatchUploader timers and event listeners on re-init

### DIFF
--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -50,6 +50,7 @@ export class BatchUploader {
     private uploadIntervalTimerId: ReturnType<typeof setTimeout> | null = null;
     private exitHandler: (() => void) | null = null;
     private visibilityChangeHandler: (() => void) | null = null;
+    private destroyed = false;
 
     /**
      * Creates an instance of a BatchUploader
@@ -113,6 +114,8 @@ export class BatchUploader {
      * is re-initialized (e.g. between tests or on repeated init calls).
      */
     public destroy(): void {
+        this.destroyed = true;
+
         if (this.uploadIntervalTimerId !== null) {
             clearTimeout(this.uploadIntervalTimerId);
             this.uploadIntervalTimerId = null;
@@ -476,7 +479,7 @@ export class BatchUploader {
             this.batchesQueuedForProcessing = [];
         }
 
-        if (triggerFuture) {
+        if (triggerFuture && !this.destroyed) {
             this.triggerUploadInterval(triggerFuture, false);
         }
     }

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -47,6 +47,9 @@ export class BatchUploader {
     private uploader: AsyncUploader;
     private lastASTEventTime: number = 0;
     private readonly AST_DEBOUNCE_MS: number = 1000; // 1 second debounce
+    private uploadIntervalTimerId: ReturnType<typeof setTimeout> | null = null;
+    private exitHandler: (() => void) | null = null;
+    private visibilityChangeHandler: (() => void) | null = null;
 
     /**
      * Creates an instance of a BatchUploader
@@ -103,6 +106,29 @@ export class BatchUploader {
 
         this.triggerUploadInterval(true, false);
         this.addEventListeners();
+    }
+
+    /**
+     * Cleans up timers and event listeners to prevent leaks when the SDK
+     * is re-initialized (e.g. between tests or on repeated init calls).
+     */
+    public destroy(): void {
+        if (this.uploadIntervalTimerId !== null) {
+            clearTimeout(this.uploadIntervalTimerId);
+            this.uploadIntervalTimerId = null;
+        }
+
+        if (this.visibilityChangeHandler) {
+            document.removeEventListener('visibilitychange', this.visibilityChangeHandler);
+        }
+
+        if (this.exitHandler) {
+            window.removeEventListener('beforeunload', this.exitHandler);
+            window.removeEventListener('pagehide', this.exitHandler);
+        }
+
+        this.exitHandler = null;
+        this.visibilityChangeHandler = null;
     }
 
     private isOfflineStorageAvailable(): boolean {
@@ -218,12 +244,17 @@ export class BatchUploader {
             // Then trigger the upload with beacon
             _this.prepareAndUpload(false, _this.isBeaconAvailable());
         };
-        // visibility change is a document property, not window
-        document.addEventListener('visibilitychange', () => {
+
+        this.exitHandler = handleExit;
+
+        this.visibilityChangeHandler = () => {
             if (document.visibilityState === 'hidden') {
                 handleExit();
             }
-        });
+        };
+
+        // visibility change is a document property, not window
+        document.addEventListener('visibilitychange', this.visibilityChangeHandler);
         window.addEventListener('beforeunload', handleExit);
         window.addEventListener('pagehide', handleExit);
     }
@@ -240,7 +271,7 @@ export class BatchUploader {
         triggerFuture: boolean = false,
         useBeacon: boolean = false
     ): void {
-        setTimeout(() => {
+        this.uploadIntervalTimerId = setTimeout(() => {
             this.prepareAndUpload(triggerFuture, useBeacon);
         }, this.uploadIntervalMillis);
     }

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -1446,6 +1446,11 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
     const kitBlocker = createKitBlocker(config, mpInstance);
     const { getFeatureFlag } = mpInstance._Helpers;
 
+    // Destroy previous batch uploader to prevent leaked timers and event listeners
+    if (mpInstance._APIClient?.uploader) {
+        mpInstance._APIClient.uploader.destroy();
+    }
+
     mpInstance._APIClient = new APIClient(mpInstance, kitBlocker);
     mpInstance._Forwarders = new Forwarders(mpInstance, kitBlocker);
     mpInstance._Store.processConfig(config);

--- a/test/jest/batchUploader.spec.ts
+++ b/test/jest/batchUploader.spec.ts
@@ -53,6 +53,7 @@ describe('BatchUploader', () => {
     });
 
     afterEach(() => {
+        batchUploader.destroy();
         jest.useRealTimers();
         global.fetch = originalFetch;
     });

--- a/test/src/config/setup.ts
+++ b/test/src/config/setup.ts
@@ -30,6 +30,13 @@ beforeEach(function() {
         clearInterval(forwardingStatsTimer);
         mParticleSDK._forwardingStatsTimer = 0;
     }
+
+    // Destroy the batch uploader to prevent leaked timers and event listeners
+    // from accumulating across tests
+    const uploader = mpInstance?._APIClient?.uploader;
+    if (uploader) {
+        uploader.destroy();
+    }
     
     // mocha can't clean up after itself, so this lets
     // tests mock the current user and restores in between runs.


### PR DESCRIPTION
## Summary                                                                                                                                                                       
  - Fix resource leaks in `BatchUploader` that caused flaky test failures                                                                                                          
  - Store `setTimeout` ID and event handler references as instance properties so they can be cleaned up                                                                            
  - Add `destroy()` method to `BatchUploader` that clears timers and removes event listeners                                                                                       
  - Call `destroy()` before re-init in `completeSDKInitialization()` and in test `beforeEach` teardown                                                                             
                                                                                                                                                                                   
  ## Problem      
  Each SDK re-initialization (and each test run) was leaking:                                                                                                                      
  1. An orphaned `setTimeout` from `queueUpload()` that could fire during a later test                                                                                             
  2. Duplicate `visibilitychange`, `beforeunload`, and `pagehide` listeners that accumulated with every init                                                                       
                                                                                                                                                                                   
  This caused non-deterministic test failures depending on timer timing and listener execution order.    