### PR TITLE
fix(pre-init): stop processPreloadedItem mutating the shared ready-queue item

### DIFF
--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -25,8 +25,20 @@ export const processReadyQueue = (readyQueue): Function[] => {
 };
 
 const processPreloadedItem = (readyQueueItem): void => {
-    const args = readyQueueItem;
+    // Operate on a copy of the queued item. The ready queue can be drained more
+    // than once (e.g. a synchronous cache-hit identify re-enters processReadyQueue
+    // before the outer drain resets the queue). Splicing the shared item array in
+    // place would corrupt it on the second pass — ["Identity.login", opts] becomes
+    // [opts] — so `method` turns into a non-string/undefined and `method.split('.')`
+    // throws. Copying keeps the original item intact for any repeat pass.
+    const args = readyQueueItem.slice();
     const method = args.splice(0, 1)[0];
+
+    // Skip malformed queue entries (empty array or non-string method) instead of
+    // throwing an uncaught TypeError from method.split() below.
+    if (typeof method !== 'string' || method.length === 0) {
+        return;
+    }
 
     // if the first argument is a method on the base mParticle object, run it
     if (typeof window !== 'undefined' && window.mParticle && window.mParticle[args[0]]) {

--- a/test/jest/pre-init-utils.spec.ts
+++ b/test/jest/pre-init-utils.spec.ts
@@ -84,5 +84,44 @@ describe('pre-init-utils', () => {
             const readyQueue = [['Identity.login']];
             expect(() => processReadyQueue(readyQueue)).toThrowError("Unable to compute proper mParticle function TypeError: Cannot read properties of undefined (reading 'login')");
         });
+
+        it('should not mutate the queued item so it can be processed again', () => {
+            const functionSpy = jest.fn();
+            (window.mParticle as any) = {
+                fakeFunction: functionSpy,
+            };
+            const item = ['fakeFunction', 'foo'];
+
+            processReadyQueue([item]);
+            // The item must be left intact — a second drain must not see a stripped array.
+            expect(item).toEqual(['fakeFunction', 'foo']);
+
+            processReadyQueue([item]);
+            expect(functionSpy).toHaveBeenCalledTimes(2);
+            expect(functionSpy).toHaveBeenNthCalledWith(1, 'foo');
+            expect(functionSpy).toHaveBeenNthCalledWith(2, 'foo');
+        });
+
+        it('should not throw when the same queue is drained more than once (re-entrancy safe)', () => {
+            const functionSpy = jest.fn();
+            (window.mParticle as any) = {
+                fakeFunction: functionSpy,
+            };
+            const readyQueue = [['fakeFunction', 'foo']];
+
+            expect(() => {
+                processReadyQueue(readyQueue);
+                processReadyQueue(readyQueue);
+            }).not.toThrow();
+            expect(functionSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('should skip malformed queue items instead of throwing', () => {
+            (window.mParticle as any) = {};
+            // empty array -> method undefined; non-string method -> method.split would throw
+            expect(() => processReadyQueue([[]])).not.toThrow();
+            expect(() => processReadyQueue([[{} as any, 'arg']])).not.toThrow();
+            expect(() => processReadyQueue([[42 as any]])).not.toThrow();
+        });
     });
 });


### PR DESCRIPTION
## Problem

`processPreloadedItem` (`src/pre-init-utils.ts`) splices the queued item array **in place**:

```ts
const args = readyQueueItem;      // same reference as the item in the ready queue
const method = args.splice(0, 1)[0];
```

The ready queue can be drained more than once (e.g. a synchronous cache-hit `identify` re-enters `processReadyQueue` via `parseIdentityResponse` before the outer drain resets the queue). On a second pass over an already-consumed item, the array has already been stripped:

- `["Identity.login", opts]` → `[opts]` → `method` is an object → `method.split('.')` throws `"e.split is not a function"`
- `["logEvent"]` → `[]` → `method` is `undefined` → `"Cannot read properties of undefined (reading 'split')"`

`method.split('.')` is outside the local `try/catch`, so the TypeError propagates up through `sendIdentityRequest` and is reported with code `IDENTITY_REQUEST` (`"Error sending identity request to servers - ..."`) — even though the identity request itself succeeded. This surfaces as a high volume of misleading `IDENTITY_REQUEST` client-error reports.

## Fix

- Operate on a **copy** of the queued item (`readyQueueItem.slice()`) so a repeat drain cannot corrupt the shared array.
- **Skip malformed entries** (empty array / non-string method) instead of throwing an uncaught TypeError.

Existing behaviour is otherwise unchanged (all pre-existing tests pass untouched).

## Tests

Full jest suite green. Added regression tests in `test/jest/pre-init-utils.spec.ts`:

- the queued item is not mutated after processing (can be drained again)
- draining the same queue twice does not throw
- malformed items (empty array, non-string method) are skipped

## Follow-up (not in this PR)

This stops the crash and the mislabelled `IDENTITY_REQUEST` errors. A complementary hardening is to make the ready-queue drain itself re-entrancy-safe (reset the queue before draining) so a queued method is not executed twice under re-entrancy. There is also a separate latent issue at the `window.mParticle[args[0]]` membership check (it should key off `method`), left untouched here to keep the diff surgical.
