### PR TITLE
feat: Report deprecated method usage through logging dispatcher

### DIFF
--- a/src/consent.ts
+++ b/src/consent.ts
@@ -9,7 +9,7 @@ import KitFilterHelper from './kitFilterHelper';
 import Constants from './constants';
 import { IMParticleUser } from './identity-user-interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
-import { logDeprecatedApiUsage } from './reporting/deprecatedApiLogger';
+import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 
 const { CCPAPurpose } = Constants;
 
@@ -506,8 +506,8 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
 
         // TODO: Can we remove this? It is deprecated.
         function removeCCPAState(this: ConsentState) {
-            logDeprecatedApiUsage(mpInstance, {
-                methodName: 'removeCCPAState',
+            logDeprecatedMethodUsage(mpInstance, {
+                methodName: 'Consent.removeCCPAState',
                 warningMessage: 'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead',
             });
             // @ts-ignore

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -506,10 +506,14 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
 
         // TODO: Can we remove this? It is deprecated.
         function removeCCPAState(this: ConsentState) {
-            logDeprecatedMethodUsage(mpInstance, {
-                methodName: 'Consent.removeCCPAState',
-                warningMessage: 'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead',
-            });
+            logDeprecatedMethodUsage(
+                mpInstance.Logger,
+                mpInstance._LoggingDispatcher,
+                {
+                    methodName: 'Consent.removeCCPAState',
+                    warningMessage: 'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead',
+                }
+            );
             // @ts-ignore
             return removeCCPAConsentState();
         }

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -9,6 +9,7 @@ import KitFilterHelper from './kitFilterHelper';
 import Constants from './constants';
 import { IMParticleUser } from './identity-user-interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
+import { logDeprecatedApiUsage } from './reporting/deprecatedApiLogger';
 
 const { CCPAPurpose } = Constants;
 
@@ -505,9 +506,10 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
 
         // TODO: Can we remove this? It is deprecated.
         function removeCCPAState(this: ConsentState) {
-            mpInstance.Logger.warning(
-                'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead'
-            );
+            logDeprecatedApiUsage(mpInstance, {
+                methodName: 'removeCCPAState',
+                warningMessage: 'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead',
+            });
             // @ts-ignore
             return removeCCPAConsentState();
         }

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -507,12 +507,12 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
         // TODO: Can we remove this? It is deprecated.
         function removeCCPAState(this: ConsentState) {
             logDeprecatedMethodUsage(
-                mpInstance.Logger,
-                mpInstance._LoggingDispatcher,
                 {
                     methodName: 'Consent.removeCCPAState',
                     warningMessage: 'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead',
-                }
+                },
+                mpInstance.Logger,
+                mpInstance._LoggingDispatcher
             );
             // @ts-ignore
             return removeCCPAConsentState();

--- a/src/identity.js
+++ b/src/identity.js
@@ -20,7 +20,7 @@ import {
 } from './utils';
 import { hasMPIDAndUserLoginChanged, hasMPIDChanged } from './user-utils';
 import { processReadyQueue } from './pre-init-utils';
-import { logDeprecatedApiUsage } from './reporting/deprecatedApiLogger';
+import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 
 export default function Identity(mpInstance) {
     const { getFeatureFlag, extend } = mpInstance._Helpers;
@@ -1253,7 +1253,7 @@ export default function Identity(mpInstance) {
              * @return a cart object
              */
             getCart: function() {
-                logDeprecatedApiUsage(mpInstance, {
+                logDeprecatedMethodUsage(mpInstance, {
                     methodName: 'Identity.getCurrentUser().getCart()',
                     warningMessage:
                         'Deprecated function Identity.getCurrentUser().getCart() will be removed in future releases',
@@ -1337,7 +1337,7 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             add: function() {
-                logDeprecatedApiUsage(mpInstance, {
+                logDeprecatedMethodUsage(mpInstance, {
                     methodName: 'Identity.getCurrentUser().getCart().add()',
                     warningMessage: generateDeprecationMessage(
                         'Identity.getCurrentUser().getCart().add()',
@@ -1353,7 +1353,7 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             remove: function() {
-                logDeprecatedApiUsage(mpInstance, {
+                logDeprecatedMethodUsage(mpInstance, {
                     methodName: 'Identity.getCurrentUser().getCart().remove()',
                     warningMessage: generateDeprecationMessage(
                         'Identity.getCurrentUser().getCart().remove()',
@@ -1369,7 +1369,7 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             clear: function() {
-                logDeprecatedApiUsage(mpInstance, {
+                logDeprecatedMethodUsage(mpInstance, {
                     methodName: 'Identity.getCurrentUser().getCart().clear()',
                     warningMessage: generateDeprecationMessage(
                         'Identity.getCurrentUser().getCart().clear()',
@@ -1386,7 +1386,7 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             getCartProducts: function() {
-                logDeprecatedApiUsage(mpInstance, {
+                logDeprecatedMethodUsage(mpInstance, {
                     methodName:
                         'Identity.getCurrentUser().getCart().getCartProducts()',
                     warningMessage: generateDeprecationMessage(
@@ -1785,7 +1785,7 @@ function tryOnUserAlias(previousUser, newUser, identityApiData, mpInstance) {
         isFunction(identityApiData.onUserAlias)
     ) {
         try {
-            logDeprecatedApiUsage(mpInstance, {
+            logDeprecatedMethodUsage(mpInstance, {
                 methodName: 'onUserAlias',
                 warningMessage: generateDeprecationMessage('onUserAlias'),
             });

--- a/src/identity.js
+++ b/src/identity.js
@@ -1254,13 +1254,13 @@ export default function Identity(mpInstance) {
              */
             getCart: function() {
                 logDeprecatedMethodUsage(
-                    mpInstance.Logger,
-                    mpInstance._LoggingDispatcher,
                     {
                         methodName: 'Identity.getCurrentUser().getCart()',
                         warningMessage:
                             'Deprecated function Identity.getCurrentUser().getCart() will be removed in future releases',
-                    }
+                    },
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher
                 );
                 return self.mParticleUserCart();
             },
@@ -1342,8 +1342,6 @@ export default function Identity(mpInstance) {
              */
             add: function() {
                 logDeprecatedMethodUsage(
-                    mpInstance.Logger,
-                    mpInstance._LoggingDispatcher,
                     {
                         methodName: 'Identity.getCurrentUser().getCart().add()',
                         warningMessage: generateDeprecationMessage(
@@ -1352,7 +1350,9 @@ export default function Identity(mpInstance) {
                             'eCommerce.logProductAction()',
                             'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
                         ),
-                    }
+                    },
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher
                 );
             },
             /**
@@ -1362,8 +1362,6 @@ export default function Identity(mpInstance) {
              */
             remove: function() {
                 logDeprecatedMethodUsage(
-                    mpInstance.Logger,
-                    mpInstance._LoggingDispatcher,
                     {
                         methodName:
                             'Identity.getCurrentUser().getCart().remove()',
@@ -1373,7 +1371,9 @@ export default function Identity(mpInstance) {
                             'eCommerce.logProductAction()',
                             'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
                         ),
-                    }
+                    },
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher
                 );
             },
             /**
@@ -1383,8 +1383,6 @@ export default function Identity(mpInstance) {
              */
             clear: function() {
                 logDeprecatedMethodUsage(
-                    mpInstance.Logger,
-                    mpInstance._LoggingDispatcher,
                     {
                         methodName:
                             'Identity.getCurrentUser().getCart().clear()',
@@ -1394,7 +1392,9 @@ export default function Identity(mpInstance) {
                             '',
                             'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
                         ),
-                    }
+                    },
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher
                 );
             },
             /**
@@ -1405,8 +1405,6 @@ export default function Identity(mpInstance) {
              */
             getCartProducts: function() {
                 logDeprecatedMethodUsage(
-                    mpInstance.Logger,
-                    mpInstance._LoggingDispatcher,
                     {
                         methodName:
                             'Identity.getCurrentUser().getCart().getCartProducts()',
@@ -1416,7 +1414,9 @@ export default function Identity(mpInstance) {
                             'eCommerce.logProductAction()',
                             'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
                         ),
-                    }
+                    },
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher
                 );
                 return [];
             },
@@ -1819,10 +1819,14 @@ function tryOnUserAlias(
         isFunction(identityApiData.onUserAlias)
     ) {
         try {
-            logDeprecatedMethodUsage(logger, loggingDispatcher, {
-                methodName: 'onUserAlias',
-                warningMessage: generateDeprecationMessage('onUserAlias'),
-            });
+            logDeprecatedMethodUsage(
+                {
+                    methodName: 'onUserAlias',
+                    warningMessage: generateDeprecationMessage('onUserAlias'),
+                },
+                logger,
+                loggingDispatcher
+            );
             identityApiData.onUserAlias(previousUser, newUser);
         } catch (e) {
             logger.error(

--- a/src/identity.js
+++ b/src/identity.js
@@ -1253,11 +1253,15 @@ export default function Identity(mpInstance) {
              * @return a cart object
              */
             getCart: function() {
-                logDeprecatedMethodUsage(mpInstance, {
-                    methodName: 'Identity.getCurrentUser().getCart()',
-                    warningMessage:
-                        'Deprecated function Identity.getCurrentUser().getCart() will be removed in future releases',
-                });
+                logDeprecatedMethodUsage(
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher,
+                    {
+                        methodName: 'Identity.getCurrentUser().getCart()',
+                        warningMessage:
+                            'Deprecated function Identity.getCurrentUser().getCart() will be removed in future releases',
+                    }
+                );
                 return self.mParticleUserCart();
             },
 
@@ -1337,15 +1341,19 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             add: function() {
-                logDeprecatedMethodUsage(mpInstance, {
-                    methodName: 'Identity.getCurrentUser().getCart().add()',
-                    warningMessage: generateDeprecationMessage(
-                        'Identity.getCurrentUser().getCart().add()',
-                        true,
-                        'eCommerce.logProductAction()',
-                        'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    ),
-                });
+                logDeprecatedMethodUsage(
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher,
+                    {
+                        methodName: 'Identity.getCurrentUser().getCart().add()',
+                        warningMessage: generateDeprecationMessage(
+                            'Identity.getCurrentUser().getCart().add()',
+                            true,
+                            'eCommerce.logProductAction()',
+                            'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
+                        ),
+                    }
+                );
             },
             /**
              * Removes a cart product from the current user cart
@@ -1353,15 +1361,20 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             remove: function() {
-                logDeprecatedMethodUsage(mpInstance, {
-                    methodName: 'Identity.getCurrentUser().getCart().remove()',
-                    warningMessage: generateDeprecationMessage(
-                        'Identity.getCurrentUser().getCart().remove()',
-                        true,
-                        'eCommerce.logProductAction()',
-                        'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    ),
-                });
+                logDeprecatedMethodUsage(
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher,
+                    {
+                        methodName:
+                            'Identity.getCurrentUser().getCart().remove()',
+                        warningMessage: generateDeprecationMessage(
+                            'Identity.getCurrentUser().getCart().remove()',
+                            true,
+                            'eCommerce.logProductAction()',
+                            'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
+                        ),
+                    }
+                );
             },
             /**
              * Clears the user's cart
@@ -1369,15 +1382,20 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             clear: function() {
-                logDeprecatedMethodUsage(mpInstance, {
-                    methodName: 'Identity.getCurrentUser().getCart().clear()',
-                    warningMessage: generateDeprecationMessage(
-                        'Identity.getCurrentUser().getCart().clear()',
-                        true,
-                        '',
-                        'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    ),
-                });
+                logDeprecatedMethodUsage(
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher,
+                    {
+                        methodName:
+                            'Identity.getCurrentUser().getCart().clear()',
+                        warningMessage: generateDeprecationMessage(
+                            'Identity.getCurrentUser().getCart().clear()',
+                            true,
+                            '',
+                            'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
+                        ),
+                    }
+                );
             },
             /**
              * Returns all cart products
@@ -1386,16 +1404,20 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             getCartProducts: function() {
-                logDeprecatedMethodUsage(mpInstance, {
-                    methodName:
-                        'Identity.getCurrentUser().getCart().getCartProducts()',
-                    warningMessage: generateDeprecationMessage(
-                        'Identity.getCurrentUser().getCart().getCartProducts()',
-                        true,
-                        'eCommerce.logProductAction()',
-                        'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    ),
-                });
+                logDeprecatedMethodUsage(
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher,
+                    {
+                        methodName:
+                            'Identity.getCurrentUser().getCart().getCartProducts()',
+                        warningMessage: generateDeprecationMessage(
+                            'Identity.getCurrentUser().getCart().getCartProducts()',
+                            true,
+                            'eCommerce.logProductAction()',
+                            'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
+                        ),
+                    }
+                );
                 return [];
             },
         };
@@ -1544,7 +1566,13 @@ export default function Identity(mpInstance) {
                 newUser = mpInstance.Identity.getCurrentUser();
 
                 // https://go.mparticle.com/work/SQDSDKS-6359
-                tryOnUserAlias(prevUser, newUser, identityApiData, mpInstance);
+                tryOnUserAlias(
+                    prevUser,
+                    newUser,
+                    identityApiData,
+                    mpInstance.Logger,
+                    mpInstance._LoggingDispatcher
+                );
 
                 const persistence = mpInstance._Persistence.getPersistence();
 
@@ -1778,20 +1806,26 @@ export default function Identity(mpInstance) {
 }
 
 // https://go.mparticle.com/work/SQDSDKS-6359
-function tryOnUserAlias(previousUser, newUser, identityApiData, mpInstance) {
+function tryOnUserAlias(
+    previousUser,
+    newUser,
+    identityApiData,
+    logger,
+    loggingDispatcher
+) {
     if (
         identityApiData &&
         identityApiData.onUserAlias &&
         isFunction(identityApiData.onUserAlias)
     ) {
         try {
-            logDeprecatedMethodUsage(mpInstance, {
+            logDeprecatedMethodUsage(logger, loggingDispatcher, {
                 methodName: 'onUserAlias',
                 warningMessage: generateDeprecationMessage('onUserAlias'),
             });
             identityApiData.onUserAlias(previousUser, newUser);
         } catch (e) {
-            mpInstance.Logger.error(
+            logger.error(
                 'There was an error with your onUserAlias function - ' + e
             );
         }

--- a/src/identity.js
+++ b/src/identity.js
@@ -20,6 +20,7 @@ import {
 } from './utils';
 import { hasMPIDAndUserLoginChanged, hasMPIDChanged } from './user-utils';
 import { processReadyQueue } from './pre-init-utils';
+import { logDeprecatedApiUsage } from './reporting/deprecatedApiLogger';
 
 export default function Identity(mpInstance) {
     const { getFeatureFlag, extend } = mpInstance._Helpers;
@@ -1252,9 +1253,11 @@ export default function Identity(mpInstance) {
              * @return a cart object
              */
             getCart: function() {
-                mpInstance.Logger.warning(
-                    'Deprecated function Identity.getCurrentUser().getCart() will be removed in future releases'
-                );
+                logDeprecatedApiUsage(mpInstance, {
+                    methodName: 'Identity.getCurrentUser().getCart()',
+                    warningMessage:
+                        'Deprecated function Identity.getCurrentUser().getCart() will be removed in future releases',
+                });
                 return self.mParticleUserCart();
             },
 
@@ -1334,14 +1337,15 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             add: function() {
-                mpInstance.Logger.warning(
-                    generateDeprecationMessage(
+                logDeprecatedApiUsage(mpInstance, {
+                    methodName: 'Identity.getCurrentUser().getCart().add()',
+                    warningMessage: generateDeprecationMessage(
                         'Identity.getCurrentUser().getCart().add()',
                         true,
                         'eCommerce.logProductAction()',
                         'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    )
-                );
+                    ),
+                });
             },
             /**
              * Removes a cart product from the current user cart
@@ -1349,14 +1353,15 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             remove: function() {
-                mpInstance.Logger.warning(
-                    generateDeprecationMessage(
+                logDeprecatedApiUsage(mpInstance, {
+                    methodName: 'Identity.getCurrentUser().getCart().remove()',
+                    warningMessage: generateDeprecationMessage(
                         'Identity.getCurrentUser().getCart().remove()',
                         true,
                         'eCommerce.logProductAction()',
                         'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    )
-                );
+                    ),
+                });
             },
             /**
              * Clears the user's cart
@@ -1364,14 +1369,15 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             clear: function() {
-                mpInstance.Logger.warning(
-                    generateDeprecationMessage(
+                logDeprecatedApiUsage(mpInstance, {
+                    methodName: 'Identity.getCurrentUser().getCart().clear()',
+                    warningMessage: generateDeprecationMessage(
                         'Identity.getCurrentUser().getCart().clear()',
                         true,
                         '',
                         'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    )
-                );
+                    ),
+                });
             },
             /**
              * Returns all cart products
@@ -1380,14 +1386,16 @@ export default function Identity(mpInstance) {
              * @deprecated
              */
             getCartProducts: function() {
-                mpInstance.Logger.warning(
-                    generateDeprecationMessage(
+                logDeprecatedApiUsage(mpInstance, {
+                    methodName:
+                        'Identity.getCurrentUser().getCart().getCartProducts()',
+                    warningMessage: generateDeprecationMessage(
                         'Identity.getCurrentUser().getCart().getCartProducts()',
                         true,
                         'eCommerce.logProductAction()',
                         'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    )
-                );
+                    ),
+                });
                 return [];
             },
         };
@@ -1536,12 +1544,7 @@ export default function Identity(mpInstance) {
                 newUser = mpInstance.Identity.getCurrentUser();
 
                 // https://go.mparticle.com/work/SQDSDKS-6359
-                tryOnUserAlias(
-                    prevUser,
-                    newUser,
-                    identityApiData,
-                    mpInstance.Logger
-                );
+                tryOnUserAlias(prevUser, newUser, identityApiData, mpInstance);
 
                 const persistence = mpInstance._Persistence.getPersistence();
 
@@ -1775,17 +1778,20 @@ export default function Identity(mpInstance) {
 }
 
 // https://go.mparticle.com/work/SQDSDKS-6359
-function tryOnUserAlias(previousUser, newUser, identityApiData, logger) {
+function tryOnUserAlias(previousUser, newUser, identityApiData, mpInstance) {
     if (
         identityApiData &&
         identityApiData.onUserAlias &&
         isFunction(identityApiData.onUserAlias)
     ) {
         try {
-            logger.warning(generateDeprecationMessage('onUserAlias'));
+            logDeprecatedApiUsage(mpInstance, {
+                methodName: 'onUserAlias',
+                warningMessage: generateDeprecationMessage('onUserAlias'),
+            });
             identityApiData.onUserAlias(previousUser, newUser);
         } catch (e) {
-            logger.error(
+            mpInstance.Logger.error(
                 'There was an error with your onUserAlias function - ' + e
             );
         }

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -774,8 +774,6 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              */
             add: function(product, logEventBoolean) {
                 logDeprecatedMethodUsage(
-                    self.Logger,
-                    self._LoggingDispatcher,
                     {
                         methodName: 'mPInstance.eCommerce.Cart.add()',
                         warningMessage: generateDeprecationMessage(
@@ -784,7 +782,9 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                             'eCommerce.logProductAction()',
                             'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
                         ),
-                    }
+                    },
+                    self.Logger,
+                    self._LoggingDispatcher
                 );
             },
             /**
@@ -796,8 +796,6 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              */
             remove: function(product, logEventBoolean) {
                 logDeprecatedMethodUsage(
-                    self.Logger,
-                    self._LoggingDispatcher,
                     {
                         methodName: 'mPInstance.eCommerce.Cart.remove()',
                         warningMessage: generateDeprecationMessage(
@@ -806,7 +804,9 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                             'eCommerce.logProductAction()',
                             'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
                         ),
-                    }
+                    },
+                    self.Logger,
+                    self._LoggingDispatcher
                 );
             },
             /**
@@ -816,8 +816,6 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              */
             clear: function() {
                 logDeprecatedMethodUsage(
-                    self.Logger,
-                    self._LoggingDispatcher,
                     {
                         methodName: 'mPInstance.eCommerce.Cart.clear()',
                         warningMessage: generateDeprecationMessage(
@@ -826,7 +824,9 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                             '',
                             'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
                         ),
-                    }
+                    },
+                    self.Logger,
+                    self._LoggingDispatcher
                 );
             },
         },
@@ -957,12 +957,12 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
          */
         logCheckout: function(step, option, attrs, customFlags) {
             logDeprecatedMethodUsage(
-                self.Logger,
-                self._LoggingDispatcher,
                 {
                     methodName: 'mParticle.logCheckout',
                     warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
-                }
+                },
+                self.Logger,
+                self._LoggingDispatcher
             );
 
             if (!self._Store.isInitialized) {
@@ -1042,12 +1042,12 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             customFlags
         ) {
             logDeprecatedMethodUsage(
-                self.Logger,
-                self._LoggingDispatcher,
                 {
                     methodName: 'mParticle.logPurchase',
                     warningMessage: 'mParticle.logPurchase is deprecated, please use mParticle.logProductAction instead',
-                }
+                },
+                self.Logger,
+                self._LoggingDispatcher
             );
             if (!self._Store.isInitialized) {
                 self.ready(function() {
@@ -1159,12 +1159,12 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             customFlags
         ) {
             logDeprecatedMethodUsage(
-                self.Logger,
-                self._LoggingDispatcher,
                 {
                     methodName: 'mParticle.logRefund',
                     warningMessage: 'mParticle.logRefund is deprecated, please use mParticle.logProductAction instead',
-                }
+                },
+                self.Logger,
+                self._LoggingDispatcher
             );
             if (!self._Store.isInitialized) {
                 self.ready(function() {

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -773,15 +773,19 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             add: function(product, logEventBoolean) {
-                logDeprecatedMethodUsage(self, {
-                    methodName: 'mPInstance.eCommerce.Cart.add()',
-                    warningMessage: generateDeprecationMessage(
-                        'eCommerce.Cart.add()',
-                        true,
-                        'eCommerce.logProductAction()',
-                        'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    ),
-                });
+                logDeprecatedMethodUsage(
+                    self.Logger,
+                    self._LoggingDispatcher,
+                    {
+                        methodName: 'mPInstance.eCommerce.Cart.add()',
+                        warningMessage: generateDeprecationMessage(
+                            'eCommerce.Cart.add()',
+                            true,
+                            'eCommerce.logProductAction()',
+                            'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
+                        ),
+                    }
+                );
             },
             /**
              * Removes a product from the cart
@@ -791,15 +795,19 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             remove: function(product, logEventBoolean) {
-                logDeprecatedMethodUsage(self, {
-                    methodName: 'mPInstance.eCommerce.Cart.remove()',
-                    warningMessage: generateDeprecationMessage(
-                        'eCommerce.Cart.remove()',
-                        true,
-                        'eCommerce.logProductAction()',
-                        'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    ),
-                });
+                logDeprecatedMethodUsage(
+                    self.Logger,
+                    self._LoggingDispatcher,
+                    {
+                        methodName: 'mPInstance.eCommerce.Cart.remove()',
+                        warningMessage: generateDeprecationMessage(
+                            'eCommerce.Cart.remove()',
+                            true,
+                            'eCommerce.logProductAction()',
+                            'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
+                        ),
+                    }
+                );
             },
             /**
              * Clears the cart
@@ -807,15 +815,19 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             clear: function() {
-                logDeprecatedMethodUsage(self, {
-                    methodName: 'mPInstance.eCommerce.Cart.clear()',
-                    warningMessage: generateDeprecationMessage(
-                        'eCommerce.Cart.clear()',
-                        true,
-                        '',
-                        'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    ),
-                });
+                logDeprecatedMethodUsage(
+                    self.Logger,
+                    self._LoggingDispatcher,
+                    {
+                        methodName: 'mPInstance.eCommerce.Cart.clear()',
+                        warningMessage: generateDeprecationMessage(
+                            'eCommerce.Cart.clear()',
+                            true,
+                            '',
+                            'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
+                        ),
+                    }
+                );
             },
         },
         /**
@@ -944,10 +956,14 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
          * @deprecated
          */
         logCheckout: function(step, option, attrs, customFlags) {
-            logDeprecatedMethodUsage(self, {
-                methodName: 'mParticle.logCheckout',
-                warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
-            });
+            logDeprecatedMethodUsage(
+                self.Logger,
+                self._LoggingDispatcher,
+                {
+                    methodName: 'mParticle.logCheckout',
+                    warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
+                }
+            );
 
             if (!self._Store.isInitialized) {
                 self.ready(function() {
@@ -1025,10 +1041,14 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             attrs,
             customFlags
         ) {
-            logDeprecatedMethodUsage(self, {
-                methodName: 'mParticle.logPurchase',
-                warningMessage: 'mParticle.logPurchase is deprecated, please use mParticle.logProductAction instead',
-            });
+            logDeprecatedMethodUsage(
+                self.Logger,
+                self._LoggingDispatcher,
+                {
+                    methodName: 'mParticle.logPurchase',
+                    warningMessage: 'mParticle.logPurchase is deprecated, please use mParticle.logProductAction instead',
+                }
+            );
             if (!self._Store.isInitialized) {
                 self.ready(function() {
                     self.eCommerce.logPurchase(
@@ -1138,10 +1158,14 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             attrs,
             customFlags
         ) {
-            logDeprecatedMethodUsage(self, {
-                methodName: 'mParticle.logRefund',
-                warningMessage: 'mParticle.logRefund is deprecated, please use mParticle.logProductAction instead',
-            });
+            logDeprecatedMethodUsage(
+                self.Logger,
+                self._LoggingDispatcher,
+                {
+                    methodName: 'mParticle.logRefund',
+                    warningMessage: 'mParticle.logRefund is deprecated, please use mParticle.logProductAction instead',
+                }
+            );
             if (!self._Store.isInitialized) {
                 self.ready(function() {
                     self.eCommerce.logRefund(

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -55,6 +55,7 @@ import CookieConsentManager, { ICookieConsentManager } from './cookieConsentMana
 import { ErrorReportingDispatcher } from './reporting/errorReportingDispatcher';
 import { LoggingDispatcher } from './reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService } from './reporting/types';
+import { logDeprecatedApiUsage } from './reporting/deprecatedApiLogger';
 
 export interface IErrorLogMessage {
     message?: string;
@@ -772,14 +773,15 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             add: function(product, logEventBoolean) {
-                self.Logger.warning(
-                    generateDeprecationMessage(
+                logDeprecatedApiUsage(self, {
+                    methodName: 'eCommerce.Cart.add()',
+                    warningMessage: generateDeprecationMessage(
                         'eCommerce.Cart.add()',
                         true,
                         'eCommerce.logProductAction()',
                         'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    )
-                );
+                    ),
+                });
             },
             /**
              * Removes a product from the cart
@@ -789,14 +791,15 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             remove: function(product, logEventBoolean) {
-                self.Logger.warning(
-                    generateDeprecationMessage(
+                logDeprecatedApiUsage(self, {
+                    methodName: 'eCommerce.Cart.remove()',
+                    warningMessage: generateDeprecationMessage(
                         'eCommerce.Cart.remove()',
                         true,
                         'eCommerce.logProductAction()',
                         'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    )
-                );
+                    ),
+                });
             },
             /**
              * Clears the cart
@@ -804,14 +807,15 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             clear: function() {
-                self.Logger.warning(
-                    generateDeprecationMessage(
+                logDeprecatedApiUsage(self, {
+                    methodName: 'eCommerce.Cart.clear()',
+                    warningMessage: generateDeprecationMessage(
                         'eCommerce.Cart.clear()',
                         true,
                         '',
                         'https://docs.mparticle.com/developers/sdk/web/commerce-tracking'
-                    )
-                );
+                    ),
+                });
             },
         },
         /**
@@ -940,9 +944,10 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
          * @deprecated
          */
         logCheckout: function(step, option, attrs, customFlags) {
-            self.Logger.warning(
-                'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead'
-            );
+            logDeprecatedApiUsage(self, {
+                methodName: 'mParticle.logCheckout',
+                warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
+            });
 
             if (!self._Store.isInitialized) {
                 self.ready(function() {
@@ -1020,9 +1025,10 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             attrs,
             customFlags
         ) {
-            self.Logger.warning(
-                'mParticle.logPurchase is deprecated, please use mParticle.logProductAction instead'
-            );
+            logDeprecatedApiUsage(self, {
+                methodName: 'mParticle.logPurchase',
+                warningMessage: 'mParticle.logPurchase is deprecated, please use mParticle.logProductAction instead',
+            });
             if (!self._Store.isInitialized) {
                 self.ready(function() {
                     self.eCommerce.logPurchase(
@@ -1132,9 +1138,10 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             attrs,
             customFlags
         ) {
-            self.Logger.warning(
-                'mParticle.logRefund is deprecated, please use mParticle.logProductAction instead'
-            );
+            logDeprecatedApiUsage(self, {
+                methodName: 'mParticle.logRefund',
+                warningMessage: 'mParticle.logRefund is deprecated, please use mParticle.logProductAction instead',
+            });
             if (!self._Store.isInitialized) {
                 self.ready(function() {
                     self.eCommerce.logRefund(
@@ -1741,4 +1748,3 @@ function queueIfNotInitialized(func, self) {
     });
     return true;
 }
-

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -55,7 +55,7 @@ import CookieConsentManager, { ICookieConsentManager } from './cookieConsentMana
 import { ErrorReportingDispatcher } from './reporting/errorReportingDispatcher';
 import { LoggingDispatcher } from './reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService } from './reporting/types';
-import { logDeprecatedApiUsage } from './reporting/deprecatedApiLogger';
+import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 
 export interface IErrorLogMessage {
     message?: string;
@@ -773,8 +773,8 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             add: function(product, logEventBoolean) {
-                logDeprecatedApiUsage(self, {
-                    methodName: 'eCommerce.Cart.add()',
+                logDeprecatedMethodUsage(self, {
+                    methodName: 'mPInstance.eCommerce.Cart.add()',
                     warningMessage: generateDeprecationMessage(
                         'eCommerce.Cart.add()',
                         true,
@@ -791,8 +791,8 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             remove: function(product, logEventBoolean) {
-                logDeprecatedApiUsage(self, {
-                    methodName: 'eCommerce.Cart.remove()',
+                logDeprecatedMethodUsage(self, {
+                    methodName: 'mPInstance.eCommerce.Cart.remove()',
                     warningMessage: generateDeprecationMessage(
                         'eCommerce.Cart.remove()',
                         true,
@@ -807,8 +807,8 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
              * @deprecated
              */
             clear: function() {
-                logDeprecatedApiUsage(self, {
-                    methodName: 'eCommerce.Cart.clear()',
+                logDeprecatedMethodUsage(self, {
+                    methodName: 'mPInstance.eCommerce.Cart.clear()',
                     warningMessage: generateDeprecationMessage(
                         'eCommerce.Cart.clear()',
                         true,
@@ -944,7 +944,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
          * @deprecated
          */
         logCheckout: function(step, option, attrs, customFlags) {
-            logDeprecatedApiUsage(self, {
+            logDeprecatedMethodUsage(self, {
                 methodName: 'mParticle.logCheckout',
                 warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
             });
@@ -1025,7 +1025,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             attrs,
             customFlags
         ) {
-            logDeprecatedApiUsage(self, {
+            logDeprecatedMethodUsage(self, {
                 methodName: 'mParticle.logPurchase',
                 warningMessage: 'mParticle.logPurchase is deprecated, please use mParticle.logProductAction instead',
             });
@@ -1138,7 +1138,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             attrs,
             customFlags
         ) {
-            logDeprecatedApiUsage(self, {
+            logDeprecatedMethodUsage(self, {
                 methodName: 'mParticle.logRefund',
                 warningMessage: 'mParticle.logRefund is deprecated, please use mParticle.logProductAction instead',
             });

--- a/src/reporting/deprecatedApiLogger.ts
+++ b/src/reporting/deprecatedApiLogger.ts
@@ -1,0 +1,24 @@
+import { ErrorCodes, ILoggingService } from './types';
+
+interface DeprecatedApiLoggerInstance {
+    Logger?: {
+        warning(message: string): void;
+    };
+    _LoggingDispatcher?: ILoggingService;
+}
+
+interface DeprecatedApiUsage {
+    methodName: string;
+    warningMessage: string;
+}
+
+export function logDeprecatedApiUsage(
+    mpInstance: DeprecatedApiLoggerInstance,
+    usage: DeprecatedApiUsage
+): void {
+    mpInstance.Logger?.warning(usage.warningMessage);
+    mpInstance._LoggingDispatcher?.log({
+        message: usage.methodName,
+        code: ErrorCodes.MP_DEPRECATED_METHOD_USAGE,
+    });
+}

--- a/src/reporting/deprecatedMethodLogger.ts
+++ b/src/reporting/deprecatedMethodLogger.ts
@@ -1,11 +1,5 @@
 import { ErrorCodes, ILoggingService } from './types';
-
-interface DeprecatedMethodLoggerInstance {
-    Logger?: {
-        warning(message: string): void;
-    };
-    _LoggingDispatcher?: ILoggingService;
-}
+import { SDKLoggerApi } from '../sdkRuntimeModels';
 
 interface DeprecatedMethodUsage {
     methodName: string;
@@ -13,11 +7,12 @@ interface DeprecatedMethodUsage {
 }
 
 export function logDeprecatedMethodUsage(
-    mpInstance: DeprecatedMethodLoggerInstance,
+    logger: Pick<SDKLoggerApi, 'warning'> | undefined,
+    loggingDispatcher: ILoggingService | undefined,
     usage: DeprecatedMethodUsage
 ): void {
-    mpInstance.Logger?.warning(usage.warningMessage);
-    mpInstance._LoggingDispatcher?.log({
+    logger?.warning(usage.warningMessage);
+    loggingDispatcher?.log({
         message: usage.methodName,
         code: ErrorCodes.MP_DEPRECATED_METHOD_USAGE,
     });

--- a/src/reporting/deprecatedMethodLogger.ts
+++ b/src/reporting/deprecatedMethodLogger.ts
@@ -7,9 +7,9 @@ interface DeprecatedMethodUsage {
 }
 
 export function logDeprecatedMethodUsage(
+    usage: DeprecatedMethodUsage,
     logger: Pick<SDKLoggerApi, 'warning'>,
-    loggingDispatcher: ILoggingService | undefined,
-    usage: DeprecatedMethodUsage
+    loggingDispatcher: ILoggingService | undefined
 ): void {
     logger.warning(usage.warningMessage);
     loggingDispatcher?.log({

--- a/src/reporting/deprecatedMethodLogger.ts
+++ b/src/reporting/deprecatedMethodLogger.ts
@@ -1,20 +1,20 @@
 import { ErrorCodes, ILoggingService } from './types';
 
-interface DeprecatedApiLoggerInstance {
+interface DeprecatedMethodLoggerInstance {
     Logger?: {
         warning(message: string): void;
     };
     _LoggingDispatcher?: ILoggingService;
 }
 
-interface DeprecatedApiUsage {
+interface DeprecatedMethodUsage {
     methodName: string;
     warningMessage: string;
 }
 
-export function logDeprecatedApiUsage(
-    mpInstance: DeprecatedApiLoggerInstance,
-    usage: DeprecatedApiUsage
+export function logDeprecatedMethodUsage(
+    mpInstance: DeprecatedMethodLoggerInstance,
+    usage: DeprecatedMethodUsage
 ): void {
     mpInstance.Logger?.warning(usage.warningMessage);
     mpInstance._LoggingDispatcher?.log({

--- a/src/reporting/deprecatedMethodLogger.ts
+++ b/src/reporting/deprecatedMethodLogger.ts
@@ -7,11 +7,11 @@ interface DeprecatedMethodUsage {
 }
 
 export function logDeprecatedMethodUsage(
-    logger: Pick<SDKLoggerApi, 'warning'> | undefined,
+    logger: Pick<SDKLoggerApi, 'warning'>,
     loggingDispatcher: ILoggingService | undefined,
     usage: DeprecatedMethodUsage
 ): void {
-    logger?.warning(usage.warningMessage);
+    logger.warning(usage.warningMessage);
     loggingDispatcher?.log({
         message: usage.methodName,
         code: ErrorCodes.MP_DEPRECATED_METHOD_USAGE,

--- a/src/reporting/types.ts
+++ b/src/reporting/types.ts
@@ -6,6 +6,7 @@ export const ErrorCodes = {
     IDENTITY_REQUEST: 'IDENTITY_REQUEST',
     IDENTITY_MISMATCH: 'IDENTITY_MISMATCH',
     ROKT_KIT_ATTACHED: 'ROKT_KIT_ATTACHED',
+    MP_DEPRECATED_METHOD_USAGE: 'MP_DEPRECATED_METHOD_USAGE',
 } as const;
 
 export type ErrorCodes = valueof<typeof ErrorCodes>;

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -6,7 +6,7 @@ import { generateDeprecationMessage } from './utils';
 import { IMParticleUser } from './identity-user-interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { hasIdentityRequestChanged, hasExplicitIdentifier } from './identity-utils';
-import { logDeprecatedApiUsage } from './reporting/deprecatedApiLogger';
+import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 
 const { Messages } = Constants;
 
@@ -68,7 +68,7 @@ export default function SessionManager(
     };
 
     this.getSession = function (): string {
-        logDeprecatedApiUsage(mpInstance, {
+        logDeprecatedMethodUsage(mpInstance, {
             methodName: 'SessionManager.getSession()',
             warningMessage: generateDeprecationMessage(
                 'SessionManager.getSession()',

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -69,8 +69,6 @@ export default function SessionManager(
 
     this.getSession = function (): string {
         logDeprecatedMethodUsage(
-            mpInstance.Logger,
-            mpInstance._LoggingDispatcher,
             {
                 methodName: 'SessionManager.getSession()',
                 warningMessage: generateDeprecationMessage(
@@ -78,7 +76,9 @@ export default function SessionManager(
                     false,
                     'SessionManager.getSessionId()'
                 ),
-            }
+            },
+            mpInstance.Logger,
+            mpInstance._LoggingDispatcher
         );
         return this.getSessionId();
     };

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -6,6 +6,7 @@ import { generateDeprecationMessage } from './utils';
 import { IMParticleUser } from './identity-user-interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { hasIdentityRequestChanged, hasExplicitIdentifier } from './identity-utils';
+import { logDeprecatedApiUsage } from './reporting/deprecatedApiLogger';
 
 const { Messages } = Constants;
 
@@ -67,13 +68,14 @@ export default function SessionManager(
     };
 
     this.getSession = function (): string {
-        mpInstance.Logger.warning(
-            generateDeprecationMessage(
+        logDeprecatedApiUsage(mpInstance, {
+            methodName: 'SessionManager.getSession()',
+            warningMessage: generateDeprecationMessage(
                 'SessionManager.getSession()',
                 false,
                 'SessionManager.getSessionId()'
-            )
-        );
+            ),
+        });
         return this.getSessionId();
     };
 

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -68,14 +68,18 @@ export default function SessionManager(
     };
 
     this.getSession = function (): string {
-        logDeprecatedMethodUsage(mpInstance, {
-            methodName: 'SessionManager.getSession()',
-            warningMessage: generateDeprecationMessage(
-                'SessionManager.getSession()',
-                false,
-                'SessionManager.getSessionId()'
-            ),
-        });
+        logDeprecatedMethodUsage(
+            mpInstance.Logger,
+            mpInstance._LoggingDispatcher,
+            {
+                methodName: 'SessionManager.getSession()',
+                warningMessage: generateDeprecationMessage(
+                    'SessionManager.getSession()',
+                    false,
+                    'SessionManager.getSessionId()'
+                ),
+            }
+        );
         return this.getSessionId();
     };
 

--- a/test/jest/reportingLogger.spec.ts
+++ b/test/jest/reportingLogger.spec.ts
@@ -136,10 +136,8 @@ describe('logDeprecatedMethodUsage', () => {
         const log = jest.fn();
 
         logDeprecatedMethodUsage(
-            {
-                Logger: { warning },
-                _LoggingDispatcher: { log },
-            },
+            { warning },
+            { log },
             {
                 methodName: 'mParticle.logCheckout',
                 warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
@@ -159,7 +157,8 @@ describe('logDeprecatedMethodUsage', () => {
         const warning = jest.fn();
 
         expect(() => logDeprecatedMethodUsage(
-            { Logger: { warning } },
+            { warning },
+            undefined,
             {
                 methodName: 'onUserAlias',
                 warningMessage: 'onUserAlias is a deprecated method and will be removed in future releases.',

--- a/test/jest/reportingLogger.spec.ts
+++ b/test/jest/reportingLogger.spec.ts
@@ -1,6 +1,7 @@
 import { ErrorReportingDispatcher } from '../../src/reporting/errorReportingDispatcher';
 import { LoggingDispatcher } from '../../src/reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService, ISDKError, ISDKLogEntry, WSDKErrorSeverity, ErrorCodes } from '../../src/reporting/types';
+import { logDeprecatedApiUsage } from '../../src/reporting/deprecatedApiLogger';
 
 describe('ErrorReportingDispatcher', () => {
     let dispatcher: ErrorReportingDispatcher;
@@ -126,5 +127,46 @@ describe('LoggingDispatcher', () => {
 
         expect(service1.log).toHaveBeenCalledWith(entry);
         expect(service2.log).toHaveBeenCalledWith(entry);
+    });
+});
+
+describe('logDeprecatedApiUsage', () => {
+    it('keeps the console warning and emits structured usage details', () => {
+        const warning = jest.fn();
+        const log = jest.fn();
+
+        logDeprecatedApiUsage(
+            {
+                Logger: { warning },
+                _LoggingDispatcher: { log },
+            },
+            {
+                methodName: 'mParticle.logCheckout',
+                warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
+            }
+        );
+
+        expect(warning).toHaveBeenCalledWith(
+            'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead'
+        );
+        expect(log).toHaveBeenCalledWith({
+            message: 'mParticle.logCheckout',
+            code: ErrorCodes.MP_DEPRECATED_METHOD_USAGE,
+        });
+    });
+
+    it('does not require a registered logging dispatcher', () => {
+        const warning = jest.fn();
+
+        expect(() => logDeprecatedApiUsage(
+            { Logger: { warning } },
+            {
+                methodName: 'onUserAlias',
+                warningMessage: 'onUserAlias is a deprecated method and will be removed in future releases.',
+            }
+        )).not.toThrow();
+        expect(warning).toHaveBeenCalledWith(
+            'onUserAlias is a deprecated method and will be removed in future releases.'
+        );
     });
 });

--- a/test/jest/reportingLogger.spec.ts
+++ b/test/jest/reportingLogger.spec.ts
@@ -1,7 +1,7 @@
 import { ErrorReportingDispatcher } from '../../src/reporting/errorReportingDispatcher';
 import { LoggingDispatcher } from '../../src/reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService, ISDKError, ISDKLogEntry, WSDKErrorSeverity, ErrorCodes } from '../../src/reporting/types';
-import { logDeprecatedApiUsage } from '../../src/reporting/deprecatedApiLogger';
+import { logDeprecatedMethodUsage } from '../../src/reporting/deprecatedMethodLogger';
 
 describe('ErrorReportingDispatcher', () => {
     let dispatcher: ErrorReportingDispatcher;
@@ -130,12 +130,12 @@ describe('LoggingDispatcher', () => {
     });
 });
 
-describe('logDeprecatedApiUsage', () => {
+describe('logDeprecatedMethodUsage', () => {
     it('keeps the console warning and emits structured usage details', () => {
         const warning = jest.fn();
         const log = jest.fn();
 
-        logDeprecatedApiUsage(
+        logDeprecatedMethodUsage(
             {
                 Logger: { warning },
                 _LoggingDispatcher: { log },
@@ -158,7 +158,7 @@ describe('logDeprecatedApiUsage', () => {
     it('does not require a registered logging dispatcher', () => {
         const warning = jest.fn();
 
-        expect(() => logDeprecatedApiUsage(
+        expect(() => logDeprecatedMethodUsage(
             { Logger: { warning } },
             {
                 methodName: 'onUserAlias',

--- a/test/jest/reportingLogger.spec.ts
+++ b/test/jest/reportingLogger.spec.ts
@@ -136,12 +136,12 @@ describe('logDeprecatedMethodUsage', () => {
         const log = jest.fn();
 
         logDeprecatedMethodUsage(
-            { warning },
-            { log },
             {
                 methodName: 'mParticle.logCheckout',
                 warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
-            }
+            },
+            { warning },
+            { log }
         );
 
         expect(warning).toHaveBeenCalledWith(
@@ -157,12 +157,12 @@ describe('logDeprecatedMethodUsage', () => {
         const warning = jest.fn();
 
         expect(() => logDeprecatedMethodUsage(
-            { warning },
-            undefined,
             {
                 methodName: 'onUserAlias',
                 warningMessage: 'onUserAlias is a deprecated method and will be removed in future releases.',
-            }
+            },
+            { warning },
+            undefined
         )).not.toThrow();
         expect(warning).toHaveBeenCalledWith(
             'onUserAlias is a deprecated method and will be removed in future releases.'


### PR DESCRIPTION
## Summary
- Add a core helper for deprecated API usage that preserves existing console warnings and emits structured logging dispatcher events.
- Report deprecated usage with code MP_DEPRECATED_METHOD_USAGE and message set to the deprecated method name.
- Wire existing deprecated method warnings through the helper across core, identity, session, and consent code paths.


## Verification
- Focused Jest reporting logger spec passed.
- npm run lint passed.

## Notes
- Existing unrelated workspace changes were left unstaged and are not included in this PR.