### PR TITLE
fix(pre-init): drain ready queue before processing to stop re-entrant re-execution

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -1657,7 +1657,8 @@ export default function Identity(mpInstance) {
         mpInstance._RoktManager.onIdentityComplete();
 
         mpInstance._preInit.readyQueue = processReadyQueue(
-            mpInstance._preInit.readyQueue
+            mpInstance._preInit.readyQueue,
+            mpInstance.Logger
         );
     };
 

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -162,7 +162,10 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
 
         if (self._Store?.identityCallFailed && self._RoktManager?.isReady()) {
             self._RoktManager.processMessageQueue();
-            self._preInit.readyQueue = processReadyQueue(self._preInit.readyQueue);
+            self._preInit.readyQueue = processReadyQueue(
+                self._preInit.readyQueue,
+                self.Logger
+            );
         }
     };
 
@@ -179,7 +182,10 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             !hasExplicitIdentifier(self._Store);
 
         if (noFunctionalWithoutId) {
-            self._preInit.readyQueue = processReadyQueue(self._preInit.readyQueue);
+            self._preInit.readyQueue = processReadyQueue(
+                self._preInit.readyQueue,
+                self.Logger
+            );
         }
     };
 
@@ -1599,7 +1605,8 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
         );
 
         mpInstance._preInit.readyQueue = processReadyQueue(
-            mpInstance._preInit.readyQueue
+            mpInstance._preInit.readyQueue,
+            mpInstance.Logger
         );
     }
 

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -47,8 +47,6 @@ export const processReadyQueue = (
 };
 
 const formatReadyQueueItemError = (e: unknown): string => {
-    // Only Errors and strings are described; anything else would stringify to
-    // "[object Object]" and tell us nothing.
     let detail = 'unknown error';
     if (e instanceof Error) {
         detail = e.message;

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -1,5 +1,6 @@
 import { IPixelConfiguration } from './cookieSyncManager';
 import { MPForwarder } from './forwarders.interfaces';
+import { Logger } from './logger';
 import { IntegrationDelays } from './mp-instance';
 import { isEmpty, isFunction } from './utils';
 
@@ -11,7 +12,10 @@ export interface IPreInit {
     isDevelopmentMode?: boolean;
 }
 
-export const processReadyQueue = (readyQueue): Function[] => {
+export const processReadyQueue = (
+    readyQueue,
+    logger: Logger
+): Function[] => {
     if (isEmpty(readyQueue)) {
         return [];
     }
@@ -35,18 +39,14 @@ export const processReadyQueue = (readyQueue): Function[] => {
                 processPreloadedItem(readyQueueItem);
             }
         } catch (e) {
-            logReadyQueueItemError(e);
+            logger.error(formatReadyQueueItemError(e));
         }
     });
 
     return [];
 };
 
