### PR TITLE
fix: prevent storage quota errors during event logging

### DIFF
--- a/dist/mparticle.js
+++ b/dist/mparticle.js
@@ -2371,13 +2371,18 @@ var mParticle = (function () {
        */
       BaseVault.prototype.store = function (item) {
         var stringifiedItem;
-        this.contents = item;
-        if (isNumber(item) || !isEmpty(item)) {
-          stringifiedItem = JSON.stringify(item);
-        } else {
-          stringifiedItem = '';
+        try {
+          if (isNumber(item) || !isEmpty(item)) {
+            stringifiedItem = JSON.stringify(item);
+          } else {
+            stringifiedItem = '';
+          }
+          this.storageObject.setItem(this._storageKey, stringifiedItem);
+          this.contents = item;
+          return true;
+        } catch (e) {
+          return false;
         }
-        this.storageObject.setItem(this._storageKey, stringifiedItem);
       };
       /**
        * Retrieve StorableItem from Storage
@@ -2385,10 +2390,13 @@ var mParticle = (function () {
        * @returns {StorableItem}
        */
       BaseVault.prototype.retrieve = function () {
-        // TODO: Handle cases where Local Storage is unavailable
         // https://go.mparticle.com/work/SQDSDKS-5022
-        var item = this.storageObject.getItem(this._storageKey);
-        this.contents = item ? JSON.parse(item) : null;
+        try {
+          var item = this.storageObject.getItem(this._storageKey);
+          this.contents = item ? JSON.parse(item) : null;
+        } catch (e) {
+          this.contents = null;
+        }
         return this.contents;
       };
       /**
@@ -2398,7 +2406,11 @@ var mParticle = (function () {
        */
       BaseVault.prototype.purge = function () {
         this.contents = null;
-        this.storageObject.removeItem(this._storageKey);
+        try {
+          this.storageObject.removeItem(this._storageKey);
+        } catch (e) {
+          // Storage persistence is best effort.
+        }
       };
       return BaseVault;
     }();
@@ -2427,6 +2439,7 @@ var mParticle = (function () {
       }
       DisabledVault.prototype.store = function (_item) {
         this.contents = null;
+        return true;
       };
       DisabledVault.prototype.retrieve = function () {
         return this.contents;
@@ -2933,9 +2946,7 @@ var mParticle = (function () {
                   // therefore NOT overwrite Offline Storage when beacon returns, so that we can retry
                   // uploading saved batches at a later time. Batches should only be removed from
                   // Local Storage once we can confirm they are successfully uploaded.
-                  this.batchVault.store(this.batchesQueuedForProcessing);
-                  // Clear batch queue since everything should be in Offline Storage
-                  this.batchesQueuedForProcessing = [];
+                  this.storeBatchesQueuedForProcessing();
                 }
                 if (triggerFuture && !this.destroyed) {
                   this.triggerUploadInterval(triggerFuture, false);
@@ -2946,6 +2957,29 @@ var mParticle = (function () {
         });
       };
 
+      BatchUploader.prototype.storeBatchesQueuedForProcessing = function () {
+        var batchesToStore = this.batchesQueuedForProcessing.slice();
+        var storedBatches = batchesToStore.slice();
+        while (storedBatches.length) {
+          if (this.batchVault.store(storedBatches)) {
+            this.logDroppedOfflineBatches(batchesToStore.length - storedBatches.length);
+            this.batchesQueuedForProcessing = [];
+            return;
+          }
+          storedBatches = storedBatches.slice(1);
+        }
+        if (this.batchVault.store([])) {
+          this.logDroppedOfflineBatches(batchesToStore.length);
+          this.batchesQueuedForProcessing = [];
+          return;
+        }
+        this.mpInstance.Logger.warning('Offline batch storage is unavailable. Retaining batches in memory.');
+      };
+      BatchUploader.prototype.logDroppedOfflineBatches = function (droppedBatchCount) {
+        if (droppedBatchCount > 0) {
+          this.mpInstance.Logger.warning('Offline batch storage is over quota. Dropped ' + "".concat(droppedBatchCount, " oldest batch(es)."));
+        }
+      };
       BatchUploader.prototype.uploadBatches = function (batches, useBeacon) {
         return __awaiter(this, void 0, void 0, function () {
           var uploads, uploadsToLog, i, fetchPayload, blob, response, e_1;
@@ -6059,7 +6093,11 @@ var mParticle = (function () {
           window.document.cookie = encodeURIComponent(key) + '=' + encodedCookiesWithExpirationAndPath;
         } else {
           if (mpInstance._Store.isLocalStorageAvailable) {
-            localStorage.setItem(mpInstance._Store.storageName, encodedPersistence);
+            try {
+              localStorage.setItem(mpInstance._Store.storageName, encodedPersistence);
+            } catch (e) {
+              mpInstance.Logger.error('Error saving persistence to localStorage.');
+            }
           }
         }
       };

--- a/dist/mparticle.js
+++ b/dist/mparticle.js
@@ -2371,18 +2371,13 @@ var mParticle = (function () {
        */
       BaseVault.prototype.store = function (item) {
         var stringifiedItem;
-        try {
-          if (isNumber(item) || !isEmpty(item)) {
-            stringifiedItem = JSON.stringify(item);
-          } else {
-            stringifiedItem = '';
-          }
-          this.storageObject.setItem(this._storageKey, stringifiedItem);
-          this.contents = item;
-          return true;
-        } catch (e) {
-          return false;
+        this.contents = item;
+        if (isNumber(item) || !isEmpty(item)) {
+          stringifiedItem = JSON.stringify(item);
+        } else {
+          stringifiedItem = '';
         }
+        this.storageObject.setItem(this._storageKey, stringifiedItem);
       };
       /**
        * Retrieve StorableItem from Storage
@@ -2390,13 +2385,10 @@ var mParticle = (function () {
        * @returns {StorableItem}
        */
       BaseVault.prototype.retrieve = function () {
+        // TODO: Handle cases where Local Storage is unavailable
         // https://go.mparticle.com/work/SQDSDKS-5022
-        try {
-          var item = this.storageObject.getItem(this._storageKey);
-          this.contents = item ? JSON.parse(item) : null;
-        } catch (e) {
-          this.contents = null;
-        }
+        var item = this.storageObject.getItem(this._storageKey);
+        this.contents = item ? JSON.parse(item) : null;
         return this.contents;
       };
       /**
@@ -2406,11 +2398,7 @@ var mParticle = (function () {
        */
       BaseVault.prototype.purge = function () {
         this.contents = null;
-        try {
-          this.storageObject.removeItem(this._storageKey);
-        } catch (e) {
-          // Storage persistence is best effort.
-        }
+        this.storageObject.removeItem(this._storageKey);
       };
       return BaseVault;
     }();
@@ -2439,7 +2427,6 @@ var mParticle = (function () {
       }
       DisabledVault.prototype.store = function (_item) {
         this.contents = null;
-        return true;
       };
       DisabledVault.prototype.retrieve = function () {
         return this.contents;
@@ -2946,7 +2933,9 @@ var mParticle = (function () {
                   // therefore NOT overwrite Offline Storage when beacon returns, so that we can retry
                   // uploading saved batches at a later time. Batches should only be removed from
                   // Local Storage once we can confirm they are successfully uploaded.
-                  this.storeBatchesQueuedForProcessing();
+                  this.batchVault.store(this.batchesQueuedForProcessing);
+                  // Clear batch queue since everything should be in Offline Storage
+                  this.batchesQueuedForProcessing = [];
                 }
                 if (triggerFuture && !this.destroyed) {
                   this.triggerUploadInterval(triggerFuture, false);
@@ -2957,29 +2946,6 @@ var mParticle = (function () {
         });
       };
 
-      BatchUploader.prototype.storeBatchesQueuedForProcessing = function () {
-        var batchesToStore = this.batchesQueuedForProcessing.slice();
-        var storedBatches = batchesToStore.slice();
-        while (storedBatches.length) {
-          if (this.batchVault.store(storedBatches)) {
-            this.logDroppedOfflineBatches(batchesToStore.length - storedBatches.length);
-            this.batchesQueuedForProcessing = [];
-            return;
-          }
-          storedBatches = storedBatches.slice(1);
-        }
-        if (this.batchVault.store([])) {
-          this.logDroppedOfflineBatches(batchesToStore.length);
-          this.batchesQueuedForProcessing = [];
-          return;
-        }
-        this.mpInstance.Logger.warning('Offline batch storage is unavailable. Retaining batches in memory.');
-      };
-      BatchUploader.prototype.logDroppedOfflineBatches = function (droppedBatchCount) {
-        if (droppedBatchCount > 0) {
-          this.mpInstance.Logger.warning('Offline batch storage is over quota. Dropped ' + "".concat(droppedBatchCount, " oldest batch(es)."));
-        }
-      };
       BatchUploader.prototype.uploadBatches = function (batches, useBeacon) {
         return __awaiter(this, void 0, void 0, function () {
           var uploads, uploadsToLog, i, fetchPayload, blob, response, e_1;
@@ -6093,11 +6059,7 @@ var mParticle = (function () {
           window.document.cookie = encodeURIComponent(key) + '=' + encodedCookiesWithExpirationAndPath;
         } else {
           if (mpInstance._Store.isLocalStorageAvailable) {
-            try {
-              localStorage.setItem(mpInstance._Store.storageName, encodedPersistence);
-            } catch (e) {
-              mpInstance.Logger.error('Error saving persistence to localStorage.');
-            }
+            localStorage.setItem(mpInstance._Store.storageName, encodedPersistence);
           }
         }
       };

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -463,13 +463,47 @@ export class BatchUploader {
             // uploading saved batches at a later time. Batches should only be removed from
             // Local Storage once we can confirm they are successfully uploaded.
             
-            this.batchVault.store(this.batchesQueuedForProcessing);
-            // Clear batch queue since everything should be in Offline Storage
-            this.batchesQueuedForProcessing = [];
+            this.storeBatchesQueuedForProcessing();
         }
 
         if (triggerFuture && !this.destroyed) {
             this.triggerUploadInterval(triggerFuture, false);
+        }
+    }
+
+    private storeBatchesQueuedForProcessing(): void {
+        const batchesToStore = this.batchesQueuedForProcessing.slice();
+        let storedBatches = batchesToStore.slice();
+
+        while (storedBatches.length) {
+            if (this.batchVault.store(storedBatches)) {
+                this.logDroppedOfflineBatches(
+                    batchesToStore.length - storedBatches.length
+                );
+                this.batchesQueuedForProcessing = [];
+                return;
+            }
+
+            storedBatches = storedBatches.slice(1);
+        }
+
+        if (this.batchVault.store([])) {
+            this.logDroppedOfflineBatches(batchesToStore.length);
+            this.batchesQueuedForProcessing = [];
+            return;
+        }
+
+        this.mpInstance.Logger.warning(
+            'Offline batch storage is unavailable. Retaining batches in memory.'
+        );
+    }
+
+    private logDroppedOfflineBatches(droppedBatchCount: number): void {
+        if (droppedBatchCount > 0) {
+            this.mpInstance.Logger.warning(
+                'Offline batch storage is over quota. Dropped ' +
+                    `${droppedBatchCount} oldest batch(es).`
+            );
         }
     }
 

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -473,6 +473,14 @@ export class BatchUploader {
 
     private storeBatchesQueuedForProcessing(): void {
         const batchesToStore = this.batchesQueuedForProcessing.slice();
+
+        // Nothing to persist: reset offline storage to an empty state.
+        if (isEmpty(batchesToStore)) {
+            this.batchVault.store([]);
+            this.batchesQueuedForProcessing = [];
+            return;
+        }
+
         let storedBatches = batchesToStore.slice();
 
         while (storedBatches.length) {
@@ -487,12 +495,7 @@ export class BatchUploader {
             storedBatches = storedBatches.slice(1);
         }
 
-        if (this.batchVault.store([])) {
-            this.logDroppedOfflineBatches(batchesToStore.length);
-            this.batchesQueuedForProcessing = [];
-            return;
-        }
-
+        // Could not persist any batches; retain them in memory to retry later.
         this.mpInstance.Logger.warning(
             'Offline batch storage is unavailable. Retaining batches in memory.'
         );

--- a/src/batchUploader.ts
+++ b/src/batchUploader.ts
@@ -4,7 +4,7 @@ import { SDKEvent, SDKEventCustomFlags } from './sdkRuntimeModels';
 import { convertEvents } from './sdkToEventsApiConverter';
 import { MessageType, EventType } from './types';
 import { getRampNumber, getHref, isEmpty, obfuscateDevData } from './utils';
-import { SessionStorageVault, LocalStorageVault } from './vault';
+import { SessionStorageVault, LocalStorageVault, StorageResult } from './vault';
 import {
     AsyncUploader,
     FetchUploader,
@@ -90,8 +90,12 @@ export class BatchUploader {
                 `${mpInstance._Store.storageName}-batches`
             );
 
-            // Load Events from Session Storage in case we have any in storage
-            this.eventsQueuedForProcessing.push(...this.eventVault.retrieve());
+            // Load Events from Session Storage in case we have any in storage.
+            // retrieve() returns null for empty/corrupt storage, so default to
+            // an empty array to keep the spread safe.
+            this.eventsQueuedForProcessing.push(
+                ...(this.eventVault.retrieve() ?? [])
+            );
         }
 
         const { SDKConfig, devToken } = this.mpInstance._Store;
@@ -426,7 +430,7 @@ export class BatchUploader {
         // Top Load any older Batches from Offline Storage so they go out first
         if (this.offlineStorageEnabled && this.batchVault) {
             this.batchesQueuedForProcessing.unshift(
-                ...this.batchVault.retrieve()
+                ...(this.batchVault.retrieve() ?? [])
             );
 
             // Remove batches from local storage before transmit to
@@ -472,27 +476,30 @@ export class BatchUploader {
     }
 
     private storeBatchesQueuedForProcessing(): void {
-        const batchesToStore = this.batchesQueuedForProcessing.slice();
+        const batches = this.batchesQueuedForProcessing;
 
         // Nothing to persist: reset offline storage to an empty state.
-        if (isEmpty(batchesToStore)) {
+        if (isEmpty(batches)) {
             this.batchVault.store([]);
             this.batchesQueuedForProcessing = [];
             return;
         }
 
-        let storedBatches = batchesToStore.slice();
+        // Drop oldest batches until storage accepts the payload. Only quota
+        // failures are recoverable by trimming; if storage is unavailable,
+        // dropping batches won't help, so retain them in memory.
+        for (let dropped = 0; dropped < batches.length; dropped++) {
+            const result = this.batchVault.store(batches.slice(dropped));
 
-        while (storedBatches.length) {
-            if (this.batchVault.store(storedBatches)) {
-                this.logDroppedOfflineBatches(
-                    batchesToStore.length - storedBatches.length
-                );
+            if (result === StorageResult.Success) {
+                this.logDroppedOfflineBatches(dropped);
                 this.batchesQueuedForProcessing = [];
                 return;
             }
 
-            storedBatches = storedBatches.slice(1);
+            if (result === StorageResult.Unavailable) {
+                break;
+            }
         }
 
         // Could not persist any batches; retain them in memory to retry later.

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -853,10 +853,16 @@ export default function _Persistence(mpInstance) {
                 encodedCookiesWithExpirationAndPath;
         } else {
             if (mpInstance._Store.isLocalStorageAvailable) {
-                localStorage.setItem(
-                    mpInstance._Store.storageName,
-                    encodedPersistence
-                );
+                try {
+                    localStorage.setItem(
+                        mpInstance._Store.storageName,
+                        encodedPersistence
+                    );
+                } catch (e) {
+                    mpInstance.Logger.error(
+                        'Error saving persistence to localStorage.'
+                    );
+                }
             }
         }
     };

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -1,5 +1,22 @@
 import { isEmpty, isNumber } from './utils';
 
+// Outcome of a vault write so callers can react to the cause of a failure.
+// `Unavailable` covers storage being blocked/disabled (e.g. SecurityError),
+// where retrying with a smaller payload cannot succeed.
+export enum StorageResult {
+    Success = 'Success',
+    QuotaExceeded = 'QuotaExceeded',
+    Unavailable = 'Unavailable',
+}
+
+const isQuotaExceededError = (e: unknown): boolean =>
+    e instanceof DOMException &&
+    // Standard quota errors, plus Firefox's legacy name/code.
+    (e.code === 22 ||
+        e.code === 1014 ||
+        e.name === 'QuotaExceededError' ||
+        e.name === 'NS_ERROR_DOM_QUOTA_REACHED');
+
 export abstract class BaseVault<StorableItem> {
     public contents: StorableItem;
     protected readonly _storageKey: string;
@@ -25,7 +42,7 @@ export abstract class BaseVault<StorableItem> {
      * @method store
      * @param item {StorableItem}
      */
-    public store(item: StorableItem): boolean {
+    public store(item: StorableItem): StorageResult {
         let stringifiedItem: string;
 
         try {
@@ -37,9 +54,11 @@ export abstract class BaseVault<StorableItem> {
 
             this.storageObject.setItem(this._storageKey, stringifiedItem);
             this.contents = item;
-            return true;
+            return StorageResult.Success;
         } catch (e) {
-            return false;
+            return isQuotaExceededError(e)
+                ? StorageResult.QuotaExceeded
+                : StorageResult.Unavailable;
         }
     }
 
@@ -97,9 +116,9 @@ export class DisabledVault<StorableItem> extends BaseVault<StorableItem> {
         this.storageObject.removeItem(this._storageKey);
     }
 
-    public store(_item: StorableItem): boolean {
+    public store(_item: StorableItem): StorageResult {
         this.contents = null;
-        return true;
+        return StorageResult.Success;
     }
 
     public retrieve(): StorableItem | null {

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -25,17 +25,22 @@ export abstract class BaseVault<StorableItem> {
      * @method store
      * @param item {StorableItem}
      */
-    public store(item: StorableItem): void {
+    public store(item: StorableItem): boolean {
         let stringifiedItem: string;
-        this.contents = item;
 
-        if (isNumber(item) || !isEmpty(item)) {
-            stringifiedItem = JSON.stringify(item);
-        } else {
-            stringifiedItem = '';
+        try {
+            if (isNumber(item) || !isEmpty(item)) {
+                stringifiedItem = JSON.stringify(item);
+            } else {
+                stringifiedItem = '';
+            }
+
+            this.storageObject.setItem(this._storageKey, stringifiedItem);
+            this.contents = item;
+            return true;
+        } catch (e) {
+            return false;
         }
-
-        this.storageObject.setItem(this._storageKey, stringifiedItem);
     }
 
     /**
@@ -44,11 +49,14 @@ export abstract class BaseVault<StorableItem> {
      * @returns {StorableItem}
      */
     public retrieve(): StorableItem | null {
-        // TODO: Handle cases where Local Storage is unavailable
         // https://go.mparticle.com/work/SQDSDKS-5022
-        const item: string = this.storageObject.getItem(this._storageKey);
+        try {
+            const item: string = this.storageObject.getItem(this._storageKey);
 
-        this.contents = item ? JSON.parse(item) : null;
+            this.contents = item ? JSON.parse(item) : null;
+        } catch (e) {
+            this.contents = null;
+        }
 
         return this.contents;
     }
@@ -60,7 +68,12 @@ export abstract class BaseVault<StorableItem> {
      */
     public purge(): void {
         this.contents = null;
-        this.storageObject.removeItem(this._storageKey);
+
+        try {
+            this.storageObject.removeItem(this._storageKey);
+        } catch (e) {
+            // Storage persistence is best effort.
+        }
     }
 }
 
@@ -84,8 +97,9 @@ export class DisabledVault<StorableItem> extends BaseVault<StorableItem> {
         this.storageObject.removeItem(this._storageKey);
     }
 
-    public store(_item: StorableItem): void {
+    public store(_item: StorableItem): boolean {
         this.contents = null;
+        return true;
     }
 
     public retrieve(): StorableItem | null {

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -1094,9 +1094,8 @@ describe('batch uploader', () => {
 
             (<any>uploader).storeBatchesQueuedForProcessing();
 
-            expect(storeStub.callCount).to.equal(2);
+            expect(storeStub.callCount).to.equal(1);
             expect(storeStub.getCall(0).args[0]).to.eql([batch1]);
-            expect(storeStub.getCall(1).args[0]).to.eql([]);
             expect(uploader.batchesQueuedForProcessing).to.eql([batch1]);
             expect(
                 warningSpy.calledWith(

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -1031,6 +1031,80 @@ describe('batch uploader', () => {
             ).to.equal('Test Event 0');
         });
 
+        it('should drop oldest batches until offline storage fits', async () => {
+            window.mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = new BatchUploader(mpInstance, 1000);
+            const batchValidator = new _BatchValidator();
+            const batch1 = batchValidator.returnBatch({
+                messageType: 4,
+                name: 'Test Event 1',
+            });
+            const batch2 = batchValidator.returnBatch({
+                messageType: 4,
+                name: 'Test Event 2',
+            });
+            const batch3 = batchValidator.returnBatch({
+                messageType: 4,
+                name: 'Test Event 3',
+            });
+            const storeStub = sinon
+                .stub((<any>uploader).batchVault, 'store')
+                .callsFake((batches: Batch[]) => batches.length <= 2);
+            const warningSpy = sinon.spy(mpInstance.Logger, 'warning');
+
+            uploader.batchesQueuedForProcessing = [batch1, batch2, batch3];
+
+            (<any>uploader).storeBatchesQueuedForProcessing();
+
+            expect(storeStub.callCount).to.equal(2);
+            expect(storeStub.getCall(0).args[0]).to.eql([
+                batch1,
+                batch2,
+                batch3,
+            ]);
+            expect(storeStub.getCall(1).args[0]).to.eql([batch2, batch3]);
+            expect(uploader.batchesQueuedForProcessing).to.eql([]);
+            expect(
+                warningSpy.calledWith(
+                    'Offline batch storage is over quota. Dropped 1 oldest batch(es).'
+                )
+            ).to.equal(true);
+        });
+
+        it('should retain batches in memory when offline storage is unavailable', async () => {
+            window.mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = new BatchUploader(mpInstance, 1000);
+            const batchValidator = new _BatchValidator();
+            const batch1 = batchValidator.returnBatch({
+                messageType: 4,
+                name: 'Test Event 1',
+            });
+            const storeStub = sinon
+                .stub((<any>uploader).batchVault, 'store')
+                .returns(false);
+            const warningSpy = sinon.spy(mpInstance.Logger, 'warning');
+
+            uploader.batchesQueuedForProcessing = [batch1];
+
+            (<any>uploader).storeBatchesQueuedForProcessing();
+
+            expect(storeStub.callCount).to.equal(2);
+            expect(storeStub.getCall(0).args[0]).to.eql([batch1]);
+            expect(storeStub.getCall(1).args[0]).to.eql([]);
+            expect(uploader.batchesQueuedForProcessing).to.eql([batch1]);
+            expect(
+                warningSpy.calledWith(
+                    'Offline batch storage is unavailable. Retaining batches in memory.'
+                )
+            ).to.equal(true);
+        });
+
         it('should save batches in sequence to Local Storage when an HTTP 429 error is encountered', async () => {
             const batchStorageKey = 'mprtcl-v4_abcdef-batches';
 

--- a/test/src/tests-batchUploader.ts
+++ b/test/src/tests-batchUploader.ts
@@ -8,6 +8,7 @@ import {
 import { Batch, CustomEventData } from '@mparticle/event-models';
 import Utils from './config/utils';
 import { BatchUploader } from '../../src/batchUploader';
+import { StorageResult } from '../../src/vault';
 import { expect } from 'chai';
 import _BatchValidator from '../../src/mockBatchCreator';
 
@@ -1052,7 +1053,11 @@ describe('batch uploader', () => {
             });
             const storeStub = sinon
                 .stub((<any>uploader).batchVault, 'store')
-                .callsFake((batches: Batch[]) => batches.length <= 2);
+                .callsFake((batches: Batch[]) =>
+                    batches.length <= 2
+                        ? StorageResult.Success
+                        : StorageResult.QuotaExceeded
+                );
             const warningSpy = sinon.spy(mpInstance.Logger, 'warning');
 
             uploader.batchesQueuedForProcessing = [batch1, batch2, batch3];
@@ -1074,7 +1079,7 @@ describe('batch uploader', () => {
             ).to.equal(true);
         });
 
-        it('should retain batches in memory when offline storage is unavailable', async () => {
+        it('should retain batches in memory without trimming when offline storage is unavailable', async () => {
             window.mParticle.init(apiKey, window.mParticle.config);
             await waitForCondition(hasIdentifyReturned);
 
@@ -1085,23 +1090,68 @@ describe('batch uploader', () => {
                 messageType: 4,
                 name: 'Test Event 1',
             });
+            const batch2 = batchValidator.returnBatch({
+                messageType: 4,
+                name: 'Test Event 2',
+            });
+            const batch3 = batchValidator.returnBatch({
+                messageType: 4,
+                name: 'Test Event 3',
+            });
             const storeStub = sinon
                 .stub((<any>uploader).batchVault, 'store')
-                .returns(false);
+                .returns(StorageResult.Unavailable);
             const warningSpy = sinon.spy(mpInstance.Logger, 'warning');
 
-            uploader.batchesQueuedForProcessing = [batch1];
+            uploader.batchesQueuedForProcessing = [batch1, batch2, batch3];
 
             (<any>uploader).storeBatchesQueuedForProcessing();
 
+            // Storage being unavailable should short-circuit immediately rather
+            // than attempt to trim, so only the full payload is tried.
             expect(storeStub.callCount).to.equal(1);
-            expect(storeStub.getCall(0).args[0]).to.eql([batch1]);
-            expect(uploader.batchesQueuedForProcessing).to.eql([batch1]);
+            expect(storeStub.getCall(0).args[0]).to.eql([
+                batch1,
+                batch2,
+                batch3,
+            ]);
+            expect(uploader.batchesQueuedForProcessing).to.eql([
+                batch1,
+                batch2,
+                batch3,
+            ]);
             expect(
                 warningSpy.calledWith(
                     'Offline batch storage is unavailable. Retaining batches in memory.'
                 )
             ).to.equal(true);
+        });
+
+        it('should not throw when offline storage retrieve returns null', async () => {
+            fetchMock.post(urls.events, 200);
+
+            window.mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const mpInstance = window.mParticle.getInstance();
+            const uploader = mpInstance._APIClient.uploader;
+
+            // Corrupt/empty offline storage parses to null. Spreading it
+            // unguarded would throw `null is not iterable` and leave the
+            // upload interval un-armed.
+            sinon.stub((<any>uploader).batchVault, 'retrieve').returns(null);
+
+            let threwError = false;
+            try {
+                await uploader.prepareAndUpload();
+            } catch (e) {
+                threwError = true;
+            }
+
+            expect(
+                threwError,
+                'prepareAndUpload should not throw on null retrieve'
+            ).to.equal(false);
         });
 
         it('should save batches in sequence to Local Storage when an HTTP 429 error is encountered', async () => {

--- a/test/src/tests-persistence.ts
+++ b/test/src/tests-persistence.ts
@@ -133,6 +133,29 @@ describe('persistence', () => {
             expect(localStorageData.gs.av, 'av').to.equal('2.3.4');
             expect(localStorageData.gs.ie, 'ie').to.equal(true);
         });
+
+        it('should not throw when saving persistence to localStorage fails', async () => {
+            mParticle.config.useCookieStorage = false;
+            mParticle.init(apiKey, mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const mpInstance = mParticle.getInstance();
+            const errorSpy = sinon.spy(mpInstance.Logger, 'error');
+            sinon.stub(Storage.prototype, 'setItem').throws(
+                new DOMException('Quota exceeded', 'QuotaExceededError')
+            );
+
+            expect(() => {
+                mpInstance._Persistence.savePersistence({
+                    gs: {},
+                } as IPersistenceMinified);
+            }).to.not.throw();
+            expect(
+                errorSpy.calledWith(
+                    'Error saving persistence to localStorage.'
+                )
+            ).to.equal(true);
+        });
     });
 
     describe('#swapCurrentUser', () => {

--- a/test/src/vault.spec.ts
+++ b/test/src/vault.spec.ts
@@ -5,6 +5,7 @@ import {
     DisabledVault,
     LocalStorageVault,
     SessionStorageVault,
+    StorageResult,
 } from '../../src/vault';
 
 const testObject: Dictionary<Dictionary<string>> = {
@@ -83,7 +84,7 @@ describe('Vault', () => {
                 );
             });
 
-            it('should return false when storage throws', () => {
+            it('should return QuotaExceeded when storage is over quota', () => {
                 const storageKey = 'test-key-store-quota-error';
                 const vault = new SessionStorageVault<
                     Dictionary<Dictionary<string>>
@@ -103,7 +104,37 @@ describe('Vault', () => {
                 try {
                     const result = vault.store(testObject);
 
-                    expect(result).to.equal(false);
+                    expect(result).to.equal(StorageResult.QuotaExceeded);
+                    expect(vault.contents).to.equal(null);
+                } finally {
+                    Object.defineProperty(Storage.prototype, 'setItem', {
+                        configurable: true,
+                        value: originalSetItem,
+                    });
+                }
+            });
+
+            it('should return Unavailable when storage is disabled', () => {
+                const storageKey = 'test-key-store-unavailable';
+                const vault = new SessionStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+                const originalSetItem = Storage.prototype.setItem;
+
+                Object.defineProperty(Storage.prototype, 'setItem', {
+                    configurable: true,
+                    value: function() {
+                        throw new DOMException(
+                            'Storage disabled',
+                            'SecurityError'
+                        );
+                    },
+                });
+
+                try {
+                    const result = vault.store(testObject);
+
+                    expect(result).to.equal(StorageResult.Unavailable);
                     expect(vault.contents).to.equal(null);
                 } finally {
                     Object.defineProperty(Storage.prototype, 'setItem', {
@@ -288,7 +319,7 @@ describe('Vault', () => {
                 );
             });
 
-            it('should return false when storage throws', () => {
+            it('should return QuotaExceeded when storage is over quota', () => {
                 const storageKey = 'test-key-store-quota-error';
                 const vault = new LocalStorageVault<
                     Dictionary<Dictionary<string>>
@@ -308,7 +339,37 @@ describe('Vault', () => {
                 try {
                     const result = vault.store(testObject);
 
-                    expect(result).to.equal(false);
+                    expect(result).to.equal(StorageResult.QuotaExceeded);
+                    expect(vault.contents).to.equal(null);
+                } finally {
+                    Object.defineProperty(Storage.prototype, 'setItem', {
+                        configurable: true,
+                        value: originalSetItem,
+                    });
+                }
+            });
+
+            it('should return Unavailable when storage is disabled', () => {
+                const storageKey = 'test-key-store-unavailable';
+                const vault = new LocalStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+                const originalSetItem = Storage.prototype.setItem;
+
+                Object.defineProperty(Storage.prototype, 'setItem', {
+                    configurable: true,
+                    value: function() {
+                        throw new DOMException(
+                            'Storage disabled',
+                            'SecurityError'
+                        );
+                    },
+                });
+
+                try {
+                    const result = vault.store(testObject);
+
+                    expect(result).to.equal(StorageResult.Unavailable);
                     expect(vault.contents).to.equal(null);
                 } finally {
                     Object.defineProperty(Storage.prototype, 'setItem', {

--- a/test/src/vault.spec.ts
+++ b/test/src/vault.spec.ts
@@ -82,6 +82,36 @@ describe('Vault', () => {
                     JSON.stringify(testNumber),
                 );
             });
+
+            it('should return false when storage throws', () => {
+                const storageKey = 'test-key-store-quota-error';
+                const vault = new SessionStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+                const originalSetItem = Storage.prototype.setItem;
+
+                Object.defineProperty(Storage.prototype, 'setItem', {
+                    configurable: true,
+                    value: function() {
+                        throw new DOMException(
+                            'Quota exceeded',
+                            'QuotaExceededError'
+                        );
+                    },
+                });
+
+                try {
+                    const result = vault.store(testObject);
+
+                    expect(result).to.equal(false);
+                    expect(vault.contents).to.equal(null);
+                } finally {
+                    Object.defineProperty(Storage.prototype, 'setItem', {
+                        configurable: true,
+                        value: originalSetItem,
+                    });
+                }
+            });
         });
 
         describe('#retrieve', () => {
@@ -256,6 +286,36 @@ describe('Vault', () => {
                 expect(window.localStorage.getItem(storageKey)).to.equal(
                     JSON.stringify(testNumber),
                 );
+            });
+
+            it('should return false when storage throws', () => {
+                const storageKey = 'test-key-store-quota-error';
+                const vault = new LocalStorageVault<
+                    Dictionary<Dictionary<string>>
+                >(storageKey);
+                const originalSetItem = Storage.prototype.setItem;
+
+                Object.defineProperty(Storage.prototype, 'setItem', {
+                    configurable: true,
+                    value: function() {
+                        throw new DOMException(
+                            'Quota exceeded',
+                            'QuotaExceededError'
+                        );
+                    },
+                });
+
+                try {
+                    const result = vault.store(testObject);
+
+                    expect(result).to.equal(false);
+                    expect(vault.contents).to.equal(null);
+                } finally {
+                    Object.defineProperty(Storage.prototype, 'setItem', {
+                        configurable: true,
+                        value: originalSetItem,
+                    });
+                }
             });
         });
 


### PR DESCRIPTION
## Background

- Partner error logs showed `QuotaExceededError` surfacing from the synchronous commerce event path, including `eCommerce.logImpression`.
- The SDK had unguarded Web Storage writes in persistence and vault storage paths, so localStorage/sessionStorage quota or blocked-storage failures could escape event logging.

## What Has Changed

- Makes vault storage best-effort by catching Web Storage read/write/remove failures and returning a boolean write result.
- Guards `savePersistence()` localStorage writes so quota failures are logged without throwing.
- Adds offline batch queue trimming that drops oldest batches until localStorage accepts the payload, while retaining batches in memory if storage is fully unavailable.
- Adds regression tests for vault write failures, persistence write failures, and offline batch trimming behavior.
- Rebuilds `dist/mparticle.js`.

## Verification

- `npm run build:iife`
- `npm run build:test-bundle`
- `npm run test:jest`
- `npx karma start test/karma.config.js --browsers ChromeHeadless --single-run`

## Screenshots/Video

- N/A

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally