### PR TITLE
refactor: extract getErrorMessage utility for caught-error logging

### DIFF
--- a/src/identity-utils.ts
+++ b/src/identity-utils.ts
@@ -1,5 +1,5 @@
 import Constants, { ONE_DAY_IN_SECONDS, MILLIS_IN_ONE_SEC } from './constants';
-import { Dictionary, Environment, parseNumber, isObject, generateHash, generateUniqueId, isEmpty, isFunction } from './utils';
+import { Dictionary, Environment, parseNumber, isObject, generateHash, generateUniqueId, isEmpty, isFunction, getErrorMessage } from './utils';
 import { BaseVault } from './vault';
 import Types from './types';
 import {
@@ -414,8 +414,7 @@ export const executeSearchRequest = (
                 });
             } catch (e) {
                 Logger.error(
-                    'Error invoking search callback: ' +
-                        ((e as Error)?.message || String(e)),
+                    'Error invoking search callback: ' + getErrorMessage(e),
                 );
             }
         }

--- a/src/identity/search.ts
+++ b/src/identity/search.ts
@@ -1,6 +1,6 @@
 import Constants, { HTTP_OK, HTTP_NOT_FOUND } from '../constants';
 import { SDKLoggerApi } from '../sdkRuntimeModels';
-import { Environment, isFunction } from '../utils';
+import { Environment, isFunction, getErrorMessage } from '../utils';
 import {
     AsyncUploader,
     FetchUploader,
@@ -111,8 +111,7 @@ export const sendSearchRequest = async (
             callback(result);
         } catch (e) {
             logger.error(
-                'Error invoking search callback: ' +
-                    ((e as Error)?.message || String(e)),
+                'Error invoking search callback: ' + getErrorMessage(e),
             );
         }
     };
@@ -216,7 +215,7 @@ export const sendSearchRequest = async (
 
         safeInvoke({ httpCode: response.status, body });
     } catch (e) {
-        const message = (e as Error)?.message || String(e);
+        const message = getErrorMessage(e);
         const reportMessage = 'Error sending search request: ' + message;
         logger.error(reportMessage);
         // Mirror the identity-route pattern in identityApiClient.ts: log to

--- a/src/identityApiClient.ts
+++ b/src/identityApiClient.ts
@@ -6,7 +6,7 @@ import {
     IFetchPayload,
 } from './uploaders';
 import { CACHE_HEADER } from './identity-utils';
-import { obfuscateData, parseNumber, valueof } from './utils';
+import { obfuscateData, parseNumber, valueof, getErrorMessage } from './utils';
 import {
     IAliasCallback,
     IAliasRequest,
@@ -175,7 +175,7 @@ export default function IdentityAPIClient(
             Logger.verbose(message);
             invokeAliasCallback(aliasCallback, response.status, errorMessage);
         } catch (e) {
-            const errorMessage = (e as Error).message || e.toString();
+            const errorMessage = getErrorMessage(e);
             Logger.error('Error sending alias request to mParticle servers. ' + errorMessage);
             invokeAliasCallback(
                 aliasCallback,
@@ -338,7 +338,7 @@ export default function IdentityAPIClient(
                 mpInstance.captureTiming(`${requestCount}-identityRequestEnd`);
             }
 
-            const errorMessage = (err as Error).message || err.toString();
+            const errorMessage = getErrorMessage(err);
             const msg = 'Error sending identity request to servers' + ' - ' + errorMessage;
             Logger.error(msg);
             errorReporter?.report({

--- a/src/pre-init-utils.ts
+++ b/src/pre-init-utils.ts
@@ -2,7 +2,7 @@ import { IPixelConfiguration } from './cookieSyncManager';
 import { MPForwarder } from './forwarders.interfaces';
 import { IntegrationDelays } from './mp-instance';
 import { SDKLoggerApi } from './sdkRuntimeModels';
-import { isEmpty, isFunction } from './utils';
+import { isEmpty, isFunction, getErrorMessage } from './utils';
 
 export interface IPreInit {
     readyQueue: Function[] | any[];
@@ -39,21 +39,13 @@ export const processReadyQueue = (
                 processPreloadedItem(readyQueueItem);
             }
         } catch (e) {
-            logger.error(formatReadyQueueItemError(e));
+            logger.error(
+                'Error processing ready queue item: ' + getErrorMessage(e)
+            );
         }
     });
 
     return [];
-};
-
-const formatReadyQueueItemError = (e: unknown): string => {
-    let detail = 'unknown error';
-    if (e instanceof Error) {
-        detail = e.message;
-    } else if (typeof e === 'string') {
-        detail = e;
-    }
-    return 'Error processing ready queue item: ' + detail;
 };
 
 const processPreloadedItem = (readyQueueItem): void => {

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -10,6 +10,7 @@ import {
     AttributeValue,
     isEmpty,
     obfuscateDevData,
+    getErrorMessage,
 } from "./utils";
 import { SDKIdentityApi } from "./identity.interfaces";
 import { SDKLoggerApi } from "./sdkRuntimeModels";
@@ -338,8 +339,10 @@ export default class RoktManager {
                         }
                     );
                 } catch (error) {
-                    const errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-                    this.logger.error('Background identify threw an error: ' + errorMessage);
+                    this.logger.error(
+                        'Background identify threw an error: ' +
+                            getErrorMessage(error)
+                    );
                 }
             }
 
@@ -437,8 +440,9 @@ export default class RoktManager {
             return hashedAttributes;
             
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            this.logger.error(`Failed to hashAttributes, returning an empty object: ${errorMessage}`);
+            this.logger.error(
+                `Failed to hashAttributes, returning an empty object: ${getErrorMessage(error)}`
+            );
             return {};
         }
     }