-const logReadyQueueItemError = (e: unknown): void => {
-    if (typeof window === 'undefined') {
-        return;
-    }
-
+const formatReadyQueueItemError = (e: unknown): string => {
     // Only Errors and strings are described; anything else would stringify to
     // "[object Object]" and tell us nothing.
     let detail = 'unknown error';
@@ -55,9 +55,7 @@ const logReadyQueueItemError = (e: unknown): void => {
     } else if (typeof e === 'string') {
         detail = e;
     }
-
-    const logger = (window as any)?.mParticle?.getInstance?.()?.Logger;
-    logger?.error?.('Error processing ready queue item: ' + detail);
+    return 'Error processing ready queue item: ' + detail;
 };
 
 const processPreloadedItem = (readyQueueItem): void => {

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -1,7 +1,7 @@
 import { IPixelConfiguration } from './cookieSyncManager';
 import { MPForwarder } from './forwarders.interfaces';
-import { Logger } from './logger';
 import { IntegrationDelays } from './mp-instance';
+import { SDKLoggerApi } from './sdkRuntimeModels';
 import { isEmpty, isFunction } from './utils';
 
 export interface IPreInit {
@@ -14,7 +14,7 @@ export interface IPreInit {
 
 export const processReadyQueue = (
     readyQueue,
-    logger: Logger
+    logger: SDKLoggerApi
 ): Function[] => {
     if (isEmpty(readyQueue)) {
         return [];

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -16,14 +16,12 @@ export const processReadyQueue = (readyQueue): Function[] => {
         return [];
     }
 
-    // Drain the shared queue in place before processing. Callers only replace
-    // `_preInit.readyQueue` with the returned `[]` *after* this function
-    // returns, so a synchronous re-entry (e.g. cache-hit identify →
-    // parseIdentityResponse → processReadyQueue) still sees the same array
-    // reference. Taking the items up front means that nested call observes an
-    // empty queue and cannot re-execute the same entries — which would
-    // otherwise duplicate Identity/event calls, or nest
-    // "Unable to compute proper mParticle function" errors when an item fails.
+    // Without draining first, sync re-entry (cache-hit identify →
+    // parseIdentityResponse → processReadyQueue) re-iterates the same array:
+    // callers only replace `_preInit.readyQueue` with [] after we return, so the
+    // nested call still sees every entry. That duplicates Identity/event calls
+    // and can nest "Unable to compute proper mParticle function" wraps.
+    // Splice the queue empty up front so a nested call observes [].
     const items = readyQueue.splice(0, readyQueue.length);
 
     items.forEach(readyQueueItem => {

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -12,25 +12,34 @@ export interface IPreInit {
 }
 
 export const processReadyQueue = (readyQueue): Function[] => {
-    if (!isEmpty(readyQueue)) {
-        readyQueue.forEach(readyQueueItem => {
-            if (isFunction(readyQueueItem)) {
-                readyQueueItem();
-            } else if (Array.isArray(readyQueueItem)) {
-                processPreloadedItem(readyQueueItem);
-            }
-        });
+    if (isEmpty(readyQueue)) {
+        return [];
     }
+
+    // Drain the shared queue in place before processing. Callers only replace
+    // `_preInit.readyQueue` with the returned `[]` *after* this function
+    // returns, so a synchronous re-entry (e.g. cache-hit identify →
+    // parseIdentityResponse → processReadyQueue) still sees the same array
+    // reference. Taking the items up front means that nested call observes an
+    // empty queue and cannot re-execute the same entries — which would
+    // otherwise duplicate Identity/event calls, or nest
+    // "Unable to compute proper mParticle function" errors when an item fails.
+    const items = readyQueue.splice(0, readyQueue.length);
+
+    items.forEach(readyQueueItem => {
+        if (isFunction(readyQueueItem)) {
+            readyQueueItem();
+        } else if (Array.isArray(readyQueueItem)) {
+            processPreloadedItem(readyQueueItem);
+        }
+    });
+
     return [];
 };
 
 const processPreloadedItem = (readyQueueItem): void => {
-    // Operate on a copy of the queued item. The ready queue can be drained more
-    // than once (e.g. a synchronous cache-hit identify re-enters processReadyQueue
-    // before the outer drain resets the queue). Splicing the shared item array in
-    // place would corrupt it on the second pass — ["Identity.login", opts] becomes
-    // [opts] — so `method` turns into a non-string/undefined and `method.split('.')`
-    // throws. Copying keeps the original item intact for any repeat pass.
+    // Operate on a copy so processPreloadedItem never mutates the caller's
+    // queued item array (defensive; the queue itself is drained above).
     const args = readyQueueItem.slice();
     const method = args.splice(0, 1)[0];
 

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -43,18 +43,21 @@ export const processReadyQueue = (readyQueue): Function[] => {
 };
 
 const logReadyQueueItemError = (e: unknown): void => {
-    const message =
-        'Error processing ready queue item: ' +
-        ((e as Error)?.message || String(e));
-    try {
-        const logger = (window as any)?.mParticle?.getInstance?.()?.Logger;
-        if (logger?.error) {
-            logger.error(message);
-            return;
-        }
-    } catch (_) {
-        // Fall through if instance/logger lookup fails.
+    if (typeof window === 'undefined') {
+        return;
     }
+
+    // Only Errors and strings are described; anything else would stringify to
+    // "[object Object]" and tell us nothing.
+    let detail = 'unknown error';
+    if (e instanceof Error) {
+        detail = e.message;
+    } else if (typeof e === 'string') {
+        detail = e;
+    }
+
+    const logger = (window as any)?.mParticle?.getInstance?.()?.Logger;
+    logger?.error?.('Error processing ready queue item: ' + detail);
 };
 
 const processPreloadedItem = (readyQueueItem): void => {

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -24,15 +24,37 @@ export const processReadyQueue = (readyQueue): Function[] => {
     // Splice the queue empty up front so a nested call observes [].
     const items = readyQueue.splice(0, readyQueue.length);
 
+    // Isolate each item so one throw cannot abort the rest of this pass.
+    // Drain-first already removed siblings from the shared queue; without a
+    // per-item catch they would be lost forever when forEach aborts.
     items.forEach(readyQueueItem => {
-        if (isFunction(readyQueueItem)) {
-            readyQueueItem();
-        } else if (Array.isArray(readyQueueItem)) {
-            processPreloadedItem(readyQueueItem);
+        try {
+            if (isFunction(readyQueueItem)) {
+                readyQueueItem();
+            } else if (Array.isArray(readyQueueItem)) {
+                processPreloadedItem(readyQueueItem);
+            }
+        } catch (e) {
+            logReadyQueueItemError(e);
         }
     });
 
     return [];
+};
+
+const logReadyQueueItemError = (e: unknown): void => {
+    const message =
+        'Error processing ready queue item: ' +
+        ((e as Error)?.message || String(e));
+    try {
+        const logger = (window as any)?.mParticle?.getInstance?.()?.Logger;
+        if (logger?.error) {
+            logger.error(message);
+            return;
+        }
+    } catch (_) {
+        // Fall through if instance/logger lookup fails.
+    }
 };
 
 const processPreloadedItem = (readyQueueItem): void => {

--- a/test/jest/pre-init-utils.spec.ts
+++ b/test/jest/pre-init-utils.spec.ts
@@ -80,9 +80,56 @@ describe('pre-init-utils', () => {
             expect(functionSpy2).toHaveBeenCalledWith('bar');
         });
 
-        it('should throw an error if it cannot compute the proper mParticle function', () => {
+        it('should not throw when it cannot compute the proper mParticle function', () => {
+            // processPreloadedItem still throws, but processReadyQueue catches
+            // per item so a bad entry cannot abort the drain.
             const readyQueue = [['Identity.login']];
-            expect(() => processReadyQueue(readyQueue)).toThrowError("Unable to compute proper mParticle function TypeError: Cannot read properties of undefined (reading 'login')");
+            expect(() => processReadyQueue(readyQueue)).not.toThrow();
+            expect(readyQueue).toEqual([]);
+        });
+
+        it('should continue processing siblings after an item throws', () => {
+            const afterSpy = jest.fn();
+            const loggerError = jest.fn();
+            (window.mParticle as any) = {
+                getInstance: () => ({ Logger: { error: loggerError } }),
+                afterMethod: afterSpy,
+            };
+
+            const readyQueue = [
+                ['Identity.login'], // unresolved → throws inside processPreloadedItem
+                ['afterMethod', 'kept'],
+            ];
+
+            expect(() => processReadyQueue(readyQueue)).not.toThrow();
+            expect(afterSpy).toHaveBeenCalledTimes(1);
+            expect(afterSpy).toHaveBeenCalledWith('kept');
+            expect(readyQueue).toEqual([]);
+            expect(loggerError).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    'Error processing ready queue item: Unable to compute proper mParticle function'
+                )
+            );
+        });
+
+        it('should continue after a queued function throws', () => {
+            const afterSpy = jest.fn();
+            const loggerError = jest.fn();
+            (window.mParticle as any) = {
+                getInstance: () => ({ Logger: { error: loggerError } }),
+            };
+
+            processReadyQueue([
+                () => {
+                    throw new Error('callback blew up');
+                },
+                afterSpy,
+            ]);
+
+            expect(afterSpy).toHaveBeenCalledTimes(1);
+            expect(loggerError).toHaveBeenCalledWith(
+                'Error processing ready queue item: callback blew up'
+            );
         });
 
         it('should not mutate the queued item array itself', () => {

--- a/test/jest/pre-init-utils.spec.ts
+++ b/test/jest/pre-init-utils.spec.ts
@@ -1,10 +1,10 @@
 import { processReadyQueue } from '../../src/pre-init-utils';
-import { Logger } from '../../src/logger';
+import { SDKLoggerApi } from '../../src/sdkRuntimeModels';
 
 describe('pre-init-utils', () => {
     describe('#processReadyQueue', () => {
-        const createMockLogger = (): Logger => {
-            return { error: jest.fn() } as unknown as Logger;
+        const createMockLogger = (): SDKLoggerApi => {
+            return { error: jest.fn() } as unknown as SDKLoggerApi;
         };
 
         it('should return an empty array if readyQueue is empty', () => {

--- a/test/jest/pre-init-utils.spec.ts
+++ b/test/jest/pre-init-utils.spec.ts
@@ -1,16 +1,21 @@
 import { processReadyQueue } from '../../src/pre-init-utils';
+import { Logger } from '../../src/logger';
 
 describe('pre-init-utils', () => {
     describe('#processReadyQueue', () => {
+        const createMockLogger = (): Logger => {
+            return { error: jest.fn() } as unknown as Logger;
+        };
+
         it('should return an empty array if readyQueue is empty', () => {
-            const result = processReadyQueue([]);
+            const result = processReadyQueue([], createMockLogger());
             expect(result).toEqual([]);
         });
 
         it('should process functions passed as arguments', () => {
             const functionSpy = jest.fn();
             const readyQueue: Function[] = [functionSpy, functionSpy, functionSpy];
-            const result = processReadyQueue(readyQueue);
+            const result = processReadyQueue(readyQueue, createMockLogger());
             expect(functionSpy).toHaveBeenCalledTimes(3);
             expect(result).toEqual([]);
         });
@@ -28,7 +33,7 @@ describe('pre-init-utils', () => {
                 functionSpy,
             ];
             
-            processReadyQueue(readyQueue);
+            processReadyQueue(readyQueue, createMockLogger());
             
             expect(functionSpy).toHaveBeenCalledTimes(2);
             expect(arraySpy).toHaveBeenCalledWith('arg1');
@@ -40,7 +45,7 @@ describe('pre-init-utils', () => {
                 fakeFunction: functionSpy,
             };
             const readyQueue = [['fakeFunction']];
-            processReadyQueue(readyQueue);
+            processReadyQueue(readyQueue, createMockLogger());
             expect(functionSpy).toHaveBeenCalled();
         });
 
@@ -51,7 +56,7 @@ describe('pre-init-utils', () => {
                 args: () => {},
             };
             const readyQueue = [['fakeFunction', 'args']];
-            processReadyQueue(readyQueue);
+            processReadyQueue(readyQueue, createMockLogger());
             expect(functionSpy).toHaveBeenCalledWith('args');
         });
 
@@ -63,7 +68,7 @@ describe('pre-init-utils', () => {
                 },
             };
             const readyQueue = [['fakeFunction.anotherFakeFunction', 'foo']];
-            processReadyQueue(readyQueue);
+            processReadyQueue(readyQueue, createMockLogger());
             expect(functionSpy).toHaveBeenCalledWith('foo');
         });
 
@@ -75,7 +80,7 @@ describe('pre-init-utils', () => {
                 anotherFakeFunction: functionSpy2,
             };
             const readyQueue = [['fakeFunction', 'foo'], ['anotherFakeFunction', 'bar']];
-            processReadyQueue(readyQueue);
+            processReadyQueue(readyQueue, createMockLogger());
             expect(functionSpy).toHaveBeenCalledWith('foo');
             expect(functionSpy2).toHaveBeenCalledWith('bar');
         });
@@ -84,15 +89,16 @@ describe('pre-init-utils', () => {
             // processPreloadedItem still throws, but processReadyQueue catches
             // per item so a bad entry cannot abort the drain.
             const readyQueue = [['Identity.login']];
-            expect(() => processReadyQueue(readyQueue)).not.toThrow();
+            expect(() =>
+                processReadyQueue(readyQueue, createMockLogger())
+            ).not.toThrow();
             expect(readyQueue).toEqual([]);
         });
 
         it('should continue processing siblings after an item throws', () => {
             const afterSpy = jest.fn();
-            const loggerError = jest.fn();
+            const logger = createMockLogger();
             (window.mParticle as any) = {
-                getInstance: () => ({ Logger: { error: loggerError } }),
                 afterMethod: afterSpy,
             };
 
@@ -101,11 +107,11 @@ describe('pre-init-utils', () => {
                 ['afterMethod', 'kept'],
             ];
 
-            expect(() => processReadyQueue(readyQueue)).not.toThrow();
+            expect(() => processReadyQueue(readyQueue, logger)).not.toThrow();
             expect(afterSpy).toHaveBeenCalledTimes(1);
             expect(afterSpy).toHaveBeenCalledWith('kept');
             expect(readyQueue).toEqual([]);
-            expect(loggerError).toHaveBeenCalledWith(
+            expect(logger.error).toHaveBeenCalledWith(
                 expect.stringContaining(
                     'Error processing ready queue item: Unable to compute proper mParticle function'
                 )
@@ -114,20 +120,20 @@ describe('pre-init-utils', () => {
 
         it('should continue after a queued function throws', () => {
             const afterSpy = jest.fn();
-            const loggerError = jest.fn();
-            (window.mParticle as any) = {
-                getInstance: () => ({ Logger: { error: loggerError } }),
-            };
+            const logger = createMockLogger();
 
-            processReadyQueue([
-                () => {
-                    throw new Error('callback blew up');
-                },
-                afterSpy,
-            ]);
+            processReadyQueue(
+                [
+                    () => {
+                        throw new Error('callback blew up');
+                    },
+                    afterSpy,
+                ],
+                logger
+            );
 
             expect(afterSpy).toHaveBeenCalledTimes(1);
-            expect(loggerError).toHaveBeenCalledWith(
+            expect(logger.error).toHaveBeenCalledWith(
                 'Error processing ready queue item: callback blew up'
             );
         });
@@ -139,7 +145,7 @@ describe('pre-init-utils', () => {
             };
             const item = ['fakeFunction', 'foo'];
 
-            processReadyQueue([item]);
+            processReadyQueue([item], createMockLogger());
             // Item-level copy keeps the call shape intact even though the
             // containing queue is drained.
             expect(item).toEqual(['fakeFunction', 'foo']);
@@ -153,10 +159,11 @@ describe('pre-init-utils', () => {
                 fakeFunction: functionSpy,
             };
             const readyQueue = [['fakeFunction', 'foo']];
+            const logger = createMockLogger();
 
             expect(() => {
-                processReadyQueue(readyQueue);
-                processReadyQueue(readyQueue);
+                processReadyQueue(readyQueue, logger);
+                processReadyQueue(readyQueue, logger);
             }).not.toThrow();
             expect(readyQueue).toEqual([]);
             expect(functionSpy).toHaveBeenCalledTimes(1);
@@ -173,6 +180,7 @@ describe('pre-init-utils', () => {
             const functionSpy = jest.fn();
             const readyQueue: any[] = [];
             let hasReentered = false;
+            const logger = createMockLogger();
 
             (window.mParticle as any) = {
                 fakeFunction: (...args: any[]) => {
@@ -182,7 +190,7 @@ describe('pre-init-utils', () => {
                     // recurse forever; with it we get a clear 4-vs-2 assertion.
                     if (!hasReentered) {
                         hasReentered = true;
-                        processReadyQueue(readyQueue);
+                        processReadyQueue(readyQueue, logger);
                     }
                 },
             };
@@ -192,7 +200,7 @@ describe('pre-init-utils', () => {
                 ['fakeFunction', 'second']
             );
 
-            processReadyQueue(readyQueue);
+            processReadyQueue(readyQueue, logger);
 
             // Primary symptom: without drain-first this is 4 (each item twice).
             expect(functionSpy).toHaveBeenCalledTimes(2);
@@ -203,10 +211,13 @@ describe('pre-init-utils', () => {
 
         it('should skip malformed queue items instead of throwing', () => {
             (window.mParticle as any) = {};
+            const logger = createMockLogger();
             // empty array -> method undefined; non-string method -> method.split would throw
-            expect(() => processReadyQueue([[]])).not.toThrow();
-            expect(() => processReadyQueue([[{} as any, 'arg']])).not.toThrow();
-            expect(() => processReadyQueue([[42 as any]])).not.toThrow();
+            expect(() => processReadyQueue([[]], logger)).not.toThrow();
+            expect(() =>
+                processReadyQueue([[{} as any, 'arg']], logger)
+            ).not.toThrow();
+            expect(() => processReadyQueue([[42 as any]], logger)).not.toThrow();
         });
     });
 });

--- a/test/jest/pre-init-utils.spec.ts
+++ b/test/jest/pre-init-utils.spec.ts
@@ -85,7 +85,7 @@ describe('pre-init-utils', () => {
             expect(() => processReadyQueue(readyQueue)).toThrowError("Unable to compute proper mParticle function TypeError: Cannot read properties of undefined (reading 'login')");
         });
 
-        it('should not mutate the queued item so it can be processed again', () => {
+        it('should not mutate the queued item array itself', () => {
             const functionSpy = jest.fn();
             (window.mParticle as any) = {
                 fakeFunction: functionSpy,
@@ -93,16 +93,14 @@ describe('pre-init-utils', () => {
             const item = ['fakeFunction', 'foo'];
 
             processReadyQueue([item]);
-            // The item must be left intact — a second drain must not see a stripped array.
+            // Item-level copy keeps the call shape intact even though the
+            // containing queue is drained.
             expect(item).toEqual(['fakeFunction', 'foo']);
-
-            processReadyQueue([item]);
-            expect(functionSpy).toHaveBeenCalledTimes(2);
-            expect(functionSpy).toHaveBeenNthCalledWith(1, 'foo');
-            expect(functionSpy).toHaveBeenNthCalledWith(2, 'foo');
+            expect(functionSpy).toHaveBeenCalledTimes(1);
+            expect(functionSpy).toHaveBeenCalledWith('foo');
         });
 
-        it('should not throw when the same queue is drained more than once (re-entrancy safe)', () => {
+        it('should empty the shared queue so a second drain is a no-op', () => {
             const functionSpy = jest.fn();
             (window.mParticle as any) = {
                 fakeFunction: functionSpy,
@@ -113,7 +111,38 @@ describe('pre-init-utils', () => {
                 processReadyQueue(readyQueue);
                 processReadyQueue(readyQueue);
             }).not.toThrow();
+            expect(readyQueue).toEqual([]);
+            expect(functionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not re-execute items when processReadyQueue re-enters on the same array', () => {
+            const functionSpy = jest.fn();
+            const readyQueue: any[] = [];
+
+            (window.mParticle as any) = {
+                // Mimic cache-hit identify: executing a queued method re-enters
+                // processReadyQueue on the shared ready-queue array before the
+                // outer call has returned / been reassigned.
+                fakeFunction: (...args: any[]) => {
+                    functionSpy(...args);
+                    processReadyQueue(readyQueue);
+                },
+            };
+
+            readyQueue.push(
+                ['fakeFunction', 'first'],
+                ['fakeFunction', 'second']
+            );
+
+            processReadyQueue(readyQueue);
+
+            expect(readyQueue).toEqual([]);
+            // Drain-first ensures the nested call sees an empty queue. Without
+            // it, the nested call would re-run remaining (or all) items and
+            // recurse via fakeFunction.
             expect(functionSpy).toHaveBeenCalledTimes(2);
+            expect(functionSpy).toHaveBeenNthCalledWith(1, 'first');
+            expect(functionSpy).toHaveBeenNthCalledWith(2, 'second');
         });
 
         it('should skip malformed queue items instead of throwing', () => {

--- a/test/jest/pre-init-utils.spec.ts
+++ b/test/jest/pre-init-utils.spec.ts
@@ -116,16 +116,27 @@ describe('pre-init-utils', () => {
         });
 
         it('should not re-execute items when processReadyQueue re-enters on the same array', () => {
+            // Symptom this guards against (pre drain-first fix):
+            //   readyQueue = [login-like, logEvent-like]
+            //   outer drain runs item[0] → sync parseIdentityResponse re-enters
+            //   processReadyQueue on the SAME array → item[0] and item[1] run
+            //   again, then outer continues and runs item[1] again.
+            // Observed: each queued method fires twice (4 spy calls below).
+            // With drain-first: nested call sees [], each method fires once.
             const functionSpy = jest.fn();
             const readyQueue: any[] = [];
+            let hasReentered = false;
 
             (window.mParticle as any) = {
-                // Mimic cache-hit identify: executing a queued method re-enters
-                // processReadyQueue on the shared ready-queue array before the
-                // outer call has returned / been reassigned.
                 fakeFunction: (...args: any[]) => {
                     functionSpy(...args);
-                    processReadyQueue(readyQueue);
+                    // One-shot re-entry mimics a single cache-hit identity
+                    // completing mid-drain. Without the guard this would
+                    // recurse forever; with it we get a clear 4-vs-2 assertion.
+                    if (!hasReentered) {
+                        hasReentered = true;
+                        processReadyQueue(readyQueue);
+                    }
                 },
             };
 
@@ -136,13 +147,11 @@ describe('pre-init-utils', () => {
 
             processReadyQueue(readyQueue);
 
-            expect(readyQueue).toEqual([]);
-            // Drain-first ensures the nested call sees an empty queue. Without
-            // it, the nested call would re-run remaining (or all) items and
-            // recurse via fakeFunction.
+            // Primary symptom: without drain-first this is 4 (each item twice).
             expect(functionSpy).toHaveBeenCalledTimes(2);
             expect(functionSpy).toHaveBeenNthCalledWith(1, 'first');
             expect(functionSpy).toHaveBeenNthCalledWith(2, 'second');
+            expect(readyQueue).toEqual([]);
         });
 
         it('should skip malformed queue items instead of throwing', () => {


### PR DESCRIPTION
## Summary
- Drain `_preInit.readyQueue` in place (`splice`) **before** iterating, so a synchronous re-entry from cache-hit `identify` → `parseIdentityResponse` → `processReadyQueue` sees an empty queue and cannot re-execute the same items.
- Keeps the item-level `.slice()` from #1292 as defense in depth.
- Updates Jest coverage: queue is emptied after drain, second drain is a no-op, and mid-drain re-entry does not duplicate calls.

## Why
After #1292 stopped mutating queued items, re-entrant drains started successfully re-running the same entries. That shows up in prod as:
- duplicate `Identity.*` / `logEvent` side effects
- recursively nested `Unable to compute proper mParticle function Error: Unable to compute...` reports (only on `2.73.0`, starting at the #1292 deploy)

## Test plan
- [x] `npm run test:jest -- --testPathPattern=pre-init-utils.spec`
- [ ] Confirm nested `Unable to compute proper mParticle function Error:` volume drops after rollout
- [ ] Spot-check that `IDENTITY_REQUEST` no longer shows duplicate-driven nesting for `2.73.x+`