### PR TITLE
test 3.0.0

### DIFF
--- a/dist/mparticle.js
+++ b/dist/mparticle.js
@@ -203,7 +203,7 @@ var mParticle = (function () {
       Base64: Base64$1
     };
 
-    var version = "2.68.0";
+    var version = "3.0.0";
 
     var Constants = {
       sdkVersion: version,


### PR DESCRIPTION
## Summary
- Test PR bumping the SDK version string in `dist/mparticle.js` from `2.68.0` to `3.0.0`.

## Test plan
- [ ] Verify `dist/mparticle.js` reports `sdkVersion: "3.0.0"` at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)