@@ -452,8 +456,9 @@ export default class RoktManager {
         try {
             this.kit.setExtensionData<T>(extensionData);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            throw new Error('Error setting extension data: ' + errorMessage);
+            throw new Error(
+                'Error setting extension data: ' + getErrorMessage(error)
+            );
         }
     }
 
@@ -478,8 +483,9 @@ export default class RoktManager {
         try {
             this.kit.onShoppableAdsReady(callback);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            this.logger.error(`Failed to register onShoppableAdsReady callback: ${errorMessage}`);
+            this.logger.error(
+                `Failed to register onShoppableAdsReady callback: ${getErrorMessage(error)}`
+            );
         }
     }
 
@@ -517,8 +523,9 @@ export default class RoktManager {
             const normalizedValue = String(attribute).trim().toLocaleLowerCase();
             return await this.sha256Hex(normalizedValue);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            this.logger.error(`Failed to hashSha256, returning undefined: ${errorMessage}`);
+            this.logger.error(
+                `Failed to hashSha256, returning undefined: ${getErrorMessage(error)}`
+            );
             return undefined;
         }
     }
@@ -607,8 +614,9 @@ export default class RoktManager {
             const reject = message.reject;
 
             const handleError = (error: unknown) => {
-                const errorMessage = error instanceof Error ? error.message : String(error);
-                this.logger?.error(`RoktManager: Error processing message '${message.methodName}': ${errorMessage}`);
+                this.logger?.error(
+                    `RoktManager: Error processing message '${message.methodName}': ${getErrorMessage(error)}`
+                );
                 if (reject) {
                     reject(error);
                 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -625,11 +625,6 @@ function extend(...args: any[]): any {
     return target;
 }
 
-/**
- * Normalize a caught value into a loggable string.
- * Prefer Error.message and plain strings; anything else would stringify to
- * "[object Object]" and tell us nothing, so fall back to a fixed label.
- */
 const getErrorMessage = (
     e: unknown,
     fallback = 'unknown error'
@@ -639,6 +634,14 @@ const getErrorMessage = (
     }
     if (typeof e === 'string') {
         return e;
+    }
+    // fetch-mock and some network libs reject with { message } rather than Error
+    if (
+        e &&
+        typeof e === 'object' &&
+        typeof (e as { message?: unknown }).message === 'string'
+    ) {
+        return (e as { message: string }).message;
     }
     return fallback;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -625,6 +625,24 @@ function extend(...args: any[]): any {
     return target;
 }
 
+/**
+ * Normalize a caught value into a loggable string.
+ * Prefer Error.message and plain strings; anything else would stringify to
+ * "[object Object]" and tell us nothing, so fall back to a fixed label.
+ */
+const getErrorMessage = (
+    e: unknown,
+    fallback = 'unknown error'
+): string => {
+    if (e instanceof Error) {
+        return e.message;
+    }
+    if (typeof e === 'string') {
+        return e;
+    }
+    return fallback;
+};
+
 export {
     createCookieString,
     revertCookieString,
@@ -639,6 +657,7 @@ export {
     generateDeprecationMessage,
     generateHash,
     generateUniqueId,
+    getErrorMessage,
     getRampNumber,
     inArray,
     isObject,

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -681,8 +681,15 @@ describe('Utils', () => {
             expect(getErrorMessage('plain string')).toBe('plain string');
         });
 
+        it('returns .message from plain objects (e.g. fetch-mock throws)', () => {
+            expect(getErrorMessage({ message: 'server error' })).toBe(
+                'server error'
+            );
+        });
+
         it('returns the default fallback for other values', () => {
             expect(getErrorMessage({ code: 1 })).toBe('unknown error');
+            expect(getErrorMessage({ message: 42 })).toBe('unknown error');
             expect(getErrorMessage(42)).toBe('unknown error');
             expect(getErrorMessage(null)).toBe('unknown error');
             expect(getErrorMessage(undefined)).toBe('unknown error');

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -13,6 +13,7 @@ import {
     parseSettingsString,
     obfuscateData,
     obfuscateDevData,
+    getErrorMessage,
 } from '../../src/utils';
 import { deleteAllCookies } from './utils';
 
@@ -668,6 +669,27 @@ describe('Utils', () => {
 
         it('treats undefined isDevelopmentMode as false and returns obfuscated data', () => {
             expect(obfuscateDevData({ email: 'a@b.com' }, undefined)).toEqual({ email: 'string' });
+        });
+    });
+
+    describe('#getErrorMessage', () => {
+        it('returns Error.message for Error instances', () => {
+            expect(getErrorMessage(new Error('boom'))).toBe('boom');
+        });
+
+        it('returns the string when the caught value is a string', () => {
+            expect(getErrorMessage('plain string')).toBe('plain string');
+        });
+
+        it('returns the default fallback for other values', () => {
+            expect(getErrorMessage({ code: 1 })).toBe('unknown error');
+            expect(getErrorMessage(42)).toBe('unknown error');
+            expect(getErrorMessage(null)).toBe('unknown error');
+            expect(getErrorMessage(undefined)).toBe('unknown error');
+        });
+
+        it('uses a custom fallback when provided', () => {
+            expect(getErrorMessage({}, 'fallback')).toBe('fallback');
         });
     });
 });


### PR DESCRIPTION
## Summary
- Add `getErrorMessage(e, fallback?)` in `utils.ts` to normalize caught values into loggable strings (Error → message, string → as-is, else → `'unknown error'`).
- Replace the local `formatReadyQueueItemError` helper introduced in #1296 with a one-line prefix + `getErrorMessage`.
- Migrate the duplicated `instanceof Error ? .message : String(e)` / `(e as Error).message || String(e)` patterns in `roktManager`, `identityApiClient`, `identity/search`, and `identity-utils`.

Follow-up from Alex's review on #1296: the ready-queue formatter was doing the same work already copied across several modules.

Left alone on purpose: `Promise.reject(error instanceof Error ? error : new Error(...))` in RoktManager — that preserves Error objects for rejection, not message extraction.

## Test plan
- [x] Jest: `utils.spec.ts` (new `getErrorMessage` cases) + `pre-init-utils.spec.ts`
- [x] `npm run build:iife` (rollup TypeScript check)
- [x] `npm run lint`
- [ ] CI green on this PR (Jest matrix, Core Tests, integrations)