### PR TITLE
fix: normalize Rokt noDeviceId launcher option

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -56,6 +56,7 @@ import { ErrorReportingDispatcher } from './reporting/errorReportingDispatcher';
 import { LoggingDispatcher } from './reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService } from './reporting/types';
 import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
+import { normalizeRoktLauncherOptions } from './roktLauncherOptions';
 
 export interface IErrorLogMessage {
     message?: string;
@@ -1695,7 +1696,9 @@ function runPreConfigFetchInitialization(mpInstance, apiKey, config) {
     mpInstance.Logger.verbose(StartingInitialization);
 
     // Initialize CookieConsentManager with privacy flags from launcherOptions
-    const { noFunctional, noTargeting } = config?.launcherOptions ?? {};
+    const { noFunctional, noTargeting } = normalizeRoktLauncherOptions(
+        config?.launcherOptions
+    );
     mpInstance._CookieConsentManager = new CookieConsentManager({ noFunctional, noTargeting });
 
     // Check to see if localStorage is available before main configuration runs

--- a/src/roktLauncherOptions.ts
+++ b/src/roktLauncherOptions.ts
@@ -16,6 +16,7 @@ export function normalizeRoktLauncherOptions(
         normalizedOptions.noDeviceID === true;
 
     if (hasNoDeviceId) {
+        // noDeviceId is the strongest Rokt privacy flag and implies the newer flags.
         normalizedOptions.noDeviceId = true;
         normalizedOptions.noFunctional = true;
         normalizedOptions.noTargeting = true;

--- a/src/roktLauncherOptions.ts
+++ b/src/roktLauncherOptions.ts
@@ -1,0 +1,25 @@
+import { Dictionary } from './utils';
+
+export interface IRoktLauncherOptions extends Dictionary<any> {
+    noDeviceId?: boolean;
+    noDeviceID?: boolean;
+    noFunctional?: boolean;
+    noTargeting?: boolean;
+}
+
+export function normalizeRoktLauncherOptions(
+    launcherOptions?: IRoktLauncherOptions
+): IRoktLauncherOptions {
+    const normalizedOptions = { ...(launcherOptions || {}) };
+    const hasNoDeviceId =
+        normalizedOptions.noDeviceId === true ||
+        normalizedOptions.noDeviceID === true;
+
+    if (hasNoDeviceId) {
+        normalizedOptions.noDeviceId = true;
+        normalizedOptions.noFunctional = true;
+        normalizedOptions.noTargeting = true;
+    }
+
+    return normalizedOptions;
+}

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -17,6 +17,7 @@ import { IStore, LocalSessionAttributes } from "./store";
 import { UserIdentities } from "@mparticle/web-sdk";
 import { IdentityType, PerformanceMarkType } from "./types";
 import { ErrorCodes, IErrorReportingService, ILoggingService, WSDKErrorSeverity } from "./reporting/types";
+import { IRoktLauncherOptions, normalizeRoktLauncherOptions } from "./roktLauncherOptions";
 
 // https://docs.rokt.com/developers/integration-guides/web/library/attributes
 export type RoktAttributeValueArray = Array<string | number | boolean>;
@@ -88,7 +89,7 @@ export interface IRoktOptions {
     domain?: string;
 }
 
-export type IRoktLauncherOptions = Dictionary<any>;
+export type { IRoktLauncherOptions } from "./roktLauncherOptions";
 
 const ON_SHOPPABLE_ADS_READY_METHOD = 'onShoppableAdsReady'
 
@@ -186,7 +187,10 @@ export default class RoktManager {
 
         // Launcher options are set here for the kit to pick up and pass through
         // to the Rokt Launcher.
-        this.launcherOptions = { sandbox, ...options?.launcherOptions };
+        const launcherOptions = normalizeRoktLauncherOptions(
+            options?.launcherOptions
+        );
+        this.launcherOptions = { sandbox, ...launcherOptions };
 
         if (options?.domain) {
             this.domain = options.domain;

--- a/src/store.ts
+++ b/src/store.ts
@@ -41,6 +41,7 @@ import {
 import { CookieSyncDates, IPixelConfiguration } from './cookieSyncManager';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import ForegroundTimer from './foregroundTimeTracker';
+import { normalizeRoktLauncherOptions } from './roktLauncherOptions';
 
 const { Messages } = Constants;
 
@@ -729,7 +730,9 @@ export default function Store(
 
         if (workspaceToken) {
             this.SDKConfig.workspaceToken = workspaceToken;
-            const noFunctional = config?.launcherOptions?.noFunctional === true;
+            const { noFunctional } = normalizeRoktLauncherOptions(
+                config?.launcherOptions
+            );
             mpInstance._timeOnSiteTimer = new ForegroundTimer(workspaceToken, noFunctional);
         } else {
             mpInstance.Logger.warning(

--- a/test/jest/roktLauncherOptions.spec.ts
+++ b/test/jest/roktLauncherOptions.spec.ts
@@ -1,0 +1,40 @@
+import { normalizeRoktLauncherOptions } from '../../src/roktLauncherOptions';
+
+describe('normalizeRoktLauncherOptions', () => {
+    it('should leave launcher options unchanged when noDeviceId is not enabled', () => {
+        const launcherOptions = {
+            integrationName: 'customIntegration',
+            noFunctional: false,
+            noTargeting: true,
+        };
+
+        expect(normalizeRoktLauncherOptions(launcherOptions)).toEqual(
+            launcherOptions
+        );
+    });
+
+    it('should expand noDeviceId to noFunctional and noTargeting', () => {
+        const launcherOptions = normalizeRoktLauncherOptions({
+            noDeviceId: true,
+            noFunctional: false,
+            noTargeting: false,
+        });
+
+        expect(launcherOptions.noDeviceId).toBe(true);
+        expect(launcherOptions.noFunctional).toBe(true);
+        expect(launcherOptions.noTargeting).toBe(true);
+    });
+
+    it('should normalize legacy noDeviceID casing to canonical noDeviceId', () => {
+        const launcherOptions = normalizeRoktLauncherOptions({
+            noDeviceID: true,
+            noFunctional: false,
+            noTargeting: false,
+        });
+
+        expect(launcherOptions.noDeviceId).toBe(true);
+        expect(launcherOptions.noDeviceID).toBe(true);
+        expect(launcherOptions.noFunctional).toBe(true);
+        expect(launcherOptions.noTargeting).toBe(true);
+    });
+});

--- a/test/jest/roktLauncherOptions.spec.ts
+++ b/test/jest/roktLauncherOptions.spec.ts
@@ -1,6 +1,10 @@
 import { normalizeRoktLauncherOptions } from '../../src/roktLauncherOptions';
 
 describe('normalizeRoktLauncherOptions', () => {
+    it('should return an empty object when launcher options are not provided', () => {
+        expect(normalizeRoktLauncherOptions()).toEqual({});
+    });
+
     it('should leave launcher options unchanged when noDeviceId is not enabled', () => {
         const launcherOptions = {
             integrationName: 'customIntegration',
@@ -15,11 +19,13 @@ describe('normalizeRoktLauncherOptions', () => {
 
     it('should expand noDeviceId to noFunctional and noTargeting', () => {
         const launcherOptions = normalizeRoktLauncherOptions({
+            integrationName: 'customIntegration',
             noDeviceId: true,
             noFunctional: false,
             noTargeting: false,
         });
 
+        expect(launcherOptions.integrationName).toBe('customIntegration');
         expect(launcherOptions.noDeviceId).toBe(true);
         expect(launcherOptions.noFunctional).toBe(true);
         expect(launcherOptions.noTargeting).toBe(true);
@@ -27,11 +33,13 @@ describe('normalizeRoktLauncherOptions', () => {
 
     it('should normalize legacy noDeviceID casing to canonical noDeviceId', () => {
         const launcherOptions = normalizeRoktLauncherOptions({
+            integrationName: 'customIntegration',
             noDeviceID: true,
             noFunctional: false,
             noTargeting: false,
         });
 
+        expect(launcherOptions.integrationName).toBe('customIntegration');
         expect(launcherOptions.noDeviceId).toBe(true);
         expect(launcherOptions.noDeviceID).toBe(true);
         expect(launcherOptions.noFunctional).toBe(true);

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -464,6 +464,28 @@ describe('RoktManager', () => {
             expect(roktManager['launcherOptions'].noFunctional).toBe(false);
         });
 
+        it('should expand noDeviceID launcher option casing before attaching the Rokt kit', () => {
+            roktManager.init(
+                {} as IKitConfigs,
+                {} as IMParticleUser,
+                mockMPInstance.Identity,
+                mockMPInstance._Store,
+                mockMPInstance.Logger,
+                {
+                    launcherOptions: {
+                        noDeviceID: true,
+                        noFunctional: false,
+                        noTargeting: false,
+                    },
+                },
+            );
+
+            expect(roktManager['launcherOptions'].noDeviceId).toBe(true);
+            expect(roktManager['launcherOptions'].noDeviceID).toBe(true);
+            expect(roktManager['launcherOptions'].noFunctional).toBe(true);
+            expect(roktManager['launcherOptions'].noTargeting).toBe(true);
+        });
+
         it('should capture jointSdkRoktKitInit timing when init is called with captureTiming', () => {
             const mockCaptureTiming = jest.fn();
             roktManager.init(

--- a/test/src/tests-identity.ts
+++ b/test/src/tests-identity.ts
@@ -4524,6 +4524,16 @@ describe('identity', function() {
                 expect(localStorage.getItem(idCacheStorageKey)).not.to.be.ok;
             });
 
+            it('should NOT save id cache to local storage when noDeviceID is true', async () => {
+                mParticle.config.launcherOptions = {
+                    noDeviceID: true,
+                    noFunctional: false,
+                };
+                mParticle.init(apiKey, window.mParticle.config);
+                await waitForCondition(hasIdentifyReturned);
+                expect(localStorage.getItem(idCacheStorageKey)).not.to.be.ok;
+            });
+
             it('should save id cache to local storage when noFunctional is false', async () => {
                 mParticle.config.launcherOptions = { noFunctional: false };
                 mParticle.init(apiKey, window.mParticle.config);

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1425,6 +1425,26 @@ describe('Store', () => {
             );
         });
 
+        it('should treat noDeviceID as noFunctional when creating foreground timer', () => {
+            const config = {
+                ...sampleConfig,
+                workspaceToken: 'foo',
+                launcherOptions: {
+                    noDeviceID: true,
+                    noFunctional: false,
+                },
+            };
+            const mpInstance = window.mParticle.getInstance();
+            const store: IStore = new Store(config, mpInstance);
+
+            store.processConfig(config);
+
+            expect(
+                mpInstance._timeOnSiteTimer['noFunctional'],
+                'foreground timer noFunctional'
+            ).to.equal(true);
+        });
+
         it('should warn if workspace token is missing', () => {
             const config = {
                 ...sampleConfig,


### PR DESCRIPTION
## Background

- Rokt launcher options were passed through as a generic object, but mParticle core only interpreted `noFunctional` and `noTargeting` for its own storage and cookie behavior.
- This meant `noDeviceId: true` was not equivalent inside mParticle.
- Assumption: the external Rokt launcher consumes canonical `noDeviceId` casing. The normalized output also preserves legacy `noDeviceID` casing, so the pass-through is robust either way.

## What Has Changed

- Added shared Rokt launcher option normalization.
- Expands `noDeviceId: true` and `noDeviceID: true` into canonical `noDeviceId: true`, `noFunctional: true`, and `noTargeting: true`.
- Applies the normalized flags before initializing mParticle cookie consent, foreground time tracking, and Rokt kit launcher options.
- Added coverage for undefined input, unrelated-key preservation, Rokt manager pass-through, foreground timer wiring, and identity-cache behavior.

## Screenshots/Video

- Leave for author

## Verification

- `npm run test:jest -- roktLauncherOptions roktManager foregroundTimeTracker`
- `npm run lint`
- `npm run build:test-bundle` blocked by existing unrelated `src/sdkToEventsApiConverter.ts:666` `active_time_on_site_ms` type error.

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally