### PR TITLE
fix: honor config.domain when directURLRouting is enabled

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -800,6 +800,13 @@ export function processBaseUrls(
     // Set default baseUrls
     let baseUrls: Dictionary<string>;
 
+    // A CNAME (config.domain, e.g. set by the snippet v2.6+) takes precedence
+    // over direct URL routing so that customer-configured first-party domains
+    // and the snippet's fallback domain are always honored.
+    if (!isEmpty(config.domain)) {
+        return processCustomBaseUrls(config);
+    }
+
     // When direct URL routing is false, update baseUrls based custom urls
     // passed to the config
     if (flags.directURLRouting) {

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1803,6 +1803,71 @@ describe('Store', () => {
 
                 expect(result).to.deep.equal(expectedResult);
             });
+
+            it('should append url paths to domain when config.domain is set, ignoring silo routing', () => {
+                // Regression guard: when a customer uses a CNAME (partner
+                // first-party domain or the Rokt snippet's fallback domain),
+                // config.domain MUST win over direct-URL routing. Without this
+                // the snippet's apps.roktecommerce.com fallback is defeated
+                // because identity/alias/etc. keep pointing at the silo host.
+                const featureFlags = { directURLRouting: true };
+
+                const config = {
+                    domain: 'custom.domain.com'
+                };
+
+                const result = processBaseUrls(
+                    (config as unknown) as SDKInitConfig,
+                    (featureFlags as unknown) as IFeatureFlags,
+                    'apikey'
+                );
+
+                const expectedResult = {
+                    configUrl: 'custom.domain.com/tags/JS/v2/',
+                    identityUrl: 'custom.domain.com/identity/v1/',
+                    aliasUrl: 'custom.domain.com/webevents/v1/identity/',
+                    v1SecureServiceUrl: 'custom.domain.com/webevents/v1/JS/',
+                    v2SecureServiceUrl: 'custom.domain.com/webevents/v2/JS/',
+                    v3SecureServiceUrl: 'custom.domain.com/webevents/v3/JS/',
+                };
+
+                expect(result).to.deep.equal(expectedResult);
+            });
+
+            it('should prioritize domain over custom baseUrls when both are set', () => {
+                // The server-side app.js template stamps in explicit
+                // identityUrl/aliasUrl/etc. via the `|| default` pattern.
+                // When the snippet also sets config.domain, domain must still
+                // win so downstream calls follow the CNAME / fallback host.
+                const featureFlags = { directURLRouting: true };
+
+                const config = {
+                    domain: 'custom.domain.com',
+                    v1SecureServiceUrl: 'foo.customer.mp.com/v1/JS/',
+                    v2SecureServiceUrl: 'foo.customer.mp.com/v2/JS/',
+                    v3SecureServiceUrl: 'foo.customer.mp.com/v3/JS/',
+                    configUrl: 'foo-configUrl.customer.mp.com/v2/JS/',
+                    identityUrl: 'foo-identity.customer.mp.com/',
+                    aliasUrl: 'foo-alias.customer.mp.com/',
+                };
+
+                const result = processBaseUrls(
+                    (config as unknown) as SDKInitConfig,
+                    (featureFlags as unknown) as IFeatureFlags,
+                    'apikey'
+                );
+
+                const expectedResult = {
+                    configUrl: 'custom.domain.com/tags/JS/v2/',
+                    identityUrl: 'custom.domain.com/identity/v1/',
+                    aliasUrl: 'custom.domain.com/webevents/v1/identity/',
+                    v1SecureServiceUrl: 'custom.domain.com/webevents/v1/JS/',
+                    v2SecureServiceUrl: 'custom.domain.com/webevents/v2/JS/',
+                    v3SecureServiceUrl: 'custom.domain.com/webevents/v3/JS/',
+                };
+
+                expect(result).to.deep.equal(expectedResult);
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary

`processDirectBaseUrls` did not consult `config.domain` when building the base URLs used for identity, alias, audience, config, and webevents requests. As a result, when the `directURLRouting` feature flag is enabled for a workspace, any customer-configured first-party (CNAME) domain — or a fallback domain set by the snippet when the primary script fails to load — was silently ignored and those requests continued to hit the silo-prefixed defaults.

This PR brings the two code paths into alignment by hoisting the CNAME check into the `processBaseUrls` dispatcher: `config.domain` is now honored regardless of the `directURLRouting` flag, matching the intent documented in `store.ts:816-819` and the behavior already implemented in `processCustomBaseUrls`.

## Motivation

This closes a resilience gap for two related scenarios:

1. **First-party domains / CNAMEs.** Customers who serve the SDK through a CNAME they own expect every downstream endpoint — identity, alias, audience, webevents — to follow that same domain. Without this fix, workspaces with `directURLRouting === true` saw those requests pinned to the silo host regardless of the snippet's `config.domain` setting.
2. **Fallback domain support.** The snippet sets `config.domain` to an alternate host inside its `onerror` handler when the primary script cannot be fetched. For direct-routed workspaces this fallback had no effect: all subsequent API calls still targeted the primary. After this change, the fallback path delivers on its promise and keeps the integration operational.

## Change

`src/store.ts` — inside `processBaseUrls`, short-circuit to the CNAME path when `config.domain` is set, before the `directURLRouting` branch is considered:

```ts
if (!isEmpty(config.domain)) {
    return processCustomBaseUrls(config);
}

if (flags.directURLRouting) {
    return processDirectBaseUrls(config, apiKey);
} else {
    return processCustomBaseUrls(config);
}
```

No other behavior changes: when `config.domain` is absent, both routing paths execute exactly as before.

## Tests

`test/src/tests-store.ts` — two new cases added under `describe('directURLRouting === true')`, mirroring the coverage that already existed under `directURLRouting === false`:

- `config.domain` alone produces URLs composed from `{domain}{CNAMEUrlPath}` for every base URL.
- `config.domain` combined with explicit per-URL overrides (`identityUrl`, `aliasUrl`, etc.) continues to resolve to the domain-derived URLs — domain wins.

Full Karma suite passes locally across Chrome Headless 147 and Firefox 149 (2110 tests, 0 failures).

## Test plan

- [ ] CI green (Karma + jest + integration suites)
- [ ] Manual verification: workspace with `directURLRouting: True`, snippet supplying a custom `ROKT_DOMAIN` (first-party CNAME or the snippet's fallback host). DevTools → Network confirms identity / alias / audience / config / webevents requests resolve to that domain, not the silo default.
- [ ] Regression check: workspace with `directURLRouting: True` and no `config.domain` — silo prefixing still applied as before.
