### PR TITLE
fix: report deprecated method usage as WARNING

### DIFF
--- a/src/consent.ts
+++ b/src/consent.ts
@@ -512,7 +512,7 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
                     warningMessage: 'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead',
                 },
                 mpInstance.Logger,
-                mpInstance._LoggingDispatcher
+                mpInstance._ErrorReportingDispatcher
             );
             // @ts-ignore
             return removeCCPAConsentState();

--- a/src/identity.js
+++ b/src/identity.js
@@ -1260,7 +1260,7 @@ export default function Identity(mpInstance) {
                             'Deprecated function Identity.getCurrentUser().getCart() will be removed in future releases',
                     },
                     mpInstance.Logger,
-                    mpInstance._LoggingDispatcher
+                    mpInstance._ErrorReportingDispatcher
                 );
                 return self.mParticleUserCart();
             },
@@ -1352,7 +1352,7 @@ export default function Identity(mpInstance) {
                         ),
                     },
                     mpInstance.Logger,
-                    mpInstance._LoggingDispatcher
+                    mpInstance._ErrorReportingDispatcher
                 );
             },
             /**
@@ -1373,7 +1373,7 @@ export default function Identity(mpInstance) {
                         ),
                     },
                     mpInstance.Logger,
-                    mpInstance._LoggingDispatcher
+                    mpInstance._ErrorReportingDispatcher
                 );
             },
             /**
@@ -1394,7 +1394,7 @@ export default function Identity(mpInstance) {
                         ),
                     },
                     mpInstance.Logger,
-                    mpInstance._LoggingDispatcher
+                    mpInstance._ErrorReportingDispatcher
                 );
             },
             /**
@@ -1416,7 +1416,7 @@ export default function Identity(mpInstance) {
                         ),
                     },
                     mpInstance.Logger,
-                    mpInstance._LoggingDispatcher
+                    mpInstance._ErrorReportingDispatcher
                 );
                 return [];
             },
@@ -1571,7 +1571,7 @@ export default function Identity(mpInstance) {
                     newUser,
                     identityApiData,
                     mpInstance.Logger,
-                    mpInstance._LoggingDispatcher
+                    mpInstance._ErrorReportingDispatcher
                 );
 
                 const persistence = mpInstance._Persistence.getPersistence();
@@ -1812,7 +1812,7 @@ function tryOnUserAlias(
     newUser,
     identityApiData,
     logger,
-    loggingDispatcher
+    errorReporter
 ) {
     if (
         identityApiData &&
@@ -1826,7 +1826,7 @@ function tryOnUserAlias(
                     warningMessage: generateDeprecationMessage('onUserAlias'),
                 },
                 logger,
-                loggingDispatcher
+                errorReporter
             );
             identityApiData.onUserAlias(previousUser, newUser);
         } catch (e) {

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -792,7 +792,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                         ),
                     },
                     self.Logger,
-                    self._LoggingDispatcher
+                    self._ErrorReportingDispatcher
                 );
             },
             /**
@@ -814,7 +814,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                         ),
                     },
                     self.Logger,
-                    self._LoggingDispatcher
+                    self._ErrorReportingDispatcher
                 );
             },
             /**
@@ -834,7 +834,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                         ),
                     },
                     self.Logger,
-                    self._LoggingDispatcher
+                    self._ErrorReportingDispatcher
                 );
             },
         },
@@ -970,7 +970,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                     warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
                 },
                 self.Logger,
-                self._LoggingDispatcher
+                self._ErrorReportingDispatcher
             );
 
             if (!self._Store.isInitialized) {
@@ -1055,7 +1055,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                     warningMessage: 'mParticle.logPurchase is deprecated, please use mParticle.logProductAction instead',
                 },
                 self.Logger,
-                self._LoggingDispatcher
+                self._ErrorReportingDispatcher
             );
             if (!self._Store.isInitialized) {
                 self.ready(function() {
@@ -1172,7 +1172,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
                     warningMessage: 'mParticle.logRefund is deprecated, please use mParticle.logProductAction instead',
                 },
                 self.Logger,
-                self._LoggingDispatcher
+                self._ErrorReportingDispatcher
             );
             if (!self._Store.isInitialized) {
                 self.ready(function() {

--- a/src/reporting/deprecatedMethodLogger.ts
+++ b/src/reporting/deprecatedMethodLogger.ts
@@ -1,4 +1,4 @@
-import { ErrorCodes, ILoggingService } from './types';
+import { ErrorCodes, IErrorReportingService, WSDKErrorSeverity } from './types';
 import { SDKLoggerApi } from '../sdkRuntimeModels';
 
 interface DeprecatedMethodUsage {
@@ -9,11 +9,12 @@ interface DeprecatedMethodUsage {
 export function logDeprecatedMethodUsage(
     usage: DeprecatedMethodUsage,
     logger: Pick<SDKLoggerApi, 'warning'>,
-    loggingDispatcher: ILoggingService | undefined
+    errorReporter: IErrorReportingService | undefined
 ): void {
     logger.warning(usage.warningMessage);
-    loggingDispatcher?.log({
+    errorReporter?.report({
         message: usage.methodName,
         code: ErrorCodes.MP_DEPRECATED_METHOD_USAGE,
+        severity: WSDKErrorSeverity.WARNING,
     });
 }

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -78,7 +78,7 @@ export default function SessionManager(
                 ),
             },
             mpInstance.Logger,
-            mpInstance._LoggingDispatcher
+            mpInstance._ErrorReportingDispatcher
         );
         return this.getSessionId();
     };

--- a/test/jest/reportingLogger.spec.ts
+++ b/test/jest/reportingLogger.spec.ts
@@ -131,9 +131,9 @@ describe('LoggingDispatcher', () => {
 });
 
 describe('logDeprecatedMethodUsage', () => {
-    it('keeps the console warning and emits structured usage details', () => {
+    it('keeps the console warning and reports structured usage as a warning', () => {
         const warning = jest.fn();
-        const log = jest.fn();
+        const report = jest.fn();
 
         logDeprecatedMethodUsage(
             {
@@ -141,19 +141,20 @@ describe('logDeprecatedMethodUsage', () => {
                 warningMessage: 'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead',
             },
             { warning },
-            { log }
+            { report }
         );
 
         expect(warning).toHaveBeenCalledWith(
             'mParticle.logCheckout is deprecated, please use mParticle.logProductAction instead'
         );
-        expect(log).toHaveBeenCalledWith({
+        expect(report).toHaveBeenCalledWith({
             message: 'mParticle.logCheckout',
             code: ErrorCodes.MP_DEPRECATED_METHOD_USAGE,
+            severity: WSDKErrorSeverity.WARNING,
         });
     });
 
-    it('does not require a registered logging dispatcher', () => {
+    it('does not require a registered error reporter', () => {
         const warning = jest.fn();
 
         expect(() => logDeprecatedMethodUsage(


### PR DESCRIPTION
## Summary
- Route deprecated method usage through `_ErrorReportingDispatcher` with `severity: WARNING` instead of `_LoggingDispatcher` (INFO)
- When a kit (e.g. Rokt) is connected, Datadog will now receive these as WARNING rather than INFO
- Console `Logger.warning` behavior is unchanged

## Test plan
- [ ] Confirm Jest `reportingLogger` tests pass
- [ ] With Rokt kit connected and logging enabled, invoke a deprecated method (e.g. `eCommerce.Cart.add()`, `logCheckout`) and verify Datadog shows `MP_DEPRECATED_METHOD_USAGE` at WARNING
- [ ] Confirm no INFO entries are emitted for deprecated method usage via the logging endpoint