### PR TITLE
feat: inject passbackconversiontrackingid into selectPlacements attributes

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -1560,7 +1560,8 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
                 roktOptions,
                 mpInstance.captureTiming,
                 mpInstance._ErrorReportingDispatcher,
-                mpInstance._LoggingDispatcher
+                mpInstance._LoggingDispatcher,
+                mpInstance._IntegrationCapture,
             );
         }
 

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -374,6 +374,7 @@ export default class RoktManager {
             }
 
             if (!enrichedAttributes[PASSBACK_CONVERSION_TRACKING_ID]) {
+                this.integrationCapture?.capture();
                 const capturedAttrs = this.integrationCapture?.getClickIdsAsIntegrationAttributes();
                 const passbackId = capturedAttrs?.[PARTNER_MODULE_IDS.Rokt]?.[PASSBACK_CONVERSION_TRACKING_ID];
                 if (passbackId) {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -18,6 +18,10 @@ import { UserIdentities } from "@mparticle/web-sdk";
 import { IdentityType, PerformanceMarkType } from "./types";
 import { ErrorCodes, IErrorReportingService, ILoggingService, WSDKErrorSeverity } from "./reporting/types";
 import { IRoktLauncherOptions, normalizeRoktLauncherOptions } from "./roktLauncherOptions";
+import { PARTNER_MODULE_IDS } from "./cookieSyncManager";
+import IntegrationCapture from "./integrationCapture";
+
+const PASSBACK_CONVERSION_TRACKING_ID = 'passbackconversiontrackingid';
 
 // https://docs.rokt.com/developers/integration-guides/web/library/attributes
 export type RoktAttributeValueArray = Array<string | number | boolean>;
@@ -118,6 +122,7 @@ export default class RoktManager {
     private domain?: string;
     private mappedEmailShaIdentityType?: string | null;
     private captureTiming?: (metricsName: string) => void;
+    private integrationCapture?: IntegrationCapture;
     private onReadyCallback: (() => void) | null = null;
     private initialized: boolean = false;
     private isShoppableAdsLoaded: boolean = false;
@@ -152,7 +157,8 @@ export default class RoktManager {
         options?: IRoktOptions,
         captureTiming?: (metricsName: string) => void,
         errorReporter?: IErrorReportingService,
-        loggingService?: ILoggingService
+        loggingService?: ILoggingService,
+        integrationCapture?: IntegrationCapture,
     ): void {
         const { userAttributeFilters, settings } = roktConfig || {};
         const { placementAttributesMapping, hashedEmailUserIdentityType } = settings || {};
@@ -164,6 +170,7 @@ export default class RoktManager {
         this.errorReporter = errorReporter;
         this.loggingService = loggingService;
         this.captureTiming = captureTiming;
+        this.integrationCapture = integrationCapture;
 
         this.captureTiming?.(PerformanceMarkType.JointSdkRoktKitInit);
 
@@ -363,6 +370,14 @@ export default class RoktManager {
                     !enrichedAttributes[this.mappedEmailShaIdentityType]
                 ) {
                     enrichedAttributes.emailsha256 = hashedEmail;
+                }
+            }
+
+            if (!enrichedAttributes[PASSBACK_CONVERSION_TRACKING_ID]) {
+                const capturedAttrs = this.integrationCapture?.getClickIdsAsIntegrationAttributes();
+                const passbackId = capturedAttrs?.[PARTNER_MODULE_IDS.Rokt]?.[PASSBACK_CONVERSION_TRACKING_ID];
+                if (passbackId) {
+                    enrichedAttributes[PASSBACK_CONVERSION_TRACKING_ID] = passbackId;
                 }
             }
 

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -2555,6 +2555,108 @@ describe('RoktManager', () => {
                 `mParticle.Rokt selectPlacements called with attributes:\n${JSON.stringify({ email: 'string', customAttr: 'string' }, null, 2)}`
             );
         });
+
+        describe('passbackconversiontrackingid injection', () => {
+            let kit: IRoktKit;
+
+            beforeEach(() => {
+                kit = {
+                    launcher: {
+                        selectPlacements: jest.fn().mockResolvedValue({ close: jest.fn(), getPlacements: jest.fn() }),
+                        hashAttributes: jest.fn(),
+                        use: jest.fn(),
+                    },
+                    filters: undefined,
+                    filteredUser: undefined,
+                    userAttributes: undefined,
+                    selectPlacements: jest.fn().mockResolvedValue({ close: jest.fn(), getPlacements: jest.fn() }),
+                    hashAttributes: jest.fn(),
+                    setExtensionData: jest.fn(),
+                    use: jest.fn(),
+                    onShoppableAdsReady: jest.fn(),
+                };
+
+                roktManager.attachKit(kit);
+                roktManager['store'].identityCallInFlight = false;
+            });
+
+            it('should inject passbackconversiontrackingid from IntegrationCapture when not provided by partner', async () => {
+                roktManager['integrationCapture'] = {
+                    getClickIdsAsIntegrationAttributes: jest.fn().mockReturnValue({
+                        1277: { passbackconversiontrackingid: 'rclid-from-capture' },
+                    }),
+                } as any;
+
+                await roktManager.selectPlacements({
+                    attributes: { email: 'user@example.com' },
+                });
+
+                expect(kit.selectPlacements).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        attributes: expect.objectContaining({
+                            passbackconversiontrackingid: 'rclid-from-capture',
+                        }),
+                    }),
+                );
+            });
+
+            it('should not overwrite passbackconversiontrackingid when partner explicitly provides it', async () => {
+                roktManager['integrationCapture'] = {
+                    getClickIdsAsIntegrationAttributes: jest.fn().mockReturnValue({
+                        1277: { passbackconversiontrackingid: 'rclid-from-capture' },
+                    }),
+                } as any;
+
+                await roktManager.selectPlacements({
+                    attributes: {
+                        email: 'user@example.com',
+                        passbackconversiontrackingid: 'partner-provided-rclid',
+                    },
+                });
+
+                expect(kit.selectPlacements).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        attributes: expect.objectContaining({
+                            passbackconversiontrackingid: 'partner-provided-rclid',
+                        }),
+                    }),
+                );
+            });
+
+            it('should not inject passbackconversiontrackingid when IntegrationCapture has no Rokt attributes', async () => {
+                roktManager['integrationCapture'] = {
+                    getClickIdsAsIntegrationAttributes: jest.fn().mockReturnValue({}),
+                } as any;
+
+                await roktManager.selectPlacements({
+                    attributes: { email: 'user@example.com' },
+                });
+
+                expect(kit.selectPlacements).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        attributes: expect.not.objectContaining({
+                            passbackconversiontrackingid: expect.anything(),
+                        }),
+                    }),
+                );
+            });
+
+            it('should not inject passbackconversiontrackingid when IntegrationCapture is not provided', async () => {
+                roktManager['integrationCapture'] = undefined;
+
+                await roktManager.selectPlacements({
+                    attributes: { email: 'user@example.com' },
+                });
+
+                expect(kit.selectPlacements).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        attributes: expect.not.objectContaining({
+                            passbackconversiontrackingid: expect.anything(),
+                        }),
+                    }),
+                );
+            });
+        });
     });
 
     describe('#setExtensionData', () => {

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -2582,6 +2582,7 @@ describe('RoktManager', () => {
 
             it('should inject passbackconversiontrackingid from IntegrationCapture when not provided by partner', async () => {
                 roktManager['integrationCapture'] = {
+                    capture: jest.fn(),
                     getClickIdsAsIntegrationAttributes: jest.fn().mockReturnValue({
                         1277: { passbackconversiontrackingid: 'rclid-from-capture' },
                     }),
@@ -2600,8 +2601,25 @@ describe('RoktManager', () => {
                 );
             });
 
+            it('should call capture() before reading to pick up late-arriving IDs', async () => {
+                const mockCapture = jest.fn();
+                roktManager['integrationCapture'] = {
+                    capture: mockCapture,
+                    getClickIdsAsIntegrationAttributes: jest.fn().mockReturnValue({
+                        1277: { passbackconversiontrackingid: 'fresh-rclid' },
+                    }),
+                } as any;
+
+                await roktManager.selectPlacements({
+                    attributes: { email: 'user@example.com' },
+                });
+
+                expect(mockCapture).toHaveBeenCalled();
+            });
+
             it('should not overwrite passbackconversiontrackingid when partner explicitly provides it', async () => {
                 roktManager['integrationCapture'] = {
+                    capture: jest.fn(),
                     getClickIdsAsIntegrationAttributes: jest.fn().mockReturnValue({
                         1277: { passbackconversiontrackingid: 'rclid-from-capture' },
                     }),
@@ -2625,6 +2643,7 @@ describe('RoktManager', () => {
 
             it('should not inject passbackconversiontrackingid when IntegrationCapture has no Rokt attributes', async () => {
                 roktManager['integrationCapture'] = {
+                    capture: jest.fn(),
                     getClickIdsAsIntegrationAttributes: jest.fn().mockReturnValue({}),
                 } as any;
 


### PR DESCRIPTION
## Background
- When a joint SDK partner implements the mParticle Web SDK (which loads the Rokt SDK), the `IntegrationCapture` module automatically captures `rclid`/`rtid`/`RoktTransactionId` from URL query params, cookies, or localStorage and stores it as `integrationAttributes[1277].passbackconversiontrackingid`. However, this captured value was never being injected into the attributes passed to the Rokt SDK's `selectPlacements` call, meaning returning users could not be attributed back to the original Rokt placement that drove them. This is a use case for partners turned advertisers who implemented conversions not using mparticle.logevent, but are still using `mParticle.Rokt.selectPlacements...`

## What Has Changed
- `RoktManager.selectPlacements()` now reads `passbackconversiontrackingid` from `store.integrationAttributes[1277]` (populated by `IntegrationCapture`) and merges it into the enriched attributes before forwarding to the Rokt Kit.
- The partner-supplied value takes precedence — if the partner explicitly passes `passbackconversiontrackingid` in their attributes, it is not overwritten.
- Added 3 unit tests covering: injection when present, no-overwrite when partner supplies it, and no-injection when the store is empty.