### PR TITLE
ci: Remove pushing to main as part of the release process

### DIFF
--- a/.github/workflows/staging-step-3.yml
+++ b/.github/workflows/staging-step-3.yml
@@ -26,12 +26,10 @@ jobs:
         - name: Push release commits to development
           run: |
             git push origin HEAD:development
-        
-        # We will eventually replace master with main
-        - name: Push release commits to main and master
+
+        - name: Push release commits to master
           run: |
             git push origin HEAD:master
-            git push origin HEAD:main
 
         - name: Push release commits to Release Order Branches
           run: |


### PR DESCRIPTION
## Background
Previously we pushed to master and main due us assuming we'd move from master to main at some point in the future. master and main in this scenario are both v2 of the web sdk.  We've decided we'll make main v3, and so due to some experimentation on this branch causing the commit history to change, this step fails. It is an artifact of the past.

## What Has Changed
Remove pushing to main from master. 

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}