### PR TITLE
fix(pre-init): put unresolved method path on stackTrace

### DIFF
--- a/src/identityApiClient.ts
+++ b/src/identityApiClient.ts
@@ -345,6 +345,7 @@ export default function IdentityAPIClient(
                 message: msg,
                 code: ErrorCodes.IDENTITY_REQUEST,
                 severity: WSDKErrorSeverity.ERROR,
+                stackTrace: (err as Error).stack,
             });
 
             mpInstance.processQueueOnIdentityFailure?.();

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -11,6 +11,26 @@ export interface IPreInit {
     isDevelopmentMode?: boolean;
 }
 
+// Kept free of the method path so it stays low-cardinality for monitors and
+// grouping. The path itself travels on the error's `stack`, which the reporting
+// pipeline forwards to a dedicated stackTrace field.
+const UNRESOLVED_METHOD_MESSAGE =
+    'Unable to compute proper mParticle function - method not found';
+
+/**
+ * A queued entry named a method that does not resolve on `window.mParticle`.
+ * Distinct from a method that resolved and then threw on its own.
+ */
+const unresolvedMethodError = (method: string): Error => {
+    const error = new Error(UNRESOLVED_METHOD_MESSAGE);
+    error.stack =
+        'mParticle pre-init method not found: ' +
+        method +
+        '\n' +
+        (error.stack || '');
+    return error;
+};
+
 export const processReadyQueue = (readyQueue): Function[] => {
     if (!isEmpty(readyQueue)) {
         readyQueue.forEach(readyQueueItem => {
@@ -46,16 +66,25 @@ const processPreloadedItem = (readyQueueItem): void => {
         // otherwise, the method is on either eCommerce or Identity objects, ie. "eCommerce.setCurrencyCode", "Identity.login"
     } else {
         const methodArray = method.split('.');
+        let computedMPFunction = window.mParticle;
+        let context = window.mParticle;
+
+        // Track both the function and its context
+        for (const currentMethod of methodArray) {
+            context = computedMPFunction; // Keep track of the parent object
+            computedMPFunction = computedMPFunction?.[currentMethod];
+        }
+
+        // Resolution failures and failures thrown by a resolved method are
+        // different problems and are reported separately. Resolving with `?.`
+        // also stops a missing intermediate object (ie. "Identity" on
+        // "Identity.login") from surfacing as an incidental TypeError that
+        // named the property rather than the queued method.
+        if (!isFunction(computedMPFunction)) {
+            throw unresolvedMethodError(method);
+        }
+
         try {
-            let computedMPFunction = window.mParticle;
-            let context = window.mParticle;
-            
-            // Track both the function and its context
-            for (const currentMethod of methodArray) {
-                context = computedMPFunction;  // Keep track of the parent object
-                computedMPFunction = computedMPFunction[currentMethod];
-            }
-            
             // Apply the function with its proper context
             ((computedMPFunction as unknown) as Function).apply(context, args);
         } catch (e) {

--- a/test/jest/pre-init-utils.spec.ts
+++ b/test/jest/pre-init-utils.spec.ts
@@ -82,7 +82,53 @@ describe('pre-init-utils', () => {
 
         it('should throw an error if it cannot compute the proper mParticle function', () => {
             const readyQueue = [['Identity.login']];
-            expect(() => processReadyQueue(readyQueue)).toThrowError("Unable to compute proper mParticle function TypeError: Cannot read properties of undefined (reading 'login')");
+            expect(() => processReadyQueue(readyQueue)).toThrowError(
+                'Unable to compute proper mParticle function - method not found'
+            );
+        });
+
+        it('should name the unresolved method path on the error stack', () => {
+            // The path travels on `stack` rather than `message` so the message
+            // stays low-cardinality for monitors while the path remains
+            // queryable via the reporting pipeline's stackTrace field.
+            (window.mParticle as any) = {};
+
+            let caught: Error | null = null;
+            try {
+                processReadyQueue([['Identity.login']]);
+            } catch (e) {
+                caught = e as Error;
+            }
+
+            expect(caught).not.toBeNull();
+            expect(caught!.message).toBe(
+                'Unable to compute proper mParticle function - method not found'
+            );
+            expect(caught!.stack).toContain(
+                'mParticle pre-init method not found: Identity.login'
+            );
+        });
+
+        it('should distinguish a resolved method that throws from an unresolved one', () => {
+            (window.mParticle as any) = {
+                Identity: {
+                    login: () => {
+                        throw new Error('login blew up');
+                    },
+                },
+            };
+
+            expect(() => processReadyQueue([['Identity.login']])).toThrowError(
+                'Unable to compute proper mParticle function Error: login blew up'
+            );
+        });
+
+        it('should treat a resolved non-function property as unresolved', () => {
+            (window.mParticle as any) = { Identity: { login: 'not-a-function' } };
+
+            expect(() => processReadyQueue([['Identity.login']])).toThrowError(
+                'Unable to compute proper mParticle function - method not found'
+            );
         });
 
         it('should not mutate the queued item so it can be processed again', () => {


### PR DESCRIPTION
## Summary
- When a pre-init ready-queue method fails to resolve, put the method path on the error `stack` (e.g. `mParticle pre-init method not found: Identity.login`) and forward it via `stackTrace` from `identityApiClient` so Datadog can query it.
- Keep the error **message** low-cardinality (`Unable to compute proper mParticle function - method not found`) so existing monitors still match the shared prefix.
- Separate unresolved methods from resolved methods that throw, so those two failure modes are no longer collapsed into the same TypeError-from-`.apply` shape.

## Why
~947k of the recent `IDENTITY_REQUEST` / `Unable to compute proper mParticle function` errors were **single-wrap** failures where Datadog could not show which queued method failed (`StackTrace: null`, no method in the message). Partner investigation (Wingstop) showed the high-volume case was largely the pre-2.73.0 item-mutation bug reading an *argument* as the method name — but without a method path on the report we could not confirm that from telemetry alone.

## Test plan
- [x] Jest: unresolved method throws the new message
- [x] Jest: method path is present on `error.stack`
- [x] Jest: resolved method that throws still uses the existing wrapper message
- [x] Jest: non-function property treated as unresolved
- [x] `npm run lint`
- [ ] After merge/deploy: Datadog `@errorInfo.StackTrace` (or equivalent) contains `mParticle pre-init method not found: <path>` for unresolved methods
- [ ] Confirm existing monitors on `Unable to compute proper mParticle function` still match the new `- method not found` suffix