### PR TITLE
refactor: migrate helpers module to TS

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,12 +3,20 @@ import Constants from './constants';
 import * as utils from './utils';
 import Validators from './validators';
 import KitFilterHelper from './kitFilterHelper';
+import { IMParticleWebSDKInstance } from './mp-instance';
+import { SDKHelpersApi } from './sdkRuntimeModels';
+import { Dictionary } from './utils';
+import { IMParticleUser } from './identity-user-interfaces';
+import { MPID } from '@mparticle/web-sdk';
 
-var StorageNames = Constants.StorageNames;
+const StorageNames = Constants.StorageNames;
 
-export default function Helpers(mpInstance) {
-    var self = this;
-    this.canLog = function() {
+export default function Helpers(
+    this: SDKHelpersApi,
+    mpInstance: IMParticleWebSDKInstance
+): void {
+    const self = this;
+    this.canLog = function(): boolean {
         if (
             mpInstance._Store.isEnabled &&
             (mpInstance._Store.devToken ||
@@ -20,7 +28,7 @@ export default function Helpers(mpInstance) {
         return false;
     };
 
-    this.getFeatureFlag = function(feature) {
+    this.getFeatureFlag = function(feature: string): boolean | string {
         if (mpInstance._Store.SDKConfig.flags.hasOwnProperty(feature)) {
             return mpInstance._Store.SDKConfig.flags[feature];
         }
@@ -28,12 +36,12 @@ export default function Helpers(mpInstance) {
     };
 
     this.invokeCallback = function(
-        callback,
-        code,
-        body,
-        mParticleUser,
-        previousMpid
-    ) {
+        callback: Function,
+        code: number,
+        body: string,
+        mParticleUser?: IMParticleUser,
+        previousMpid?: MPID
+    ): void {
         if (!callback) {
             mpInstance.Logger.warning('There is no callback provided');
         }
@@ -51,9 +59,9 @@ export default function Helpers(mpInstance) {
                     },
                     getPreviousUser: function() {
                         if (!previousMpid) {
-                            var users = mpInstance.Identity.getUsers();
-                            var mostRecentUser = users.shift();
-                            var currentUser =
+                            const users = mpInstance.Identity.getUsers();
+                            let mostRecentUser = users.shift();
+                            const currentUser =
                                 mParticleUser ||
                                 mpInstance.Identity.getCurrentUser();
                             if (
@@ -78,13 +86,17 @@ export default function Helpers(mpInstance) {
         }
     };
 
-    this.invokeAliasCallback = function(callback, code, message) {
+    this.invokeAliasCallback = function(
+        callback: Function,
+        code: number,
+        message?: string
+    ): void {
         if (!callback) {
             mpInstance.Logger.warning('There is no callback provided');
         }
         try {
             if (self.Validators.isFunction(callback)) {
-                var callbackMessage = {
+                const callbackMessage: Dictionary = {
                     httpCode: code,
                 };
                 if (message) {
@@ -101,12 +113,15 @@ export default function Helpers(mpInstance) {
 
     this.extend = utils.extend;
 
-    this.createServiceUrl = function(secureServiceUrl, devToken) {
-        var serviceScheme =
+    this.createServiceUrl = function(
+        secureServiceUrl: string,
+        devToken?: string
+    ): string {
+        const serviceScheme =
             window.mParticle && mpInstance._Store.SDKConfig.forceHttps
                 ? 'https://'
                 : window.location.protocol + '//';
-        var baseUrl;
+        let baseUrl;
         if (mpInstance._Store.SDKConfig.forceHttps) {
             baseUrl = 'https://' + secureServiceUrl;
         } else {
@@ -118,8 +133,8 @@ export default function Helpers(mpInstance) {
         return baseUrl;
     };
 
-    this.createXHR = function(cb) {
-        var xhr;
+    this.createXHR = function(cb: () => void): XMLHttpRequest {
+        let xhr;
 
         try {
             xhr = new window.XMLHttpRequest();
@@ -129,11 +144,11 @@ export default function Helpers(mpInstance) {
 
         if (xhr && cb && 'withCredentials' in xhr) {
             xhr.onreadystatechange = cb;
-        } else if (typeof window.XDomainRequest !== 'undefined') {
+        } else if (typeof (window as Dictionary).XDomainRequest !== 'undefined') {
             mpInstance.Logger.verbose('Creating XDomainRequest object');
 
             try {
-                xhr = new window.XDomainRequest();
+                xhr = new (window as Dictionary).XDomainRequest();
                 xhr.onload = cb;
             } catch (e) {
                 mpInstance.Logger.error('Error creating XDomainRequest object');
@@ -143,17 +158,23 @@ export default function Helpers(mpInstance) {
         return xhr;
     };
 
-    this.filterUserIdentities = function(userIdentitiesObject, filterList) {
-        var filteredUserIdentities = [];
+    this.filterUserIdentities = function(
+        userIdentitiesObject: Dictionary<string>,
+        filterList: number[]
+    ): Array<{ Type: number; Identity: string }> {
+        const filteredUserIdentities: Array<{
+            Type: number;
+            Identity: string;
+        }> = [];
 
         if (userIdentitiesObject && Object.keys(userIdentitiesObject).length) {
-            for (var userIdentityName in userIdentitiesObject) {
+            for (const userIdentityName in userIdentitiesObject) {
                 if (userIdentitiesObject.hasOwnProperty(userIdentityName)) {
-                    var userIdentityType = Types.IdentityType.getIdentityType(
+                    const userIdentityType = Types.IdentityType.getIdentityType(
                         userIdentityName
                     );
                     if (!self.inArray(filterList, userIdentityType)) {
-                        var identity = {
+                        const identity = {
                             Type: userIdentityType,
                             Identity: userIdentitiesObject[userIdentityName],
                         };
@@ -176,8 +197,8 @@ export default function Helpers(mpInstance) {
         KitFilterHelper.filterUserIdentities;
     this.filterUserAttributes = KitFilterHelper.filterUserAttributes;
 
-    this.isEventType = function(type) {
-        for (var prop in Types.EventType) {
+    this.isEventType = function(type: number): boolean {
+        for (const prop in Types.EventType) {
             if (Types.EventType.hasOwnProperty(prop)) {
                 if (Types.EventType[prop] === type) {
                     return true;
@@ -187,14 +208,17 @@ export default function Helpers(mpInstance) {
         return false;
     };
 
-    this.sanitizeAttributes = function(attrs, name) {
+    this.sanitizeAttributes = function(
+        attrs: Dictionary,
+        name: string
+    ): Dictionary<string> | null {
         if (!attrs || !self.isObject(attrs)) {
             return null;
         }
 
-        var sanitizedAttrs = {};
+        const sanitizedAttrs: Dictionary<string> = {};
 
-        for (var prop in attrs) {
+        for (const prop in attrs) {
             // Make sure that attribute values are not objects or arrays, which are not valid
             if (
                 attrs.hasOwnProperty(prop) &&
@@ -216,17 +240,17 @@ export default function Helpers(mpInstance) {
     };
 
     this.isDelayedByIntegration = function(
-        delayedIntegrations,
-        timeoutStart,
-        now
-    ) {
+        delayedIntegrations: Dictionary<boolean>,
+        timeoutStart: number,
+        now: number
+    ): boolean {
         if (
             now - timeoutStart >
             mpInstance._Store.SDKConfig.integrationDelayTimeout
         ) {
             return false;
         }
-        for (var integration in delayedIntegrations) {
+        for (const integration in delayedIntegrations) {
             if (delayedIntegrations[integration] === true) {
                 return true;
             } else {
@@ -236,7 +260,7 @@ export default function Helpers(mpInstance) {
         return false;
     };
 
-    this.createMainStorageName = function(workspaceToken) {
+    this.createMainStorageName = function(workspaceToken: string): string {
         if (workspaceToken) {
             return StorageNames.currentStorageName + '_' + workspaceToken;
         } else {
@@ -254,7 +278,7 @@ export default function Helpers(mpInstance) {
     this.isObject = utils.isObject;
     this.decoded = utils.decoded;
     this.parseStringOrNumber = utils.parseStringOrNumber;
-    this.generateHash = utils.generateHash;
+    this.generateHash = utils.generateHash as unknown as SDKHelpersApi['generateHash'];
     this.generateUniqueId = utils.generateUniqueId;
 
     // Imported Validators

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,10 +5,8 @@ import Validators from './validators';
 import KitFilterHelper from './kitFilterHelper';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { SDKHelpersApi } from './sdkRuntimeModels';
-import { Dictionary, valueof } from './utils';
-import { IMParticleUser } from './identity-user-interfaces';
+import { IMParticleUser, ISDKUserIdentity } from './identity-user-interfaces';
 import { MPID } from '@mparticle/web-sdk';
-import { EventType } from './types';
 
 const StorageNames = Constants.StorageNames;
 
@@ -97,7 +95,7 @@ export default function Helpers(
         }
         try {
             if (self.Validators.isFunction(callback)) {
-                const callbackMessage: Dictionary = {
+                const callbackMessage: utils.Dictionary = {
                     httpCode: code,
                 };
                 if (message) {
@@ -145,11 +143,13 @@ export default function Helpers(
 
         if (xhr && cb && 'withCredentials' in xhr) {
             xhr.onreadystatechange = cb;
-        } else if (typeof (window as Dictionary).XDomainRequest !== 'undefined') {
+        } else if (
+            typeof (window as utils.Dictionary).XDomainRequest !== 'undefined'
+        ) {
             mpInstance.Logger.verbose('Creating XDomainRequest object');
 
             try {
-                xhr = new (window as Dictionary).XDomainRequest();
+                xhr = new (window as utils.Dictionary).XDomainRequest();
                 xhr.onload = cb;
             } catch (e) {
                 mpInstance.Logger.error('Error creating XDomainRequest object');
@@ -160,13 +160,10 @@ export default function Helpers(
     };
 
     this.filterUserIdentities = function(
-        userIdentitiesObject: Dictionary<string>,
+        userIdentitiesObject: utils.Dictionary<string>,
         filterList: number[]
-    ): Array<{ Type: number; Identity: string }> {
-        const filteredUserIdentities: Array<{
-            Type: number;
-            Identity: string;
-        }> = [];
+    ): ISDKUserIdentity[] {
+        const filteredUserIdentities: ISDKUserIdentity[] = [];
 
         if (userIdentitiesObject && Object.keys(userIdentitiesObject).length) {
             for (const userIdentityName in userIdentitiesObject) {
@@ -175,7 +172,7 @@ export default function Helpers(
                         userIdentityName
                     );
                     if (!self.inArray(filterList, userIdentityType)) {
-                        const identity = {
+                        const identity: ISDKUserIdentity = {
                             Type: userIdentityType,
                             Identity: userIdentitiesObject[userIdentityName],
                         };
@@ -198,7 +195,9 @@ export default function Helpers(
         KitFilterHelper.filterUserIdentities;
     this.filterUserAttributes = KitFilterHelper.filterUserAttributes;
 
-    this.isEventType = function(type: valueof<typeof EventType>): boolean {
+    this.isEventType = function(
+        type: utils.valueof<typeof Types.EventType>
+    ): boolean {
         for (const prop in Types.EventType) {
             if (Types.EventType.hasOwnProperty(prop)) {
                 if (Types.EventType[prop] === type) {
@@ -210,14 +209,14 @@ export default function Helpers(
     };
 
     this.sanitizeAttributes = function(
-        attrs: Dictionary,
+        attrs: utils.Dictionary,
         name: string
-    ): Dictionary<string> | null {
+    ): utils.Dictionary<string> | null {
         if (!attrs || !self.isObject(attrs)) {
             return null;
         }
 
-        const sanitizedAttrs: Dictionary<string> = {};
+        const sanitizedAttrs: utils.Dictionary<string> = {};
 
         for (const prop in attrs) {
             // Make sure that attribute values are not objects or arrays, which are not valid
@@ -241,7 +240,7 @@ export default function Helpers(
     };
 
     this.isDelayedByIntegration = function(
-        delayedIntegrations: Dictionary<boolean>,
+        delayedIntegrations: utils.Dictionary<boolean>,
         timeoutStart: number,
         now: number
     ): boolean {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,12 +1,14 @@
 import Types from './types';
 import Constants from './constants';
 import * as utils from './utils';
+import { Dictionary } from './utils';
 import Validators from './validators';
 import KitFilterHelper from './kitFilterHelper';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { SDKHelpersApi } from './sdkRuntimeModels';
-import { IMParticleUser, ISDKUserIdentity } from './identity-user-interfaces';
-import { MPID } from '@mparticle/web-sdk';
+import { IMParticleUser, IdentityCallback, IdentityResult, ISDKUserIdentity } from './identity-user-interfaces';
+import { IAliasResult } from './identity.interfaces';
+import { AliasUsersCallback, MPID } from '@mparticle/web-sdk';
 
 const StorageNames = Constants.StorageNames;
 
@@ -35,7 +37,7 @@ export default function Helpers(
     };
 
     this.invokeCallback = function(
-        callback: Function,
+        callback: IdentityCallback,
         code: number,
         body: string,
         mParticleUser?: IMParticleUser,
@@ -76,7 +78,7 @@ export default function Helpers(
                             return mpInstance.Identity.getUser(previousMpid);
                         }
                     },
-                });
+                } as unknown as IdentityResult);
             }
         } catch (e) {
             mpInstance.Logger.error(
@@ -86,7 +88,7 @@ export default function Helpers(
     };
 
     this.invokeAliasCallback = function(
-        callback: Function,
+        callback: AliasUsersCallback,
         code: number,
         message?: string
     ): void {
@@ -95,13 +97,13 @@ export default function Helpers(
         }
         try {
             if (self.Validators.isFunction(callback)) {
-                const callbackMessage: utils.Dictionary = {
+                const callbackMessage: Dictionary = {
                     httpCode: code,
                 };
                 if (message) {
                     callbackMessage.message = message;
                 }
-                callback(callbackMessage);
+                callback(callbackMessage as IAliasResult);
             }
         } catch (e) {
             mpInstance.Logger.error(
@@ -144,12 +146,12 @@ export default function Helpers(
         if (xhr && cb && 'withCredentials' in xhr) {
             xhr.onreadystatechange = cb;
         } else if (
-            typeof (window as utils.Dictionary).XDomainRequest !== 'undefined'
+            typeof (window as Dictionary).XDomainRequest !== 'undefined'
         ) {
             mpInstance.Logger.verbose('Creating XDomainRequest object');
 
             try {
-                xhr = new (window as utils.Dictionary).XDomainRequest();
+                xhr = new (window as Dictionary).XDomainRequest();
                 xhr.onload = cb;
             } catch (e) {
                 mpInstance.Logger.error('Error creating XDomainRequest object');
@@ -160,7 +162,7 @@ export default function Helpers(
     };
 
     this.filterUserIdentities = function(
-        userIdentitiesObject: utils.Dictionary<string>,
+        userIdentitiesObject: Dictionary<string>,
         filterList: number[]
     ): ISDKUserIdentity[] {
         const filteredUserIdentities: ISDKUserIdentity[] = [];
@@ -209,14 +211,14 @@ export default function Helpers(
     };
 
     this.sanitizeAttributes = function(
-        attrs: utils.Dictionary,
+        attrs: Dictionary,
         name: string
-    ): utils.Dictionary<string> | null {
+    ): Dictionary<string> | null {
         if (!attrs || !self.isObject(attrs)) {
             return null;
         }
 
-        const sanitizedAttrs: utils.Dictionary<string> = {};
+        const sanitizedAttrs: Dictionary<string> = {};
 
         for (const prop in attrs) {
             // Make sure that attribute values are not objects or arrays, which are not valid
@@ -240,7 +242,7 @@ export default function Helpers(
     };
 
     this.isDelayedByIntegration = function(
-        delayedIntegrations: utils.Dictionary<boolean>,
+        delayedIntegrations: Dictionary<boolean>,
         timeoutStart: number,
         now: number
     ): boolean {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,9 +5,10 @@ import Validators from './validators';
 import KitFilterHelper from './kitFilterHelper';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { SDKHelpersApi } from './sdkRuntimeModels';
-import { Dictionary } from './utils';
+import { Dictionary, valueof } from './utils';
 import { IMParticleUser } from './identity-user-interfaces';
 import { MPID } from '@mparticle/web-sdk';
+import { EventType } from './types';
 
 const StorageNames = Constants.StorageNames;
 
@@ -197,7 +198,7 @@ export default function Helpers(
         KitFilterHelper.filterUserIdentities;
     this.filterUserAttributes = KitFilterHelper.filterUserAttributes;
 
-    this.isEventType = function(type: number): boolean {
+    this.isEventType = function(type: valueof<typeof EventType>): boolean {
         for (const prop in Types.EventType) {
             if (Types.EventType.hasOwnProperty(prop)) {
                 if (Types.EventType[prop] === type) {

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -378,17 +378,33 @@ export interface SDKHelpersApi {
     generateHash?(value: string): string;
     // https://go.mparticle.com/work/SQDSDKS-6317
     getFeatureFlag?(feature: string): boolean | string; // TODO: Feature Constants should be converted to enum
+    decoded?(s: string): string;
+    parseStringOrNumber?(value: string | number): string | number | null;
+    inArray?(items: any[], value: any): boolean;
+    converted?(s: string): string;
+    filterUserIdentitiesForForwarders?(
+        userIdentities: Dictionary,
+        filterList: number[]
+    ): Dictionary;
+    filterUserAttributes?(
+        userAttributes: Dictionary,
+        filterList: number[]
+    ): Dictionary;
+    filterUserIdentities?(
+        userIdentitiesObject: Dictionary<string>,
+        filterList: number[]
+    ): Array<{ Type: number; Identity: string }>;
     invokeAliasCallback(
         aliasCallback: IAliasCallback,
         number: number,
-        errorMessage: string
+        errorMessage?: string
     ): void;
     isDelayedByIntegration?(
         delayedIntegrations: Dictionary<boolean>,
         timeoutStart: number,
         now: number
     ): boolean;
-    isEventType?(type: valueof<typeof EventType>): boolean;
+    isEventType?(type: number | valueof<typeof EventType>): boolean;
     isObject?(item: any);
     invokeCallback?(
         callback: IdentityCallback,

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -404,7 +404,7 @@ export interface SDKHelpersApi {
         timeoutStart: number,
         now: number
     ): boolean;
-    isEventType?(type: number | valueof<typeof EventType>): boolean;
+    isEventType?(type: valueof<typeof EventType>): boolean;
     isObject?(item: any);
     invokeCallback?(
         callback: IdentityCallback,

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -393,7 +393,7 @@ export interface SDKHelpersApi {
     filterUserIdentities?(
         userIdentitiesObject: Dictionary<string>,
         filterList: number[]
-    ): Array<{ Type: number; Identity: string }>;
+    ): ISDKUserIdentity[];
     invokeAliasCallback(
         aliasCallback: IAliasCallback,
         number: number,


### PR DESCRIPTION
## Background
- Continuing the effort to migrate remaining JavaScript modules to TypeScript for improved type safety and developer experience across the SDK codebase.


## What Has Changed
- Converted src/helpers.js to src/helpers.ts with full type annotations on all methods, parameters, and return types
- Converted test/src/tests-helpers.js to test/src/tests-helpers.ts with necessary type adjustments
- Updated src/sdkRuntimeModels.ts with expanded SDKHelpersApi interface definitions to support the conversion
- Updated src/consent.ts with import path adjustment for the renamed module
- Replaced var declarations with const/let to satisfy SonarCloud linting rules
- Replaced const self = this pattern with arrow functions using lexical this to resolve SonarCloud violation

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/SDKE-1111
