### PR TITLE
feat: forward active time-on-site to Rokt selectPlacements

### DIFF
--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -354,10 +354,12 @@ export default class RoktManager {
 
             this.setUserAttributes(mappedAttributes);
 
+            const timeOnSite = this.store?.getTimeOnSite?.() ?? 0;
+
             const enrichedAttributes: RoktAttributes = {
                 ...mappedAttributes,
                 ...(sandboxValue !== null ? { sandbox: sandboxValue } : {}),
-                active_time_on_site_ms: this.store?.getTimeOnSite?.() ?? 0,
+                ...(timeOnSite > 0 ? { active_time_on_site_ms: timeOnSite } : {}),
             };
 
             // Propagate email from current user identities if not already in attributes

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -357,6 +357,7 @@ export default class RoktManager {
             const enrichedAttributes: RoktAttributes = {
                 ...mappedAttributes,
                 ...(sandboxValue !== null ? { sandbox: sandboxValue } : {}),
+                active_time_on_site_ms: this.store?.getTimeOnSite?.() ?? 0,
             };
 
             // Propagate email from current user identities if not already in attributes

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -354,12 +354,12 @@ export default class RoktManager {
 
             this.setUserAttributes(mappedAttributes);
 
-            const timeOnSite = this.store?.getTimeOnSite?.() ?? 0;
+            const timeOnSite = this.store?.getTimeOnSite?.();
 
             const enrichedAttributes: RoktAttributes = {
                 ...mappedAttributes,
                 ...(sandboxValue !== null ? { sandbox: sandboxValue } : {}),
-                ...(timeOnSite > 0 ? { active_time_on_site_ms: timeOnSite } : {}),
+                ...(timeOnSite !== undefined ? { active_time_on_site_ms: timeOnSite } : {}),
             };
 
             // Propagate email from current user identities if not already in attributes

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -354,12 +354,12 @@ export default class RoktManager {
 
             this.setUserAttributes(mappedAttributes);
 
-            const timeOnSite = this.store?.getTimeOnSite?.() || null;
+            const timeOnSite = this.store?.getTimeOnSite?.();
 
             const enrichedAttributes: RoktAttributes = {
                 ...mappedAttributes,
                 ...(sandboxValue !== null ? { sandbox: sandboxValue } : {}),
-                ...(timeOnSite !== null ? { active_time_on_site_ms: timeOnSite } : {}),
+                ...(timeOnSite ? { active_time_on_site_ms: timeOnSite } : {}),
             };
 
             // Propagate email from current user identities if not already in attributes

--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -354,12 +354,12 @@ export default class RoktManager {
 
             this.setUserAttributes(mappedAttributes);
 
-            const timeOnSite = this.store?.getTimeOnSite?.();
+            const timeOnSite = this.store?.getTimeOnSite?.() || null;
 
             const enrichedAttributes: RoktAttributes = {
                 ...mappedAttributes,
                 ...(sandboxValue !== null ? { sandbox: sandboxValue } : {}),
-                ...(timeOnSite !== undefined ? { active_time_on_site_ms: timeOnSite } : {}),
+                ...(timeOnSite !== null ? { active_time_on_site_ms: timeOnSite } : {}),
             };
 
             // Propagate email from current user identities if not already in attributes

--- a/src/store.ts
+++ b/src/store.ts
@@ -684,9 +684,6 @@ export default function Store(
         this.integrationName = integrationName;
     };
 
-    // Active foreground time-on-site in ms. Mirrors the ActiveTimeOnSite value
-    // stamped on events (see serverModel/batchUploader) so selectPlacements can
-    // forward it downstream. Falls back to 0 when the timer is unavailable.
     this.getTimeOnSite = () =>
         mpInstance._timeOnSiteTimer?.getTimeInForeground() || 0;
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -232,6 +232,7 @@ export interface IStore {
     setUserIdentities?(mpid: MPID, userIdentities: UserIdentities): void;
     getRoktAccountId?(): string;
     setRoktAccountId?(accountId: string): void;
+    getTimeOnSite?(): number;
     getIntegrationName?(): string;
     setIntegrationName?(integrationName: string): void;
 
@@ -682,6 +683,12 @@ export default function Store(
     this.setIntegrationName = (integrationName: string) => {
         this.integrationName = integrationName;
     };
+
+    // Active foreground time-on-site in ms. Mirrors the ActiveTimeOnSite value
+    // stamped on events (see serverModel/batchUploader) so selectPlacements can
+    // forward it downstream. Falls back to 0 when the timer is unavailable.
+    this.getTimeOnSite = () =>
+        mpInstance._timeOnSiteTimer?.getTimeInForeground() || 0;
 
     this.addMpidToSessionHistory = (mpid: MPID, previousMPID?: MPID): void => {
         const indexOfMPID = this.currentSessionMPIDs.indexOf(mpid);

--- a/src/store.ts
+++ b/src/store.ts
@@ -232,7 +232,7 @@ export interface IStore {
     setUserIdentities?(mpid: MPID, userIdentities: UserIdentities): void;
     getRoktAccountId?(): string;
     setRoktAccountId?(accountId: string): void;
-    getTimeOnSite?(): number;
+    getTimeOnSite?(): number | undefined;
     getIntegrationName?(): string;
     setIntegrationName?(integrationName: string): void;
 
@@ -685,7 +685,7 @@ export default function Store(
     };
 
     this.getTimeOnSite = () =>
-        mpInstance._timeOnSiteTimer?.getTimeInForeground() || 0;
+        mpInstance._timeOnSiteTimer?.getTimeInForeground();
 
     this.addMpidToSessionHistory = (mpid: MPID, previousMPID?: MPID): void => {
         const indexOfMPID = this.currentSessionMPIDs.indexOf(mpid);

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -883,8 +883,7 @@ describe('RoktManager', () => {
             const expectedMappedOptions = {
                 attributes: {
                     mapped_key: 'test_value',  // This key should be mapped
-                    other_attr: 'other_value',  // This key should remain unchanged
-                    active_time_on_site_ms: 0  // Injected active time-on-site
+                    other_attr: 'other_value'  // This key should remain unchanged
                 }
             };
 
@@ -1015,7 +1014,7 @@ describe('RoktManager', () => {
             roktManager.selectPlacements(options);
             expect(kit.selectPlacements).toHaveBeenCalledWith({
                 ...options,
-                attributes: { active_time_on_site_ms: 0 },
+                attributes: {},
             });
         });
 
@@ -1051,7 +1050,7 @@ describe('RoktManager', () => {
             await roktManager.selectPlacements(options);
             expect(kit.selectPlacements).toHaveBeenCalledWith({
                 ...options,
-                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+                attributes: { ...options.attributes },
             });
         });
 
@@ -1121,7 +1120,7 @@ describe('RoktManager', () => {
             expect(roktManager['messageQueue'].size).toBe(0);
             expect(kit.selectPlacements).toHaveBeenCalledWith({
                 ...options,
-                attributes: { active_time_on_site_ms: 0 },
+                attributes: {},
             });
             expect(result).toEqual(expectedResult);
         });
@@ -1166,7 +1165,7 @@ describe('RoktManager', () => {
             roktManager.selectPlacements(options);
             const expectedOptions = {
                 ...options,
-                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+                attributes: { ...options.attributes },
             };
             expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
             expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
@@ -1202,7 +1201,7 @@ describe('RoktManager', () => {
             roktManager.selectPlacements(options);
             expect(kit.selectPlacements).toHaveBeenCalledWith({
                 ...options,
-                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+                attributes: { ...options.attributes },
             });
         });
 
@@ -1238,7 +1237,7 @@ describe('RoktManager', () => {
             expect(roktManager['sandbox']).toBeTruthy();
             expect(kit.selectPlacements).toHaveBeenCalledWith({
                 ...options,
-                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+                attributes: { ...options.attributes },
             });
         });
 
@@ -1273,7 +1272,7 @@ describe('RoktManager', () => {
             roktManager.selectPlacements(options);
             expect(kit.selectPlacements).toHaveBeenCalledWith({
                 ...options,
-                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+                attributes: { ...options.attributes },
             });
         });
 
@@ -1320,7 +1319,6 @@ describe('RoktManager', () => {
                     firstname: 'John',
                     lastname: 'Doe',
                     score: 42,
-                    active_time_on_site_ms: 0,
                 }
             };
 
@@ -1357,7 +1355,7 @@ describe('RoktManager', () => {
             roktManager.selectPlacements(options);
             expect(kit.selectPlacements).toHaveBeenCalledWith({
                 ...options,
-                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+                attributes: { ...options.attributes },
             });
         });
 
@@ -1452,7 +1450,7 @@ describe('RoktManager', () => {
             await roktManager.selectPlacements(options);
             expect(kit.selectPlacements).toHaveBeenCalledWith({
                 ...options,
-                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+                attributes: { ...options.attributes },
             });
             expect(setUserAttributesSpy).not.toHaveBeenCalledWith({
                 sandbox: true
@@ -2748,7 +2746,7 @@ describe('RoktManager', () => {
                 );
             });
 
-            it('should inject active_time_on_site_ms as 0 when the timer reports no active time', async () => {
+            it('should omit active_time_on_site_ms when the timer reports no active time', async () => {
                 (roktManager['store'].getTimeOnSite as jest.Mock).mockReturnValue(0);
 
                 await roktManager.selectPlacements({
@@ -2757,14 +2755,14 @@ describe('RoktManager', () => {
 
                 expect(kit.selectPlacements).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        attributes: expect.objectContaining({
-                            active_time_on_site_ms: 0,
+                        attributes: expect.not.objectContaining({
+                            active_time_on_site_ms: expect.anything(),
                         }),
                     }),
                 );
             });
 
-            it('should inject active_time_on_site_ms as 0 when getTimeOnSite is unavailable on the store', async () => {
+            it('should omit active_time_on_site_ms when getTimeOnSite is unavailable on the store', async () => {
                 (roktManager['store'] as Partial<IStore>).getTimeOnSite = undefined;
 
                 await roktManager.selectPlacements({
@@ -2773,8 +2771,8 @@ describe('RoktManager', () => {
 
                 expect(kit.selectPlacements).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        attributes: expect.objectContaining({
-                            active_time_on_site_ms: 0,
+                        attributes: expect.not.objectContaining({
+                            active_time_on_site_ms: expect.anything(),
                         }),
                     }),
                 );

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -2734,7 +2734,7 @@ describe('RoktManager', () => {
                 );
             });
 
-            it('should inject active_time_on_site_ms when the timer reports zero active time', async () => {
+            it('should omit active_time_on_site_ms when the timer reports zero active time', async () => {
                 (roktManager['store'].getTimeOnSite as jest.Mock).mockReturnValue(0);
 
                 await roktManager.selectPlacements({
@@ -2743,8 +2743,8 @@ describe('RoktManager', () => {
 
                 expect(kit.selectPlacements).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        attributes: expect.objectContaining({
-                            active_time_on_site_ms: 0,
+                        attributes: expect.not.objectContaining({
+                            active_time_on_site_ms: expect.anything(),
                         }),
                     }),
                 );

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -1012,10 +1012,7 @@ describe('RoktManager', () => {
             } as IRoktSelectPlacementsOptions;
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith({
-                ...options,
-                attributes: {},
-            });
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should call kit.selectPlacements with passed in attributes', async () => {
@@ -1048,10 +1045,7 @@ describe('RoktManager', () => {
             };
 
             await roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith({
-                ...options,
-                attributes: { ...options.attributes },
-            });
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should queue the selectPlacements method if no launcher or kit is attached', () => {
@@ -1118,10 +1112,7 @@ describe('RoktManager', () => {
             
             expect(roktManager['kit']).not.toBeNull();
             expect(roktManager['messageQueue'].size).toBe(0);
-            expect(kit.selectPlacements).toHaveBeenCalledWith({
-                ...options,
-                attributes: {},
-            });
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
             expect(result).toEqual(expectedResult);
         });
 
@@ -1163,12 +1154,8 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            const expectedOptions = {
-                ...options,
-                attributes: { ...options.attributes },
-            };
-            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
-            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should pass sandbox flag as an attribute through to kit.selectPlacements', () => {
@@ -1199,10 +1186,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith({
-                ...options,
-                attributes: { ...options.attributes },
-            });
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should NOT override global sandbox in placement attributes when initialized as true', () => {
@@ -1235,10 +1219,7 @@ describe('RoktManager', () => {
             roktManager.selectPlacements(options);
 
             expect(roktManager['sandbox']).toBeTruthy();
-            expect(kit.selectPlacements).toHaveBeenCalledWith({
-                ...options,
-                attributes: { ...options.attributes },
-            });
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should set sandbox in placement attributes when not initialized globally', () => {
@@ -1270,10 +1251,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith({
-                ...options,
-                attributes: { ...options.attributes },
-            });
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should pass mapped attributes to kit.launcher.selectPlacements', () => {
@@ -1353,10 +1331,7 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith({
-                ...options,
-                attributes: { ...options.attributes },
-            });
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
         });
 
         it('should set the mapped attributes on the current user via setUserAttributes', async () => {
@@ -1448,10 +1423,7 @@ describe('RoktManager', () => {
             };
 
             await roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith({
-                ...options,
-                attributes: { ...options.attributes },
-            });
+            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
             expect(setUserAttributesSpy).not.toHaveBeenCalledWith({
                 sandbox: true
             });

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -37,6 +37,7 @@ describe('RoktManager', () => {
         _Store: {
             setLocalSessionAttributes: jest.fn(),
             getLocalSessionAttributes: jest.fn().mockReturnValue({}),
+            getTimeOnSite: jest.fn().mockReturnValue(0),
             identityCallInFlight: false,
         },
         Logger: {
@@ -882,7 +883,8 @@ describe('RoktManager', () => {
             const expectedMappedOptions = {
                 attributes: {
                     mapped_key: 'test_value',  // This key should be mapped
-                    other_attr: 'other_value'  // This key should remain unchanged
+                    other_attr: 'other_value',  // This key should remain unchanged
+                    active_time_on_site_ms: 0  // Injected active time-on-site
                 }
             };
 
@@ -1011,7 +1013,10 @@ describe('RoktManager', () => {
             } as IRoktSelectPlacementsOptions;
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith({
+                ...options,
+                attributes: { active_time_on_site_ms: 0 },
+            });
         });
 
         it('should call kit.selectPlacements with passed in attributes', async () => {
@@ -1044,7 +1049,10 @@ describe('RoktManager', () => {
             };
 
             await roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith({
+                ...options,
+                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+            });
         });
 
         it('should queue the selectPlacements method if no launcher or kit is attached', () => {
@@ -1111,7 +1119,10 @@ describe('RoktManager', () => {
             
             expect(roktManager['kit']).not.toBeNull();
             expect(roktManager['messageQueue'].size).toBe(0);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith({
+                ...options,
+                attributes: { active_time_on_site_ms: 0 },
+            });
             expect(result).toEqual(expectedResult);
         });
 
@@ -1153,8 +1164,12 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
-            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(options);
+            const expectedOptions = {
+                ...options,
+                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+            };
+            expect(kit.selectPlacements).toHaveBeenCalledWith(expectedOptions);
+            expect(kit.launcher.selectPlacements).toHaveBeenCalledWith(expectedOptions);
         });
 
         it('should pass sandbox flag as an attribute through to kit.selectPlacements', () => {
@@ -1185,7 +1200,10 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options); 
+            expect(kit.selectPlacements).toHaveBeenCalledWith({
+                ...options,
+                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+            });
         });
 
         it('should NOT override global sandbox in placement attributes when initialized as true', () => {
@@ -1218,7 +1236,10 @@ describe('RoktManager', () => {
             roktManager.selectPlacements(options);
 
             expect(roktManager['sandbox']).toBeTruthy();
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith({
+                ...options,
+                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+            });
         });
 
         it('should set sandbox in placement attributes when not initialized globally', () => {
@@ -1250,7 +1271,10 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith({
+                ...options,
+                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+            });
         });
 
         it('should pass mapped attributes to kit.launcher.selectPlacements', () => {
@@ -1296,6 +1320,7 @@ describe('RoktManager', () => {
                     firstname: 'John',
                     lastname: 'Doe',
                     score: 42,
+                    active_time_on_site_ms: 0,
                 }
             };
 
@@ -1330,7 +1355,10 @@ describe('RoktManager', () => {
             };
 
             roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith({
+                ...options,
+                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+            });
         });
 
         it('should set the mapped attributes on the current user via setUserAttributes', async () => {
@@ -1422,7 +1450,10 @@ describe('RoktManager', () => {
             };
 
             await roktManager.selectPlacements(options);
-            expect(kit.selectPlacements).toHaveBeenCalledWith(options);
+            expect(kit.selectPlacements).toHaveBeenCalledWith({
+                ...options,
+                attributes: { ...options.attributes, active_time_on_site_ms: 0 },
+            });
             expect(setUserAttributesSpy).not.toHaveBeenCalledWith({
                 sandbox: true
             });
@@ -2671,6 +2702,79 @@ describe('RoktManager', () => {
                     expect.objectContaining({
                         attributes: expect.not.objectContaining({
                             passbackconversiontrackingid: expect.anything(),
+                        }),
+                    }),
+                );
+            });
+        });
+
+        describe('active_time_on_site_ms injection', () => {
+            let kit: IRoktKit;
+
+            beforeEach(() => {
+                kit = {
+                    launcher: {
+                        selectPlacements: jest.fn().mockResolvedValue({ close: jest.fn(), getPlacements: jest.fn() }),
+                        hashAttributes: jest.fn(),
+                        use: jest.fn(),
+                    },
+                    filters: undefined,
+                    filteredUser: undefined,
+                    userAttributes: undefined,
+                    selectPlacements: jest.fn().mockResolvedValue({ close: jest.fn(), getPlacements: jest.fn() }),
+                    hashAttributes: jest.fn(),
+                    setExtensionData: jest.fn(),
+                    use: jest.fn(),
+                    onShoppableAdsReady: jest.fn(),
+                };
+
+                roktManager.attachKit(kit);
+                roktManager['store'].identityCallInFlight = false;
+            });
+
+            it('should inject active_time_on_site_ms from the store time-on-site value', async () => {
+                (roktManager['store'].getTimeOnSite as jest.Mock).mockReturnValue(12345);
+
+                await roktManager.selectPlacements({
+                    attributes: { email: 'user@example.com' },
+                });
+
+                expect(kit.selectPlacements).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        attributes: expect.objectContaining({
+                            active_time_on_site_ms: 12345,
+                        }),
+                    }),
+                );
+            });
+
+            it('should inject active_time_on_site_ms as 0 when the timer reports no active time', async () => {
+                (roktManager['store'].getTimeOnSite as jest.Mock).mockReturnValue(0);
+
+                await roktManager.selectPlacements({
+                    attributes: { email: 'user@example.com' },
+                });
+
+                expect(kit.selectPlacements).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        attributes: expect.objectContaining({
+                            active_time_on_site_ms: 0,
+                        }),
+                    }),
+                );
+            });
+
+            it('should inject active_time_on_site_ms as 0 when getTimeOnSite is unavailable on the store', async () => {
+                (roktManager['store'] as Partial<IStore>).getTimeOnSite = undefined;
+
+                await roktManager.selectPlacements({
+                    attributes: { email: 'user@example.com' },
+                });
+
+                expect(kit.selectPlacements).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        attributes: expect.objectContaining({
+                            active_time_on_site_ms: 0,
                         }),
                     }),
                 );

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -37,7 +37,7 @@ describe('RoktManager', () => {
         _Store: {
             setLocalSessionAttributes: jest.fn(),
             getLocalSessionAttributes: jest.fn().mockReturnValue({}),
-            getTimeOnSite: jest.fn().mockReturnValue(0),
+            getTimeOnSite: jest.fn().mockReturnValue(undefined),
             identityCallInFlight: false,
         },
         Logger: {
@@ -2718,8 +2718,8 @@ describe('RoktManager', () => {
                 );
             });
 
-            it('should omit active_time_on_site_ms when the timer reports no active time', async () => {
-                (roktManager['store'].getTimeOnSite as jest.Mock).mockReturnValue(0);
+            it('should omit active_time_on_site_ms when the timer is not initialized', async () => {
+                (roktManager['store'].getTimeOnSite as jest.Mock).mockReturnValue(undefined);
 
                 await roktManager.selectPlacements({
                     attributes: { email: 'user@example.com' },
@@ -2729,6 +2729,22 @@ describe('RoktManager', () => {
                     expect.objectContaining({
                         attributes: expect.not.objectContaining({
                             active_time_on_site_ms: expect.anything(),
+                        }),
+                    }),
+                );
+            });
+
+            it('should inject active_time_on_site_ms when the timer reports zero active time', async () => {
+                (roktManager['store'].getTimeOnSite as jest.Mock).mockReturnValue(0);
+
+                await roktManager.selectPlacements({
+                    attributes: { email: 'user@example.com' },
+                });
+
+                expect(kit.selectPlacements).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        attributes: expect.objectContaining({
+                            active_time_on_site_ms: 0,
                         }),
                     }),
                 );


### PR DESCRIPTION
## What

Wires the SDK's existing **active time-on-site** value into the `attributes` map passed to Rokt's `selectPlacements`, so it flows downstream (Rokt Kit → Rokt Web SDK → Transactions API).

The value is injected into `enrichedAttributes` in `roktManager.ts`, but only when there is a real, non-zero value to report:

```ts
const timeOnSite = this.store?.getTimeOnSite?.();

const enrichedAttributes: RoktAttributes = {
    ...mappedAttributes,
    ...(sandboxValue !== null ? { sandbox: sandboxValue } : {}),
    ...(timeOnSite ? { active_time_on_site_ms: timeOnSite } : {}),
};
```

## How

- **New `IStore.getTimeOnSite()` accessor** (`store.ts`) returning `mpInstance._timeOnSiteTimer?.getTimeInForeground()`. This keeps `RoktManager`'s existing dependency surface (it holds `store`, not `mpInstance`) rather than widening `RoktManager.init`.
- The accessor returns **`number | undefined`**: the live active-foreground time in ms when the timer exists, or `undefined` when `_timeOnSiteTimer` isn't initialized yet. It deliberately does **not** fall back to `0` — a `0` would tell downstream consumers the user spent zero active time on site, when the truth is "no data available." Returning `undefined` keeps the accessor honest.
- `getTimeInForeground()` computes the current active segment on read. It counts time the tab is visible + focused and excludes backgrounded time, exactly the value already stamped on events as `ActiveTimeOnSite` (`serverModel.ts`, `batchUploader.ts`).
- The call site reads the accessor directly and uses a truthy conditional-spread, mirroring the `sandboxValue` pattern directly above it. Because both `undefined` (uninitialized timer) and a legitimate `0` are falsy, the `timeOnSite ? … : {}` guard omits the attribute in both cases — a zero value is bad data for downstream processing at Rokt, so it is not sent.

## Decisions

| Question | Decision | Rationale |
|---|---|---|
| Which value | `getTimeInForeground()` | The single active-engagement value the batch already uses; no second value exists |
| Units | milliseconds | Timer returns ms; matches downstream precedent |
| Attribute key | `active_time_on_site_ms` | Already the canonical Events API field name in `sdkToEventsApiConverter.ts`; snake_case aligns with the Transactions API `time_on_site` lineage |
| Accessor return type | `number \| undefined` | A `0` fallback misreports "no data" as "zero active time"; `undefined` is the honest signal for an uninitialized timer |
| Zero / undefined | Omit the attribute | Zero is bad data downstream at Rokt; reading the accessor directly and using a truthy spread drops both `0` and `undefined`, mirroring `sandboxValue` |

## Testing

- `active_time_on_site_ms` is included in `selectPlacements` offers requests when the timer reports a positive value.
- The attribute is **omitted** when the timer reports `0`, when the timer is not initialized (`getTimeOnSite` returns `undefined`), and when the accessor is unavailable on the store.
