### PR TITLE
feat: sync major drift kits from upstream

### DIFF
--- a/kits/adobe/HeartbeatKit/src/event-handler.js
+++ b/kits/adobe/HeartbeatKit/src/event-handler.js
@@ -18,12 +18,12 @@ var MediaEventType = {
     SegmentStart: 43,
     SegmentEnd: 44,
     SegmentSkip: 45,
-    UpdateQoS: 46,
+    UpdateQoS: 46
 };
 
 var ContentType = {
     Audio: 'Audio',
-    Video: 'Video',
+    Video: 'Video'
 };
 
 var StreamType = {
@@ -31,7 +31,7 @@ var StreamType = {
     OnDemand: 'OnDemand',
     Linear: 'Linear',
     Podcast: 'Podcast',
-    Audiobook: 'Audiobook',
+    Audiobook: 'Audiobook'
 };
 
 function EventHandler(common) {
@@ -259,7 +259,7 @@ var getAdobeMetadataKeys = function(attributes, Heartbeat) {
         content_mvpd: Heartbeat.VideoMetadataKeys.MVPD,
         content_authorized: Heartbeat.VideoMetadataKeys.AUTHORIZED,
         content_daypart: Heartbeat.VideoMetadataKeys.DAY_PART,
-        content_feed: Heartbeat.VideoMetadataKeys.FEED,
+        content_feed: Heartbeat.VideoMetadataKeys.FEED
     };
 
     var adobeMetadataKeys = {};

--- a/kits/adobe/HeartbeatKit/src/index.js
+++ b/kits/adobe/HeartbeatKit/src/index.js
@@ -26,7 +26,7 @@ var MessageType = {
     CrashReport: 5,
     OptOut: 6,
     Commerce: 16,
-    Media: 20,
+    Media: 20
 };
 
 function constructor() {
@@ -110,7 +110,7 @@ function constructor() {
             return true;
         } catch (e) {
             return {
-                error: 'Error logging event on forwarder ' + name + '; ' + e,
+                error: 'Error logging event on forwarder ' + name + '; ' + e
             };
         }
     }
@@ -124,5 +124,5 @@ if (window.mParticle && window.mParticle.registerHBK) {
 }
 
 module.exports = {
-    AdobeHbkConstructor: constructor,
+    AdobeHbkConstructor: constructor
 };

--- a/kits/adobe/HeartbeatKit/src/initialization.js
+++ b/kits/adobe/HeartbeatKit/src/initialization.js
@@ -119,7 +119,7 @@ var Initialization = {
         }
 
         initHeartbeatCallback();
-    },
+    }
 };
 
 module.exports = Initialization;

--- a/kits/adobe/packages/AdobeClient/src/AdobeClientSideKit.js
+++ b/kits/adobe/packages/AdobeClient/src/AdobeClientSideKit.js
@@ -30,7 +30,7 @@ var name = 'Adobe',
         CrashReport: 5,
         OptOut: 6,
         Commerce: 16,
-        Media: 20,
+        Media: 20
     },
     //Custom Flag Names
     LINK_NAME = 'Adobe.LinkName',
@@ -187,14 +187,14 @@ var constructor = function() {
                 }
 
                 return {
-                    result: false,
+                    result: false
                 };
             });
 
             if (filteredArray && filteredArray.length > 0) {
                 return {
                     result: true,
-                    matches: filteredArray,
+                    matches: filteredArray
                 };
             }
         }
@@ -608,7 +608,7 @@ var constructor = function() {
             if (Object.keys(userIdentities).length) {
                 for (var identity in userIdentities) {
                     identitiesToSet[identity] = {
-                        id: userIdentities[identity],
+                        id: userIdentities[identity]
                     };
                 }
             } else {
@@ -653,7 +653,7 @@ if (window && window.mParticle && window.mParticle.addForwarder) {
     window.mParticle.addForwarder({
         name: name,
         constructor: constructor,
-        getId: getId,
+        getId: getId
     });
 }
 
@@ -674,12 +674,12 @@ function register(config) {
 
     if (isObject(config.kits)) {
         config.kits[name] = {
-            constructor: constructor,
+            constructor: constructor
         };
     } else {
         config.kits = {};
         config.kits[name] = {
-            constructor: constructor,
+            constructor: constructor
         };
     }
     window.console.log(
@@ -694,5 +694,5 @@ function isObject(val) {
 }
 
 export default {
-    register: register,
+    register: register
 };

--- a/kits/adobe/packages/AdobeServer/src/AdobeServerSideKit.js
+++ b/kits/adobe/packages/AdobeServer/src/AdobeServerSideKit.js
@@ -20,7 +20,7 @@
 import { AdobeHbkConstructor } from '../../../HeartbeatKit/dist/AdobeHBKit.esm.js';
 
 var MessageType = {
-    Media: 20,
+    Media: 20
 };
 var name = 'Adobe',
     MARKETINGCLOUDIDKEY = 'mid',
@@ -104,7 +104,7 @@ if (window && window.mParticle && window.mParticle.addForwarder) {
         name: name,
         suffix: suffix,
         constructor: constructor,
-        getId: getId,
+        getId: getId
     });
 }
 
@@ -127,12 +127,12 @@ function register(config) {
 
     if (isObject(config.kits)) {
         config.kits[forwarderNameWithSuffix] = {
-            constructor: constructor,
+            constructor: constructor
         };
     } else {
         config.kits = {};
         config.kits[forwarderNameWithSuffix] = {
-            constructor: constructor,
+            constructor: constructor
         };
     }
     window.console.log(
@@ -149,5 +149,5 @@ function isObject(val) {
 }
 
 export default {
-    register: register,
+    register: register
 };

--- a/kits/adwords/src/GoogleAdWordsEventForwarder.js
+++ b/kits/adwords/src/GoogleAdWordsEventForwarder.js
@@ -15,821 +15,683 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var name = 'GoogleAdWords',
-    moduleId = 82,
-    MessageType = {
-        SessionStart: 1,
-        SessionEnd: 2,
-        PageView: 3,
-        PageEvent: 4,
-        CrashReport: 5,
-        OptOut: 6,
-        Commerce: 16,
-    },
-    ENHANCED_CONVERSION_DATA = 'GoogleAds.ECData';
+    var name = 'GoogleAdWords',
+        moduleId = 82,
+        MessageType = {
+            SessionStart: 1,
+            SessionEnd: 2,
+            PageView: 3,
+            PageEvent: 4,
+            CrashReport: 5,
+            OptOut: 6,
+            Commerce: 16
+        },
+        ENHANCED_CONVERSION_DATA = "GoogleAds.ECData";
 
-// Declares valid Google consent values
-var googleConsentValues = {
-    // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
-    // However, this is not used by Google's Web SDK. We are referencing it here as a comment
-    // as a record of this distinction and for posterity.
-    // If Google ever adds this for web, the line can just be uncommented to support this.
-    //
-    // Docs:
-    // Web: https://developers.google.com/tag-platform/gtagjs/reference#consent
-    // S2S: https://developers.google.com/google-ads/api/reference/rpc/v15/ConsentStatusEnum.ConsentStatus
-    //
-    // Unspecified: 'unspecified',
-    Denied: 'denied',
-    Granted: 'granted',
-};
+    // Declares valid Google consent values
+    var googleConsentValues = {
+        // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
+        // However, this is not used by Google's Web SDK. We are referencing it here as a comment
+        // as a record of this distinction and for posterity.
+        // If Google ever adds this for web, the line can just be uncommented to support this.
+        //
+        // Docs:
+        // Web: https://developers.google.com/tag-platform/gtagjs/reference#consent
+        // S2S: https://developers.google.com/google-ads/api/reference/rpc/v15/ConsentStatusEnum.ConsentStatus
+        //
+        // Unspecified: 'unspecified',
+        Denied: 'denied',
+        Granted: 'granted',
+    };
 
-// Declares list of valid Google Consent Properties
-var googleConsentProperties = [
-    'ad_storage',
-    'ad_user_data',
-    'ad_personalization',
-    'analytics_storage',
-];
+    // Declares list of valid Google Consent Properties
+    var googleConsentProperties = [
+        'ad_storage',
+        'ad_user_data',
+        'ad_personalization',
+        'analytics_storage',
+    ];
 
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings,
-        labels,
-        customAttributeMappings,
-        consentMappings = [],
-        consentPayloadDefaults = {},
-        consentPayloadAsString = '',
-        reportingService,
-        eventQueue = [],
-        gtagSiteId;
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            forwarderSettings,
+            labels,
+            customAttributeMappings,
+            consentMappings = [],
+            consentPayloadDefaults = {},
+            consentPayloadAsString = '',
+            reportingService,
+            eventQueue = [],
+            gtagSiteId;
 
-    self.name = name;
+        self.name = name;
 
-    function processEvent(event) {
-        var reportEvent = false;
-        var sendEventFunction = function() {};
-        var generateEventFunction = function() {};
-        var conversionLabel;
-        var eventPayload;
+        function processEvent(event) {
+            var reportEvent = false;
+            var sendEventFunction = function() {};
+            var generateEventFunction = function () {};
+            var conversionLabel;
+            var eventPayload;
 
-        if (isInitialized) {
-            // First, process anything in the queue
-            processQueue(eventQueue);
+            if (isInitialized) {
+                // First, process anything in the queue
+                processQueue(eventQueue);
 
-            try {
+                try {
+                    if (window.gtag && forwarderSettings.enableGtag == 'True') {
+                        // If consent payload is empty,
+                        // we never sent an initial default consent state
+                        // so we shouldn't send an update.
+                        var eventConsentState = getEventConsentState(event.ConsentState);
+                        maybeSendConsentUpdateToGoogle(eventConsentState)
+
+                        if (
+                            forwarderSettings.enableEnhancedConversions ===
+                                'True' &&
+                            hasEnhancedConversionData(event.CustomFlags)
+                        ) {
+                            window.enhanced_conversion_data =
+                                parseEnhancedConversionData(
+                                    event.CustomFlags[ENHANCED_CONVERSION_DATA]
+                                );
+                        }
+
+                        sendEventFunction = sendGtagEvent;
+                        generateEventFunction = generateGtagEvent;
+                        generateCommerceEvent = generateGtagCommerceEvent;
+
+                    } else if (window.google_trackConversion) {
+                        // window.google_trackConversion is a legacy API and will be deprecated
+                        sendEventFunction = sendAdwordsEvent;
+                        generateEventFunction = generateAdwordsEvent;
+                        generateCommerceEvent = generateAdwordsCommerceEvent;
+
+                    } else {
+                        eventQueue.push({
+                            action: processEvent,
+                            data: event
+                        })
+
+                        return 'Can\'t send to forwarder ' + name + ', not initialized. Event added to queue.';
+                    }
+
+                    // Get conversionLabel to be used for event generation
+                    var conversionLabel = getConversionLabel(event);
+                    var customProps = getCustomProps(event);
+
+                    if (conversionLabel) {
+                        // Determines the proper event to fire
+                        if (event.EventDataType == MessageType.PageView || event.EventDataType == MessageType.PageEvent) {
+                            eventPayload = generateEventFunction(event, conversionLabel, customProps);
+                        } else if (event.EventDataType == MessageType.Commerce && event.ProductAction) {
+                            eventPayload = generateCommerceEvent(event, conversionLabel, customProps);
+                        }
+
+                        if (eventPayload) {
+                           reportEvent = sendEventFunction(eventPayload);
+                        }
+
+                        if (reportEvent && reportingService) {
+                            reportingService(self, event);
+
+                            return 'Successfully sent to ' + name;
+                        }
+                    }
+
+                    return 'Can\'t send to forwarder: ' + name + '. Event not mapped';
+                } catch (e) {
+                    console.error('Can\t send to forwarder', e);
+                    return 'Can\'t send to forwarder: ' + name + ' ' + e;
+                }
+            } else {
+                eventQueue.push({
+                    action: processEvent,
+                    data: event
+                })
+            }
+
+            return 'Can\'t send to forwarder ' + name + ', not initialized. Event added to queue.';
+        }
+
+        function hasEnhancedConversionData(customFlags) {
+            return customFlags && Object.keys(customFlags).length && customFlags[ENHANCED_CONVERSION_DATA];
+        }
+
+        function parseEnhancedConversionData(conversionData) {
+            // Checks if conversion data in custom flags is a stringified object
+            // Conversion data should only be a stringified object or a JS object
+            if (typeof conversionData === 'string') {
+                try {
+                    return JSON.parse(conversionData);
+                } catch (error) {
+                    console.warn('Unrecognized Enhanced Conversion Data Format', conversionData, error);
+                    return {};
+                }
+            } else if (typeof conversionData === 'object') {
+                // Not a stringified object so it can be used as-is. However,
+                // we want to avoid mutating the original state, so we make a copy.
+                return cloneObject(conversionData);
+            } else {
+                console.warn('Unrecognized Enhanced Conversion Data Format', conversionData);
+                return {};
+            }
+
+        }
+
+        // Converts an mParticle Commerce Event into either Legacy or gtag Event
+        function generateCommerceEvent(mPEvent, conversionLabel, isPageEvent) {
+            if (mPEvent.ProductAction
+                && mPEvent.ProductAction.ProductList
+                && mPEvent.ProductAction.ProductActionType) {
+
                 if (window.gtag && forwarderSettings.enableGtag == 'True') {
-                    // If consent payload is empty,
-                    // we never sent an initial default consent state
-                    // so we shouldn't send an update.
-                    var eventConsentState = getEventConsentState(
-                        event.ConsentState
-                    );
-                    maybeSendConsentUpdateToGoogle(eventConsentState);
-
-                    if (
-                        forwarderSettings.enableEnhancedConversions ===
-                            'True' &&
-                        hasEnhancedConversionData(event.CustomFlags)
-                    ) {
-                        window.enhanced_conversion_data = parseEnhancedConversionData(
-                            event.CustomFlags[ENHANCED_CONVERSION_DATA]
-                        );
-                    }
-
-                    sendEventFunction = sendGtagEvent;
-                    generateEventFunction = generateGtagEvent;
-                    generateCommerceEvent = generateGtagCommerceEvent;
+                    return generateGtagCommerceEvent(mPEvent, conversionLabel, isPageEvent);
                 } else if (window.google_trackConversion) {
-                    // window.google_trackConversion is a legacy API and will be deprecated
-                    sendEventFunction = sendAdwordsEvent;
-                    generateEventFunction = generateAdwordsEvent;
-                    generateCommerceEvent = generateAdwordsCommerceEvent;
+                    return generateAdwordsCommerceEvent(mPEvent, conversionLabel, isPageEvent);
                 } else {
-                    eventQueue.push({
-                        action: processEvent,
-                        data: event,
-                    });
-
-                    return (
-                        "Can't send to forwarder " +
-                        name +
-                        ', not initialized. Event added to queue.'
-                    );
+                    console.error('Unrecognized Commerce Event', mPEvent);
+                    return false;
                 }
 
-                // Get conversionLabel to be used for event generation
-                var conversionLabel = getConversionLabel(event);
-                var customProps = getCustomProps(event);
-
-                if (conversionLabel) {
-                    // Determines the proper event to fire
-                    if (
-                        event.EventDataType == MessageType.PageView ||
-                        event.EventDataType == MessageType.PageEvent
-                    ) {
-                        eventPayload = generateEventFunction(
-                            event,
-                            conversionLabel,
-                            customProps
-                        );
-                    } else if (
-                        event.EventDataType == MessageType.Commerce &&
-                        event.ProductAction
-                    ) {
-                        eventPayload = generateCommerceEvent(
-                            event,
-                            conversionLabel,
-                            customProps
-                        );
-                    }
-
-                    if (eventPayload) {
-                        reportEvent = sendEventFunction(eventPayload);
-                    }
-
-                    if (reportEvent && reportingService) {
-                        reportingService(self, event);
-
-                        return 'Successfully sent to ' + name;
-                    }
-                }
-
-                return (
-                    "Can't send to forwarder: " + name + '. Event not mapped'
-                );
-            } catch (e) {
-                console.error('Can\t send to forwarder', e);
-                return "Can't send to forwarder: " + name + ' ' + e;
-            }
-        } else {
-            eventQueue.push({
-                action: processEvent,
-                data: event,
-            });
-        }
-
-        return (
-            "Can't send to forwarder " +
-            name +
-            ', not initialized. Event added to queue.'
-        );
-    }
-
-    function hasEnhancedConversionData(customFlags) {
-        return (
-            customFlags &&
-            Object.keys(customFlags).length &&
-            customFlags[ENHANCED_CONVERSION_DATA]
-        );
-    }
-
-    function parseEnhancedConversionData(conversionData) {
-        // Checks if conversion data in custom flags is a stringified object
-        // Conversion data should only be a stringified object or a JS object
-        if (typeof conversionData === 'string') {
-            try {
-                return JSON.parse(conversionData);
-            } catch (error) {
-                console.warn(
-                    'Unrecognized Enhanced Conversion Data Format',
-                    conversionData,
-                    error
-                );
-                return {};
-            }
-        } else if (typeof conversionData === 'object') {
-            // Not a stringified object so it can be used as-is. However,
-            // we want to avoid mutating the original state, so we make a copy.
-            return cloneObject(conversionData);
-        } else {
-            console.warn(
-                'Unrecognized Enhanced Conversion Data Format',
-                conversionData
-            );
-            return {};
-        }
-    }
-
-    // Converts an mParticle Commerce Event into either Legacy or gtag Event
-    function generateCommerceEvent(mPEvent, conversionLabel, isPageEvent) {
-        if (
-            mPEvent.ProductAction &&
-            mPEvent.ProductAction.ProductList &&
-            mPEvent.ProductAction.ProductActionType
-        ) {
-            if (window.gtag && forwarderSettings.enableGtag == 'True') {
-                return generateGtagCommerceEvent(
-                    mPEvent,
-                    conversionLabel,
-                    isPageEvent
-                );
-            } else if (window.google_trackConversion) {
-                return generateAdwordsCommerceEvent(
-                    mPEvent,
-                    conversionLabel,
-                    isPageEvent
-                );
             } else {
-                console.error('Unrecognized Commerce Event', mPEvent);
                 return false;
             }
-        } else {
-            return false;
         }
-    }
 
-    function getUserConsentState() {
-        var userConsentState = {};
+        function getUserConsentState() {
+            var userConsentState = {};
 
-        if (
-            window.mParticle &&
-            window.mParticle.Identity &&
-            window.mParticle.Identity.getCurrentUser
-        ) {
-            var currentUser = window.mParticle.Identity.getCurrentUser();
+            if (window.mParticle && window.mParticle.Identity && window.mParticle.Identity.getCurrentUser) {
+                var currentUser = window.mParticle.Identity.getCurrentUser();
 
-            if (!currentUser) {
-                return {};
+                if (!currentUser) {
+                    return {};
+                }
+
+                var consentState =
+                    window.mParticle.Identity.getCurrentUser().getConsentState();
+
+                if (consentState && consentState.getGDPRConsentState) {
+                    userConsentState = consentState.getGDPRConsentState();
+                }
             }
 
-            var consentState = window.mParticle.Identity.getCurrentUser().getConsentState();
-
-            if (consentState && consentState.getGDPRConsentState) {
-                userConsentState = consentState.getGDPRConsentState();
-            }
+            return userConsentState;
         }
 
-        return userConsentState;
-    }
-
-    function getEventConsentState(eventConsentState) {
-        return eventConsentState && eventConsentState.getGDPRConsentState
-            ? eventConsentState.getGDPRConsentState()
-            : {};
-    }
-
-    // ** Adwords Events
-    function getBaseAdWordEvent() {
-        var adWordEvent = {};
-        adWordEvent.google_conversion_value = 0;
-        adWordEvent.google_conversion_language = 'en';
-        adWordEvent.google_conversion_format = '3';
-        adWordEvent.google_conversion_color = 'ffffff';
-        adWordEvent.google_remarketing_only =
-            forwarderSettings.remarketingOnly == 'True';
-        adWordEvent.google_conversion_id = forwarderSettings.conversionId;
-        return adWordEvent;
-    }
-
-    function generateAdwordsEvent(mPEvent, conversionLabel, customProps) {
-        var adWordEvent = getBaseAdWordEvent();
-        adWordEvent.google_conversion_label = conversionLabel;
-        adWordEvent.google_custom_params = customProps;
-
-        return adWordEvent;
-    }
-
-    function generateAdwordsCommerceEvent(
-        mPEvent,
-        conversionLabel,
-        customProps
-    ) {
-        var adWordEvent = getBaseAdWordEvent();
-        adWordEvent.google_conversion_label = conversionLabel;
-
-        if (
-            mPEvent.ProductAction.ProductActionType ===
-                mParticle.ProductActionType.Purchase &&
-            mPEvent.ProductAction.TransactionId
-        ) {
-            adWordEvent.google_conversion_order_id =
-                mPEvent.ProductAction.TransactionId;
-        }
-
-        if (mPEvent.CurrencyCode) {
-            adWordEvent.google_conversion_currency = mPEvent.CurrencyCode;
-        }
-
-        if (mPEvent.ProductAction.TotalAmount) {
-            adWordEvent.google_conversion_value =
-                mPEvent.ProductAction.TotalAmount;
-        }
-
-        adWordEvent.google_custom_params = customProps;
-        return adWordEvent;
-    }
-
-    function getConsentSettings() {
-        var consentSettings = {};
-
-        var googleToMpConsentSettingsMapping = {
-            // Inherited from S2S Integration Settings
-            ad_user_data: 'defaultAdUserDataConsent',
-            ad_personalization: 'defaultAdPersonalizationConsent',
-
-            // Unique to Web Kits
-            ad_storage: 'defaultAdStorageConsentWeb',
-            analytics_storage: 'defaultAnalyticsStorageConsentWeb',
+        function getEventConsentState(eventConsentState) {
+            return eventConsentState && eventConsentState.getGDPRConsentState
+                ? eventConsentState.getGDPRConsentState()
+                : {};
         };
 
-        Object.keys(googleToMpConsentSettingsMapping).forEach(function(
-            googleConsentKey
-        ) {
-            var mpConsentSettingKey =
-                googleToMpConsentSettingsMapping[googleConsentKey];
-            var googleConsentValuesKey = forwarderSettings[mpConsentSettingKey];
+        // ** Adwords Events
+        function getBaseAdWordEvent() {
+            var adWordEvent = {};
+            adWordEvent.google_conversion_value = 0;
+            adWordEvent.google_conversion_language = 'en';
+            adWordEvent.google_conversion_format = '3';
+            adWordEvent.google_conversion_color = 'ffffff';
+            adWordEvent.google_remarketing_only = forwarderSettings.remarketingOnly == 'True';
+            adWordEvent.google_conversion_id = forwarderSettings.conversionId;
+            return adWordEvent;
+        }
 
-            if (googleConsentValuesKey && mpConsentSettingKey) {
-                consentSettings[googleConsentKey] =
-                    googleConsentValues[googleConsentValuesKey];
+        function generateAdwordsEvent(mPEvent, conversionLabel, customProps) {
+            var adWordEvent = getBaseAdWordEvent();
+            adWordEvent.google_conversion_label = conversionLabel;
+            adWordEvent.google_custom_params = customProps;
+
+            return adWordEvent;
+        }
+
+        function generateAdwordsCommerceEvent(mPEvent, conversionLabel, customProps) {
+            var adWordEvent = getBaseAdWordEvent();
+            adWordEvent.google_conversion_label = conversionLabel;
+
+            if (mPEvent.ProductAction.ProductActionType === mParticle.ProductActionType.Purchase
+                && mPEvent.ProductAction.TransactionId) {
+                adWordEvent.google_conversion_order_id = mPEvent.ProductAction.TransactionId;
             }
-        });
 
-        return consentSettings;
-    }
+            if (mPEvent.CurrencyCode) {
+                adWordEvent.google_conversion_currency = mPEvent.CurrencyCode;
+            }
 
-    // gtag Events
-    function getBaseGtagEvent(conversionLabel) {
-        return {
-            send_to: gtagSiteId + '/' + conversionLabel,
-            value: 0,
-            language: 'en',
-            remarketing_only: forwarderSettings.remarketingOnly == 'True',
-        };
-    }
+            if (mPEvent.ProductAction.TotalAmount) {
+                adWordEvent.google_conversion_value = mPEvent.ProductAction.TotalAmount;
+            }
 
-    function generateGtagEvent(mPEvent, conversionLabel, customProps) {
-        if (!conversionLabel) {
-            return null;
+            adWordEvent.google_custom_params = customProps;
+            return adWordEvent;
         }
 
-        var conversionPayload = getBaseGtagEvent(conversionLabel);
-        conversionPayload.transaction_id = mPEvent.SourceMessageId;
-        return mergeObjects(conversionPayload, customProps);
-    }
+        function getConsentSettings() {
+            var consentSettings = {};
 
-    function generateGtagCommerceEvent(mPEvent, conversionLabel, customProps) {
-        if (!conversionLabel) {
-            return null;
+            var googleToMpConsentSettingsMapping = {
+                // Inherited from S2S Integration Settings
+                ad_user_data: 'defaultAdUserDataConsent',
+                ad_personalization: 'defaultAdPersonalizationConsent',
+
+                // Unique to Web Kits
+                ad_storage: 'defaultAdStorageConsentWeb',
+                analytics_storage: 'defaultAnalyticsStorageConsentWeb'
+            }
+
+            Object.keys(googleToMpConsentSettingsMapping).forEach(function (googleConsentKey) {
+                var mpConsentSettingKey = googleToMpConsentSettingsMapping[googleConsentKey];
+                var googleConsentValuesKey = forwarderSettings[mpConsentSettingKey]
+
+                if (googleConsentValuesKey && mpConsentSettingKey){
+                    consentSettings[googleConsentKey] = googleConsentValues[googleConsentValuesKey];
+                }
+            });
+
+            return consentSettings;
         }
 
-        var conversionPayload = getBaseGtagEvent(conversionLabel);
+        // gtag Events
+        function getBaseGtagEvent(conversionLabel) {
+            return {
+                'send_to': gtagSiteId + '/' + conversionLabel,
+                'value': 0,
+                'language': 'en',
+                'remarketing_only': forwarderSettings.remarketingOnly == 'True'
+            }
+        }
 
-        if (
-            mPEvent.ProductAction.ProductActionType ===
-                mParticle.ProductActionType.Purchase &&
-            mPEvent.ProductAction.TransactionId
-        ) {
-            conversionPayload.transaction_id =
-                mPEvent.ProductAction.TransactionId;
-        } else {
+        function generateGtagEvent(mPEvent, conversionLabel, customProps) {
+            if (!conversionLabel) { return null; };
+
+            var conversionPayload = getBaseGtagEvent(conversionLabel);
             conversionPayload.transaction_id = mPEvent.SourceMessageId;
+            return mergeObjects(conversionPayload, customProps);
         }
 
-        if (mPEvent.CurrencyCode) {
-            conversionPayload.currency = mPEvent.CurrencyCode;
-        }
+        function generateGtagCommerceEvent(mPEvent, conversionLabel, customProps) {
+            if (!conversionLabel) { return null; };
 
-        if (mPEvent.ProductAction.TotalAmount) {
-            conversionPayload.value = mPEvent.ProductAction.TotalAmount;
-        }
+            var conversionPayload = getBaseGtagEvent(conversionLabel);
 
-        return mergeObjects(conversionPayload, customProps);
-    }
-
-    function sendGtagEvent(payload) {
-        // https://go.mparticle.com/work/SQDSDKS-6165
-        try {
-            gtag('event', 'conversion', payload);
-        } catch (e) {
-            console.error(
-                'gtag is not available to send payload: ',
-                payload,
-                e
-            );
-            return false;
-        }
-        return true;
-    }
-
-    function maybeSendConsentUpdateToGoogle(consentState) {
-        if (
-            consentPayloadAsString &&
-            forwarderSettings.consentMappingWeb &&
-            !isEmpty(consentState)
-        ) {
-            var updatedConsentPayload = generateConsentStatePayloadFromMappings(
-                consentState,
-                consentMappings
-            );
-
-            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
-
-            if (eventConsentAsString !== consentPayloadAsString) {
-                sendGtagConsentUpdate(updatedConsentPayload);
-                consentPayloadAsString = eventConsentAsString;
+            if (mPEvent.ProductAction.ProductActionType === mParticle.ProductActionType.Purchase
+                && mPEvent.ProductAction.TransactionId) {
+                conversionPayload.transaction_id = mPEvent.ProductAction.TransactionId;
+            } else {
+                conversionPayload.transaction_id = mPEvent.SourceMessageId;
             }
+
+            if (mPEvent.CurrencyCode) {
+                conversionPayload.currency = mPEvent.CurrencyCode;
+            }
+
+            if (mPEvent.ProductAction.TotalAmount) {
+                conversionPayload.value = mPEvent.ProductAction.TotalAmount;
+            }
+
+            return mergeObjects(conversionPayload, customProps);
         }
-    }
 
-    function sendGtagConsentDefaults(payload) {
-        // https://go.mparticle.com/work/SQDSDKS-6165
-        consentPayloadAsString = JSON.stringify(payload);
-
-        try {
-            gtag('consent', 'default', payload);
-        } catch (e) {
-            console.error(
-                'gtag is not available to send consent defaults: ',
-                payload,
-                e
-            );
-            return false;
+        function sendGtagEvent(payload) {
+            // https://go.mparticle.com/work/SQDSDKS-6165
+            try {
+                gtag('event', 'conversion', payload);
+            } catch (e) {
+                console.error('gtag is not available to send payload: ', payload, e);
+                return false;
+            }
+            return true;
         }
-        return true;
-    }
 
-    function sendGtagConsentUpdate(payload) {
-        // https://go.mparticle.com/work/SQDSDKS-6165
-        try {
-            gtag('consent', 'update', payload);
-        } catch (e) {
-            console.error(
-                'gtag is not available to send consent update: ',
-                payload,
-                e
-            );
-            return false;
-        }
-        return true;
-    }
-
-    function sendAdwordsEvent(payload) {
-        try {
-            window.google_trackConversion(payload);
-        } catch (e) {
-            console.error(
-                'google_trackConversion is not available to send payload: ',
-                payload,
-                e
-            );
-            return false;
-        }
-        return true;
-    }
-
-    // Creates a new Consent State Payload based on Consent State and Mapping
-    function generateConsentStatePayloadFromMappings(consentState, mappings) {
-        if (!mappings) return {};
-        var payload = cloneObject(consentPayloadDefaults);
-
-        for (var i = 0; i <= mappings.length - 1; i++) {
-            var mappingEntry = mappings[i];
-            // Although consent purposes can be inputted into the UI in any casing
-            // the SDK will automatically lowercase them to prevent pseudo-duplicate
-            // consent purposes, so we call `toLowerCase` on the consentMapping purposes here
-            var mpMappedConsentName = mappingEntry.map.toLowerCase();
-            // var mpMappedConsentName = mappingEntry.map;
-            var googleMappedConsentName = mappingEntry.value;
-
+        function maybeSendConsentUpdateToGoogle(consentState) {
             if (
-                consentState[mpMappedConsentName] &&
-                googleConsentProperties.indexOf(googleMappedConsentName) !== -1
+                consentPayloadAsString &&
+                forwarderSettings.consentMappingWeb &&
+                !isEmpty(consentState)
             ) {
-                payload[googleMappedConsentName] = consentState[
-                    mpMappedConsentName
-                ].Consented
-                    ? googleConsentValues.Granted
-                    : googleConsentValues.Denied;
+                var updatedConsentPayload = generateConsentStatePayloadFromMappings(
+                    consentState,
+                    consentMappings,
+                );
+
+                var eventConsentAsString =
+                    JSON.stringify(updatedConsentPayload);
+
+                if (eventConsentAsString !== consentPayloadAsString) {
+                    sendGtagConsentUpdate(updatedConsentPayload);
+                    consentPayloadAsString = eventConsentAsString;
+                }
             }
         }
 
-        return payload;
-    }
+        function sendGtagConsentDefaults(payload) {
+            // https://go.mparticle.com/work/SQDSDKS-6165
+            consentPayloadAsString = JSON.stringify(
+                payload
+            );
 
-    // Looks up an Event's conversionLabel from customAttributeMappings based on computed jsHash value
-    function getConversionLabel(event) {
-        var jsHash = calculateJSHash(
-            event.EventDataType,
-            event.EventCategory,
-            event.EventName
-        );
-        var type =
-            event.EventDataType === MessageType.PageEvent
-                ? 'EventClass.Id'
-                : 'EventClassDetails.Id';
-        var conversionLabel = null;
-        var mappingEntry = findValueInMapping(jsHash, type, labels);
-
-        if (mappingEntry) {
-            conversionLabel = mappingEntry.value;
+            try {
+                gtag('consent', 'default', payload);
+            } catch (e) {
+                console.error('gtag is not available to send consent defaults: ', payload, e);
+                return false;
+            }
+            return true;
         }
 
-        return conversionLabel;
-    }
+        function sendGtagConsentUpdate(payload) {
+            // https://go.mparticle.com/work/SQDSDKS-6165
+            try {
+                gtag('consent', 'update', payload);
+            } catch (e) {
+                console.error('gtag is not available to send consent update: ', payload, e);
+                return false;
+            }
+            return true;
+        }
 
-    // Filters Event.EventAttributes for attributes that are in customAttributeMappings
-    function getCustomProps(event) {
-        var customProps = {};
-        var attributes = event.EventAttributes;
-        var type =
-            event.EventDataType === MessageType.PageEvent
-                ? 'EventAttributeClass.Id'
-                : 'EventAttributeClassDetails.Id';
+        function sendAdwordsEvent(payload) {
+            try {
+                window.google_trackConversion(payload);
+            } catch (e) {
+                console.error('google_trackConversion is not available to send payload: ', payload, e);
+                return false;
+            }
+            return true;
+        }
 
-        if (attributes) {
-            for (var attributeKey in attributes) {
-                if (attributes.hasOwnProperty(attributeKey)) {
-                    var jsHash = calculateJSHash(
-                        event.EventDataType,
-                        event.EventCategory,
-                        attributeKey
-                    );
-                    var mappingEntry = findValueInMapping(
-                        jsHash,
-                        type,
-                        customAttributeMappings
-                    );
-                    if (mappingEntry) {
-                        customProps[mappingEntry.value] =
-                            attributes[attributeKey];
+        // Creates a new Consent State Payload based on Consent State and Mapping
+        function generateConsentStatePayloadFromMappings(consentState, mappings) {
+            if (!mappings) return {};
+            var payload = cloneObject(consentPayloadDefaults);
+
+            for (var i = 0; i <= mappings.length - 1; i++) {
+                var mappingEntry = mappings[i];
+                // Although consent purposes can be inputted into the UI in any casing
+                // the SDK will automatically lowercase them to prevent pseudo-duplicate
+                // consent purposes, so we call `toLowerCase` on the consentMapping purposes here
+                var mpMappedConsentName = mappingEntry.map.toLowerCase();
+                // var mpMappedConsentName = mappingEntry.map;
+                var googleMappedConsentName = mappingEntry.value;
+
+                if (
+                    consentState[mpMappedConsentName] &&
+                    googleConsentProperties.indexOf(googleMappedConsentName) !== -1
+                ) {
+                    payload[googleMappedConsentName] = consentState[mpMappedConsentName]
+                        .Consented
+                        ? googleConsentValues.Granted
+                        : googleConsentValues.Denied;
+                }
+            }
+
+            return payload;
+        }
+
+        // Looks up an Event's conversionLabel from customAttributeMappings based on computed jsHash value
+        function getConversionLabel(event) {
+            var jsHash = calculateJSHash(event.EventDataType, event.EventCategory, event.EventName);
+            var type = event.EventDataType === MessageType.PageEvent ? 'EventClass.Id' : 'EventClassDetails.Id';
+            var conversionLabel = null;
+            var mappingEntry = findValueInMapping(jsHash, type, labels);
+
+            if (mappingEntry) {
+                conversionLabel = mappingEntry.value;
+            }
+
+            return conversionLabel;
+        }
+
+        // Filters Event.EventAttributes for attributes that are in customAttributeMappings
+        function getCustomProps(event) {
+            var customProps = {};
+            var attributes = event.EventAttributes;
+            var type = event.EventDataType === MessageType.PageEvent ? 'EventAttributeClass.Id' : 'EventAttributeClassDetails.Id';
+
+            if (attributes) {
+                for (var attributeKey in attributes) {
+                    if (attributes.hasOwnProperty(attributeKey)) {
+                        var jsHash = calculateJSHash(event.EventDataType, event.EventCategory, attributeKey);
+                        var mappingEntry = findValueInMapping(jsHash, type, customAttributeMappings);
+                        if (mappingEntry) {
+                            customProps[mappingEntry.value] = attributes[attributeKey];
+                        }
                     }
                 }
             }
+
+            return customProps;
         }
 
-        return customProps;
-    }
+        function findValueInMapping(jsHash, type, mapping) {
+            if (mapping) {
+                var filteredArray = mapping.filter(function (mappingEntry) {
 
-    function findValueInMapping(jsHash, type, mapping) {
-        if (mapping) {
-            var filteredArray = mapping.filter(function(mappingEntry) {
-                if (
-                    mappingEntry.jsmap &&
-                    mappingEntry.maptype &&
-                    mappingEntry.value
-                ) {
-                    return (
-                        mappingEntry.jsmap == jsHash &&
-                        mappingEntry.maptype == type
-                    );
+                    if (mappingEntry.jsmap && mappingEntry.maptype && mappingEntry.value) {
+                        return mappingEntry.jsmap == jsHash && mappingEntry.maptype == type;
+                    }
+
+                    return false;
+                });
+
+                if (filteredArray && filteredArray.length > 0) {
+                    return filteredArray[0];
+                }
+            }
+            return null;
+        }
+
+        function calculateJSHash(eventDataType, eventCategory, name) {
+            var preHash = [eventDataType, eventCategory, name].join('');
+
+            return mParticle.generateHash(preHash);
+        }
+
+        function loadGtagSnippet() {
+            (function () {
+                window.dataLayer = window.dataLayer || [];
+                window.gtag = function(){dataLayer.push(arguments);}
+
+                var gTagScript = document.createElement('script');
+                gTagScript.async = true;
+                gTagScript.onload = function () {
+                    gtag('js', new Date());
+                    if (forwarderSettings.enableEnhancedConversions === 'True') {
+                        gtag('config', gtagSiteId, {
+                            allow_enhanced_conversions: true
+                        });
+                    } else {
+                        gtag('config', gtagSiteId);
+                    }
+                    isInitialized = true;
+                    processQueue(eventQueue);
+                };
+                gTagScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + gtagSiteId;
+                document.getElementsByTagName('head')[0].appendChild(gTagScript);
+            })();
+        }
+
+        function loadLegacySnippet() {
+            (function () {
+                var googleAdwords = document.createElement('script');
+                googleAdwords.type = 'text/javascript';
+                googleAdwords.async = true;
+                googleAdwords.onload = function() {
+                    isInitialized = true;
+                    processQueue(eventQueue);
+                };
+                googleAdwords.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://www.googleadservices.com/pagead/conversion_async.js';
+                document.getElementsByTagName('head')[0].appendChild(googleAdwords);
+            })();
+        }
+
+        // https://go.mparticle.com/work/SQDSDKS-6166
+        function initForwarder(settings, service, testMode) {
+            window.enhanced_conversion_data = {};
+            forwarderSettings = settings;
+            reportingService = service;
+
+            try {
+                if (!forwarderSettings.conversionId) {
+                    return 'Can\'t initialize forwarder: ' + name + ', conversionId is not defined';
                 }
 
-                return false;
+                gtagSiteId = "AW-" + forwarderSettings.conversionId;
+
+                if (testMode !== true) {
+                    if (forwarderSettings.enableGtag == 'True') {
+                        loadGtagSnippet();
+                    } else {
+                        loadLegacySnippet();
+                    }
+                } else {
+                    isInitialized = true;
+                    processQueue(eventQueue);
+                }
+
+                if (!forwarderSettings.conversionId) {
+                    return 'Can\'t initialize forwarder: ' + name + ', conversionId is not defined';
+                }
+
+                // https://go.mparticle.com/work/SQDSDKS-6165
+                if (window.gtag && forwarderSettings.enableGtag === 'True') {
+                    if (forwarderSettings.consentMappingWeb) {
+                        consentMappings = parseSettingsString(
+                            forwarderSettings.consentMappingWeb
+                        );
+                    } else {
+                        // Ensures consent mappings is an empty array
+                        // for future use
+                        consentMappings = [];
+                    }
+
+                    consentPayloadDefaults = getConsentSettings();
+                    var defaultConsentPayload = cloneObject(consentPayloadDefaults);
+                    var updatedConsentState = getUserConsentState();
+                    var updatedDefaultConsentPayload =
+                        generateConsentStatePayloadFromMappings(
+                            updatedConsentState,
+                            consentMappings
+                        );
+
+                    if (!isEmpty(defaultConsentPayload)) {
+                        sendGtagConsentDefaults(defaultConsentPayload)
+                    } else if (!isEmpty(updatedDefaultConsentPayload)) {
+                        sendGtagConsentDefaults(updatedDefaultConsentPayload)
+                    }
+
+                    maybeSendConsentUpdateToGoogle(updatedConsentState)
+
+                }
+
+                forwarderSettings.remarketingOnly = forwarderSettings.remarketingOnly == 'True';
+
+                try {
+                    if (forwarderSettings.labels) {
+                        labels = JSON.parse(forwarderSettings.labels.replace(/&quot;/g, '"'));
+                    }
+
+                    if (forwarderSettings.customParameters) {
+                        customAttributeMappings = JSON.parse(forwarderSettings.customParameters.replace(/&quot;/g, '"'));
+                    }
+                } catch (e) {
+                    return 'Can\'t initialize forwarder: ' + name + ', Could not process event to label mapping';
+                }
+
+                return 'Successfully initialized: ' + name;
+            }
+            catch (e) {
+                return 'Failed to initialize: ' + name;
+            }
+        }
+
+        function processQueue(queue) {
+            var item;
+
+            if ((window.gtag || window.google_trackConversion) && queue.length > 0) {
+                try {
+                    while (queue.length > 0) {
+                        item = queue.shift()
+                        item.action(item.data);
+                    }
+                } catch (e) {
+                    console.error('Error on mParticle Adwords Kit', e);
+                }
+            }
+        }
+
+        this.init = initForwarder;
+        this.process = processEvent;
+        this.processQueue = processQueue;
+    };
+
+    function getId() {
+        return moduleId;
+    }
+
+    function register(config) {
+        if (!config) {
+            console.log('You must pass a config object to register the kit ' + name);
+            return;
+        }
+
+        if (!isObject(config)) {
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
+
+        if (isObject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    function parseSettingsString(settingsString) {
+        return JSON.parse(settingsString.replace(/&quot;/g, '"'));
+    }
+
+    function isObject(val) {
+        return val != null && typeof val === 'object' && Array.isArray(val) === false;
+    }
+
+    function isEmpty(value) {
+        return value == null || !(Object.keys(value) || value).length;
+    }
+
+    function mergeObjects() {
+        var resObj = {};
+        for(var i=0; i < arguments.length; i += 1) {
+             var obj = arguments[i],
+                 keys = Object.keys(obj);
+             for(var j=0; j < keys.length; j += 1) {
+                 resObj[keys[j]] = obj[keys[j]];
+             }
+        }
+        return resObj;
+    }
+
+    function cloneObject(obj) {
+        return JSON.parse(JSON.stringify(obj));
+    }
+
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
             });
-
-            if (filteredArray && filteredArray.length > 0) {
-                return filteredArray[0];
-            }
-        }
-        return null;
-    }
-
-    function calculateJSHash(eventDataType, eventCategory, name) {
-        var preHash = [eventDataType, eventCategory, name].join('');
-
-        return mParticle.generateHash(preHash);
-    }
-
-    function loadGtagSnippet() {
-        (function() {
-            window.dataLayer = window.dataLayer || [];
-            window.gtag = function() {
-                dataLayer.push(arguments);
-            };
-
-            var gTagScript = document.createElement('script');
-            gTagScript.async = true;
-            gTagScript.onload = function() {
-                gtag('js', new Date());
-                if (forwarderSettings.enableEnhancedConversions === 'True') {
-                    gtag('config', gtagSiteId, {
-                        allow_enhanced_conversions: true,
-                    });
-                } else {
-                    gtag('config', gtagSiteId);
-                }
-                isInitialized = true;
-                processQueue(eventQueue);
-            };
-            gTagScript.src =
-                'https://www.googletagmanager.com/gtag/js?id=' + gtagSiteId;
-            document.getElementsByTagName('head')[0].appendChild(gTagScript);
-        })();
-    }
-
-    function loadLegacySnippet() {
-        (function() {
-            var googleAdwords = document.createElement('script');
-            googleAdwords.type = 'text/javascript';
-            googleAdwords.async = true;
-            googleAdwords.onload = function() {
-                isInitialized = true;
-                processQueue(eventQueue);
-            };
-            googleAdwords.src =
-                ('https:' == document.location.protocol ? 'https' : 'http') +
-                '://www.googleadservices.com/pagead/conversion_async.js';
-            document.getElementsByTagName('head')[0].appendChild(googleAdwords);
-        })();
-    }
-
-    // https://go.mparticle.com/work/SQDSDKS-6166
-    function initForwarder(settings, service, testMode) {
-        window.enhanced_conversion_data = {};
-        forwarderSettings = settings;
-        reportingService = service;
-
-        try {
-            if (!forwarderSettings.conversionId) {
-                return (
-                    "Can't initialize forwarder: " +
-                    name +
-                    ', conversionId is not defined'
-                );
-            }
-
-            gtagSiteId = 'AW-' + forwarderSettings.conversionId;
-
-            if (testMode !== true) {
-                if (forwarderSettings.enableGtag == 'True') {
-                    loadGtagSnippet();
-                } else {
-                    loadLegacySnippet();
-                }
-            } else {
-                isInitialized = true;
-                processQueue(eventQueue);
-            }
-
-            if (!forwarderSettings.conversionId) {
-                return (
-                    "Can't initialize forwarder: " +
-                    name +
-                    ', conversionId is not defined'
-                );
-            }
-
-            // https://go.mparticle.com/work/SQDSDKS-6165
-            if (window.gtag && forwarderSettings.enableGtag === 'True') {
-                if (forwarderSettings.consentMappingWeb) {
-                    consentMappings = parseSettingsString(
-                        forwarderSettings.consentMappingWeb
-                    );
-                } else {
-                    // Ensures consent mappings is an empty array
-                    // for future use
-                    consentMappings = [];
-                }
-
-                consentPayloadDefaults = getConsentSettings();
-                var defaultConsentPayload = cloneObject(consentPayloadDefaults);
-                var updatedConsentState = getUserConsentState();
-                var updatedDefaultConsentPayload = generateConsentStatePayloadFromMappings(
-                    updatedConsentState,
-                    consentMappings
-                );
-
-                if (!isEmpty(defaultConsentPayload)) {
-                    sendGtagConsentDefaults(defaultConsentPayload);
-                } else if (!isEmpty(updatedDefaultConsentPayload)) {
-                    sendGtagConsentDefaults(updatedDefaultConsentPayload);
-                }
-
-                maybeSendConsentUpdateToGoogle(updatedConsentState);
-            }
-
-            forwarderSettings.remarketingOnly =
-                forwarderSettings.remarketingOnly == 'True';
-
-            try {
-                if (forwarderSettings.labels) {
-                    labels = JSON.parse(
-                        forwarderSettings.labels.replace(/&quot;/g, '"')
-                    );
-                }
-
-                if (forwarderSettings.customParameters) {
-                    customAttributeMappings = JSON.parse(
-                        forwarderSettings.customParameters.replace(
-                            /&quot;/g,
-                            '"'
-                        )
-                    );
-                }
-            } catch (e) {
-                return (
-                    "Can't initialize forwarder: " +
-                    name +
-                    ', Could not process event to label mapping'
-                );
-            }
-
-            return 'Successfully initialized: ' + name;
-        } catch (e) {
-            return 'Failed to initialize: ' + name;
         }
     }
 
-    function processQueue(queue) {
-        var item;
-
-        if (
-            (window.gtag || window.google_trackConversion) &&
-            queue.length > 0
-        ) {
-            try {
-                while (queue.length > 0) {
-                    item = queue.shift();
-                    item.action(item.data);
-                }
-            } catch (e) {
-                console.error('Error on mParticle Adwords Kit', e);
-            }
-        }
-    }
-
-    this.init = initForwarder;
-    this.process = processEvent;
-    this.processQueue = processQueue;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
-    }
-
-    if (!isObject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isObject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-function parseSettingsString(settingsString) {
-    return JSON.parse(settingsString.replace(/&quot;/g, '"'));
-}
-
-function isObject(val) {
-    return (
-        val != null && typeof val === 'object' && Array.isArray(val) === false
-    );
-}
-
-function isEmpty(value) {
-    return value == null || !(Object.keys(value) || value).length;
-}
-
-function mergeObjects() {
-    var resObj = {};
-    for (var i = 0; i < arguments.length; i += 1) {
-        var obj = arguments[i],
-            keys = Object.keys(obj);
-        for (var j = 0; j < keys.length; j += 1) {
-            resObj[keys[j]] = obj[keys[j]];
-        }
-    }
-    return resObj;
-}
-
-function cloneObject(obj) {
-    return JSON.parse(JSON.stringify(obj));
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-export default {
-    register: register,
-};
+    export default {
+        register: register
+    };

--- a/kits/criteo/src/CriteoEventForwarder.js
+++ b/kits/criteo/src/CriteoEventForwarder.js
@@ -14,331 +14,300 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-var name = 'Criteo',
-    moduleId = 1010,
-    MessageType = {
-        SessionStart: 1,
-        SessionEnd: 2,
-        PageView: 3,
-        PageEvent: 4,
-        CrashReport: 5,
-        OptOut: 6,
-        Commerce: 16,
-    },
-    // below are custom types for logging page views and setting site types for Criteo
-    CRITEO_SITETYPE = 'CRITEO_SITETYPE',
-    CRITEO_VIEW_HOMEPAGE = 'CRITEO_VIEW_HOMEPAGE';
+    var name = 'Criteo',
+        moduleId = 1010,
+        MessageType = {
+            SessionStart: 1,
+            SessionEnd: 2,
+            PageView: 3,
+            PageEvent: 4,
+            CrashReport: 5,
+            OptOut: 6,
+            Commerce: 16
+        },
+        // below are custom types for logging page views and setting site types for Criteo
+        CRITEO_SITETYPE = 'CRITEO_SITETYPE',
+        CRITEO_VIEW_HOMEPAGE = 'CRITEO_VIEW_HOMEPAGE';
 
-var constructor = function() {
-    var self = this,
-        reportingService,
-        mpCustomFlags;
+    var constructor = function () {
+        var self = this,
+            reportingService,
+            mpCustomFlags;
 
-    setDefaultCriteoEvents();
+        setDefaultCriteoEvents();
 
-    self.name = name;
+        self.name = name;
 
-    function initForwarder(
-        forwarderSettings,
-        service,
-        testMode,
-        trackerId,
-        userAttributes,
-        userIdentities,
-        appVersion,
-        appName,
-        customFlags
-    ) {
-        mpCustomFlags = customFlags;
-        if (!testMode) {
-            reportingService = service;
-            settings = forwarderSettings;
+        function initForwarder(forwarderSettings, service, testMode, trackerId, userAttributes, userIdentities, appVersion, appName, customFlags) {
+            mpCustomFlags = customFlags;
+            if (!testMode) {
+                reportingService = service;
+                settings = forwarderSettings;
+                try {
+                    var criteoScript = document.createElement('script');
+                    window.criteo_q = window.criteo_q || [];
+                    criteoScript.type = 'text/javascript';
+                    criteoScript.async = true;
+                    criteoScript.src = 'https://static.criteo.net/js/ld/ld.js';
+                    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(criteoScript);
+                }
+                catch (e) {
+                    return 'Failed to initialize: ' + e;
+                }
+            } else {
+                // each event needs to be defaulted for tests
+                setDefaultCriteoEvents();
+            }
+
+            setAccountEvent.account = forwarderSettings.apiKey;
+            return 'Criteo successfully loaded';
+        }
+
+        // each of the following Criteo Event Types are set and then an
+        // array of them are processed in processQueuedCriteoEvent
+        function setDefaultCriteoEvents() {
+            setAccountEvent = { event: 'setAccount' },
+            setSiteTypeEvent = { event: 'setSiteType' },
+            setEmailEvent = { event: 'setEmail' },
+            setCustomerIdEvent = { event: 'setCustomerId' },
+            setDataEvent = { event: 'setData' };
+        }
+
+        function processEvent(event) {
+            var reportEvent = false;
+            var criteoEvent;
+
             try {
-                var criteoScript = document.createElement('script');
-                window.criteo_q = window.criteo_q || [];
-                criteoScript.type = 'text/javascript';
-                criteoScript.async = true;
-                criteoScript.src = 'https://static.criteo.net/js/ld/ld.js';
-                (
-                    document.getElementsByTagName('head')[0] ||
-                    document.getElementsByTagName('body')[0]
-                ).appendChild(criteoScript);
-            } catch (e) {
-                return 'Failed to initialize: ' + e;
-            }
-        } else {
-            // each event needs to be defaulted for tests
-            setDefaultCriteoEvents();
-        }
-
-        setAccountEvent.account = forwarderSettings.apiKey;
-        return 'Criteo successfully loaded';
-    }
-
-    // each of the following Criteo Event Types are set and then an
-    // array of them are processed in processQueuedCriteoEvent
-    function setDefaultCriteoEvents() {
-        (setAccountEvent = { event: 'setAccount' }),
-            (setSiteTypeEvent = { event: 'setSiteType' }),
-            (setEmailEvent = { event: 'setEmail' }),
-            (setCustomerIdEvent = { event: 'setCustomerId' }),
-            (setDataEvent = { event: 'setData' });
-    }
-
-    function processEvent(event) {
-        var reportEvent = false;
-        var criteoEvent;
-
-        try {
-            if (event.EventDataType === MessageType.Commerce) {
-                if (
-                    event.EventCategory ===
-                    mParticle.CommerceEventType.ProductAddToCart
-                ) {
-                    criteoEvent = createViewBasket(event);
-                } else if (
-                    event.EventCategory ===
-                    mParticle.CommerceEventType.ProductViewDetail
-                ) {
-                    criteoEvent = createViewProduct(event);
-                } else if (
-                    event.EventCategory ===
-                    mParticle.CommerceEventType.ProductImpression
-                ) {
-                    criteoEvent = createViewList(event);
-                } else if (
-                    event.EventCategory ===
-                    mParticle.CommerceEventType.ProductPurchase
-                ) {
-                    criteoEvent = createTrackTransactionEvent(event);
+                if (event.EventDataType === MessageType.Commerce) {
+                    if (event.EventCategory === mParticle.CommerceEventType.ProductAddToCart) {
+                        criteoEvent = createViewBasket(event);
+                    }
+                    else if (event.EventCategory === mParticle.CommerceEventType.ProductViewDetail) {
+                        criteoEvent = createViewProduct(event);
+                    }
+                    else if (event.EventCategory === mParticle.CommerceEventType.ProductImpression) {
+                        criteoEvent = createViewList(event);
+                    }
+                    else if (event.EventCategory === mParticle.CommerceEventType.ProductPurchase) {
+                        criteoEvent = createTrackTransactionEvent(event);
+                    }
                 }
-            } else if (event.EventDataType === MessageType.PageView) {
-                if (
-                    event.CustomFlags &&
-                    event.CustomFlags[CRITEO_VIEW_HOMEPAGE]
-                ) {
-                    criteoEvent = { event: 'viewHome' };
+                else if (event.EventDataType === MessageType.PageView) {
+                    if (event.CustomFlags && event.CustomFlags[CRITEO_VIEW_HOMEPAGE]) {
+                        criteoEvent = { event: 'viewHome' };
+                    } else {
+                        return 'Error - Criteo home page views are logged via mParticle.logPageView(\'homepage\), no other logPageViews are sent to Criteo';
+                    }
                 } else {
-                    return "Error - Criteo home page views are logged via mParticle.logPageView('homepage), no other logPageViews are sent to Criteo";
+                    return 'Error - Criteo does not support the event type - ' + event.EventDataType;
                 }
-            } else {
-                return (
-                    'Error - Criteo does not support the event type - ' +
-                    event.EventDataType
-                );
+
+                modifySetSiteTypeEvent();
+                modifySetDataEvent(event);
+                queueCriteoEvent(criteoEvent);
+
+                reportEvent = true;
+
+                if (reportEvent === true && reportingService) {
+                    reportingService(self, event);
+                    return 'Successfully sent to ' + name;
+                }
+                else {
+                    return 'Error logging event or event type not supported - ' + reportEvent.error;
+                }
             }
-
-            modifySetSiteTypeEvent();
-            modifySetDataEvent(event);
-            queueCriteoEvent(criteoEvent);
-
-            reportEvent = true;
-
-            if (reportEvent === true && reportingService) {
-                reportingService(self, event);
-                return 'Successfully sent to ' + name;
-            } else {
-                return (
-                    'Error logging event or event type not supported - ' +
-                    reportEvent.error
-                );
+            catch (e) {
+                return 'Failed to send to: ' + name + ' ' + e;
             }
-        } catch (e) {
-            return 'Failed to send to: ' + name + ' ' + e;
         }
-    }
 
-    function modifySetSiteTypeEvent() {
-        if (mpCustomFlags && mpCustomFlags[CRITEO_SITETYPE]) {
-            setSiteTypeEvent.type = mpCustomFlags[CRITEO_SITETYPE];
-        } else {
-            setSiteTypeEvent.type = 'd';
+        function modifySetSiteTypeEvent() {
+            if (mpCustomFlags && mpCustomFlags[CRITEO_SITETYPE]) {
+                setSiteTypeEvent.type = mpCustomFlags[CRITEO_SITETYPE];
+            } else {
+                setSiteTypeEvent.type = 'd';
+            }
         }
-    }
 
-    function modifySetDataEvent(event) {
-        var eventAttributes = event.EventAttributes || {};
+        function modifySetDataEvent(event) {
+            var eventAttributes = event.EventAttributes || {};
 
-        if (Object.keys(eventAttributes).length) {
-            for (var key in eventAttributes) {
-                if (key !== 'siteType') {
-                    if (eventAttributes.hasOwnProperty(key)) {
-                        setDataEvent[key] = eventAttributes[key];
+            if (Object.keys(eventAttributes).length) {
+                for (var key in eventAttributes) {
+                    if (key !=='siteType') {
+                        if (eventAttributes.hasOwnProperty(key)) {
+                            setDataEvent[key] = eventAttributes[key];
+                        }
                     }
                 }
             }
         }
-    }
 
-    function resetSetDataEventAfterQueuingEvent() {
-        setDataEvent = {
-            event: 'setData',
-        };
-    }
-
-    function queueCriteoEvent(criteoEvent) {
-        var eventQueue = [setAccountEvent, setSiteTypeEvent];
-        if (setEmailEvent.email) {
-            eventQueue.push(setEmailEvent);
-        }
-        if (setCustomerIdEvent.id) {
-            eventQueue.push(setCustomerIdEvent);
+        function resetSetDataEventAfterQueuingEvent() {
+            setDataEvent = {
+                event: 'setData'
+            };
         }
 
-        eventQueue.push(criteoEvent);
-
-        if (Object.keys(setDataEvent).length > 1) {
-            eventQueue.push(setDataEvent);
-        }
-
-        window.criteo_q.push.apply(
-            window.criteo_q,
-            JSON.parse(JSON.stringify(eventQueue))
-        );
-
-        resetSetDataEventAfterQueuingEvent();
-    }
-
-    function createViewBasket(event) {
-        var criteoEvent = { event: 'viewBasket' },
-            items = [];
-
-        event.ProductAction.ProductList.forEach(function(product) {
-            items.push({
-                id: product.Sku,
-                price: product.Price,
-                quantity: product.Quantity,
-            });
-        });
-
-        criteoEvent.item = items;
-
-        return criteoEvent;
-    }
-
-    function createViewProduct(event) {
-        var criteoEvent = { event: 'viewItem' },
-            items = [];
-
-        event.ProductAction.ProductList.forEach(function(product) {
-            if (product.Sku) {
-                items.push(product.Sku);
+        function queueCriteoEvent(criteoEvent) {
+            var eventQueue = [setAccountEvent, setSiteTypeEvent];
+            if (setEmailEvent.email) {
+                eventQueue.push(setEmailEvent);
             }
-        });
+            if (setCustomerIdEvent.id) {
+                eventQueue.push(setCustomerIdEvent);
+            }
 
-        criteoEvent.item = items;
+            eventQueue.push(criteoEvent);
 
-        return criteoEvent;
-    }
+            if (Object.keys(setDataEvent).length > 1) {
+                eventQueue.push(setDataEvent);
+            }
 
-    function createViewList(event) {
-        var criteoEvent = { event: 'viewList' },
-            items = [];
+            window.criteo_q.push.apply(window.criteo_q, JSON.parse(JSON.stringify(eventQueue)));
 
-        event.ProductImpressions.forEach(function(impression) {
-            impression.ProductList.forEach(function(product) {
+            resetSetDataEventAfterQueuingEvent();
+        }
+
+        function createViewBasket(event) {
+            var criteoEvent = { event: 'viewBasket' },
+                items = [];
+
+            event.ProductAction.ProductList.forEach(function(product) {
+                items.push({
+                    id: product.Sku,
+                    price: product.Price,
+                    quantity: product.Quantity
+                });
+            });
+
+            criteoEvent.item = items;
+
+            return criteoEvent;
+        }
+
+        function createViewProduct(event) {
+            var criteoEvent = { event: 'viewItem' },
+                items = [];
+
+            event.ProductAction.ProductList.forEach(function(product) {
                 if (product.Sku) {
                     items.push(product.Sku);
                 }
             });
-        });
 
-        criteoEvent.item = items;
+            criteoEvent.item = items;
 
-        return criteoEvent;
-    }
-
-    function createTrackTransactionEvent(event) {
-        var criteoEvent = { event: 'trackTransaction' };
-
-        if (event.ProductAction.TransactionId) {
-            criteoEvent.id = event.ProductAction.TransactionId;
+            return criteoEvent;
         }
 
-        var criteoProductList = [];
+        function createViewList(event) {
+            var criteoEvent = { event: 'viewList' },
+                items = [];
 
-        event.ProductAction.ProductList.forEach(function(product) {
-            criteoProductList.push({
-                id: product.Sku,
-                price: parseFloat(product.Price),
-                quantity: product.Quantity,
+            event.ProductImpressions.forEach(function(impression) {
+                impression.ProductList.forEach(function(product) {
+                    if (product.Sku) {
+                        items.push(product.Sku);
+                    }
+                });
             });
-        });
 
-        criteoEvent.item = criteoProductList;
+            criteoEvent.item = items;
 
-        return criteoEvent;
+            return criteoEvent;
+        }
+
+        function createTrackTransactionEvent(event) {
+            var criteoEvent = { event: 'trackTransaction' };
+
+            if (event.ProductAction.TransactionId) {
+                criteoEvent.id = event.ProductAction.TransactionId;
+            }
+
+            var criteoProductList = [];
+
+            event.ProductAction.ProductList.forEach(function(product) {
+                criteoProductList.push({
+                    id: product.Sku,
+                    price: parseFloat(product.Price),
+                    quantity: product.Quantity
+                });
+            });
+
+            criteoEvent.item = criteoProductList;
+
+            return criteoEvent;
+        }
+
+        function setUserIdentity(id, type) {
+            try {
+                if (type === window.mParticle.IdentityType.CustomerId) {
+                    setCustomerIdEvent.id = id;
+                }
+                else if (type === window.mParticle.IdentityType.Email) {
+                    setEmailEvent.email = id.trim().toLowerCase();
+                }
+                else {
+                    return 'Only CustomerID and Email types are available on Criteo';
+                }
+            }
+            catch (e) {
+                return 'Failed to call setUserIdentity on ' + name + ' ' + e;
+            }
+        }
+
+        this.init = initForwarder;
+        this.process = processEvent;
+        this.setUserIdentity = setUserIdentity;
+    };
+
+    function getId() {
+        return moduleId;
     }
 
-    function setUserIdentity(id, type) {
-        try {
-            if (type === window.mParticle.IdentityType.CustomerId) {
-                setCustomerIdEvent.id = id;
-            } else if (type === window.mParticle.IdentityType.Email) {
-                setEmailEvent.email = id.trim().toLowerCase();
-            } else {
-                return 'Only CustomerID and Email types are available on Criteo';
-            }
-        } catch (e) {
-            return 'Failed to call setUserIdentity on ' + name + ' ' + e;
+    function isObject(val) {
+        return (
+            val != null &&
+            typeof val === 'object' &&
+            Array.isArray(val) === false
+        );
+    }
+
+    function register(config) {
+        if (!config) {
+            console.log('You must pass a config object to register the kit ' + name);
+            return;
+        }
+
+        if (!isObject(config)) {
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
+
+        if (isObject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
         }
     }
 
-    this.init = initForwarder;
-    this.process = processEvent;
-    this.setUserIdentity = setUserIdentity;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function isObject(val) {
-    return (
-        val != null && typeof val === 'object' && Array.isArray(val) === false
-    );
-}
-
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
-    }
-
-    if (!isObject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isObject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/device-match/src/DeviceMatchEventForwarder.js
+++ b/kits/device-match/src/DeviceMatchEventForwarder.js
@@ -12,113 +12,103 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-var isobject = require('isobject');
+    var isobject = require('isobject');
 
-var name = 'DeviceMatchEventForwarder',
-    moduleId = 109;
+    var name = 'DeviceMatchEventForwarder',
+        moduleId = 109;
 
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings = null,
-        reportingService = null;
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            forwarderSettings = null,
+            reportingService  = null;
 
-    self.name = name;
+        self.name = name;
 
-    function initForwarder(
-        settings,
-        service,
-        testMode,
-        sendForwardingStats,
-        temp,
-        temp1,
-        userAttributes,
-        userIdentities,
-        appVersion,
-        appName,
-        customFlags,
-        clientId
-    ) {
-        forwarderSettings = settings;
-        reportingService = service;
+        function initForwarder(settings,
+            service,
+            testMode,
+            sendForwardingStats,
+            temp,
+            temp1,
+            userAttributes,
+            userIdentities,
+            appVersion,
+            appName,
+            customFlags,
+            clientId) {
 
-        try {
-            if (!testMode) {
-                var partnerId = forwarderSettings.partnerId,
-                    url =
-                        'https://tapestry.tapad.com/tapestry/1?ta_partner_id=' +
-                        partnerId +
-                        ' &ta_partner_did=' +
-                        clientId +
-                        '&ta_format=png;',
-                    body = document.getElementsByTagName('body')[0],
-                    noscript = document.createElement('noscript'),
-                    img = document.createElement('img');
+            forwarderSettings = settings;
+            reportingService = service;
 
-                img.src = url;
-                img.style.display = 'none';
-                img.setAttribute('height', '1');
-                img.setAttribute('width', '1');
+            try {
+                if(!testMode) {
+                    var partnerId = forwarderSettings.partnerId,
+                        url = 'https://tapestry.tapad.com/tapestry/1?ta_partner_id=' + partnerId + ' &ta_partner_did=' + clientId + '&ta_format=png;',
+                        body = document.getElementsByTagName('body')[0],
+                        noscript = document.createElement('noscript'),
+                        img = document.createElement('img');
 
-                noscript.appendChild(img);
+                    img.src = url;
+                    img.style.display = 'none';
+                    img.setAttribute('height', '1');
+                    img.setAttribute('width', '1');
 
-                body.appendChild(noscript);
+                    noscript.appendChild(img);
+
+                    body.appendChild(noscript);
+                }
+
+                isInitialized = true;
+                return 'Successfully initialized: ' + self.name;
+
             }
+            catch (e) {
+                return 'Can\'t initialize forwarder: ' + self.name + ': ' + e;
+            }
+        }
 
-            isInitialized = true;
-            return 'Successfully initialized: ' + self.name;
-        } catch (e) {
-            return "Can't initialize forwarder: " + self.name + ': ' + e;
+        this.init = initForwarder;
+    };
+
+    function getId() {
+        return moduleId;
+    }
+
+    function register(config) {
+        if (!config) {
+            console.log('You must pass a config object to register the kit ' + name);
+            return;
+        }
+
+        if (!isobject(config)) {
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
+
+        if (isobject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
         }
     }
 
-    this.init = initForwarder;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
-    }
-
-    if (!isobject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isobject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/doubleclick/src/commerce-handler.js
+++ b/kits/doubleclick/src/commerce-handler.js
@@ -1,6 +1,6 @@
 var salesCounterTypes = {
     transactions: 1,
-    items_sold: 1,
+    items_sold: 1
 };
 var ITEMS_SOLD = 'items_sold';
 

--- a/kits/doubleclick/src/common.js
+++ b/kits/doubleclick/src/common.js
@@ -30,7 +30,7 @@ Common.prototype.setCustomFields = function(event, gtagProperties) {
         }
     }
     if (hasMappings) {
-        gtagProperties['dc_custom_params'] = dc_custom_params;
+        gtagProperties["dc_custom_params"] = dc_custom_params;
     }
 };
 Common.prototype.setSendTo = function(mapping, customFlags, gtagProperties) {
@@ -61,20 +61,20 @@ Common.prototype.sendGtag = function(type, properties, isInitialization) {
     }
 };
 
-Common.prototype.sendGtagConsent = function(type, payload) {
+Common.prototype.sendGtagConsent = function (type, payload) {
     function gtag() {
         window.dataLayer.push(arguments);
     }
     gtag('consent', type, payload);
 };
 
-Common.prototype.getEventConsentState = function(eventConsentState) {
+Common.prototype.getEventConsentState = function (eventConsentState) {
     return eventConsentState && eventConsentState.getGDPRConsentState
         ? eventConsentState.getGDPRConsentState()
         : {};
 };
 
-Common.prototype.maybeSendConsentUpdateToGoogle = function(consentState) {
+Common.prototype.maybeSendConsentUpdateToGoogle = function (consentState) {
     // If consent payload is empty,
     // we never sent an initial default consent state
     // so we shouldn't send an update.
@@ -83,10 +83,11 @@ Common.prototype.maybeSendConsentUpdateToGoogle = function(consentState) {
         this.consentMappings &&
         !this.isEmpty(consentState)
     ) {
-        var updatedConsentPayload = this.consentHandler.generateConsentStatePayloadFromMappings(
-            consentState,
-            this.consentMappings
-        );
+        var updatedConsentPayload =
+            this.consentHandler.generateConsentStatePayloadFromMappings(
+                consentState,
+                this.consentMappings
+            );
 
         var eventConsentAsString = JSON.stringify(updatedConsentPayload);
 
@@ -97,13 +98,13 @@ Common.prototype.maybeSendConsentUpdateToGoogle = function(consentState) {
     }
 };
 
-Common.prototype.sendDefaultConsentPayloadToGoogle = function(consentPayload) {
+Common.prototype.sendDefaultConsentPayloadToGoogle = function (consentPayload) {
     this.consentPayloadAsString = JSON.stringify(consentPayload);
 
     this.sendGtagConsent('default', consentPayload);
 };
 
-Common.prototype.cloneObject = function(obj) {
+Common.prototype.cloneObject = function (obj) {
     return JSON.parse(JSON.stringify(obj));
 };
 
@@ -125,14 +126,14 @@ function findValueInMapping(jsHash, mapping) {
             }
 
             return {
-                result: false,
+                result: false
             };
         });
 
         if (filteredArray && filteredArray.length > 0) {
             return {
                 result: true,
-                match: filteredArray[0],
+                match: filteredArray[0]
             };
         }
     }

--- a/kits/doubleclick/src/consent.js
+++ b/kits/doubleclick/src/consent.js
@@ -25,7 +25,7 @@ function ConsentHandler(common) {
     this.common = common || {};
 }
 
-ConsentHandler.prototype.getUserConsentState = function() {
+ConsentHandler.prototype.getUserConsentState = function () {
     var userConsentState = {};
 
     if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
@@ -35,7 +35,8 @@ ConsentHandler.prototype.getUserConsentState = function() {
             return {};
         }
 
-        var consentState = mParticle.Identity.getCurrentUser().getConsentState();
+        var consentState =
+            mParticle.Identity.getCurrentUser().getConsentState();
 
         if (consentState && consentState.getGDPRConsentState) {
             userConsentState = consentState.getGDPRConsentState();
@@ -45,7 +46,7 @@ ConsentHandler.prototype.getUserConsentState = function() {
     return userConsentState;
 };
 
-ConsentHandler.prototype.getConsentSettings = function() {
+ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 
     var googleToMpConsentSettingsMapping = {
@@ -57,7 +58,7 @@ ConsentHandler.prototype.getConsentSettings = function() {
 
     var settings = this.common.settings;
 
-    Object.keys(googleToMpConsentSettingsMapping).forEach(function(
+    Object.keys(googleToMpConsentSettingsMapping).forEach(function (
         googleConsentKey
     ) {
         var mpConsentSettingKey =
@@ -73,7 +74,7 @@ ConsentHandler.prototype.getConsentSettings = function() {
     return consentSettings;
 };
 
-ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function(
+ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function (
     consentState,
     mappings
 ) {

--- a/kits/doubleclick/src/event-handler.js
+++ b/kits/doubleclick/src/event-handler.js
@@ -3,14 +3,14 @@ var common = require('./common');
 var eventCounterTypes = {
     standard: 1,
     unique: 1,
-    per_session: 1,
+    per_session: 1
 };
 
 function EventHandler(common) {
     this.common = common || {};
 }
 
-EventHandler.prototype.logEvent = function(event) {
+EventHandler.prototype.logEvent = function (event) {
     var eventConsentState = this.common.getEventConsentState(
         event.ConsentState
     );

--- a/kits/doubleclick/src/initialization.js
+++ b/kits/doubleclick/src/initialization.js
@@ -1,16 +1,7 @@
 var initialization = {
     name: 'DoubleclickDFP',
     moduleId: 41,
-    initForwarder: function(
-        settings,
-        testMode,
-        userAttributes,
-        userIdentities,
-        processEvent,
-        eventQueue,
-        isInitialized,
-        common
-    ) {
+    initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, common) {
         common.settings = settings;
 
         if (common.settings.consentMappingWeb) {
@@ -27,18 +18,13 @@ var initialization = {
 
         window.dataLayer = window.dataLayer || [];
         if (!testMode) {
-            var url =
-                'https://www.googletagmanager.com/gtag/js?id=' +
-                settings.advertiserId;
+            var url = 'https://www.googletagmanager.com/gtag/js?id=' + settings.advertiserId;
 
             var gTagScript = document.createElement('script');
             gTagScript.type = 'text/javascript';
             gTagScript.async = true;
             gTagScript.src = url;
-            (
-                document.getElementsByTagName('head')[0] ||
-                document.getElementsByTagName('body')[0]
-            ).appendChild(gTagScript);
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(gTagScript);
             gTagScript.onload = function() {
                 isInitialized = true;
 
@@ -49,7 +35,7 @@ var initialization = {
                     for (var i = 0; i < eventQueue.length; i++) {
                         processEvent(eventQueue[i]);
                     }
-                    // now that each queued event is processed, we empty the eventQueue
+                     // now that each queued event is processed, we empty the eventQueue
                     eventQueue = [];
                 }
             };
@@ -57,21 +43,23 @@ var initialization = {
             initializeGoogleDFP(common, settings, isInitialized);
         }
 
-        common.consentPayloadDefaults = common.consentHandler.getConsentSettings();
+        common.consentPayloadDefaults =
+            common.consentHandler.getConsentSettings();
         var defaultConsentPayload = common.cloneObject(
             common.consentPayloadDefaults
         );
         var updatedConsentState = common.consentHandler.getUserConsentState();
-        var updatedDefaultConsentPayload = common.consentHandler.generateConsentStatePayloadFromMappings(
-            updatedConsentState,
-            common.consentMappings
-        );
+        var updatedDefaultConsentPayload =
+            common.consentHandler.generateConsentStatePayloadFromMappings(
+                updatedConsentState,
+                common.consentMappings
+            );
 
         // If a default consent payload exists (as selected in the mParticle UI), set it as the default
         if (!common.isEmpty(defaultConsentPayload)) {
             common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload);
-            // If a default consent payload does not exist, but the user currently has updated their consent,
-            // send that as the default because a default must be sent
+        // If a default consent payload does not exist, but the user currently has updated their consent,
+        // send that as the default because a default must be sent
         } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
             common.sendDefaultConsentPayloadToGoogle(
                 updatedDefaultConsentPayload
@@ -87,13 +75,13 @@ function initializeGoogleDFP(common, settings, isInitialized) {
 
     common.customVariablesMappings = parseSettingsString(
         settings.customVariables
-    ).reduce(function(a, b) {
+    ).reduce(function (a, b) {
         a[b.map] = b.value;
         return a;
     }, {});
     common.customFieldMappings = parseSettingsString(
         settings.customParams
-    ).reduce(function(a, b) {
+    ).reduce(function (a, b) {
         a[b.map] = b.value;
         return a;
     }, {});

--- a/kits/doubleclick/src/session-handler.js
+++ b/kits/doubleclick/src/session-handler.js
@@ -1,6 +1,10 @@
 var sessionHandler = {
-    onSessionStart: function(event) {},
-    onSessionEnd: function(event) {},
+    onSessionStart: function(event) {
+
+    },
+    onSessionEnd: function(event) {
+
+    }
 };
 
 module.exports = sessionHandler;

--- a/kits/facebook/src/FacebookEventForwarder.js
+++ b/kits/facebook/src/FacebookEventForwarder.js
@@ -57,7 +57,7 @@ var name = 'Facebook',
     PURCHASE_EVENT_NAME = 'Purchase',
     REMOVE_FROM_CART_EVENT_NAME = 'RemoveFromCart',
     VIEW_CONTENT_EVENT_NAME = 'ViewContent',
-    constructor = function() {
+    constructor = function () {
         var self = this,
             isInitialized = false,
             reportingService = null,
@@ -66,14 +66,7 @@ var name = 'Facebook',
 
         self.name = name;
 
-        function initForwarder(
-            forwarderSettings,
-            service,
-            testMode,
-            trackerId,
-            userAttributes,
-            userIdentities
-        ) {
+        function initForwarder(forwarderSettings, service, testMode, trackerId, userAttributes, userIdentities) {
             settings = forwarderSettings;
             reportingService = service;
 
@@ -83,55 +76,29 @@ var name = 'Facebook',
                 mParticle.ProductActionType.AddToCart,
                 mParticle.ProductActionType.RemoveFromCart,
                 mParticle.ProductActionType.AddToWishlist,
-                mParticle.ProductActionType.ViewDetail,
+                mParticle.ProductActionType.ViewDetail
             ];
 
             try {
                 if (!testMode) {
-                    !(function(f, b, e, v, n, t, s) {
-                        if (f.fbq) return;
-                        n = f.fbq = function() {
-                            n.callMethod
-                                ? n.callMethod.apply(n, arguments)
-                                : n.queue.push(arguments);
-                        };
-                        if (!f._fbq) f._fbq = n;
-                        n.push = n;
-                        n.loaded = !0;
-                        n.version = '2.0';
-                        n.queue = [];
-                        t = b.createElement(e);
-                        t.async = !0;
-                        t.src = v;
-                        s = b.getElementsByTagName(e)[0];
+                    !function (f, b, e, v, n, t, s) {
+                        if (f.fbq) return; n = f.fbq = function () { n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments); }; if (!f._fbq) f._fbq = n;
+                        n.push = n; n.loaded = !0; n.version = '2.0'; n.queue = []; t = b.createElement(e); t.async = !0; t.src = v; s = b.getElementsByTagName(e)[0];
                         s.parentNode.insertBefore(t, s);
-                    })(
-                        window,
-                        document,
-                        'script',
-                        'https://connect.facebook.net/en_US/fbevents.js'
-                    );
+                    } (window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js');
 
                     var visitorData = {};
 
-                    if (
-                        settings.externalUserIdentityType &&
-                        userIdentities &&
-                        userIdentities.length > 0
-                    ) {
-                        var selectedType =
-                            IdentityType[settings.externalUserIdentityType];
-                        var selectedIdentity = userIdentities.filter(function(
-                            identityElement
-                        ) {
+                    if(settings.externalUserIdentityType && userIdentities && userIdentities.length > 0) {
+                        var selectedType = IdentityType[settings.externalUserIdentityType];
+                        var selectedIdentity = userIdentities.filter(function (identityElement) {
                             if (identityElement.Type === selectedType) {
                                 return identityElement.Identity;
                             }
-                        });
+                        })
 
                         if (selectedIdentity.length > 0) {
-                            visitorData['external_id'] =
-                                selectedIdentity[0].Identity;
+                            visitorData['external_id'] = selectedIdentity[0].Identity;
                         }
                     }
                 }
@@ -149,34 +116,36 @@ var name = 'Facebook',
                 isInitialized = true;
 
                 return 'Successfully initialized: ' + name;
-            } catch (e) {
-                return "Can't initialize forwarder: " + name + ':' + e;
+
+            }
+            catch (e) {
+                return 'Can\'t initialize forwarder: ' + name + ':' + e;
             }
         }
 
         function loadMappings() {
             productAttributeMapping = settings.productAttributeMapping
-                ? JSON.parse(
-                      settings.productAttributeMapping.replace(/&quot;/g, '"')
-                  )
-                : [];
+            ? JSON.parse(settings.productAttributeMapping.replace(/&quot;/g, '"'))
+            : [];
         }
 
         function processEvent(event) {
             var reportEvent = false;
 
             if (!isInitialized) {
-                return "Can't send forwarder " + name + ', not initialized';
+                return 'Can\'t send forwarder ' + name + ', not initialized';
             }
 
             try {
                 if (event.EventDataType == MessageType.PageView) {
                     reportEvent = true;
                     logPageView(event);
-                } else if (event.EventDataType == MessageType.PageEvent) {
+                }
+                else if (event.EventDataType == MessageType.PageEvent) {
                     reportEvent = true;
                     logPageEvent(event);
-                } else if (event.EventDataType == MessageType.Commerce) {
+                }
+                else if (event.EventDataType == MessageType.Commerce) {
                     reportEvent = logCommerceEvent(event);
                 }
 
@@ -185,26 +154,22 @@ var name = 'Facebook',
                 }
 
                 return 'Successfully sent to forwarder ' + name;
-            } catch (error) {
-                return "Can't send to forwarder: " + name + ' ' + error;
+            }
+            catch (error) {
+                return 'Can\'t send to forwarder: ' + name + ' ' + error;
             }
         }
 
         function logCommerceEvent(event) {
-            if (
-                event.ProductAction &&
+            if (event.ProductAction &&
                 event.ProductAction.ProductList &&
                 event.ProductAction.ProductActionType &&
-                SupportedCommerceTypes.indexOf(
-                    event.ProductAction.ProductActionType
-                ) > -1
-            ) {
+                SupportedCommerceTypes.indexOf(event.ProductAction.ProductActionType) > -1) {
                 var eventName,
                     totalValue,
                     params = cloneEventAttributes(event),
                     eventID = createEventId(event),
-                    sendProductNamesAsContents =
-                        settings.sendProductNamesasContents || false;
+                    sendProductNamesAsContents = settings.sendProductNamesasContents || false;
 
                 params['currency'] = event.CurrencyCode || 'USD';
 
@@ -212,15 +177,12 @@ var name = 'Facebook',
                     params['content_name'] = event.EventName;
                 }
 
-                var productSkus = event.ProductAction.ProductList.reduce(
-                    function(arr, curr) {
-                        if (curr.Sku) {
-                            arr.push(curr.Sku);
-                        }
-                        return arr;
-                    },
-                    []
-                );
+                var productSkus = event.ProductAction.ProductList.reduce(function (arr, curr) {
+                    if (curr.Sku) {
+                        arr.push(curr.Sku);
+                    }
+                    return arr;
+                }, []);
 
                 if (productSkus && productSkus.length > 0) {
                     params['content_ids'] = productSkus;
@@ -228,9 +190,7 @@ var name = 'Facebook',
 
                 // Override content_name with product names array if setting enabled
                 if (sendProductNamesAsContents) {
-                    var productNames = buildProductNames(
-                        event.ProductAction.ProductList
-                    );
+                    var productNames = buildProductNames(event.ProductAction.ProductList);
                     if (productNames && productNames.length > 0) {
                         params['content_name'] = productNames;
                     }
@@ -242,99 +202,64 @@ var name = 'Facebook',
                 }
 
                 // Build contents array
-                var contents = buildProductContents(
-                    event.ProductAction.ProductList
-                );
+                var contents = buildProductContents(event.ProductAction.ProductList);
                 if (contents && contents.length > 0) {
                     params['contents'] = contents;
                 }
 
-                if (
-                    event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.AddToWishlist ||
-                    event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.Checkout
-                ) {
+                if (event.ProductAction.ProductActionType == mParticle.ProductActionType.AddToWishlist ||
+                    event.ProductAction.ProductActionType == mParticle.ProductActionType.Checkout) {
                     var eventCategory = getEventCategoryString(event);
                     if (eventCategory) {
                         params['content_category'] = eventCategory;
                     }
-                    if (
-                        event.ProductAction.ProductActionType ==
-                            mParticle.ProductActionType.Checkout &&
-                        event.ProductAction.CheckoutStep
-                    ) {
-                        params['checkout_step'] =
-                            event.ProductAction.CheckoutStep;
+                    if (event.ProductAction.ProductActionType == mParticle.ProductActionType.Checkout && event.ProductAction.CheckoutStep) {
+                        params['checkout_step'] = event.ProductAction.CheckoutStep;
                     }
                 }
 
-                if (
-                    event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.AddToCart ||
-                    event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.AddToWishlist ||
-                    event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.ViewDetail
-                ) {
-                    totalValue = event.ProductAction.ProductList.reduce(
-                        function(sum, product) {
-                            if (
-                                isNumeric(product.Price) &&
-                                isNumeric(product.Quantity)
-                            ) {
-                                sum += product.Price * product.Quantity;
-                            }
-                            return sum;
-                        },
-                        0
-                    );
+                if (event.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ||
+                    event.ProductAction.ProductActionType == mParticle.ProductActionType.AddToWishlist ||
+                    event.ProductAction.ProductActionType == mParticle.ProductActionType.ViewDetail) {
+
+                    totalValue = event.ProductAction.ProductList.reduce(function(sum, product){
+                        if (isNumeric(product.Price) && isNumeric(product.Quantity)) {
+                            sum += product.Price * product.Quantity;
+                        }
+                        return sum;
+                    }, 0);
 
                     params['value'] = totalValue;
 
-                    if (
-                        event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.AddToWishlist
-                    ) {
+                    if (event.ProductAction.ProductActionType == mParticle.ProductActionType.AddToWishlist){
                         eventName = ADD_TO_WISHLIST_EVENT_NAME;
-                    } else if (
-                        event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.AddToCart
-                    ) {
+                    }
+                    else if (event.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart){
                         eventName = ADD_TO_CART_EVENT_NAME;
-                    } else {
+                    }
+                    else{
                         eventName = VIEW_CONTENT_EVENT_NAME;
                     }
-                } else if (
-                    event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.Checkout ||
-                    event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.Purchase
-                ) {
-                    eventName =
-                        event.ProductAction.ProductActionType ==
-                        mParticle.ProductActionType.Checkout
-                            ? CHECKOUT_EVENT_NAME
-                            : PURCHASE_EVENT_NAME;
+
+                }
+                else if (event.ProductAction.ProductActionType == mParticle.ProductActionType.Checkout ||
+                        event.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
+
+                    eventName = event.ProductAction.ProductActionType == mParticle.ProductActionType.Checkout ? CHECKOUT_EVENT_NAME : PURCHASE_EVENT_NAME;
 
                     if (event.ProductAction.TotalAmount) {
                         params['value'] = event.ProductAction.TotalAmount;
                     }
 
-                    var num_items = event.ProductAction.ProductList.reduce(
-                        function(sum, product) {
-                            if (isNumeric(product.Quantity)) {
-                                sum += product.Quantity;
-                            }
-                            return sum;
-                        },
-                        0
-                    );
+                    var num_items = event.ProductAction.ProductList.reduce(function(sum, product){
+                        if (isNumeric(product.Quantity)) {
+                            sum += product.Quantity;
+                        }
+                        return sum;
+                    }, 0);
                     params['num_items'] = num_items;
-                } else if (
-                    event.ProductAction.ProductActionType ==
-                    mParticle.ProductActionType.RemoveFromCart
-                ) {
+                }
+                else if (event.ProductAction.ProductActionType == mParticle.ProductActionType.RemoveFromCart) {
                     eventName = REMOVE_FROM_CART_EVENT_NAME;
 
                     // remove from cart can be performed in 1 of 2 ways:
@@ -344,31 +269,24 @@ var name = 'Facebook',
                     if (event.ProductAction.TotalAmount) {
                         totalValue = event.ProductAction.TotalAmount;
                     } else {
-                        totalValue = event.ProductAction.ProductList.reduce(
-                            function(sum, product) {
-                                if (isNumeric(product.TotalAmount)) {
-                                    sum += product.TotalAmount;
-                                }
-                                return sum;
-                            },
-                            0
-                        );
+                        totalValue = event.ProductAction.ProductList.reduce(function(sum, product) {
+                            if (isNumeric(product.TotalAmount)) {
+                                sum += product.TotalAmount;
+                            }
+                            return sum;
+                        }, 0);
                     }
 
                     params['value'] = totalValue;
 
-                    fbq(
-                        'trackCustom',
-                        eventName || 'customEvent',
-                        params,
-                        eventID
-                    );
+                    fbq('trackCustom', eventName || 'customEvent', params, eventID);
                     return true;
                 }
 
                 if (eventName) {
                     fbq('track', eventName, params, eventID);
-                } else {
+                }
+                else {
                     return false;
                 }
 
@@ -399,7 +317,8 @@ var name = 'Facebook',
             if (event && event.EventAttributes) {
                 try {
                     attr = JSON.parse(JSON.stringify(event.EventAttributes));
-                } catch (e) {
+                }
+                catch (e) {
                     //
                 }
             }
@@ -411,21 +330,20 @@ var name = 'Facebook',
         }
 
         function getEventCategoryString(event) {
+
             var enumTypeValues;
             var enumValue;
             if (event.EventDataType == MessageType.Commerce) {
-                enumTypeValues = event.EventCategory
-                    ? mParticle.CommerceEventType
-                    : mParticle.ProductActionType;
-                enumValue =
-                    event.EventCategory ||
-                    event.ProductAction.ProductActionType;
-            } else {
+                enumTypeValues = event.EventCategory ? mParticle.CommerceEventType : mParticle.ProductActionType;
+                enumValue = event.EventCategory || event.ProductAction.ProductActionType;
+            }
+            else {
                 enumTypeValues = mParticle.EventType;
                 enumValue = event.EventCategory;
             }
 
             if (enumTypeValues && enumValue) {
+
                 for (var category in enumTypeValues) {
                     if (enumValue == enumTypeValues[category]) {
                         return category;
@@ -455,25 +373,17 @@ var name = 'Facebook',
                 .map(function(product) {
                     var contentItem = {
                         id: product.Sku,
-                        quantity: isNumeric(product.Quantity)
-                            ? product.Quantity
-                            : 1,
+                        quantity: isNumeric(product.Quantity) ? product.Quantity : 1,
                         name: product.Name,
                         brand: product.Brand,
                         category: product.Category,
                         variant: product.Variant,
-                        item_price: isNumeric(product.Price)
-                            ? product.Price
-                            : null,
+                        item_price: isNumeric(product.Price) ? product.Price : null
                     };
 
                     // Apply configured mappings to custom attributes
                     productAttributeMapping.forEach(function(productMapping) {
-                        if (
-                            !isobject(productMapping) ||
-                            !productMapping.map ||
-                            !productMapping.value
-                        ) {
+                        if (!isobject(productMapping) || !productMapping.map || !productMapping.value) {
                             return;
                         }
 
@@ -486,10 +396,7 @@ var name = 'Facebook',
                             value = product[sourceField];
                         }
                         // then check for Product.Attributes level field
-                        else if (
-                            product.Attributes &&
-                            product.Attributes[sourceField]
-                        ) {
+                        else if (product.Attributes && product.Attributes[sourceField]) {
                             value = product.Attributes[sourceField];
                         }
 
@@ -504,8 +411,8 @@ var name = 'Facebook',
         // https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events#event-deduplication-options
         function createEventId(event) {
             return {
-                eventID: event.SourceMessageId || null,
-            };
+                eventID: event.SourceMessageId || null
+            }
         }
 
         /**
@@ -537,32 +444,26 @@ function getId() {
 
 function register(config) {
     if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
+        console.log('You must pass a config object to register the kit ' + name);
         return;
     }
 
     if (!isobject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
+        console.log('\'config\' must be an object. You passed in a ' + typeof config);
         return;
     }
 
     if (isobject(config.kits)) {
         config.kits[name] = {
-            constructor: constructor,
+            constructor: constructor
         };
     } else {
         config.kits = {};
         config.kits[name] = {
-            constructor: constructor,
+            constructor: constructor
         };
     }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
+    console.log('Successfully registered ' + name + ' to your mParticle configuration');
 }
 
 if (typeof window !== 'undefined') {
@@ -570,11 +471,11 @@ if (typeof window !== 'undefined') {
         window.mParticle.addForwarder({
             name: name,
             constructor: constructor,
-            getId: getId,
+            getId: getId
         });
     }
 }
 
 module.exports = {
-    register: register,
+    register: register
 };

--- a/kits/google-analytics-4/packages/GA4Client/src/commerce-handler.js
+++ b/kits/google-analytics-4/packages/GA4Client/src/commerce-handler.js
@@ -31,7 +31,7 @@ var ADD_SHIPPING_INFO = 'add_shipping_info',
     ADD_PAYMENT_INFO = 'add_payment_info',
     VIEW_CART = 'view_cart';
 
-CommerceHandler.prototype.logCommerceEvent = function(event) {
+CommerceHandler.prototype.logCommerceEvent = function (event) {
     var needsCurrency = true,
         needsValue = true,
         ga4CommerceEventParameters = {},
@@ -142,7 +142,7 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
     );
 };
 
-CommerceHandler.prototype.sendCommerceEventToGA4 = function(
+CommerceHandler.prototype.sendCommerceEventToGA4 = function (
     eventName,
     eventAttributes
 ) {
@@ -158,7 +158,7 @@ CommerceHandler.prototype.sendCommerceEventToGA4 = function(
 // Google previously had a CheckoutOption event, and now this has been split into 2 GA4 events - add_shipping_info and add_payment_info
 // Since MP still uses CheckoutOption, we must map this to the 2 events using custom flags.  To prevent any data loss from customers
 // migrating from UA to GA4, we will set a default `set_checkout_option` which matches Firebase's data model.
-CommerceHandler.prototype.logCheckoutOptionEvent = function(
+CommerceHandler.prototype.logCheckoutOptionEvent = function (
     event,
     affiliation
 ) {
@@ -213,11 +213,11 @@ CommerceHandler.prototype.logCheckoutOptionEvent = function(
     );
 };
 
-CommerceHandler.prototype.logPromotionEvent = function(event) {
+CommerceHandler.prototype.logPromotionEvent = function (event) {
     var self = this;
     try {
         var ga4CommerceEventParameters;
-        event.PromotionAction.PromotionList.forEach(function(promotion) {
+        event.PromotionAction.PromotionList.forEach(function (promotion) {
             ga4CommerceEventParameters = buildPromotion(promotion);
 
             ga4CommerceEventParameters = self.common.mergeObjects(
@@ -241,11 +241,11 @@ CommerceHandler.prototype.logPromotionEvent = function(event) {
     }
 };
 
-CommerceHandler.prototype.logImpressionEvent = function(event, affiliation) {
+CommerceHandler.prototype.logImpressionEvent = function (event, affiliation) {
     var self = this;
     try {
         var ga4CommerceEventParameters;
-        event.ProductImpressions.forEach(function(impression) {
+        event.ProductImpressions.forEach(function (impression) {
             ga4CommerceEventParameters = parseImpression(
                 impression,
                 affiliation
@@ -272,7 +272,7 @@ CommerceHandler.prototype.logImpressionEvent = function(event, affiliation) {
     }
 };
 
-CommerceHandler.prototype.logViewCart = function(event, affiliation) {
+CommerceHandler.prototype.logViewCart = function (event, affiliation) {
     var ga4CommerceEventParameters = buildViewCart(event, affiliation);
     ga4CommerceEventParameters = this.common.mergeObjects(
         ga4CommerceEventParameters,
@@ -490,7 +490,7 @@ function parsePromotion(_promotion) {
 function buildProductsList(products, affiliation) {
     var productsList = [];
 
-    products.forEach(function(product) {
+    products.forEach(function (product) {
         productsList.push(parseProduct(product, affiliation));
     });
 

--- a/kits/google-analytics-4/packages/GA4Client/src/common.js
+++ b/kits/google-analytics-4/packages/GA4Client/src/common.js
@@ -52,7 +52,7 @@ function Common() {
 
 Common.prototype.forwarderSettings = null;
 
-Common.prototype.mergeObjects = function() {
+Common.prototype.mergeObjects = function () {
     var resObj = {};
     for (var i = 0; i < arguments.length; i += 1) {
         var obj = arguments[i],
@@ -64,7 +64,7 @@ Common.prototype.mergeObjects = function() {
     return resObj;
 };
 
-Common.prototype.truncateAttributes = function(
+Common.prototype.truncateAttributes = function (
     attributes,
     keyLimit,
     valueLimit
@@ -72,7 +72,7 @@ Common.prototype.truncateAttributes = function(
     var truncatedAttributes = {};
 
     if (!isEmpty(attributes)) {
-        Object.keys(attributes).forEach(function(attribute) {
+        Object.keys(attributes).forEach(function (attribute) {
             var key = truncateString(attribute, keyLimit);
             var valueLimitOverride;
             switch (key) {
@@ -96,7 +96,7 @@ Common.prototype.truncateAttributes = function(
     return truncatedAttributes;
 };
 
-Common.prototype.limitAttributes = function(attributes, limitNumber) {
+Common.prototype.limitAttributes = function (attributes, limitNumber) {
     if (isEmpty(attributes)) {
         return {};
     }
@@ -107,7 +107,7 @@ Common.prototype.limitAttributes = function(attributes, limitNumber) {
 
     var limitedAttributes = attributeKeys
         .slice(0, limitNumber)
-        .reduce(function(obj, key) {
+        .reduce(function (obj, key) {
             obj[key] = attributes[key];
             return obj;
         }, {});
@@ -115,11 +115,11 @@ Common.prototype.limitAttributes = function(attributes, limitNumber) {
     return limitedAttributes;
 };
 
-Common.prototype.limitEventAttributes = function(attributes) {
+Common.prototype.limitEventAttributes = function (attributes) {
     return this.limitAttributes(attributes, EVENT_ATTRIBUTE_MAX_NUMBER);
 };
 
-Common.prototype.limitProductAttributes = function(attributes) {
+Common.prototype.limitProductAttributes = function (attributes) {
     var productAttributes = {};
     var reservedAttributes = {};
 
@@ -139,13 +139,13 @@ Common.prototype.limitProductAttributes = function(attributes) {
     return this.mergeObjects(limitedProductAttributes, reservedAttributes);
 };
 
-Common.prototype.getEventConsentState = function(eventConsentState) {
+Common.prototype.getEventConsentState = function (eventConsentState) {
     return eventConsentState && eventConsentState.getGDPRConsentState
         ? eventConsentState.getGDPRConsentState()
         : {};
 };
 
-Common.prototype.maybeSendConsentUpdateToGoogle = function(consentState) {
+Common.prototype.maybeSendConsentUpdateToGoogle = function (consentState) {
     // If consent payload is empty,
     // we never sent an initial default consent state
     // so we shouldn't send an update.
@@ -154,10 +154,11 @@ Common.prototype.maybeSendConsentUpdateToGoogle = function(consentState) {
         this.consentMappings &&
         !this.isEmpty(consentState)
     ) {
-        var updatedConsentPayload = this.consentHandler.generateConsentStatePayloadFromMappings(
-            consentState,
-            this.consentMappings
-        );
+        var updatedConsentPayload =
+            this.consentHandler.generateConsentStatePayloadFromMappings(
+                consentState,
+                this.consentMappings
+            );
 
         var eventConsentAsString = JSON.stringify(updatedConsentPayload);
 
@@ -168,17 +169,17 @@ Common.prototype.maybeSendConsentUpdateToGoogle = function(consentState) {
     }
 };
 
-Common.prototype.sendDefaultConsentPayloadToGoogle = function(consentPayload) {
+Common.prototype.sendDefaultConsentPayloadToGoogle = function (consentPayload) {
     this.consentPayloadAsString = JSON.stringify(consentPayload);
 
     gtag('consent', 'default', consentPayload);
 };
 
-Common.prototype.truncateEventName = function(eventName) {
+Common.prototype.truncateEventName = function (eventName) {
     return truncateString(eventName, EVENT_NAME_MAX_LENGTH);
 };
 
-Common.prototype.truncateEventAttributes = function(eventAttributes) {
+Common.prototype.truncateEventAttributes = function (eventAttributes) {
     return this.truncateAttributes(
         eventAttributes,
         EVENT_ATTRIBUTE_KEY_MAX_LENGTH,
@@ -186,7 +187,7 @@ Common.prototype.truncateEventAttributes = function(eventAttributes) {
     );
 };
 
-Common.prototype.standardizeParameters = function(parameters) {
+Common.prototype.standardizeParameters = function (parameters) {
     var standardizedParameters = {};
     for (var key in parameters) {
         var standardizedKey = this.standardizeName(key);
@@ -195,16 +196,10 @@ Common.prototype.standardizeParameters = function(parameters) {
     return standardizedParameters;
 };
 
-Common.prototype.standardizeName = function(name) {
-    if (
-        window.GoogleAnalytics4Kit.hasOwnProperty(
-            'setCustomNameStandardization'
-        )
-    ) {
+Common.prototype.standardizeName = function (name) {
+    if (window.GoogleAnalytics4Kit.hasOwnProperty('setCustomNameStandardization')) {
         try {
-            name = window.GoogleAnalytics4Kit.setCustomNameStandardization(
-                name
-            );
+            name = window.GoogleAnalytics4Kit.setCustomNameStandardization(name);
         } catch (e) {
             console.warn(
                 'Error calling setCustomNameStandardization callback. Check your callback.  Data will still be sent without user-defined standardization. See our docs for proper use - https://docs.mparticle.com/integrations/google-analytics-4/event/',
@@ -251,7 +246,7 @@ Common.prototype.standardizeName = function(name) {
     function removeForbiddenPrefix(name) {
         var str = name.slice();
 
-        FORBIDDEN_PREFIXES.forEach(function(prefix) {
+        FORBIDDEN_PREFIXES.forEach(function (prefix) {
             if (str.indexOf(prefix) === 0) {
                 str = str.replace(prefix, '');
             }
@@ -272,16 +267,15 @@ Common.prototype.standardizeName = function(name) {
         !doesNameStartsWithLetter(standardizedName) ||
         doesNameStartWithForbiddenPrefix(standardizedName)
     ) {
-        standardizedName = removeNonAlphabetCharacterFromStart(
-            standardizedName
-        );
+        standardizedName =
+            removeNonAlphabetCharacterFromStart(standardizedName);
         standardizedName = removeForbiddenPrefix(standardizedName);
     }
 
     return standardizedName;
 };
 
-Common.prototype.truncateUserAttributes = function(userAttributes) {
+Common.prototype.truncateUserAttributes = function (userAttributes) {
     return this.truncateAttributes(
         userAttributes,
         USER_ATTRIBUTE_KEY_MAX_LENGTH,
@@ -289,7 +283,7 @@ Common.prototype.truncateUserAttributes = function(userAttributes) {
     );
 };
 
-Common.prototype.getUserId = function(
+Common.prototype.getUserId = function (
     user,
     externalUserIdentityType,
     hashUserId
@@ -376,7 +370,7 @@ Common.prototype.getUserId = function(
     }
 };
 
-Common.prototype.cloneObject = function(obj) {
+Common.prototype.cloneObject = function (obj) {
     return JSON.parse(JSON.stringify(obj));
 };
 

--- a/kits/google-analytics-4/packages/GA4Client/src/consent.js
+++ b/kits/google-analytics-4/packages/GA4Client/src/consent.js
@@ -28,7 +28,7 @@ function ConsentHandler(common) {
     this.common = common || {};
 }
 
-ConsentHandler.prototype.getUserConsentState = function() {
+ConsentHandler.prototype.getUserConsentState = function () {
     var userConsentState = {};
 
     if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
@@ -38,7 +38,8 @@ ConsentHandler.prototype.getUserConsentState = function() {
             return {};
         }
 
-        var consentState = mParticle.Identity.getCurrentUser().getConsentState();
+        var consentState =
+            mParticle.Identity.getCurrentUser().getConsentState();
 
         if (consentState && consentState.getGDPRConsentState) {
             userConsentState = consentState.getGDPRConsentState();
@@ -48,7 +49,7 @@ ConsentHandler.prototype.getUserConsentState = function() {
     return userConsentState;
 };
 
-ConsentHandler.prototype.getConsentSettings = function() {
+ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 
     var googleToMpConsentSettingsMapping = {
@@ -63,7 +64,7 @@ ConsentHandler.prototype.getConsentSettings = function() {
 
     var forwarderSettings = this.common.forwarderSettings;
 
-    Object.keys(googleToMpConsentSettingsMapping).forEach(function(
+    Object.keys(googleToMpConsentSettingsMapping).forEach(function (
         googleConsentKey
     ) {
         var mpConsentSettingKey =
@@ -79,7 +80,7 @@ ConsentHandler.prototype.getConsentSettings = function() {
     return consentSettings;
 };
 
-ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function(
+ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function (
     consentState,
     mappings
 ) {

--- a/kits/google-analytics-4/packages/GA4Client/src/event-handler.js
+++ b/kits/google-analytics-4/packages/GA4Client/src/event-handler.js
@@ -3,14 +3,13 @@ function EventHandler(common) {
 }
 
 // TODO: https://mparticle-eng.atlassian.net/browse/SQDSDKS-5715
-EventHandler.prototype.sendEventToGA4 = function(eventName, eventAttributes) {
+EventHandler.prototype.sendEventToGA4 = function (eventName, eventAttributes) {
     var standardizedEventName;
     var standardizedAttributes;
     if (this.common.forwarderSettings.enableDataCleansing) {
         standardizedEventName = this.common.standardizeName(eventName);
-        standardizedAttributes = this.common.standardizeParameters(
-            eventAttributes
-        );
+        standardizedAttributes =
+            this.common.standardizeParameters(eventAttributes);
     } else {
         standardizedEventName = eventName;
         standardizedAttributes = eventAttributes;
@@ -21,7 +20,8 @@ EventHandler.prototype.sendEventToGA4 = function(eventName, eventAttributes) {
     );
 
     if (this.common.forwarderSettings.measurementId) {
-        standardizedAttributes.send_to = this.common.forwarderSettings.measurementId;
+        standardizedAttributes.send_to =
+            this.common.forwarderSettings.measurementId;
     }
 
     gtag(
@@ -31,7 +31,7 @@ EventHandler.prototype.sendEventToGA4 = function(eventName, eventAttributes) {
     );
 };
 
-EventHandler.prototype.logEvent = function(event) {
+EventHandler.prototype.logEvent = function (event) {
     var eventConsentState = this.common.getEventConsentState(
         event.ConsentState
     );
@@ -39,11 +39,11 @@ EventHandler.prototype.logEvent = function(event) {
     this.sendEventToGA4(event.EventName, event.EventAttributes);
 };
 
-EventHandler.prototype.logError = function() {
+EventHandler.prototype.logError = function () {
     console.warn('Google Analytics 4 does not support error events.');
 };
 
-EventHandler.prototype.logPageView = function(event) {
+EventHandler.prototype.logPageView = function (event) {
     var TITLE = 'GA4.Title';
     var LOCATION = 'GA4.Location';
     var REFERRER = 'GA4.Referrer';

--- a/kits/google-analytics-4/packages/GA4Client/src/identity-handler.js
+++ b/kits/google-analytics-4/packages/GA4Client/src/identity-handler.js
@@ -21,7 +21,7 @@ For more userIdentity types, see http://docs.mparticle.com/developers/sdk/javasc
 function IdentityHandler(common) {
     this.common = common || {};
 }
-IdentityHandler.prototype.onUserIdentified = function(mParticleUser) {
+IdentityHandler.prototype.onUserIdentified = function (mParticleUser) {
     var configSettings = {};
     var userId = this.common.getUserId(
         mParticleUser,
@@ -38,19 +38,19 @@ IdentityHandler.prototype.onUserIdentified = function(mParticleUser) {
         user_id: userId,
     });
 };
-IdentityHandler.prototype.onIdentifyComplete = function(
+IdentityHandler.prototype.onIdentifyComplete = function (
     mParticleUser,
     identityApiRequest
 ) {};
-IdentityHandler.prototype.onLoginComplete = function(
+IdentityHandler.prototype.onLoginComplete = function (
     mParticleUser,
     identityApiRequest
 ) {};
-IdentityHandler.prototype.onLogoutComplete = function(
+IdentityHandler.prototype.onLogoutComplete = function (
     mParticleUser,
     identityApiRequest
 ) {};
-IdentityHandler.prototype.onModifyComplete = function(
+IdentityHandler.prototype.onModifyComplete = function (
     mParticleUser,
     identityApiRequest
 ) {};
@@ -59,7 +59,7 @@ IdentityHandler.prototype.onModifyComplete = function(
     kits is only reachable via the onSetUserIdentity method below. We recommend
     filling out `onSetUserIdentity` for maximum compatibility
 */
-IdentityHandler.prototype.onSetUserIdentity = function(
+IdentityHandler.prototype.onSetUserIdentity = function (
     forwarderSettings,
     id,
     type

--- a/kits/google-analytics-4/packages/GA4Client/src/initialization.js
+++ b/kits/google-analytics-4/packages/GA4Client/src/initialization.js
@@ -11,7 +11,7 @@ var initialization = {
     userIdentities example: { 1: 'customerId', 2: 'facebookId', 7: 'emailid@email.com' }
     additional identityTypes can be found at https://github.com/mParticle/mparticle-sdk-javascript/blob/master-v2/src/types.js#L88-L101
 */
-    initForwarder: function(
+    initForwarder: function (
         forwarderSettings,
         testMode,
         userAttributes,
@@ -55,7 +55,7 @@ var initialization = {
 
         window.dataLayer = window.dataLayer || [];
 
-        window.gtag = function() {
+        window.gtag = function () {
             window.dataLayer.push(arguments);
         };
         gtag('js', new Date());
@@ -74,7 +74,7 @@ var initialization = {
         }
         gtag('config', measurementId, configSettings);
 
-        gtag('get', measurementId, 'client_id', function(clientId) {
+        gtag('get', measurementId, 'client_id', function (clientId) {
             setClientId(clientId, initialization.moduleId);
         });
 
@@ -89,7 +89,7 @@ var initialization = {
                 document.getElementsByTagName('body')[0]
             ).appendChild(clientScript);
 
-            clientScript.onload = function() {
+            clientScript.onload = function () {
                 isInitialized = true;
 
                 if (window.dataLayer && gtag && eventQueue.length > 0) {
@@ -103,21 +103,23 @@ var initialization = {
             isInitialized = true;
         }
 
-        common.consentPayloadDefaults = common.consentHandler.getConsentSettings();
+        common.consentPayloadDefaults =
+            common.consentHandler.getConsentSettings();
         var defaultConsentPayload = common.cloneObject(
             common.consentPayloadDefaults
         );
         var updatedConsentState = common.consentHandler.getUserConsentState();
-        var updatedDefaultConsentPayload = common.consentHandler.generateConsentStatePayloadFromMappings(
-            updatedConsentState,
-            common.consentMappings
-        );
+        var updatedDefaultConsentPayload =
+            common.consentHandler.generateConsentStatePayloadFromMappings(
+                updatedConsentState,
+                common.consentMappings
+            );
 
         // If a default consent payload exists (as selected in the mParticle UI), set it as the default
         if (!common.isEmpty(defaultConsentPayload)) {
             common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload);
-            // If a default consent payload does not exist, but the user currently has updated their consent,
-            // send that as the default because a default must be sent
+        // If a default consent payload does not exist, but the user currently has updated their consent,
+        // send that as the default because a default must be sent
         } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
             common.sendDefaultConsentPayloadToGoogle(
                 updatedDefaultConsentPayload

--- a/kits/google-analytics-4/packages/GA4Client/src/session-handler.js
+++ b/kits/google-analytics-4/packages/GA4Client/src/session-handler.js
@@ -1,6 +1,10 @@
 var sessionHandler = {
-    onSessionStart: function(event) {},
-    onSessionEnd: function(event) {},
+    onSessionStart: function(event) {
+
+    },
+    onSessionEnd: function(event) {
+
+    }
 };
 
 module.exports = sessionHandler;

--- a/kits/google-analytics-4/packages/GA4Client/src/user-attribute-handler.js
+++ b/kits/google-analytics-4/packages/GA4Client/src/user-attribute-handler.js
@@ -2,7 +2,7 @@ function UserAttributeHandler(common) {
     this.common = common || {};
 }
 
-UserAttributeHandler.prototype.sendUserPropertiesToGA4 = function(
+UserAttributeHandler.prototype.sendUserPropertiesToGA4 = function (
     userAttributes
 ) {
     gtag(
@@ -16,13 +16,13 @@ UserAttributeHandler.prototype.sendUserPropertiesToGA4 = function(
 // In the future if mParticleUser is ever required for an implementation of any of the below APIs, see https://github.com/mparticle-integrations/mparticle-javascript-integration-example/blob/master/src/user-attribute-handler.js
 // for previous function signatures
 
-UserAttributeHandler.prototype.onRemoveUserAttribute = function(key) {
+UserAttributeHandler.prototype.onRemoveUserAttribute = function (key) {
     var userAttributes = {};
     userAttributes[key] = null;
     this.sendUserPropertiesToGA4(userAttributes);
 };
 
-UserAttributeHandler.prototype.onSetUserAttribute = function(key, value) {
+UserAttributeHandler.prototype.onSetUserAttribute = function (key, value) {
     var userAttributes = {};
     userAttributes[key] = value;
     this.sendUserPropertiesToGA4(userAttributes);

--- a/kits/google-analytics-4/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js
+++ b/kits/google-analytics-4/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js
@@ -15,6 +15,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+
 // This GA4 server side kit loads gtag, gets the client id, and sets it as an integration attribute on the core sdk.
 // This kit does not have a `processEvent` method because no events should be sent client side.
 

--- a/kits/heap/src/commerce-handler.js
+++ b/kits/heap/src/commerce-handler.js
@@ -8,50 +8,50 @@ var ProductActionTypes = {
     Refund: 17,
     RemoveFromCart: 11,
     ViewDetail: 15,
-};
+}
 
 var ProductActionNames = {
-    0: 'Unknown',
-    1: 'Add To Cart',
-    2: 'Remove From Cart',
-    3: 'Checkout',
-    4: 'Checkout Option',
-    5: 'Click',
-    6: 'View Detail',
-    7: 'Purchase',
-    8: 'Refund',
-    9: 'Add To Wishlist',
-    10: 'Remove From Wishlist',
-};
+    0: "Unknown",
+    1: "Add To Cart",
+    2: "Remove From Cart",
+    3: "Checkout",
+    4: "Checkout Option",
+    5: "Click",
+    6: "View Detail",
+    7: "Purchase",
+    8: "Refund",
+    9: "Add To Wishlist",
+    10: "Remove From Wishlist",
+}
 
 var PromotionType = {
     PromotionClick: 19,
     PromotionView: 18,
-};
+}
 
 var PromotionTypeNames = {
-    19: 'Click',
-    18: 'View',
-};
+    19: "Click",
+    18: "View",
+}
 var HeapConstants = {
-    EventNameItem: 'Item',
-    EventNameProductAction: 'Product Action Event',
-    EventNameProductActionPart: 'Product Action: ',
-    EventNamePromotionPart: 'Promotion: ',
-    EventNameImpression: 'Impression Event',
+    EventNameItem: "Item",
+    EventNameProductAction: "Product Action Event",
+    EventNameProductActionPart: "Product Action: ",
+    EventNamePromotionPart: "Promotion: ",
+    EventNameImpression: "Impression Event",
     MaxPropertyLength: 1023,
-    KeyProductName: 'product_name',
-    KeyProductPrice: 'product_price',
-    KeyProductQuantity: 'product_quantity',
-    KeyProductTotalProductAmount: 'total_product_amount',
-    KeyProductSku: 'product_id',
-    KeyProductBrand: 'product_brand',
-    KeyProductCategory: 'product_category',
-    KeyProductSkus: 'skus',
-    KeyPromotionCreative: 'creative',
-    KeyPromotionId: 'id',
-    KeyPromotionPosition: 'position',
-};
+    KeyProductName: "product_name",
+    KeyProductPrice: "product_price",
+    KeyProductQuantity: "product_quantity",
+    KeyProductTotalProductAmount: "total_product_amount",
+    KeyProductSku: "product_id",
+    KeyProductBrand: "product_brand",
+    KeyProductCategory: "product_category",
+    KeyProductSkus: "skus",
+    KeyPromotionCreative: "creative",
+    KeyPromotionId: "id",
+    KeyPromotionPosition: "position",
+}
 
 function CommerceHandler(common) {
     this.common = common || {};
@@ -128,7 +128,7 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
             break;
         default:
             events = buildProductActionEvents(event);
-    }
+    };
 
     for (var i = 0; i < events.length; i++) {
         var event = events[i];
@@ -144,28 +144,23 @@ function buildImpressionEvents(event) {
             var impression = event.ProductImpressions[i];
             var productSkus = [];
             if (impression.ProductList.length > 0) {
-                for (var j = 0; j < impression.ProductList.length; j++) {
+                for(var j = 0; j < impression.ProductList.length; j++) {
                     var product = impression.ProductList[j];
                     var eventObject = buildItemEvent(product);
                     events.push(eventObject.event);
-                    if (eventObject.sku) {
+                    if(eventObject.sku) {
                         productSkus.push(eventObject.sku);
                     }
                 }
             }
 
-            events.push(
-                buildActionEvent(
-                    event,
-                    HeapConstants.EventNameImpression,
-                    productSkus
-                )
-            );
+            events.push(buildActionEvent(event, HeapConstants.EventNameImpression, productSkus))
         }
     }
 
+
     return events;
-}
+};
 
 function buildPromotionEvents(event) {
     var events = [];
@@ -176,17 +171,13 @@ function buildPromotionEvents(event) {
             var eventObject = buildPromotionItemEvent(promotion);
             events.push(eventObject.event);
 
-            if (eventObject.id) {
+            if(eventObject.id) {
                 promotionIds.push(eventObject.id);
             }
         }
     }
-    var promotionActionEventName =
-        HeapConstants.EventNamePromotionPart +
-        PromotionTypeNames[event.EventCategory];
-    events.push(
-        buildActionEvent(event, promotionActionEventName, promotionIds)
-    );
+    var promotionActionEventName = HeapConstants.EventNamePromotionPart + PromotionTypeNames[event.EventCategory];
+    events.push(buildActionEvent(event, promotionActionEventName, promotionIds));
     return events;
 }
 
@@ -211,10 +202,8 @@ function buildProductActionEvents(event) {
     if (!event.ProductAction) {
         actionEventName = HeapConstants.EventNameProductAction;
     } else {
-        var productActionKey =
-            ProductActionNames[event.ProductAction.ProductActionType];
-        actionEventName =
-            HeapConstants.EventNameProductActionPart + productActionKey;
+        var productActionKey = ProductActionNames[event.ProductAction.ProductActionType];
+        actionEventName = HeapConstants.EventNameProductActionPart + productActionKey;
     }
 
     events.push(buildActionEvent(event, actionEventName, productSkus));
@@ -223,10 +212,9 @@ function buildProductActionEvents(event) {
 }
 
 function buildActionEvent(event, eventName, productSkus) {
-    var properties =
-        event && event.EventAttributes ? event.EventAttributes : {};
+    var properties = event && event.EventAttributes ? event.EventAttributes : {};
     properties[HeapConstants.KeyProductSkus] = productSkus;
-    return { Name: eventName, Properties: properties };
+    return {Name: eventName, Properties: properties};
 }
 
 function buildItemEvent(product) {
@@ -248,13 +236,9 @@ function buildItemEvent(product) {
         properties[HeapConstants.KeyProductQuantity] = validatedQuantity;
     }
 
-    var validatedTotalProductAmount = validateHeapPropertyValue(
-        product.TotalProductAmount
-    );
+    var validatedTotalProductAmount = validateHeapPropertyValue(product.TotalProductAmount);
     if (validatedTotalProductAmount) {
-        properties[
-            HeapConstants.KeyProductTotalProductAmount
-        ] = validatedTotalProductAmount;
+        properties[HeapConstants.KeyProductTotalProductAmount] = validatedTotalProductAmount;
     }
 
     var validatedSku = validateHeapPropertyValue(product.Sku);
@@ -275,19 +259,18 @@ function buildItemEvent(product) {
     event.Name = HeapConstants.EventNameItem;
     event.Properties = properties;
 
-    return { event: event, sku: validatedSku };
+    return {event: event, sku: validatedSku};
 }
 
 function buildPromotionItemEvent(promotion) {
     var event = {};
-    var properties =
-        promotion && promotion.Attributes ? promotion.Attributes : {};
+    var properties = promotion && promotion.Attributes ? promotion.Attributes : {};
 
     var validatedPromotionValues = {
         KeyPromotionCreative: validateHeapPropertyValue(promotion.Creative),
         KeyPromotionId: validateHeapPropertyValue(promotion.Id),
         KeyPromotionPosition: validateHeapPropertyValue(promotion.Position),
-    };
+    }
 
     var validatedPromotionKeys = Object.keys(validatedPromotionValues);
     for (var i = 0; i < validatedPromotionKeys.length; i++) {
@@ -303,17 +286,17 @@ function buildPromotionItemEvent(promotion) {
     event.Properties = properties;
     var promotionId = validatedPromotionValues.KeyPromotionId;
 
-    return { event: event, id: promotionId };
+    return {event: event, id: promotionId};
 }
 
-function validateHeapPropertyValue(value) {
-    if (typeof value === 'boolean' || typeof value === 'number') {
+function validateHeapPropertyValue(value){
+    if (typeof value === "boolean" || typeof value === "number") {
         return value;
     }
 
     if (value === undefined || value === null) {
         return value;
-    } else if (value.length > HeapConstants.MaxPropertyLength) {
+    } else if (value.length > HeapConstants.MaxPropertyLength){
         return value.substring(0, HeapConstants.MaxPropertyLength);
     } else {
         return value;

--- a/kits/heap/src/common.js
+++ b/kits/heap/src/common.js
@@ -1,7 +1,7 @@
 function Common() {}
 
-Common.prototype.exampleMethod = function() {
+Common.prototype.exampleMethod = function () {
     return 'I am an example';
-};
+}
 
 module.exports = Common;

--- a/kits/heap/src/event-handler.js
+++ b/kits/heap/src/event-handler.js
@@ -17,7 +17,11 @@ function EventHandler(common) {
     this.common = common || {};
 }
 EventHandler.prototype.logEvent = function(event) {
-    var ignoredEvents = ['click', 'change', 'submit'];
+    var ignoredEvents = [
+        'click',
+        'change',
+        'submit'
+    ];
 
     if (ignoredEvents.includes(event.EventName.toLowerCase())) {
         return;

--- a/kits/heap/src/identity-handler.js
+++ b/kits/heap/src/identity-handler.js
@@ -27,8 +27,7 @@ IdentityHandler.prototype.onUserIdentified = function(mParticleUser) {
     }
 
     var identitiesObject = mParticleUser.getUserIdentities();
-    var identity =
-        identitiesObject.userIdentities[this.common.userIdentificationType];
+    var identity = identitiesObject.userIdentities[this.common.userIdentificationType];
 
     if (identity) {
         window.heap.identify(identity);

--- a/kits/heap/src/initialization.js
+++ b/kits/heap/src/initialization.js
@@ -1,58 +1,7 @@
-var renderSnippet = function(appId) {
-    (window.heapReadyCb = window.heapReadyCb || []),
-        (window.heap = window.heap || []),
-        (heap.load = function(e, t) {
-            (window.heap.envId = e),
-                (window.heap.clientConfig = t = t || {}),
-                (window.heap.clientConfig.shouldFetchServerConfig = !1);
-            var a = document.createElement('script');
-            (a.type = 'text/javascript'),
-                (a.async = !0),
-                (a.src =
-                    'https://cdn.us.heap-api.com/config/' +
-                    e +
-                    '/heap_config.js');
-            var r = document.getElementsByTagName('script')[0];
-            r.parentNode.insertBefore(a, r);
-            var n = [
-                    'init',
-                    'startTracking',
-                    'stopTracking',
-                    'track',
-                    'resetIdentity',
-                    'identify',
-                    'getSessionId',
-                    'getUserId',
-                    'getIdentity',
-                    'addUserProperties',
-                    'addEventProperties',
-                    'removeEventProperty',
-                    'clearEventProperties',
-                    'addAccountProperties',
-                    'addAdapter',
-                    'addTransformer',
-                    'addTransformerFn',
-                    'onReady',
-                    'addPageviewProperties',
-                    'removePageviewProperty',
-                    'clearPageviewProperties',
-                    'trackPageview',
-                ],
-                i = function(e) {
-                    return function() {
-                        var t = Array.prototype.slice.call(arguments, 0);
-                        window.heapReadyCb.push({
-                            name: e,
-                            fn: function() {
-                                heap[e] && heap[e].apply(heap, t);
-                            },
-                        });
-                    };
-                };
-            for (var p = 0; p < n.length; p++) heap[n[p]] = i(n[p]);
-        });
+var renderSnippet = function (appId) {
+    window.heapReadyCb=window.heapReadyCb||[],window.heap=window.heap||[],heap.load=function(e,t){window.heap.envId=e,window.heap.clientConfig=t=t||{},window.heap.clientConfig.shouldFetchServerConfig=!1;var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src="https://cdn.us.heap-api.com/config/"+e+"/heap_config.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(a,r);var n=["init","startTracking","stopTracking","track","resetIdentity","identify","getSessionId","getUserId","getIdentity","addUserProperties","addEventProperties","removeEventProperty","clearEventProperties","addAccountProperties","addAdapter","addTransformer","addTransformerFn","onReady","addPageviewProperties","removePageviewProperty","clearPageviewProperties","trackPageview"],i=function(e){return function(){var t=Array.prototype.slice.call(arguments,0);window.heapReadyCb.push({name:e,fn:function(){heap[e]&&heap[e].apply(heap,t)}})}};for(var p=0;p<n.length;p++)heap[n[p]]=i(n[p])};
     heap.load(appId);
-};
+}
 var initialization = {
     name: 'Heap',
     moduleId: 31,
@@ -64,7 +13,7 @@ var initialization = {
         userIdentities example: { 1: 'customerId', 2: 'facebookId', 7: 'emailid@email.com' }
         additional identityTypes can be found at https://github.com/mParticle/mparticle-sdk-javascript/blob/master-v2/src/types.js#L88-L101
     */
-    initForwarder: function(
+    initForwarder: function (
         forwarderSettings,
         testMode,
         userAttributes,
@@ -83,11 +32,9 @@ var initialization = {
             /* Load your Web SDK here using a variant of your snippet from your readme that your customers would generally put into their <head> tags
                Generally, our integrations create script tags and append them to the <head>. Please follow the following format as a guide:
             */
-            common.userIdentificationType =
-                forwarderSettings.userIdentificationType;
+            common.userIdentificationType = forwarderSettings.userIdentificationType
 
-            var forwardWebRequestsServerSide =
-                forwarderSettings.forwardWebRequestsServerSide === 'True';
+            var forwardWebRequestsServerSide = forwarderSettings.forwardWebRequestsServerSide === 'True';
             common.forwardWebRequestsServerSide = forwardWebRequestsServerSide;
             if (!forwardWebRequestsServerSide) {
                 if (!window.heap) {

--- a/kits/heap/src/session-handler.js
+++ b/kits/heap/src/session-handler.js
@@ -1,6 +1,10 @@
 var sessionHandler = {
-    onSessionStart: function(event) {},
-    onSessionEnd: function(event) {},
+    onSessionStart: function(event) {
+
+    },
+    onSessionEnd: function(event) {
+
+    }
 };
 
 module.exports = sessionHandler;

--- a/kits/id5/id5-1/src/common.js
+++ b/kits/id5/id5-1/src/common.js
@@ -1,11 +1,11 @@
 var SHA256 = require('crypto-js/sha256');
 function Common() {}
 
-Common.prototype.exampleMethod = function() {
+Common.prototype.exampleMethod = function () {
     return 'I am an example';
-};
+}
 
-Common.prototype.logId5Id = function(id5Id) {
+Common.prototype.logId5Id = function (id5Id) {
     if (!id5Id) {
         return;
     }
@@ -16,20 +16,15 @@ Common.prototype.logId5Id = function(id5Id) {
         partnerId: this.partnerId.toString(),
     };
 
-    window.mParticle.setIntegrationAttribute(
-        this.moduleId,
-        integrationAttributes
-    );
+    window.mParticle.setIntegrationAttribute(this.moduleId, integrationAttributes);
 };
 
-Common.prototype.buildPartnerData = function(mParticleUser) {
+Common.prototype.buildPartnerData = function (mParticleUser) {
     var pdKeys = {};
     var userIdentities = mParticleUser.getUserIdentities();
 
     var email = this.normalizeEmail(userIdentities.userIdentities['email']);
-    var phone = this.normalizePhone(
-        userIdentities.userIdentities['mobile_number']
-    );
+    var phone = this.normalizePhone(userIdentities.userIdentities['mobile_number']);
 
     if (!email && !phone) {
         return null;
@@ -40,76 +35,74 @@ Common.prototype.buildPartnerData = function(mParticleUser) {
     }
 
     if (phone) {
-        pdKeys[2] = SHA256(phone);
+        pdKeys[2]= SHA256(phone);
     }
 
-    var pdRaw = Object.keys(pdKeys)
-        .map(function(key) {
-            return key + '=' + pdKeys[key];
-        })
-        .join('&');
+    var pdRaw = Object.keys(pdKeys).map(function(key){
+        return key + '=' + pdKeys[key]
+    }).join('&');
 
     return btoa(pdRaw);
-};
+}
 
 Common.prototype.normalizeEmail = function(email) {
     if (!email || !this.validateEmail(email)) {
         return null;
     }
-    var parts = email.split('@');
-    var charactersToRemove = ['+', '.'];
+    var parts = email.split("@")
+    var charactersToRemove = ['+', '.']
 
     if (parts[1] != 'gmail.com') {
         return email;
     }
 
-    parts[0] = this.replace(parts[0], charactersToRemove);
+    parts[0]= this.replace(parts[0], charactersToRemove);
 
     return parts.join('@');
-};
+}
 
 Common.prototype.normalizePhone = function(phone) {
     if (!phone) {
         return null;
     }
-    var charactersToRemove = [' ', '-', '(', ')'];
+    var charactersToRemove = [' ', '-', '(', ')']
     var normalizedPhone = this.replace(phone, charactersToRemove);
 
     if (normalizedPhone[0] !== '+') {
-        normalizedPhone = '+' + normalizedPhone;
+        normalizedPhone = '+' + normalizedPhone
     }
 
     if (!this.validatePhone(normalizedPhone)) {
         return null;
     }
     return normalizedPhone;
-};
+}
 
 Common.prototype.replace = function(string, targets) {
     var newString = '';
-    for (var i = 0; i < string.length; i++) {
+    for(var i = 0; i < string.length; i++){
         var char = string[i];
-        if (!targets.includes(char)) {
-            newString += char;
+        if (!targets.includes(char)){
+            newString += char
         }
     }
     return newString.toLowerCase();
-};
+}
 
-Common.prototype.validateEmail = function(email) {
+Common.prototype.validateEmail = function(email){
     if (!email) {
         return false;
     }
-    var emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    var emailRegex =  /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
-};
+}
 
 Common.prototype.validatePhone = function(phone) {
-    if (!phone) {
+    if (!phone){
         return false;
     }
     var e164Regex = /^\+?[1-9]\d{1,14}$/;
 
     return e164Regex.test(phone);
-};
+}
 module.exports = Common;

--- a/kits/id5/id5-1/src/identity-handler.js
+++ b/kits/id5/id5-1/src/identity-handler.js
@@ -25,7 +25,9 @@ IdentityHandler.prototype.onUserIdentified = function() {};
 IdentityHandler.prototype.onIdentifyComplete = function() {};
 
 //Must re-initialize ID5 with partner identities(pd) in the config to collect an updated ID5 ID
-IdentityHandler.prototype.onLoginComplete = function(mParticleUser) {
+IdentityHandler.prototype.onLoginComplete = function(
+    mParticleUser
+) {
     var partnerData = this.common.buildPartnerData(mParticleUser);
 
     if (partnerData) {
@@ -33,34 +35,31 @@ IdentityHandler.prototype.onLoginComplete = function(mParticleUser) {
             partnerId: this.common.partnerId,
             pd: partnerData,
             consentData: {
-                allowedVendors: this.common.allowedVendors,
-            },
-        });
+                allowedVendors: this.common.allowedVendors
+            }
+        })
         var logId5Id = this.common.logId5Id;
 
-        id5Instance.onAvailable(
-            function(status) {
-                logId5Id(status.getUserId());
-            }.bind(logId5Id)
-        );
+        id5Instance.onAvailable(function(status){
+            logId5Id(status.getUserId());
+        }.bind(logId5Id));
     }
 };
 
 //Must re-initialize ID5 without partner identities (pd) in the config to revert to an anonymous ID5 ID
-IdentityHandler.prototype.onLogoutComplete = function() {
+IdentityHandler.prototype.onLogoutComplete = function(
+) {
     var id5Instance = window.ID5.init({
         partnerId: this.common.partnerId,
         consentData: {
-            allowedVendors: this.common.allowedVendors,
-        },
-    });
+            allowedVendors: this.common.allowedVendors
+        }
+    })
     var logId5Id = this.common.logId5Id;
 
-    id5Instance.onAvailable(
-        function(status) {
-            logId5Id(status.getUserId());
-        }.bind(logId5Id)
-    );
+    id5Instance.onAvailable(function(status){
+        logId5Id(status.getUserId());
+    }.bind(logId5Id));
 };
 
 IdentityHandler.prototype.onModifyComplete = function() {};

--- a/kits/id5/id5-1/src/initialization.js
+++ b/kits/id5/id5-1/src/initialization.js
@@ -1,7 +1,7 @@
 var initialization = {
     name: 'ID5',
     moduleId: 248,
-    vendors: ['131', 'ID5-1747'],
+    vendors: [ '131', 'ID5-1747' ],
     /*  ****** Fill out initForwarder to load your SDK ******
     Note that not all arguments may apply to your SDK initialization.
     These are passed from mParticle, but leave them even if they are not being used.
@@ -10,16 +10,7 @@ var initialization = {
     userIdentities example: { 1: 'customerId', 2: 'facebookId', 7: 'emailid@email.com' }
     additional identityTypes can be found at https://github.com/mParticle/mparticle-sdk-javascript/blob/master-v2/src/types.js#L88-L101
 */
-    initForwarder: function(
-        forwarderSettings,
-        testMode,
-        userAttributes,
-        userIdentities,
-        processEvent,
-        eventQueue,
-        isInitialized,
-        common
-    ) {
+    initForwarder: function(forwarderSettings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, common) {
         /* `forwarderSettings` contains your SDK specific settings such as apiKey that your customer needs in order to initialize your SDK properly */
         common.partnerId = forwarderSettings.partnerId;
         common.id5IdType = forwarderSettings.id5IdType;
@@ -33,10 +24,7 @@ var initialization = {
             //ID5 docs on initialization can be found here: https://github.com/id5io/id5-api.js/blob/master/README.md
             var id5Script = document.createElement('script');
             id5Script.src = 'https://cdn.id5-sync.com/api/1.0/id5-api.js';
-            (
-                document.getElementsByTagName('head')[0] ||
-                document.getElementsByTagName('body')[0]
-            ).appendChild(id5Script);
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(id5Script);
 
             id5Script.onload = function() {
                 isInitialized = true;
@@ -44,28 +32,24 @@ var initialization = {
                 var id5Instance = window.ID5.init({
                     partnerId: common.partnerId,
                     consentData: {
-                        allowedVendors: common.allowedVendors,
-                    },
-                });
+                        allowedVendors: common.allowedVendors
+                    }
+                })
 
-                id5Instance.onAvailable(
-                    function(status) {
-                        common.logId5Id(status.getUserId());
-                    }.bind(common)
-                );
+                id5Instance.onAvailable(function(status){
+                    common.logId5Id(status.getUserId());
+                }.bind(common));
             };
         } else {
             isInitialized = true;
 
-            var id5Instance = window.ID5.init({ partnerId: common.partnerId });
+            var id5Instance = window.ID5.init({partnerId: common.partnerId})
 
-            id5Instance.onAvailable(
-                function(status) {
-                    common.logId5Id(status.getUserId());
-                }.bind(common)
-            );
+            id5Instance.onAvailable(function(status){
+                common.logId5Id(status.getUserId());
+            }.bind(common));
         }
-    },
+    }
 };
 
 module.exports = initialization;

--- a/kits/id5/id5-1/src/session-handler.js
+++ b/kits/id5/id5-1/src/session-handler.js
@@ -1,6 +1,10 @@
 var sessionHandler = {
-    onSessionStart: function() {},
-    onSessionEnd: function() {},
+    onSessionStart: function() {
+
+    },
+    onSessionEnd: function() {
+
+    }
 };
 
 module.exports = sessionHandler;

--- a/kits/inspectlet/src/Inspectlet.js
+++ b/kits/inspectlet/src/Inspectlet.js
@@ -13,199 +13,184 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var isobject = require('isobject');
+    var isobject = require('isobject');
 
-var MessageType = {
+    var MessageType = {
         SessionStart: 1,
         SessionEnd: 2,
         PageView: 3,
         PageEvent: 4,
         CrashReport: 5,
         OptOut: 6,
-        Commerce: 16,
+        Commerce: 16
     },
-    name = 'Inspectlet',
-    moduleId = 61;
+        name = 'Inspectlet',
+        moduleId = 61;
 
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings,
-        reportingService,
-        isTesting = false;
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            forwarderSettings,
+            reportingService,
+            isTesting = false;
 
-    self.name = name;
+        self.name = name;
 
-    function getIdentityTypeName(identityType) {
-        return mParticle.IdentityType.getName(identityType);
-    }
-
-    function reportEvent(event) {
-        if (reportingService) {
-            reportingService(self, event);
+        function getIdentityTypeName(identityType) {
+            return mParticle.IdentityType.getName(identityType);
         }
-    }
 
-    function processEvent(event) {
-        if (isInitialized) {
-            try {
-                if (event.EventDataType == MessageType.PageEvent) {
-                    if (
-                        event.EventCategory ==
-                        window.mParticle.EventType.Transaction
-                    ) {
-                        logTransaction(event);
-                        reportEvent(event);
-                        return 'Successfully sent to ' + name;
-                    } else if (
-                        event.EventCategory ==
-                        window.mParticle.EventType.Navigation
-                    ) {
-                        __insp.push(['virtualPage']);
-                        reportEvent(event);
+        function reportEvent(event) {
+            if (reportingService) {
+                reportingService(self, event);
+            }
+        }
 
-                        return 'Successfully sent virtual page view to ' + name;
+        function processEvent(event) {
+            if (isInitialized) {
+                try {
+                    if (event.EventDataType == MessageType.PageEvent) {
+                        if (event.EventCategory == window.mParticle.EventType.Transaction) {
+                            logTransaction(event);
+                            reportEvent(event);
+                            return 'Successfully sent to ' + name;
+                        }
+                        else if (event.EventCategory == window.mParticle.EventType.Navigation) {
+                            __insp.push(["virtualPage"]);
+                            reportEvent(event);
+
+                            return 'Successfully sent virtual page view to ' + name;
+                        }
                     }
-                } else if (event.EventDataType == MessageType.Commerce) {
-                    logTransaction(event);
-                }
+                    else if (event.EventDataType == MessageType.Commerce) {
+                        logTransaction(event);
+                    }
 
-                return 'Ignoring non-transaction event for ' + name;
-            } catch (e) {
-                return 'Failed to send to: ' + name + ' ' + e;
+                    return 'Ignoring non-transaction event for ' + name;
+                }
+                catch (e) {
+                    return 'Failed to send to: ' + name + ' ' + e;
+                }
+            }
+
+            return 'Can\'t send to forwarder ' + name + ', not initialized';
+        }
+
+        function logTransaction(data) {
+            __insp.push(['tagSession', "purchase"]);
+        }
+
+        function setUserAttribute(key, value) {
+            var attributeDict;
+
+            if (isInitialized) {
+                if (value) {
+                    attributeDict = {};
+                    attributeDict[key] = value;
+                    __insp.push(['tagSession', attributeDict]);
+                }
+                else {
+                    __insp.push(['tagSession', key]);
+                }
+            }
+            else {
+                return 'Can\'t call setUserAttribute on forwarder ' + name + ', not initialized';
             }
         }
 
-        return "Can't send to forwarder " + name + ', not initialized';
-    }
-
-    function logTransaction(data) {
-        __insp.push(['tagSession', 'purchase']);
-    }
-
-    function setUserAttribute(key, value) {
-        var attributeDict;
-
-        if (isInitialized) {
-            if (value) {
-                attributeDict = {};
-                attributeDict[key] = value;
-                __insp.push(['tagSession', attributeDict]);
-            } else {
-                __insp.push(['tagSession', key]);
+        function setUserIdentity(id, type) {
+            if (isInitialized) {
+                setUserAttribute(getIdentityTypeName(type), id);
             }
+            else {
+                return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
+            }
+        }
+
+        function initForwarder(settings, service, testMode) {
+            forwarderSettings = settings;
+            reportingService = service;
+            isTesting = testMode;
+
+            try {
+                function addInspectlet() {
+                    function __ldinsp() {
+                        var insp = document.createElement('script');
+                        insp.type = 'text/javascript';
+                        insp.async = true;
+                        insp.id = "inspsync";
+                        insp.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://cdn.inspectlet.com/inspectlet.js';
+                        var head = document.getElementsByTagName('head')[0];
+                        head.appendChild(insp);
+                    }
+
+                    if (window.attachEvent) {
+                        window.attachEvent('onload', __ldinsp);
+                    }
+                    else {
+                        window.addEventListener('load', __ldinsp, false);
+                    }
+                }
+
+                window.__insp = window.__insp || [];
+                __insp.push(['wid', forwarderSettings.wId]);
+
+                if (isTesting === false) {
+                    addInspectlet();
+                }
+
+                isInitialized = true;
+
+                return 'Successfully initialized: ' + name;
+            }
+            catch (e) {
+                return 'Failed to initialize: ' + name;
+            }
+        }
+
+        this.init = initForwarder;
+        this.process = processEvent;
+        this.setUserAttribute = setUserAttribute;
+        this.setUserIdentity = setUserIdentity;
+    };
+    function getId() {
+        return moduleId;
+    }
+
+    function register(config) {
+        if (!config) {
+            console.log('You must pass a config object to register the kit ' + name);
+            return;
+        }
+
+        if (!isobject(config)) {
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
+
+        if (isobject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
         } else {
-            return (
-                "Can't call setUserAttribute on forwarder " +
-                name +
-                ', not initialized'
-            );
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
         }
     }
 
-    function setUserIdentity(id, type) {
-        if (isInitialized) {
-            setUserAttribute(getIdentityTypeName(type), id);
-        } else {
-            return (
-                "Can't call setUserIdentity on forwarder " +
-                name +
-                ', not initialized'
-            );
-        }
-    }
-
-    function initForwarder(settings, service, testMode) {
-        forwarderSettings = settings;
-        reportingService = service;
-        isTesting = testMode;
-
-        try {
-            function addInspectlet() {
-                function __ldinsp() {
-                    var insp = document.createElement('script');
-                    insp.type = 'text/javascript';
-                    insp.async = true;
-                    insp.id = 'inspsync';
-                    insp.src =
-                        ('https:' == document.location.protocol
-                            ? 'https'
-                            : 'http') + '://cdn.inspectlet.com/inspectlet.js';
-                    var head = document.getElementsByTagName('head')[0];
-                    head.appendChild(insp);
-                }
-
-                if (window.attachEvent) {
-                    window.attachEvent('onload', __ldinsp);
-                } else {
-                    window.addEventListener('load', __ldinsp, false);
-                }
-            }
-
-            window.__insp = window.__insp || [];
-            __insp.push(['wid', forwarderSettings.wId]);
-
-            if (isTesting === false) {
-                addInspectlet();
-            }
-
-            isInitialized = true;
-
-            return 'Successfully initialized: ' + name;
-        } catch (e) {
-            return 'Failed to initialize: ' + name;
-        }
-    }
-
-    this.init = initForwarder;
-    this.process = processEvent;
-    this.setUserAttribute = setUserAttribute;
-    this.setUserIdentity = setUserIdentity;
-};
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
-    }
-
-    if (!isobject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isobject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/intercom/src/IntercomEventForwarder.js
+++ b/kits/intercom/src/IntercomEventForwarder.js
@@ -13,258 +13,219 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var isobject = require('isobject');
+    var isobject = require('isobject');
 
-var name = 'IntercomEventForwarder',
-    moduleId = 18,
-    MessageType = {
-        SessionStart: 1,
-        SessionEnd: 2,
-        PageView: 3,
-        PageEvent: 4,
-        CrashReport: 5,
-        OptOut: 6,
-        Commerce: 16,
+    var name = 'IntercomEventForwarder',
+        moduleId = 18,
+        MessageType = {
+            SessionStart: 1,
+            SessionEnd  : 2,
+            PageView    : 3,
+            PageEvent   : 4,
+            CrashReport : 5,
+            OptOut      : 6,
+            Commerce    : 16
+        };
+
+    function createObject(key, value) {
+        var obj  = {};
+        obj[key] = value;
+
+        return obj;
+    }
+
+    var constructor = function () {
+        var self              = this,
+            isInitialized     = false,
+            forwarderSettings = null,
+            reportingService  = null;
+
+
+        self.name = name;
+
+
+        function initForwarder(settings, service, testMode) {
+            forwarderSettings = settings;
+            reportingService  = service;
+
+            try {
+
+                if(!testMode) {
+                    (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update');}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;                    s.src='https://widget.intercom.io/widget/{app_id}';
+                    var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+                }
+
+                bootIntercom();
+                isInitialized = true;
+                return 'Successfully initialized: ' + name;
+            }
+            catch (e) {
+                return 'Can\'t initialize forwarder: ' + name + ': ' + e;
+            }
+        }
+
+        function bootIntercom() {
+            var appid = forwarderSettings.appid;
+            if(!appid) {
+                return 'Can\'t boot forwarder: ' + name + ', appid is not defined';
+            }
+
+            var obj      = createObject('app_id', appid),
+                widgetId = forwarderSettings.widgetid || '#IntercomDefaultWidget';
+
+            obj.widget   = createObject('activator', widgetId);
+
+
+            try {
+                window.Intercom('boot', obj);
+            }
+            catch (e) {
+                return 'Can\'t initialize forwarder: ' + name + ': ' + e;
+            }
+            return 'Successfully booted: ' + name;
+        }
+
+
+        function processEvent(event) {
+            var reportEvent = false;
+
+            if (!isInitialized) {
+                return 'Can\'t send to forwarder: ' + name + ', not initialized';
+            }
+
+            try {
+                if (event.EventDataType == MessageType.PageEvent ||
+                    event.EventDataType == MessageType.PageView) {
+
+                    reportEvent = true;
+                    logEvent(event);
+
+                    if(reportingService) {
+                        reportingService(self, event);
+                    }
+                }
+                return 'Successfully sent to forwarder: ' + name;
+            }
+            catch (e) {
+                return 'Can\'t send to forwarder: ' + name + ' ' + e;
+            }
+        }
+
+        function logEvent(event) {
+            if (!isInitialized) {
+                return 'Can\'t log event on forwarder: ' + name + ', not initialized';
+            }
+
+            if(!event.EventName) {
+                return 'Can\'t log event on forwarder: ' + name + ', no event name';
+            }
+
+            event.EventAttributes = event.EventAttributes || {};
+
+            try {
+                window.Intercom('trackEvent',
+                    event.EventName,
+                    event.EventAttributes);
+            }
+            catch (e) {
+                return 'Can\'t log event on forwarder: ' + name + ': ' + e;
+            }
+            return 'Successfully logged event from forwarder: ' + name;
+        }
+
+        function setUserAttribute(key, value) {
+            if (!isInitialized) {
+                return 'Can\'t set user identity on forwarder: ' + name + ', not initialized';
+            }
+
+            var attr = createObject(key, value);
+
+            try {
+                window.Intercom('update', attr);
+            }
+            catch (e) {
+                return 'Can\'t set user attribute on forwarder: ' + name + ': ' + e;
+            }
+            return 'Successfully called update on forwarder: ' + name;
+        }
+
+        function setUserIdentity(id, type) {
+
+            if (!isInitialized) {
+                return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+            }
+
+            if(!id) {
+                return 'Can\'t call setUserIdentity on forwarder: ' + name + ', without id or email';
+            }
+
+            var key = '';
+
+            if(window.mParticle.IdentityType.CustomerId === type) {
+                key = 'user_id';
+            }
+            else if(window.mParticle.IdentityType.Email === type) {
+                key = 'email';
+            }
+            else {
+                return;
+            }
+
+            var obj = createObject(key, id);
+
+            try {
+                window.Intercom('update', obj);
+            }
+            catch(e) {
+                return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+            }
+            return 'Successfully called update on forwarder: ' + name;
+        }
+
+        this.init             = initForwarder;
+        this.process          = processEvent;
+        this.setUserAttribute = setUserAttribute;
+        this.setUserIdentity  = setUserIdentity;
     };
 
-function createObject(key, value) {
-    var obj = {};
-    obj[key] = value;
-
-    return obj;
-}
-
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings = null,
-        reportingService = null;
-
-    self.name = name;
-
-    function initForwarder(settings, service, testMode) {
-        forwarderSettings = settings;
-        reportingService = service;
-
-        try {
-            if (!testMode) {
-                (function() {
-                    var w = window;
-                    var ic = w.Intercom;
-                    if (typeof ic === 'function') {
-                        ic('reattach_activator');
-                        ic('update');
-                    } else {
-                        var d = document;
-                        var i = function() {
-                            i.c(arguments);
-                        };
-                        i.q = [];
-                        i.c = function(args) {
-                            i.q.push(args);
-                        };
-                        w.Intercom = i;
-                        function l() {
-                            var s = d.createElement('script');
-                            s.type = 'text/javascript';
-                            s.async = true;
-                            s.src =
-                                'https://widget.intercom.io/widget/{app_id}';
-                            var x = d.getElementsByTagName('script')[0];
-                            x.parentNode.insertBefore(s, x);
-                        }
-                        if (w.attachEvent) {
-                            w.attachEvent('onload', l);
-                        } else {
-                            w.addEventListener('load', l, false);
-                        }
-                    }
-                })();
-            }
-
-            bootIntercom();
-            isInitialized = true;
-            return 'Successfully initialized: ' + name;
-        } catch (e) {
-            return "Can't initialize forwarder: " + name + ': ' + e;
-        }
+    function getId() {
+        return moduleId;
     }
 
-    function bootIntercom() {
-        var appid = forwarderSettings.appid;
-        if (!appid) {
-            return "Can't boot forwarder: " + name + ', appid is not defined';
-        }
-
-        var obj = createObject('app_id', appid),
-            widgetId = forwarderSettings.widgetid || '#IntercomDefaultWidget';
-
-        obj.widget = createObject('activator', widgetId);
-
-        try {
-            window.Intercom('boot', obj);
-        } catch (e) {
-            return "Can't initialize forwarder: " + name + ': ' + e;
-        }
-        return 'Successfully booted: ' + name;
-    }
-
-    function processEvent(event) {
-        var reportEvent = false;
-
-        if (!isInitialized) {
-            return "Can't send to forwarder: " + name + ', not initialized';
-        }
-
-        try {
-            if (
-                event.EventDataType == MessageType.PageEvent ||
-                event.EventDataType == MessageType.PageView
-            ) {
-                reportEvent = true;
-                logEvent(event);
-
-                if (reportingService) {
-                    reportingService(self, event);
-                }
-            }
-            return 'Successfully sent to forwarder: ' + name;
-        } catch (e) {
-            return "Can't send to forwarder: " + name + ' ' + e;
-        }
-    }
-
-    function logEvent(event) {
-        if (!isInitialized) {
-            return (
-                "Can't log event on forwarder: " + name + ', not initialized'
-            );
-        }
-
-        if (!event.EventName) {
-            return "Can't log event on forwarder: " + name + ', no event name';
-        }
-
-        event.EventAttributes = event.EventAttributes || {};
-
-        try {
-            window.Intercom(
-                'trackEvent',
-                event.EventName,
-                event.EventAttributes
-            );
-        } catch (e) {
-            return "Can't log event on forwarder: " + name + ': ' + e;
-        }
-        return 'Successfully logged event from forwarder: ' + name;
-    }
-
-    function setUserAttribute(key, value) {
-        if (!isInitialized) {
-            return (
-                "Can't set user identity on forwarder: " +
-                name +
-                ', not initialized'
-            );
-        }
-
-        var attr = createObject(key, value);
-
-        try {
-            window.Intercom('update', attr);
-        } catch (e) {
-            return "Can't set user attribute on forwarder: " + name + ': ' + e;
-        }
-        return 'Successfully called update on forwarder: ' + name;
-    }
-
-    function setUserIdentity(id, type) {
-        if (!isInitialized) {
-            return (
-                "Can't call setUserIdentity on forwarder: " +
-                name +
-                ', not initialized'
-            );
-        }
-
-        if (!id) {
-            return (
-                "Can't call setUserIdentity on forwarder: " +
-                name +
-                ', without id or email'
-            );
-        }
-
-        var key = '';
-
-        if (window.mParticle.IdentityType.CustomerId === type) {
-            key = 'user_id';
-        } else if (window.mParticle.IdentityType.Email === type) {
-            key = 'email';
-        } else {
+    function register(config) {
+        if (!config) {
+            console.log('You must pass a config object to register the kit ' + name);
             return;
         }
 
-        var obj = createObject(key, id);
-
-        try {
-            window.Intercom('update', obj);
-        } catch (e) {
-            return "Can't call identify on forwarder: " + name + ': ' + e;
+        if (!isobject(config)) {
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
         }
-        return 'Successfully called update on forwarder: ' + name;
+
+        if (isobject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
     }
 
-    this.init = initForwarder;
-    this.process = processEvent;
-    this.setUserAttribute = setUserAttribute;
-    this.setUserIdentity = setUserIdentity;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
+        }
     }
 
-    if (!isobject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isobject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/kissmetrics/src/KissMetricsForwarder.js
+++ b/kits/kissmetrics/src/KissMetricsForwarder.js
@@ -13,324 +13,298 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var isobject = require('isobject');
+    var isobject = require('isobject');
 
-var MessageType = {
+    var MessageType = {
         SessionStart: 1,
         SessionEnd: 2,
         PageView: 3,
         PageEvent: 4,
         CrashReport: 5,
         OptOut: 6,
-        Commerce: 16,
+        Commerce: 16
     },
     name = 'KISSmetricsForwarder',
     moduleId = 24;
 
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings,
-        reportingService,
-        isTesting = false;
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            forwarderSettings,
+            reportingService,
+            isTesting = false;
 
-    self.name = name;
+        self.name = name;
 
-    function getEventTypeName(eventType) {
-        return mParticle.EventType.getName(eventType);
-    }
-
-    function getIdentityTypeName(identityType) {
-        return mParticle.IdentityType.getName(identityType);
-    }
-
-    function reportEvent(event) {
-        if (reportingService) {
-            reportingService(self, event);
+        function getEventTypeName(eventType) {
+            return mParticle.EventType.getName(eventType);
         }
-    }
 
-    function processEvent(event) {
-        if (isInitialized) {
-            try {
-                if (
-                    event.EventDataType == MessageType.PageEvent ||
-                    event.EventDataType == MessageType.PageView
-                ) {
-                    if (
-                        event.EventCategory ==
-                        window.mParticle.EventType.Transaction
-                    ) {
-                        logTransaction(event);
-                    } else {
-                        logEvent(event);
+        function getIdentityTypeName(identityType) {
+            return mParticle.IdentityType.getName(identityType);
+        }
+
+        function reportEvent(event) {
+            if (reportingService) {
+                reportingService(self, event);
+            }
+        }
+
+        function processEvent(event) {
+            if (isInitialized) {
+                try {
+                    if (event.EventDataType == MessageType.PageEvent || event.EventDataType == MessageType.PageView) {
+                        if (event.EventCategory == window.mParticle.EventType.Transaction) {
+                            logTransaction(event);
+                        }
+                        else {
+                            logEvent(event);
+                        }
+
+                        reportEvent(event);
+                    }
+                    else if(event.EventDataType == MessageType.Commerce) {
+                        logCommerceEvent(event);
+                        reportEvent(event);
                     }
 
-                    reportEvent(event);
-                } else if (event.EventDataType == MessageType.Commerce) {
-                    logCommerceEvent(event);
-                    reportEvent(event);
+                    return 'Successfully sent to ' + name;
                 }
-
-                return 'Successfully sent to ' + name;
-            } catch (e) {
-                return 'Failed to send to: ' + name + ' ' + e;
-            }
-        }
-
-        return "Can't send to forwarder " + name + ', not initialized';
-    }
-
-    function setUserAttribute(key, value) {
-        if (isInitialized) {
-            if (
-                forwarderSettings.includeUserAttributes.toLowerCase() == 'true'
-            ) {
-                try {
-                    var attributeDict = {};
-                    attributeDict[key] = value;
-                    _kmq.push(['set', attributeDict]);
-
-                    return 'Successfully called SET API on ' + name;
-                } catch (e) {
-                    return 'Failed to call SET API on ' + name + ' ' + e;
+                catch (e) {
+                    return 'Failed to send to: ' + name + ' ' + e;
                 }
             }
-        } else {
-            return (
-                "Can't call setUserAttribute on forwarder " +
-                name +
-                ', not initialized'
-            );
-        }
-    }
 
-    function setUserIdentity(id, type) {
-        if (isInitialized) {
-            if (
-                forwarderSettings.useCustomerId.toLowerCase() == 'true' &&
-                type == window.mParticle.IdentityType.CustomerId
-            ) {
-                try {
-                    _kmq.push(['identify', id]);
-                    return 'Successfull called IDENTITY API on ' + name;
-                } catch (e) {
-                    return 'Failed to call IDENTITY API on ' + name + ' ' + e;
+            return 'Can\'t send to forwarder ' + name + ', not initialized';
+        }
+
+        function setUserAttribute(key, value) {
+            if (isInitialized) {
+                if (forwarderSettings.includeUserAttributes.toLowerCase() == 'true') {
+                    try {
+                        var attributeDict = {};
+                        attributeDict[key] = value;
+                        _kmq.push(['set', attributeDict]);
+
+                        return 'Successfully called SET API on ' + name;
+                    }
+                    catch (e) {
+                        return 'Failed to call SET API on ' + name + ' ' + e;
+                    }
                 }
             } else {
-                setUserAttribute(getIdentityTypeName(type), id);
+                return 'Can\'t call setUserAttribute on forwarder ' + name + ', not initialized';
             }
-        } else {
-            return (
-                "Can't call setUserIdentity on forwarder " +
-                name +
-                ', not initialized'
-            );
-        }
-    }
-
-    function logEvent(data) {
-        data.EventAttributes = data.EventAttributes || {};
-        data.EventAttributes['MPEventType'] = getEventTypeName(
-            data.EventCategory
-        );
-
-        _kmq.push(['record', data.EventName, data.EventAttributes]);
-    }
-
-    function logTransaction(data) {
-        if (
-            data.EventAttributes &&
-            data.EventAttributes.$MethodName &&
-            data.EventAttributes.$MethodName === 'LogEcommerceTransaction'
-        ) {
-            // User used logTransaction method, set the event name
-            data.EventName = 'Purchased';
         }
 
-        logEvent(data);
-    }
+        function setUserIdentity(id, type) {
+            if (isInitialized) {
+                if (forwarderSettings.useCustomerId.toLowerCase() == 'true' &&
+                    type == window.mParticle.IdentityType.CustomerId) {
 
-    function logProductData(productList) {
-        if (productList && productList.length > 0) {
-            _kmq.push(function() {
-                productList.forEach(function(product) {
-                    KM.set({
-                        'Product SKU': product.Sku,
-                        'Product Name': product.Name,
-                        Category: product.Category,
-                        Quantity: product.Quantity,
-                        Price: product.Price,
-                        _t: KM.ts(),
-                        _d: 1,
-                    });
-                });
-            });
+                    try {
+                        _kmq.push(['identify', id]);
+                        return 'Successfull called IDENTITY API on ' + name;
+                    }
+                    catch (e) {
+                        return 'Failed to call IDENTITY API on ' + name + ' ' + e;
+                    }
+                }
+                else {
+                    setUserAttribute(getIdentityTypeName(type), id);
+                }
+            }
+            else {
+                return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
+            }
         }
-    }
 
-    function logCommerceEvent(data) {
-        var eventName, attributes;
+        function logEvent(data) {
+            data.EventAttributes = data.EventAttributes || {};
+            data.EventAttributes['MPEventType'] = getEventTypeName(data.EventCategory);
 
-        if (data.ProductAction) {
-            eventName =
-                'Product ' +
-                mParticle.ProductActionType.getName(
-                    data.ProductAction.ProductActionType
-                );
+            _kmq.push(['record',
+                data.EventName,
+                data.EventAttributes]);
+        }
 
-            if (data.ProductAction.TransactionId) {
-                attributes = {
-                    'Order ID': data.ProductAction.TransactionId,
-                    'Order Total': data.ProductAction.TotalAmount,
-                    'Order Tax': data.ProductAction.TaxAmount,
-                    'Order Shipping': data.ProductAction.ShippingAmount,
-                };
-            } else if (data.ProductAction.CheckoutStep) {
-                attributes = {
-                    'Checkout Step': data.ProductAction.CheckoutStep,
-                    'Checkout Options': data.ProductAction.CheckoutOptions,
-                };
+        function logTransaction(data) {
+            if (data.EventAttributes &&
+                data.EventAttributes.$MethodName &&
+                data.EventAttributes.$MethodName === 'LogEcommerceTransaction') {
+
+                // User used logTransaction method, set the event name
+                data.EventName = 'Purchased';
             }
 
-            logProductData(data.ProductAction.ProductList);
+            logEvent(data);
+        }
 
-            if (attributes) {
-                _kmq.push(['record', eventName, attributes]);
-            } else {
-                _kmq.push(['record', eventName]);
-            }
-        } else if (data.PromotionAction) {
-            eventName = mParticle.PromotionType.getName(
-                data.PromotionAction.PromotionActionType
-            );
-
-            if (data.PromotionAction.PromotionList) {
+        function logProductData(productList) {
+            if(productList && productList.length > 0) {
                 _kmq.push(function() {
-                    data.PromotionAction.PromotionList.forEach(function(
-                        promotion
-                    ) {
-                        KM.set({
-                            'Promotion Id': promotion.Id,
-                            'Promotion Name': promotion.Name,
-                            'Promotion Creative': promotion.Creative,
-                            'Promotion Position': promotion.Position,
-                            _t: KM.ts(),
-                            _d: 1,
+                    productList.forEach(function(product) {
+                        KM.set( {
+                            'Product SKU': product.Sku,
+                            'Product Name': product.Name,
+                            'Category': product.Category,
+                            'Quantity': product.Quantity,
+                            'Price': product.Price,
+                            '_t': KM.ts(),
+                            '_d': 1
                         });
                     });
                 });
             }
+        }
 
-            _kmq.push(['record', eventName]);
-        } else if (data.ProductImpressions) {
-            eventName = 'Product Impression';
+        function logCommerceEvent(data) {
+            var eventName,
+                attributes;
 
-            _kmq.push(function() {
-                data.ProductImpressions.forEach(function(impression) {
-                    KM.set({
-                        'Impression Name': impression.Name,
-                        _t: KM.ts(),
-                        _d: 1,
+            if(data.ProductAction) {
+                eventName = 'Product ' + mParticle.ProductActionType.getName(
+                    data.ProductAction.ProductActionType);
+
+                if(data.ProductAction.TransactionId) {
+                    attributes = {
+                        'Order ID':data.ProductAction.TransactionId,
+                        'Order Total':data.ProductAction.TotalAmount,
+                        'Order Tax': data.ProductAction.TaxAmount,
+                        'Order Shipping': data.ProductAction.ShippingAmount
+                    }
+                }
+                else if(data.ProductAction.CheckoutStep) {
+                    attributes = {
+                        'Checkout Step': data.ProductAction.CheckoutStep,
+                        'Checkout Options': data.ProductAction.CheckoutOptions
+                    };
+                }
+
+                logProductData(data.ProductAction.ProductList);
+
+                if(attributes) {
+                    _kmq.push(['record', eventName, attributes]);
+                }
+                else {
+                    _kmq.push(['record', eventName]);
+                }
+            }
+            else if(data.PromotionAction) {
+                eventName = mParticle.PromotionType.getName(
+                    data.PromotionAction.PromotionActionType);
+
+                if(data.PromotionAction.PromotionList) {
+                    _kmq.push(function () {
+                        data.PromotionAction.PromotionList.forEach(function(promotion) {
+                            KM.set({
+                                'Promotion Id': promotion.Id,
+                                'Promotion Name': promotion.Name,
+                                'Promotion Creative': promotion.Creative,
+                                'Promotion Position': promotion.Position,
+                                '_t':KM.ts(),
+                                '_d':1
+                            });
+                        });
                     });
+                }
 
-                    logProductData(impression.ProductList);
+                _kmq.push(['record', eventName]);
+            }
+            else if(data.ProductImpressions) {
+                eventName = 'Product Impression';
+
+                _kmq.push(function () {
+                    data.ProductImpressions.forEach(function(impression) {
+                        KM.set({
+                            'Impression Name': impression.Name,
+                            '_t': KM.ts(),
+                            '_d': 1
+                        });
+
+                        logProductData(impression.ProductList);
+                    });
                 });
-            });
 
-            _kmq.push(['record', eventName]);
+                _kmq.push(['record', eventName]);
+            }
         }
-    }
 
-    function initForwarder(settings, service, testMode) {
-        forwarderSettings = settings;
-        reportingService = service;
-        isTesting = testMode;
+        function initForwarder(settings, service, testMode) {
+            forwarderSettings = settings;
+            reportingService = service;
+            isTesting = testMode;
 
-        try {
-            function _kms(u) {
-                setTimeout(function() {
-                    var d = document,
-                        f = d.getElementsByTagName('script')[0],
+            try {
+                function _kms(u) {
+                    setTimeout(function () {
+                        var d = document, f = d.getElementsByTagName('script')[0],
                         s = d.createElement('script');
-                    s.type = 'text/javascript';
-                    s.async = true;
-                    s.src = u;
-                    f.parentNode.insertBefore(s, f);
-                }, 1);
+                        s.type = 'text/javascript'; s.async = true; s.src = u;
+                        f.parentNode.insertBefore(s, f);
+                    }, 1);
+                }
+
+                var protocol = forwarderSettings.useSecure == 'True' ? 'https:' : '';
+
+                if(testMode !== true) {
+                    _kms(protocol + '//i.kissmetrics.com/i.js');
+                    _kms(protocol + '//doug1izaerwt3.cloudfront.net/' + forwarderSettings.apiKey + '.1.js');
+                }
+
+                isInitialized = true;
+
+                return 'Successfully initialized: ' + name;
             }
-
-            var protocol =
-                forwarderSettings.useSecure == 'True' ? 'https:' : '';
-
-            if (testMode !== true) {
-                _kms(protocol + '//i.kissmetrics.com/i.js');
-                _kms(
-                    protocol +
-                        '//doug1izaerwt3.cloudfront.net/' +
-                        forwarderSettings.apiKey +
-                        '.1.js'
-                );
+            catch (e) {
+                return 'Failed to initialize: ' + name;
             }
+        }
 
-            isInitialized = true;
+        this.init = initForwarder;
+        this.process = processEvent;
+        this.setUserIdentity = setUserIdentity;
+        this.setUserAttribute = setUserAttribute;
+    };
 
-            return 'Successfully initialized: ' + name;
-        } catch (e) {
-            return 'Failed to initialize: ' + name;
+    function getId() {
+        return moduleId;
+    }
+
+    function register(config) {
+        if (!config) {
+            console.log('You must pass a config object to register the kit ' + name);
+            return;
+        }
+
+        if (!isobject(config)) {
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
+
+        if (isobject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
         }
     }
 
-    this.init = initForwarder;
-    this.process = processEvent;
-    this.setUserIdentity = setUserIdentity;
-    this.setUserAttribute = setUserAttribute;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
-    }
-
-    if (!isobject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isobject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/leanplum/leanplum-1/src/LeanplumAnalyticsEventForwarder.js
+++ b/kits/leanplum/leanplum-1/src/LeanplumAnalyticsEventForwarder.js
@@ -15,379 +15,328 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var isobject = require('isobject');
+    var isobject = require('isobject');
 
-var name = 'Leanplum',
-    moduleId = 98,
-    MessageType = {
-        SessionStart: 1,
-        SessionEnd: 2,
-        PageView: 3,
-        PageEvent: 4,
-        CrashReport: 5,
-        OptOut: 6,
-        Commerce: 16,
-    },
-    Environment = {
-        Production: 'production',
-        Development: 'development',
-    };
-
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings,
-        reportingService,
-        isTesting,
-        constants = {
-            customerId: 'customerId',
-            mpid: 'mpid',
-            email: 'email',
+    var name = 'Leanplum',
+        moduleId = 98,
+        MessageType = {
+            SessionStart: 1,
+            SessionEnd: 2,
+            PageView: 3,
+            PageEvent: 4,
+            CrashReport: 5,
+            OptOut: 6,
+            Commerce: 16
         },
-        eventQueue = [];
+        Environment = {
+            Production: 'production',
+            Development: 'development',
+        };
 
-    self.name = name;
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            forwarderSettings,
+            reportingService,
+            isTesting,
+            constants = {
+                customerId: 'customerId',
+                mpid: 'mpid',
+                email: 'email'
+            },
+            eventQueue = [];
 
-    function processEvent(event) {
-        var reportEvent = false;
-        if (isInitialized) {
-            try {
-                if (event.EventDataType === MessageType.PageView) {
-                    reportEvent = logPageView(event);
-                } else if (
-                    event.EventDataType === MessageType.Commerce &&
-                    event.EventCategory ===
-                        mParticle.CommerceEventType.ProductPurchase
-                ) {
-                    reportEvent = logPurchaseEvent(event);
-                } else if (event.EventDataType === MessageType.Commerce) {
-                    var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(
-                        event
-                    );
-                    if (listOfPageEvents !== null) {
-                        for (var i = 0; i < listOfPageEvents.length; i++) {
-                            try {
-                                logEvent(listOfPageEvents[i]);
-                            } catch (err) {
-                                return 'Error logging page event' + err.message;
+        self.name = name;
+
+        function processEvent(event) {
+            var reportEvent = false;
+            if (isInitialized) {
+                try {
+                    if (event.EventDataType === MessageType.PageView) {
+                        reportEvent = logPageView(event);
+                    }
+                    else if (event.EventDataType === MessageType.Commerce && event.EventCategory === mParticle.CommerceEventType.ProductPurchase) {
+                        reportEvent = logPurchaseEvent(event);
+                    }
+                    else if (event.EventDataType === MessageType.Commerce) {
+                        var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(event);
+                        if (listOfPageEvents !== null) {
+                            for (var i = 0; i < listOfPageEvents.length; i++) {
+                                try {
+                                    logEvent(listOfPageEvents[i]);
+                                }
+                                catch (err) {
+                                    return 'Error logging page event' + err.message;
+                                }
                             }
                         }
                     }
-                } else if (event.EventDataType === MessageType.PageEvent) {
-                    reportEvent = logEvent(event);
-                }
-
-                if (reportEvent === true && reportingService) {
-                    reportingService(self, event);
-                    return 'Successfully sent to ' + name;
-                } else {
-                    return (
-                        'Error logging event or event type not supported - ' +
-                        reportEvent.error
-                    );
-                }
-            } catch (e) {
-                return 'Failed to send to: ' + name + ' ' + e;
-            }
-        } else {
-            eventQueue.push(event);
-        }
-
-        return (
-            "Can't send to forwarder " +
-            name +
-            ', not initialized. Event added to queue.'
-        );
-    }
-
-    function setUserIdentity(id, type) {
-        var leanPlumConfigType = forwarderSettings.userIdField;
-        if (isInitialized) {
-            try {
-                if (
-                    (type === window.mParticle.IdentityType.CustomerId &&
-                        leanPlumConfigType === constants.customerId) ||
-                    (type === window.mParticle.IdentityType.Email &&
-                        leanPlumConfigType === constants.email)
-                ) {
-                    Leanplum.setUserId(id);
-                } else {
-                    return (
-                        'User Identity type not supported on forwarder ' +
-                        name +
-                        '. Use only CustomerId or Email'
-                    );
-                }
-            } catch (e) {
-                return 'Failed to call setUserIdentity on ' + name + ' ' + e;
-            }
-        } else {
-            return (
-                "Can't call setUserIdentity on forwarder " +
-                name +
-                ', not initialized'
-            );
-        }
-    }
-    function onUserIdentified(user) {
-        if (isInitialized) {
-            if (forwarderSettings.userIdField === constants.mpid) {
-                Leanplum.setUserId(user.getMPID());
-            }
-        } else {
-            return (
-                "Can't call onUserIdentified on forwarder " +
-                name +
-                ', not initialized'
-            );
-        }
-    }
-
-    function setUserAttribute(key, value) {
-        if (isInitialized) {
-            try {
-                var attributeDict = {};
-                attributeDict[key] = value;
-                Leanplum.setUserAttributes(attributeDict);
-
-                return 'Successfully called setUserAttribute API on ' + name;
-            } catch (e) {
-                return (
-                    'Failed to call SET setUserAttribute on ' + name + ' ' + e
-                );
-            }
-        } else {
-            return (
-                "Can't call setUserAttribute on forwarder " +
-                name +
-                ', not initialized'
-            );
-        }
-    }
-
-    function removeUserAttribute(key) {
-        setUserAttribute(key, null);
-    }
-
-    function logPageView(data) {
-        try {
-            if (data.EventAttributes) {
-                Leanplum.advanceTo(data.EventName, data.EventAttributes);
-            } else {
-                Leanplum.advanceTo(data.EventName);
-            }
-            return true;
-        } catch (e) {
-            return { error: e };
-        }
-    }
-
-    function logPurchaseEvent(event) {
-        var reportEvent = false;
-        if (event.ProductAction.ProductList) {
-            try {
-                event.ProductAction.ProductList.forEach(function(product) {
-                    Leanplum.track(
-                        'Purchase',
-                        parseFloat(product.TotalAmount),
-                        product
-                    );
-                });
-                return true;
-            } catch (e) {
-                return { error: e };
-            }
-        }
-
-        return reportEvent;
-    }
-
-    function logEvent(data) {
-        try {
-            if (data.EventAttributes) {
-                Leanplum.track(data.EventName, data.EventAttributes);
-            } else {
-                Leanplum.track(data.EventName);
-            }
-            return true;
-        } catch (e) {
-            return { error: e };
-        }
-    }
-
-    function initForwarder(
-        settings,
-        service,
-        testMode,
-        trackerId,
-        userAttributes,
-        userIdentities
-    ) {
-        forwarderSettings = settings;
-        reportingService = service;
-        isTesting = testMode;
-
-        try {
-            function initialize() {
-                completeLeanPlumInitialization(userAttributes, userIdentities);
-                isInitialized = true;
-                if (Leanplum && eventQueue.length > 0) {
-                    // Process any events that may have been queued up while forwarder was being initialized.
-                    for (var i = 0; i < eventQueue.length; i++) {
-                        processEvent(eventQueue[i]);
+                    else if (event.EventDataType === MessageType.PageEvent) {
+                        reportEvent = logEvent(event);
                     }
 
-                    eventQueue = [];
+                    if (reportEvent === true && reportingService) {
+                        reportingService(self, event);
+                        return 'Successfully sent to ' + name;
+                    }
+                    else {
+                        return 'Error logging event or event type not supported - ' + reportEvent.error;
+                    }
+                }
+                catch (e) {
+                    return 'Failed to send to: ' + name + ' ' + e;
+                }
+            }
+            else {
+                eventQueue.push(event);
+            }
+
+            return 'Can\'t send to forwarder ' + name + ', not initialized. Event added to queue.';
+        }
+
+        function setUserIdentity(id, type) {
+            var leanPlumConfigType = forwarderSettings.userIdField;
+            if (isInitialized) {
+                try {
+                    if ((type === window.mParticle.IdentityType.CustomerId && leanPlumConfigType === constants.customerId) || (type === window.mParticle.IdentityType.Email && leanPlumConfigType === constants.email)) {
+                        Leanplum.setUserId(id);
+                    }
+                    else {
+                        return 'User Identity type not supported on forwarder ' + name + '. Use only CustomerId or Email';
+                    }
+                }
+                catch (e) {
+                    return 'Failed to call setUserIdentity on ' + name + ' ' + e;
+                }
+            }
+            else {
+                return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
+            }
+        }
+        function onUserIdentified(user) {
+            if (isInitialized) {
+                if (forwarderSettings.userIdField === constants.mpid) {
+                    Leanplum.setUserId(user.getMPID());
+                }
+            }
+            else {
+                return 'Can\'t call onUserIdentified on forwarder ' + name + ', not initialized';
+            }
+        }
+
+        function setUserAttribute(key, value) {
+            if (isInitialized) {
+                try {
+                    var attributeDict = {};
+                    attributeDict[key] = value;
+                    Leanplum.setUserAttributes(attributeDict);
+
+                    return 'Successfully called setUserAttribute API on ' + name;
+                }
+                catch (e) {
+                    return 'Failed to call SET setUserAttribute on ' + name + ' ' + e;
+                }
+            }
+            else {
+                return 'Can\'t call setUserAttribute on forwarder ' + name + ', not initialized';
+            }
+        }
+
+        function removeUserAttribute(key) {
+            setUserAttribute(key, null);
+        }
+
+        function logPageView(data) {
+            try {
+                if (data.EventAttributes) {
+                    Leanplum.advanceTo(data.EventName, data.EventAttributes);
+                }
+                else {
+                    Leanplum.advanceTo(data.EventName);
+                }
+                return true;
+            }
+            catch (e) {
+                return {error: e};
+            }
+        }
+
+        function logPurchaseEvent(event) {
+            var reportEvent = false;
+            if (event.ProductAction.ProductList) {
+                try {
+                    event.ProductAction.ProductList.forEach(function(product) {
+                        Leanplum.track('Purchase', parseFloat(product.TotalAmount), product);
+                    });
+                    return true;
+                }
+                catch (e) {
+                    return {error: e};
                 }
             }
 
-            if (isTesting || window.Leanplum) {
-                initialize();
+            return reportEvent;
+        }
+
+        function logEvent(data) {
+            try {
+                if (data.EventAttributes) {
+                    Leanplum.track(data.EventName, data.EventAttributes);
+                }
+                else {
+                    Leanplum.track(data.EventName);
+                }
+                return true;
+            }
+            catch (e) {
+                return {error: e};
+            }
+        }
+
+        function initForwarder(settings, service, testMode, trackerId, userAttributes, userIdentities) {
+            forwarderSettings = settings;
+            reportingService = service;
+            isTesting = testMode;
+
+            try {
+                function initialize() {
+                    completeLeanPlumInitialization(userAttributes, userIdentities);
+                    isInitialized = true;
+                    if (Leanplum && eventQueue.length > 0) {
+                        // Process any events that may have been queued up while forwarder was being initialized.
+                        for (var i = 0; i < eventQueue.length; i++) {
+                            processEvent(eventQueue[i]);
+                        }
+
+                        eventQueue = [];
+                    }
+                }
+
+                if (isTesting || window.Leanplum) {
+                    initialize();
+                } else {
+                    var leanplumScript = document.createElement('script');
+                    leanplumScript.type = 'text/javascript';
+                    leanplumScript.async = true;
+                    leanplumScript.src = 'https://cdn.jsdelivr.net/npm/leanplum-sdk@1';
+
+                    leanplumScript.onload = initialize;
+                    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(leanplumScript);
+                }
+
+                return 'Leanplum successfully loaded';
+            }
+            catch (e) {
+                return 'Failed to initialize: ' + e;
+            }
+        }
+
+        function completeLeanPlumInitialization(userAttributes, userIdentities) {
+            setLeanPlumEnvironment();
+            initializeUserId(userAttributes, userIdentities);
+        }
+
+        function setLeanPlumEnvironment() {
+            var TWO_HOURS = 2*60*60;
+            Leanplum.useSessionLength(forwarderSettings.sessionLength || TWO_HOURS);
+
+            if (forwarderSettings.enableRichInAppMessages === 'True') {
+                Leanplum.enableRichInAppMessages(true);
+            }
+
+            if (window.mParticle.getEnvironment() === Environment.Development) {
+                Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
             } else {
-                var leanplumScript = document.createElement('script');
-                leanplumScript.type = 'text/javascript';
-                leanplumScript.async = true;
-                leanplumScript.src =
-                    'https://cdn.jsdelivr.net/npm/leanplum-sdk@1';
-
-                leanplumScript.onload = initialize;
-                (
-                    document.getElementsByTagName('head')[0] ||
-                    document.getElementsByTagName('body')[0]
-                ).appendChild(leanplumScript);
+                Leanplum.setAppIdForProductionMode(forwarderSettings.appId, forwarderSettings.clientKey);
             }
-
-            return 'Leanplum successfully loaded';
-        } catch (e) {
-            return 'Failed to initialize: ' + e;
-        }
-    }
-
-    function completeLeanPlumInitialization(userAttributes, userIdentities) {
-        setLeanPlumEnvironment();
-        initializeUserId(userAttributes, userIdentities);
-    }
-
-    function setLeanPlumEnvironment() {
-        var TWO_HOURS = 2 * 60 * 60;
-        Leanplum.useSessionLength(forwarderSettings.sessionLength || TWO_HOURS);
-
-        if (forwarderSettings.enableRichInAppMessages === 'True') {
-            Leanplum.enableRichInAppMessages(true);
         }
 
-        if (window.mParticle.getEnvironment() === Environment.Development) {
-            Leanplum.setAppIdForDevelopmentMode(
-                forwarderSettings.appId,
-                forwarderSettings.clientKey
-            );
-        } else {
-            Leanplum.setAppIdForProductionMode(
-                forwarderSettings.appId,
-                forwarderSettings.clientKey
-            );
-        }
-    }
+        function initializeUserId(userAttributes, userIdentities) {
+            var user,
+                userId = null;
 
-    function initializeUserId(userAttributes, userIdentities) {
-        var user,
-            userId = null;
-
-        // if Identity object exists on mParticle, it is on V2 of SDK and we prioritize MPID
-        if (window.mParticle && window.mParticle.Identity) {
-            if (forwarderSettings.userIdField === constants.mpid) {
-                user = window.mParticle.Identity.getCurrentUser();
-                if (user) {
-                    userId = user.getMPID();
-                    Leanplum.start(userId);
-                    return;
+            // if Identity object exists on mParticle, it is on V2 of SDK and we prioritize MPID
+            if (window.mParticle && window.mParticle.Identity) {
+                if (forwarderSettings.userIdField === constants.mpid) {
+                    user = window.mParticle.Identity.getCurrentUser();
+                    if (user) {
+                        userId = user.getMPID();
+                        Leanplum.start(userId);
+                        return;
+                    }
                 }
             }
+
+            if (userIdentities.length) {
+                if (forwarderSettings.userIdField === constants.customerId) {
+                    userId = userIdentities.filter(function(identity) {
+                        return (identity.Type === window.mParticle.IdentityType.CustomerId);
+                    })[0];
+                }
+                else if (forwarderSettings.userIdField === constants.email) {
+                    userId = userIdentities.filter(function(identity) {
+                        return (identity.Type === window.mParticle.IdentityType.Email);
+                    })[0];
+                }
+
+                if (userId && userId.Identity && Object.keys(userAttributes).length) {
+                    Leanplum.start(userId.Identity, userAttributes);
+                }
+                else if (userId && userId.Identity) {
+                    Leanplum.start(userId.Identity);
+                }
+                return;
+            }
+
+            Leanplum.start();
         }
 
-        if (userIdentities.length) {
-            if (forwarderSettings.userIdField === constants.customerId) {
-                userId = userIdentities.filter(function(identity) {
-                    return (
-                        identity.Type ===
-                        window.mParticle.IdentityType.CustomerId
-                    );
-                })[0];
-            } else if (forwarderSettings.userIdField === constants.email) {
-                userId = userIdentities.filter(function(identity) {
-                    return (
-                        identity.Type === window.mParticle.IdentityType.Email
-                    );
-                })[0];
-            }
+        this.init = initForwarder;
+        this.process = processEvent;
+        this.setUserIdentity = setUserIdentity;
+        this.setUserAttribute = setUserAttribute;
+        this.removeUserAttribute = removeUserAttribute;
+        this.onUserIdentified = onUserIdentified;
+    };
 
-            if (
-                userId &&
-                userId.Identity &&
-                Object.keys(userAttributes).length
-            ) {
-                Leanplum.start(userId.Identity, userAttributes);
-            } else if (userId && userId.Identity) {
-                Leanplum.start(userId.Identity);
-            }
+    function getId() {
+        return moduleId;
+    }
+
+    function register(config) {
+        if (!config) {
+            window.console.log('You must pass a config object to register the kit ' + name);
             return;
         }
 
-        Leanplum.start();
+        if (!isobject(config)) {
+            window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
+
+        if (isobject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
     }
 
-    this.init = initForwarder;
-    this.process = processEvent;
-    this.setUserIdentity = setUserIdentity;
-    this.setUserAttribute = setUserAttribute;
-    this.removeUserAttribute = removeUserAttribute;
-    this.onUserIdentified = onUserIdentified;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        window.console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
+        }
     }
 
-    if (!isobject(config)) {
-        window.console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isobject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    window.console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/localytics/localytics-4/src/LocalyticsEventForwarder.js
+++ b/kits/localytics/localytics-4/src/LocalyticsEventForwarder.js
@@ -12,394 +12,340 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var isobject = require('isobject');
+    var isobject = require('isobject');
 
-var name = 'LocalyticsEventForwarder',
-    moduleId = 84,
-    maxAllowedDimensions = 10,
-    trackerCount = 1,
-    MessageType = {
-        PageView: 3,
-        PageEvent: 4,
-        Commerce: 16,
-    },
-    EventType = {
-        Unknown: 0,
-        Navigation: 1,
-        Location: 2,
-        Search: 3,
-        Transaction: 4,
-        UserContent: 5,
-        UserPreference: 6,
-        Social: 7,
-        Other: 8,
-        Media: 9,
-    };
+    var name                    = 'LocalyticsEventForwarder',
+        moduleId = 84,
+        maxAllowedDimensions    = 10,
+        trackerCount            = 1,
+        MessageType             = {
+                                    PageView    : 3,
+                                    PageEvent   : 4,
+                                    Commerce    : 16
+                                  },
+        EventType               = {
+                                    Unknown       : 0,
+                                    Navigation    : 1,
+                                    Location      : 2,
+                                    Search        : 3,
+                                    Transaction   : 4,
+                                    UserContent   : 5,
+                                    UserPreference: 6,
+                                    Social        : 7,
+                                    Other         : 8,
+                                    Media         : 9
+                                };
 
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings = null,
-        reportingService = null,
-        customDimensions = [],
-        initOptions = {},
-        isTesting = false,
-        trackerId = null;
+    var constructor = function () {
+        var self                = this,
+            isInitialized       = false,
+            forwarderSettings   = null,
+            reportingService    = null,
+            customDimensions    = [],
+            initOptions         = {},
+            isTesting           = false,
+            trackerId           = null;
 
-    self.name = name;
+        self.name = name;
 
-    function createTrackerId() {
-        return 'mpllTracker' + trackerCount++;
-    }
-
-    function createCmd(cmd) {
-        // Prepends the specified command with the tracker id
-        return cmd + '.' + trackerId;
-    }
-
-    function initForwarder(settings, service, testMode, tid) {
-        forwarderSettings = settings;
-        reportingService = service;
-        isTesting = testMode;
-        initOptions = getInitOptions();
-        customDimensions = getOrderedCustomDimensions();
-
-        if (!tid) {
-            trackerId = createTrackerId();
-        } else {
-            trackerId = tid;
+        function createTrackerId() {
+            return 'mpllTracker' + trackerCount++;
         }
 
-        try {
-            if (!testMode) {
-                !(function(l, y, t, i, c, s) {
-                    l['LocalyticsGlobal'] = i;
-                    l[i] = function() {
-                        (l[i].q = l[i].q || []).push(arguments);
-                    };
-                    l[i].t = +new Date();
-                    (s = y.createElement(t)).type = 'text/javascript';
-                    s.src = '//web.localytics.com/v4/localytics.min.js';
-                    (c = y.getElementsByTagName(t)[0]).parentNode.insertBefore(
-                        s,
-                        c
-                    );
-                })(window, document, 'script', 'll');
+        function createCmd(cmd) {
+            // Prepends the specified command with the tracker id
+            return cmd + '.' + trackerId;
+        }
 
-                window.ll(createCmd('init'), settings.appKey, initOptions);
+        function initForwarder(settings, service, testMode, tid) {
+            forwarderSettings   = settings;
+            reportingService    = service;
+            isTesting           = testMode;
+            initOptions         = getInitOptions();
+            customDimensions    = getOrderedCustomDimensions();
+
+            if (!tid) {
+                trackerId = createTrackerId();
+            }
+            else {
+                trackerId = tid;
             }
 
-            isInitialized = true;
-
-            return 'Successfully initialized: ' + name;
-        } catch (e) {
-            return "Can't initialize forwarder: " + name + ':' + e;
-        }
-    }
-
-    function getInitOptions() {
-        var options = {};
-
-        if (forwarderSettings.appVersion) {
-            options.appVersion = forwarderSettings.appVersion;
-        }
-
-        if (forwarderSettings.sessionTimeout) {
-            options.sessionTimeout = forwarderSettings.sessionTimeout;
-        }
-
-        if (forwarderSettings.domain) {
-            options.domain = forwarderSettings.domain;
-        }
-
-        options.trackPageView =
-            forwarderSettings.hasOwnProperty('trackPageView') &&
-            forwarderSettings.trackPageView.toLowerCase() === 'true';
-
-        return options;
-    }
-
-    function processEvent(event) {
-        var reportEvent = false;
-
-        if (!isInitialized) {
-            return "Can't send forwarder " + name + ', not initialized';
-        }
-
-        try {
-            if (event.EventDataType == MessageType.PageView) {
-                reportEvent = true;
-                logScreenViewEvent(event);
-            } else if (event.EventDataType == MessageType.Commerce) {
-                logCommerce(event);
-                reportEvent = true;
-            } else if (event.EventDataType == MessageType.PageEvent) {
-                reportEvent = true;
-                logEvent(event);
-            }
-
-            if (reportEvent && reportingService) {
-                reportingService(self, event);
-            }
-
-            return 'Successfully sent to forwarder ' + name;
-        } catch (e) {
-            return "Can't send to forwarder: " + name + ' ' + e;
-        }
-    }
-
-    function logScreenViewEvent(event) {
-        var screenName = event.EventName;
-
-        if (
-            event.hasOwnProperty('CustomFlags') &&
-            event.CustomFlags.hasOwnProperty('Localytics.ScreenName')
-        ) {
-            screenName = event.CustomFlags['Localytics.ScreenName'];
-        }
-
-        window.ll(createCmd('tagScreen'), screenName);
-    }
-
-    function logEvent(event) {
-        var ltv = null;
-        if (
-            event.hasOwnProperty('EventCategory') &&
-            event.EventCategory === EventType.Transaction
-        ) {
-            if (
-                event.hasOwnProperty('EventAttributes') &&
-                event.EventAttributes.hasOwnProperty('$Amount')
-            ) {
-                var ltvVal = event.EventAttributes['$Amount'];
-                if (!isNaN(parseFloat(ltvVal, 10))) {
-                    ltv = parseFloat(ltvVal, 10).toFixed(2);
-                }
-            }
-        }
-
-        if (ltv !== null) {
-            var multiplier = forwarderSettings.trackClvAsRawValue ? 1 : 100;
-            window.ll(
-                createCmd('tagEvent'),
-                event.EventName,
-                event.EventAttributes,
-                ltv * multiplier
-            );
-        } else {
-            window.ll(
-                createCmd('tagEvent'),
-                event.EventName,
-                event.EventAttributes
-            );
-        }
-    }
-
-    function logCommerce(data) {
-        if (!data.ProductAction)
-            return "Can't forward commerce event: No production action found";
-
-        switch (data.ProductAction.ProductActionType) {
-            case mParticle.ProductActionType.Purchase:
-            case mParticle.ProductActionType.Refund:
-                var total = null,
-                    multiplier = forwarderSettings.trackClvAsRawValue ? 1 : 100;
-
-                if (
-                    data.ProductAction.ProductActionType ==
-                    mParticle.ProductActionType.Refund
-                ) {
-                    multiplier *= -1;
-                }
-
-                if (!isNaN(parseFloat(data.ProductAction.TotalAmount, 10))) {
-                    total = parseFloat(
-                        data.ProductAction.TotalAmount,
-                        10
-                    ).toFixed(2);
-                }
-
-                if (total != null) {
-                    window.ll(
-                        createCmd('tagEvent'),
-                        data.EventName,
-                        data.EventAttributes,
-                        total * multiplier
-                    );
-                } else {
-                    return "Can't forward commerce event: TotalAmount is set incorrectly";
-                }
-                break;
-
-            default:
-                logEvent(data);
-                break;
-        }
-    }
-
-    function setUserAttribute(key, value) {
-        if (!key) {
-            return "Can't call setUserAttribute on forwarder: No key provided";
-        }
-
-        if (key === 'Localytics.CustomerName') {
             try {
-                window.ll(createCmd('setCustomerName'), value);
+                if (!testMode) {
+                    !function(l,y,t,i,c,s) {
+                        l['LocalyticsGlobal'] = i;
+                        l[i] = function() { (l[i].q = l[i].q || []).push(arguments) };
+                        l[i].t = +new Date;
+                        (s = y.createElement(t)).type = 'text/javascript';
+                        s.src = '//web.localytics.com/v4/localytics.min.js';
+                        (c = y.getElementsByTagName(t)[0]).parentNode.insertBefore(s, c);
+                    }(window, document, 'script', 'll');
+
+                    window.ll(createCmd('init'), settings.appKey, initOptions);
+                }
+
+                isInitialized = true;
+
+                return 'Successfully initialized: ' + name;
+
             } catch (e) {
-                return (
-                    "Can't call setCustomerName on forwarder: " +
-                    name +
-                    ': ' +
-                    e
-                );
-            }
-        } else {
-            if (customDimensions.length > 0) {
-                updateCustomDimension(key, value);
-            }
-        }
-    }
-
-    function removeUserAttribute(key) {
-        if (customDimensions.length > 0) {
-            updateCustomDimension(key, null);
-        }
-    }
-
-    function setUserIdentity(id, type) {
-        if (!id) {
-            return (
-                "Can't call setUserIdentity on forwarder: " +
-                name +
-                ' without ID'
-            );
-        }
-
-        if (!isInitialized) {
-            return (
-                "Can't call setUserIdentity on forwarder: " +
-                name +
-                ', not initialized'
-            );
-        }
-
-        try {
-            if (window.mParticle.IdentityType.Email == type) {
-                window.ll(createCmd('setCustomerEmail'), id);
-            } else {
-                window.ll(createCmd('setCustomerId'), id);
-            }
-
-            return 'Successfully called identify on forwarder: ' + name;
-        } catch (e) {
-            return "Can't call identify on forwarder: " + name + ': ' + e;
-        }
-    }
-
-    function updateCustomDimension(key, value) {
-        if (customDimensions.length === 0) return;
-
-        var index = -1,
-            keyLower = key.toLowerCase();
-
-        for (var i = 0; i < customDimensions.length; i++) {
-            if (customDimensions[i].toLowerCase() === keyLower) {
-                index = i;
+                return 'Can\'t initialize forwarder: '+ name +':' + e;
             }
         }
 
-        if (index >= 0) {
-            window.ll(createCmd('setCustomDimension'), index, value);
+        function getInitOptions() {
+            var options = {};
+
+            if(forwarderSettings.appVersion){
+                options.appVersion = forwarderSettings.appVersion;
+            }
+
+            if(forwarderSettings.sessionTimeout){
+                options.sessionTimeout = forwarderSettings.sessionTimeout;
+            }
+
+            if(forwarderSettings.domain){
+                options.domain = forwarderSettings.domain;
+            }
+
+            options.trackPageView = forwarderSettings.hasOwnProperty('trackPageView') &&
+                    forwarderSettings.trackPageView.toLowerCase() === 'true';
+
+            return options;
         }
-    }
 
-    function getOrderedCustomDimensions() {
-        var dimensions = null,
-            orderedDimensions = [];
+        function processEvent(event) {
+            var reportEvent = false;
 
-        try {
-            dimensions = JSON.parse(
-                forwarderSettings.customDimensions.replace(/&quot;/g, '"')
-            );
-        } catch (e) {
-            return orderedDimensions;
+            if(!isInitialized) {
+                return 'Can\'t send forwarder '+ name + ', not initialized';
+            }
+
+            try {
+                if(event.EventDataType == MessageType.PageView) {
+                    reportEvent = true;
+                    logScreenViewEvent(event);
+                } else if (event.EventDataType == MessageType.Commerce) {
+                    logCommerce(event);
+                    reportEvent = true;
+                }
+                else if (event.EventDataType == MessageType.PageEvent) {
+                    reportEvent = true;
+                    logEvent(event);
+                }
+
+                if(reportEvent && reportingService) {
+                    reportingService(self, event);
+                }
+
+                return 'Successfully sent to forwarder ' + name;
+            } catch (e) {
+                return 'Can\'t send to forwarder: ' + name + ' ' + e;
+            }
         }
 
-        if (dimensions.length > 0) {
-            for (var index = 0; index < maxAllowedDimensions; index++) {
-                for (var j = 0; j < dimensions.length; j++) {
-                    if (
-                        dimensions[j].maptype.toLowerCase() !==
-                            'userattributeclass.name' ||
-                        !dimensions[j].value ||
-                        !dimensions[j].map
-                    )
-                        continue;
+        function logScreenViewEvent(event) {
+            var screenName = event.EventName;
 
-                    if (
-                        dimensions[j].value.toLowerCase() ===
-                        'dimension ' + index
-                    ) {
-                        orderedDimensions.push(dimensions[j].map);
+            if(event.hasOwnProperty('CustomFlags') && event.CustomFlags.hasOwnProperty("Localytics.ScreenName")) {
+                screenName = event.CustomFlags["Localytics.ScreenName"];
+            }
+
+            window.ll(createCmd('tagScreen'), screenName);
+        }
+
+        function logEvent(event) {
+            var ltv = null;
+            if(event.hasOwnProperty('EventCategory') && event.EventCategory === EventType.Transaction) {
+                if(event.hasOwnProperty('EventAttributes') && event.EventAttributes.hasOwnProperty("$Amount")) {
+                    var ltvVal = event.EventAttributes["$Amount"];
+                    if(!isNaN(parseFloat(ltvVal, 10))) {
+                        ltv = parseFloat(ltvVal, 10).toFixed(2);
                     }
                 }
             }
+
+            if(ltv !== null) {
+                var multiplier = forwarderSettings.trackClvAsRawValue ? 1 : 100;
+                window.ll(createCmd('tagEvent'), event.EventName, event.EventAttributes, ltv * multiplier);
+            } else {
+                window.ll(createCmd('tagEvent'), event.EventName, event.EventAttributes);
+            }
         }
 
-        return orderedDimensions;
+        function logCommerce(data) {
+
+            if(!data.ProductAction)
+                return 'Can\'t forward commerce event: No production action found';
+
+            switch (data.ProductAction.ProductActionType) {
+                case mParticle.ProductActionType.Purchase:
+                case mParticle.ProductActionType.Refund:
+                    var total = null,
+                        multiplier = forwarderSettings.trackClvAsRawValue ? 1 : 100;
+
+                    if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Refund) {
+                        multiplier *= -1;
+                    }
+
+                    if(!isNaN(parseFloat(data.ProductAction.TotalAmount, 10))) {
+                        total = parseFloat(data.ProductAction.TotalAmount, 10).toFixed(2);
+                    }
+
+                    if(total != null) {
+                        window.ll(createCmd('tagEvent'), data.EventName, data.EventAttributes, total * multiplier);
+                    } else {
+                        return 'Can\'t forward commerce event: TotalAmount is set incorrectly';
+                    }
+                    break;
+
+                default:
+                    logEvent(data);
+                    break;
+            }
+        }
+
+        function setUserAttribute(key, value) {
+            if (!key) {
+                return 'Can\'t call setUserAttribute on forwarder: No key provided';
+            }
+
+            if(key === 'Localytics.CustomerName') {
+                try {
+                    window.ll(createCmd('setCustomerName'), value);
+                }
+                catch(e) {
+                    return 'Can\'t call setCustomerName on forwarder: ' + name + ': ' + e;
+                }
+            } else {
+                if(customDimensions.length > 0) {
+                    updateCustomDimension(key, value);
+                }
+            }
+        }
+
+        function removeUserAttribute(key) {
+            if(customDimensions.length > 0) {
+                updateCustomDimension(key, null);
+            }
+        }
+
+        function setUserIdentity(id, type) {
+            if (!id) {
+                return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
+            }
+
+            if (!isInitialized) {
+                return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+            }
+
+            try {
+                if(window.mParticle.IdentityType.Email == type) {
+                    window.ll(createCmd('setCustomerEmail'), id);
+                }
+                else {
+                    window.ll(createCmd('setCustomerId'), id);
+                }
+
+                return 'Successfully called identify on forwarder: ' + name;
+            }
+            catch (e) {
+                return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+            }
+        }
+
+        function updateCustomDimension(key, value) {
+            if(customDimensions.length === 0)
+                return;
+
+            var index = -1,
+                keyLower = key.toLowerCase();
+
+            for (var i = 0; i < customDimensions.length; i++) {
+                if(customDimensions[i].toLowerCase() === keyLower) {
+                    index = i;
+                }
+            }
+
+            if(index >= 0) {
+                window.ll(createCmd('setCustomDimension'), index, value);
+            }
+        }
+
+        function getOrderedCustomDimensions() {
+            var dimensions          = null,
+                orderedDimensions   = [];
+
+            try {
+                dimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g,'"'));
+            } catch (e) {
+                return orderedDimensions;
+            }
+
+            if(dimensions.length > 0) {
+                for (var index = 0; index < maxAllowedDimensions; index++) {
+                    for (var j = 0; j < dimensions.length; j++) {
+                        if(dimensions[j].maptype.toLowerCase() !== 'userattributeclass.name' ||
+                           !dimensions[j].value ||
+                           !dimensions[j].map)
+                            continue;
+
+                        if(dimensions[j].value.toLowerCase() === 'dimension ' + index) {
+                            orderedDimensions.push(dimensions[j].map);
+                        }
+                    }
+                }
+            }
+
+            return orderedDimensions;
+        }
+
+        this.init                   = initForwarder;
+        this.process                = processEvent;
+        this.setUserAttribute       = setUserAttribute;
+        this.setUserIdentity        = setUserIdentity;
+        this.removeUserAttribute    = removeUserAttribute;
+    };
+
+    function getId() {
+        return moduleId;
     }
 
-    this.init = initForwarder;
-    this.process = processEvent;
-    this.setUserAttribute = setUserAttribute;
-    this.setUserIdentity = setUserIdentity;
-    this.removeUserAttribute = removeUserAttribute;
-};
+    function register(config) {
+        if (!config) {
+            console.log('You must pass a config object to register the kit ' + name);
+            return;
+        }
 
-function getId() {
-    return moduleId;
-}
+        if (!isobject(config)) {
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
 
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
+        if (isobject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
     }
 
-    if (!isobject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
+        }
     }
 
-    if (isobject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/onetrust/src/integration-builder/initialization.js
+++ b/kits/onetrust/src/integration-builder/initialization.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 var CONSENT_REGULATIONS = {
     GDPR: 'gdpr',
-    CCPA: 'ccpa',
+    CCPA: 'ccpa'
 };
 var CCPA_PURPOSE = 'data_sale_opt_out';
 
@@ -21,19 +21,14 @@ var initialization = {
     parseConsentMapping: function(rawConsentMapping) {
         var _consentMapping = {};
         if (rawConsentMapping) {
-            var parsedMapping = JSON.parse(
-                rawConsentMapping.replace(/&quot;/g, '"')
-            );
+            var parsedMapping = JSON.parse(rawConsentMapping.replace(/&quot;/g, '\"'));
 
             // TODO: [67837] Revise this to use an actual 'regulation' mapping if UI ever returns this
             parsedMapping.forEach(function(mapping) {
                 var purpose = mapping.map;
                 _consentMapping[mapping.value] = {
                     purpose: purpose,
-                    regulation:
-                        purpose === CCPA_PURPOSE
-                            ? CONSENT_REGULATIONS.CCPA
-                            : CONSENT_REGULATIONS.GDPR,
+                    regulation: purpose === CCPA_PURPOSE ? CONSENT_REGULATIONS.CCPA : CONSENT_REGULATIONS.GDPR
                 };
             });
         }
@@ -60,7 +55,7 @@ var initialization = {
         // it for something custom so we can hijack
         var OptanonWrapperCopy = window.OptanonWrapper;
 
-        window.OptanonWrapper = function() {
+        window.OptanonWrapper = function () {
             if (window.Optanon && window.Optanon.OnConsentChanged) {
                 window.Optanon.OnConsentChanged(function() {
                     self.createConsentEvents();
@@ -72,7 +67,7 @@ var initialization = {
             OptanonWrapperCopy();
         };
     },
-    createConsentEvents: function() {
+    createConsentEvents: function () {
         var user = mParticle.Identity.getCurrentUser();
         if (!window.Optanon || !user) {
             return;
@@ -132,10 +127,7 @@ var initialization = {
                         consentPurpose,
                         location
                     );
-                    consentState.addGDPRConsentState(
-                        consentPurpose,
-                        gdprConsent
-                    );
+                    consentState.addGDPRConsentState(consentPurpose, gdprConsent);
                     break;
 
                 default:
@@ -228,11 +220,9 @@ function setGoogleVendorRequests(
 
         if (googleConsentedVendors && googleConsentedVendors.length) {
             for (var vendorId in googleVendorConsentMapping) {
-                var consentPurpose =
-                    googleVendorConsentMapping[vendorId].purpose;
+                var consentPurpose = googleVendorConsentMapping[vendorId].purpose;
                 // consent is true if the vendor id is in the array of consented IDs
-                var consentBoolean =
-                    googleConsentedVendors.indexOf(vendorId) > -1;
+                var consentBoolean = googleConsentedVendors.indexOf(vendorId) > -1;
                 var consent = mParticle.Consent.createGDPRConsent(
                     consentBoolean,
                     Date.now(),
@@ -263,8 +253,7 @@ function setIABVendorRequests(
         for (var vendorIndex in IABVendorConsentMappings) {
             var consentPurpose = IABVendorConsentMappings[vendorIndex].purpose;
             // consent is true if the (vendorIndex - 1) is 1
-            var consentBoolean =
-                IABConsentedVendors[parseInt(vendorIndex) - 1] === '1';
+            var consentBoolean = IABConsentedVendors[parseInt(vendorIndex) - 1] === '1';
             var consent = mParticle.Consent.createGDPRConsent(
                 consentBoolean,
                 Date.now(),
@@ -287,11 +276,9 @@ function setGeneralVendorRequests(
     try {
         if (window.Optanon) {
             for (var vendorId in generalVendorConsentMapping) {
-                var consentPurpose =
-                    generalVendorConsentMapping[vendorId].purpose;
+                var consentPurpose = generalVendorConsentMapping[vendorId].purpose;
                 // consent is true if the vendorId is in the oneTrustVendorConsent array
-                var consentBoolean =
-                    oneTrustVendorConsent.indexOf(vendorId) > -1;
+                var consentBoolean = oneTrustVendorConsent.indexOf(vendorId) > -1;
                 var consent = mParticle.Consent.createGDPRConsent(
                     consentBoolean,
                     Date.now(),

--- a/kits/onetrust/src/oneTrustWrapper.js
+++ b/kits/onetrust/src/oneTrustWrapper.js
@@ -12,13 +12,12 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-var Initialization = require('./integration-builder/initialization')
-    .initialization;
+var Initialization = require('./integration-builder/initialization').initialization;
 
 var name = Initialization.name,
     moduleId = Initialization.moduleId;
 
-var constructor = function() {
+var constructor = function () {
     var self = this,
         isInitialized = false,
         forwarderSettings;
@@ -46,26 +45,19 @@ var constructor = function() {
                 Initialization.createConsentEvents();
                 Initialization.createVendorConsentEvents();
             } catch (e) {
-                return {
-                    error:
-                        'Error setting user identity on forwarder ' +
-                        name +
-                        '; ' +
-                        e,
-                };
+                return {error: 'Error setting user identity on forwarder ' + name + '; ' + e};
             }
-        } else {
-            return (
-                "Can't set new user identities on forwader " +
-                name +
-                ', not initialized'
-            );
+        }
+        else {
+            return 'Can\'t set new user identities on forwader ' + name + ', not initialized';
         }
     }
 
     this.init = initForwarder;
     this.onUserIdentified = onUserIdentified;
-    this.process = function() {};
+    this.process = function() {
+
+    };
 };
 
 function getId() {
@@ -73,39 +65,31 @@ function getId() {
 }
 
 function isObject(val) {
-    return (
-        val != null && typeof val === 'object' && Array.isArray(val) === false
-    );
+    return val != null && typeof val === 'object' && Array.isArray(val) === false;
 }
 
 function register(config) {
     if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
+        console.log('You must pass a config object to register the kit ' + name);
         return;
     }
 
     if (!isObject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
+        console.log('\'config\' must be an object. You passed in a ' + typeof config);
         return;
     }
 
     if (isObject(config.kits)) {
         config.kits[name] = {
-            constructor: constructor,
+            constructor: constructor
         };
     } else {
         config.kits = {};
         config.kits[name] = {
-            constructor: constructor,
+            constructor: constructor
         };
     }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
+    console.log('Successfully registered ' + name + ' to your mParticle configuration');
 }
 
 if (typeof window !== 'undefined') {
@@ -113,11 +97,11 @@ if (typeof window !== 'undefined') {
         window.mParticle.addForwarder({
             name: name,
             constructor: constructor,
-            getId: getId,
+            getId: getId
         });
     }
 }
 
 module.exports = {
-    register: register,
+    register: register
 };

--- a/kits/optimizely/src/commerce-handler.js
+++ b/kits/optimizely/src/commerce-handler.js
@@ -14,21 +14,18 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
     );
 
     expandedEcommerceEvents.forEach(function(expandedEvent) {
-        if (
-            !self.common.useFullStack &&
-            optimizelyWebXEvents.events[expandedEvent.EventName]
-        ) {
+        if (!self.common.useFullStack && optimizelyWebXEvents.events[expandedEvent.EventName]) {
+
             var optimizelyWebXEvent = {
                 type: 'event',
                 eventName: event.EventName,
-                tags: {},
+                tags: {}
             };
             optimizelyWebXEvent.tags = expandedEvent.EventAttributes || {};
             if (
                 event.EventCategory ===
                     mParticle.CommerceEventType.ProductPurchase ||
-                event.EventCategory ===
-                    mParticle.CommerceEventType.ProductRefund
+                event.EventCategory === mParticle.CommerceEventType.ProductRefund
             ) {
                 if (expandedEvent.EventName.indexOf('Total') > -1) {
                     if (
@@ -83,12 +80,7 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
 
         // if optimizely full stack is being used
         if (self.common.useFullStack && window.optimizelyClientInstance) {
-            if (
-                optimizelyFullStackEvents.events[expandedEvent.EventName] ||
-                optimizelyFullStackEvents.events[
-                    event.CustomFlags['OptimizelyFullStack.EventName']
-                ]
-            ) {
+            if (optimizelyFullStackEvents.events[expandedEvent.EventName] || optimizelyFullStackEvents.events[event.CustomFlags['OptimizelyFullStack.EventName']]) {
                 var eventKey = expandedEvent.EventName,
                     userId,
                     userAttributes = self.common.userAttributes,
@@ -103,8 +95,7 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
                 if (
                     event.EventCategory ===
                         mParticle.CommerceEventType.ProductPurchase ||
-                    event.EventCategory ===
-                        mParticle.CommerceEventType.ProductRefund
+                    event.EventCategory === mParticle.CommerceEventType.ProductRefund
                 ) {
                     if (expandedEvent.EventName.indexOf('Total') > -1) {
                         if (
@@ -112,9 +103,7 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
                             event.CustomFlags['OptimizelyFullStack.EventName']
                         ) {
                             eventKey =
-                                event.CustomFlags[
-                                    'OptimizelyFullStack.EventName'
-                                ];
+                                event.CustomFlags['OptimizelyFullStack.EventName'];
                         } else {
                             eventKey = expandedEvent.EventName;
                         }
@@ -125,8 +114,7 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
                             expandedEvent.EventAttributes['Total Amount']
                         ) {
                             eventTags.revenue =
-                                expandedEvent.EventAttributes['Total Amount'] *
-                                100;
+                                expandedEvent.EventAttributes['Total Amount'] * 100;
                         }
                         // other individual product events should not have revenue tags
                         // which are added via the expandCommerceEvent method above
@@ -136,9 +124,7 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
                             event.CustomFlags['OptimizelyFullStack.EventName']
                         ) {
                             eventKey =
-                                event.CustomFlags[
-                                    'OptimizelyFullStack.EventName'
-                                ];
+                                event.CustomFlags['OptimizelyFullStack.EventName'];
                         }
                         if (eventTags.revenue) {
                             delete eventTags.revenue;
@@ -154,14 +140,10 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
                             event.CustomFlags['OptimizelyFullStack.EventName'];
                     }
                 }
-                window['optimizelyClientInstance'].track(
-                    eventKey,
-                    userId,
-                    userAttributes,
-                    eventTags
-                );
+                window['optimizelyClientInstance'].track(eventKey, userId, userAttributes, eventTags);
             }
         }
+
     });
 };
 

--- a/kits/optimizely/src/event-handler.js
+++ b/kits/optimizely/src/event-handler.js
@@ -7,13 +7,10 @@ function EventHandler(common) {
 }
 
 EventHandler.prototype.logEvent = function(event) {
-    if (
-        !this.common.useFullStack &&
-        optimizelyWebXEvents.events[event.EventName]
-    ) {
+    if (!this.common.useFullStack && optimizelyWebXEvents.events[event.EventName]) {
         var optimizelyWebXEvent = {
             type: 'event',
-            eventName: event.EventName,
+            eventName: event.EventName
         };
 
         if (event.EventAttributes) {
@@ -21,18 +18,13 @@ EventHandler.prototype.logEvent = function(event) {
         }
 
         if (event.CustomFlags && event.CustomFlags['Optimizely.Value']) {
-            optimizelyWebXEvent.tags.value =
-                event.CustomFlags['Optimizely.Value'];
+            optimizelyWebXEvent.tags.value = event.CustomFlags['Optimizely.Value'];
         }
         window['optimizely'].push(optimizelyWebXEvent);
     }
 
     // if optimizely full stack is being used
-    if (
-        this.common.useFullStack &&
-        window.optimizelyClientInstance &&
-        optimizelyFullStackEvents.events[event.EventName]
-    ) {
+    if (this.common.useFullStack && window.optimizelyClientInstance && optimizelyFullStackEvents.events[event.EventName]) {
         var eventKey = event.EventName,
             userId,
             userAttributes = this.common.userAttributes,
@@ -46,32 +38,21 @@ EventHandler.prototype.logEvent = function(event) {
             eventTags = event.EventAttributes;
         }
 
-        if (
-            event.CustomFlags &&
-            event.CustomFlags['OptimizelyFullStack.Value']
-        ) {
+        if (event.CustomFlags && event.CustomFlags['OptimizelyFullStack.Value']) {
             eventTags.value = event.CustomFlags['OptimizelyFullStack.Value'];
         }
 
-        window['optimizelyClientInstance'].track(
-            eventKey,
-            userId,
-            userAttributes,
-            eventTags
-        );
+        window['optimizelyClientInstance'].track(eventKey, userId, userAttributes, eventTags);
     }
 };
 
 EventHandler.prototype.logPageView = function(event) {
     var self = this;
 
-    if (
-        !self.common.useFullStack &&
-        optimizelyWebXEvents.pages[event.EventName]
-    ) {
+    if (!self.common.useFullStack && optimizelyWebXEvents.pages[event.EventName]) {
         var optimizelyWebXEvent = {
             type: 'page',
-            pageName: event.EventName,
+            pageName: event.EventName
         };
 
         if (event.EventAttributes) {

--- a/kits/optimizely/src/helpers.js
+++ b/kits/optimizely/src/helpers.js
@@ -4,7 +4,7 @@ var helpers = {
             obj[item[keyField]] = item;
             return obj;
         }, {});
-        return newObj;
+    return newObj;
     },
     loadScript: function(src, callback) {
         var script = document.createElement('script');
@@ -17,7 +17,7 @@ var helpers = {
         var identities = window.mParticle.Identity.getCurrentUser().getUserIdentities();
         var userIdentities = identities['userIdentities'];
         var userId;
-        switch (userIdField) {
+        switch(userIdField) {
             // The server returns `customerId` as part of the `userIdField` setting
             // but the API for identity requies it to be cased as `customerid`
             case 'customerId':

--- a/kits/optimizely/src/initialization.js
+++ b/kits/optimizely/src/initialization.js
@@ -2,28 +2,14 @@ var optimizelyWebXEvents = require('./optimizely-x-defined-events');
 var optimizelyFullStackEvents = require('./optimizely-fs-defined-events');
 var helpers = require('./helpers');
 
-var optimizelyFsSdkUrl =
-        'https://unpkg.com/@optimizely/optimizely-sdk@3.5.0/dist/optimizely.browser.umd.min.js',
+var optimizelyFsSdkUrl = 'https://unpkg.com/@optimizely/optimizely-sdk@3.5.0/dist/optimizely.browser.umd.min.js',
     dataFilePrefix = 'https://cdn.optimizely.com/datafiles/',
     dataFileURLending = '.json/tag.js';
 
 var initialization = {
     name: 'Optimizely',
     moduleId: 54,
-    initForwarder: function(
-        settings,
-        testMode,
-        userAttributes,
-        userIdentities,
-        processEvent,
-        eventQueue,
-        isInitialized,
-        common,
-        appVersion,
-        appName,
-        customFlags,
-        clientId
-    ) {
+    initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, common, appVersion, appName, customFlags, clientId) {
         common.useFullStack = settings.useFullStack === 'True';
 
         if (!testMode) {
@@ -31,14 +17,8 @@ var initialization = {
                 var optimizelyScript = document.createElement('script');
                 optimizelyScript.type = 'text/javascript';
                 optimizelyScript.async = true;
-                optimizelyScript.src =
-                    'https://cdn.optimizely.com/js/' +
-                    settings.projectId +
-                    '.js';
-                (
-                    document.getElementsByTagName('head')[0] ||
-                    document.getElementsByTagName('body')[0]
-                ).appendChild(optimizelyScript);
+                optimizelyScript.src = 'https://cdn.optimizely.com/js/' + settings.projectId + '.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(optimizelyScript);
                 optimizelyScript.onload = function() {
                     isInitialized = true;
 
@@ -61,34 +41,33 @@ var initialization = {
                 common.userAttributes = userAttributes;
                 var errorHandler = function() {};
 
-                if (
-                    customFlags &&
-                    customFlags['OptimizelyFullStack.ErrorHandler']
-                ) {
-                    errorHandler =
-                        customFlags['OptimizelyFullStack.ErrorHandler'];
+                if (customFlags && customFlags['OptimizelyFullStack.ErrorHandler']) {
+                    errorHandler = customFlags['OptimizelyFullStack.ErrorHandler'];
                 }
 
                 var instantiateFSClient = function() {
-                    window.optimizelyClientInstance = window.optimizelySdk.createInstance(
-                        {
-                            datafile: window.optimizelyDatafile,
-                            errorHandler: { handleError: errorHandler },
-                        }
-                    );
+                    window.optimizelyClientInstance = window.optimizelySdk.createInstance({
+                        datafile: window.optimizelyDatafile,
+                        errorHandler: {handleError: errorHandler}
+                    });
 
-                    window.optimizelyClientInstance.onReady().then(function() {
+                    window.optimizelyClientInstance.onReady().then(function(){
                         isInitialized = true;
                         loadFullStackEvents();
                     });
-                };
+                }
 
-                helpers.loadScript(optimizelyFsSdkUrl, function() {
-                    helpers.loadScript(
-                        dataFilePrefix + settings.projectId + dataFileURLending,
-                        instantiateFSClient
-                    );
-                });
+                helpers.loadScript(optimizelyFsSdkUrl,
+                    function() {
+                        helpers.loadScript(
+                          dataFilePrefix +
+                            settings.projectId +
+                            dataFileURLending,
+                          instantiateFSClient
+                        );
+                    }
+                );
+
             } else {
                 isInitialized = true;
                 common.userIdField = settings.userIdField;
@@ -106,7 +85,7 @@ var initialization = {
                 loadFullStackEvents();
             }
         }
-    },
+    }
 };
 
 function loadWebXEventsAndPages() {
@@ -132,13 +111,11 @@ function loadWebXEventsAndPages() {
 
 function loadFullStackEvents() {
     var fullStackData,
-        fullStackEvents = {};
+    fullStackEvents = {};
+
 
     if (window.optimizelyDatafile) {
-        fullStackData = helpers.arrayToObject(
-            window.optimizelyDatafile.events,
-            'id'
-        );
+        fullStackData = helpers.arrayToObject(window.optimizelyDatafile.events, 'id');
 
         for (var event in fullStackData) {
             fullStackEvents[fullStackData[event].key] = 1;

--- a/kits/optimizely/src/optimizely-fs-defined-events.js
+++ b/kits/optimizely/src/optimizely-fs-defined-events.js
@@ -1,3 +1,3 @@
 module.exports = {
-    events: {},
+    events: {}
 };

--- a/kits/optimizely/src/optimizely-x-defined-events.js
+++ b/kits/optimizely/src/optimizely-x-defined-events.js
@@ -1,4 +1,4 @@
 module.exports = {
     pages: {},
-    events: {},
+    events: {}
 };

--- a/kits/optimizely/src/session-handler.js
+++ b/kits/optimizely/src/session-handler.js
@@ -1,6 +1,10 @@
 var sessionHandler = {
-    onSessionStart: function(event) {},
-    onSessionEnd: function(event) {},
+    onSessionStart: function(event) {
+
+    },
+    onSessionEnd: function(event) {
+
+    }
 };
 
 module.exports = sessionHandler;

--- a/kits/optimizely/src/user-attribute-handler.js
+++ b/kits/optimizely/src/user-attribute-handler.js
@@ -8,7 +8,7 @@ UserAttributeHandler.prototype.onRemoveUserAttribute = function(key) {
         attribute[key] = null;
         window['optimizely'].push({
             type: 'user',
-            attributes: attribute,
+            attributes: attribute
         });
     }
     if (this.common.useFullStack && window.optimizelyClientInstance) {
@@ -23,7 +23,7 @@ UserAttributeHandler.prototype.onSetUserAttribute = function(key, value) {
         attribute[key] = value;
         window['optimizely'].push({
             type: 'user',
-            attributes: attribute,
+            attributes: attribute
         });
     }
     if (this.common.useFullStack && window.optimizelyClientInstance) {

--- a/kits/simplereach/src/SimpleReach.js
+++ b/kits/simplereach/src/SimpleReach.js
@@ -13,194 +13,184 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var isobject = require('isobject');
+    var isobject = require('isobject');
 
-var name = 'SimpleReach',
-    moduleId = 87,
-    SimpleReachCustomFlags = {
-        Title: 'SimpleReach.Title',
-        Url: 'SimpleReach.Url',
-        Date: 'SimpleReach.Date',
-        Authors: 'SimpleReach.Authors',
-        Channels: 'SimpleReach.Channels',
-        Tags: 'SimpleReach.Tags',
-        ContentHeight: 'SimpleReach.ContentHeight',
-    },
-    MessageType = {
-        PageView: 3,
+    var name = 'SimpleReach',
+        moduleId = 87,
+        SimpleReachCustomFlags = {
+            Title: 'SimpleReach.Title',
+            Url: 'SimpleReach.Url',
+            Date: 'SimpleReach.Date',
+            Authors: 'SimpleReach.Authors',
+            Channels: 'SimpleReach.Channels',
+            Tags: 'SimpleReach.Tags',
+            ContentHeight: 'SimpleReach.ContentHeight'
+        },
+        MessageType = {
+            PageView: 3
+        };
+
+    var constructor = function () {
+        var self = this,
+            forwarderSettings,
+            reportingService,
+            isInitialized = false,
+            isTesting = false,
+            pid = null,
+            user_id = null;
+
+        self.name = name;
+
+        function processEvent(event) {
+            var reportEvent = false;
+
+            if (isInitialized) {
+
+                if (event.EventDataType == MessageType.PageView) {
+                    reportEvent = true;
+                    processSimpleReachEvent(event);
+                }
+
+                if (reportEvent && reportingService) {
+                    reportingService(self, event);
+                }
+            }
+            else {
+                return 'Can\'t send to forwarder ' + name + ', not initialized';
+            }
+        }
+
+        function copyCustomFlags(sourceObj, destObj) {
+            if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Title)) {
+                destObj.title = sourceObj[SimpleReachCustomFlags.Title];
+            }
+
+            if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Url)) {
+                destObj.url = sourceObj[SimpleReachCustomFlags.Url];
+            }
+
+            if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Date)) {
+                destObj.date = sourceObj[SimpleReachCustomFlags.Date];
+            }
+
+            if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Authors)) {
+                destObj.authors = sourceObj[SimpleReachCustomFlags.Authors];
+            }
+
+            if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Channels)) {
+                destObj.channels = sourceObj[SimpleReachCustomFlags.Channels];
+            }
+
+            if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Tags)) {
+                destObj.tags = sourceObj[SimpleReachCustomFlags.Tags];
+            }
+
+            if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.ContentHeight)) {
+                destObj.content_height = sourceObj[SimpleReachCustomFlags.ContentHeight];
+            }
+        }
+
+        function processSimpleReachEvent(event) {
+            var eventData = {
+                title: event.EventAttributes.title,
+                pid: pid
+            };
+
+            if (event.CustomFlags) {
+                copyCustomFlags(event.CustomFlags, eventData);
+            }
+
+            window.SPR.Reach.collect(eventData);
+        }
+
+        function initForwarder(settings,
+            service,
+            testMode,
+            trackerId,
+            userAttributes,
+            userIdentities,
+            appVersion,
+            appName,
+            customFlags) {
+
+            var simpleReachConfig = {};
+
+            try {
+                forwarderSettings = settings;
+                reportingService = service;
+                isTesting = testMode;
+                pid = settings.pid;
+
+                simpleReachConfig.pid = pid;
+                simpleReachConfig.ignore_errors = false;
+
+                if (customFlags) {
+                    copyCustomFlags(customFlags, simpleReachConfig);
+                }
+
+                window.__reach_config = simpleReachConfig;
+
+                if (isTesting !== true) {
+                    (function () {
+                        var s = document.createElement('script');
+                        s.async = true;
+                        s.type = 'text/javascript';
+                        s.src = document.location.protocol + '//d8rk54i4mohrb.cloudfront.net/js/reach.js';
+                        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(s);
+                    })();
+                }
+
+                isInitialized = true;
+
+                return 'Successfully initialized: ' + name;
+            }
+            catch (e) {
+                return 'Failed to initialize: ' + name;
+            }
+        }
+
+        this.init = initForwarder;
+        this.process = processEvent;
     };
 
-var constructor = function() {
-    var self = this,
-        forwarderSettings,
-        reportingService,
-        isInitialized = false,
-        isTesting = false,
-        pid = null,
-        user_id = null;
+    function getId() {
+        return moduleId;
+    }
 
-    self.name = name;
+    function register(config) {
+        if (!config) {
+            window.console.log('You must pass a config object to register the kit ' + name);
+            return;
+        }
 
-    function processEvent(event) {
-        var reportEvent = false;
+        if (!isobject(config)) {
+            window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
 
-        if (isInitialized) {
-            if (event.EventDataType == MessageType.PageView) {
-                reportEvent = true;
-                processSimpleReachEvent(event);
-            }
-
-            if (reportEvent && reportingService) {
-                reportingService(self, event);
-            }
+        if (isobject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
         } else {
-            return "Can't send to forwarder " + name + ', not initialized';
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
         }
     }
 
-    function copyCustomFlags(sourceObj, destObj) {
-        if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Title)) {
-            destObj.title = sourceObj[SimpleReachCustomFlags.Title];
-        }
-
-        if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Url)) {
-            destObj.url = sourceObj[SimpleReachCustomFlags.Url];
-        }
-
-        if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Date)) {
-            destObj.date = sourceObj[SimpleReachCustomFlags.Date];
-        }
-
-        if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Authors)) {
-            destObj.authors = sourceObj[SimpleReachCustomFlags.Authors];
-        }
-
-        if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Channels)) {
-            destObj.channels = sourceObj[SimpleReachCustomFlags.Channels];
-        }
-
-        if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.Tags)) {
-            destObj.tags = sourceObj[SimpleReachCustomFlags.Tags];
-        }
-
-        if (sourceObj.hasOwnProperty(SimpleReachCustomFlags.ContentHeight)) {
-            destObj.content_height =
-                sourceObj[SimpleReachCustomFlags.ContentHeight];
-        }
-    }
-
-    function processSimpleReachEvent(event) {
-        var eventData = {
-            title: event.EventAttributes.title,
-            pid: pid,
-        };
-
-        if (event.CustomFlags) {
-            copyCustomFlags(event.CustomFlags, eventData);
-        }
-
-        window.SPR.Reach.collect(eventData);
-    }
-
-    function initForwarder(
-        settings,
-        service,
-        testMode,
-        trackerId,
-        userAttributes,
-        userIdentities,
-        appVersion,
-        appName,
-        customFlags
-    ) {
-        var simpleReachConfig = {};
-
-        try {
-            forwarderSettings = settings;
-            reportingService = service;
-            isTesting = testMode;
-            pid = settings.pid;
-
-            simpleReachConfig.pid = pid;
-            simpleReachConfig.ignore_errors = false;
-
-            if (customFlags) {
-                copyCustomFlags(customFlags, simpleReachConfig);
-            }
-
-            window.__reach_config = simpleReachConfig;
-
-            if (isTesting !== true) {
-                (function() {
-                    var s = document.createElement('script');
-                    s.async = true;
-                    s.type = 'text/javascript';
-                    s.src =
-                        document.location.protocol +
-                        '//d8rk54i4mohrb.cloudfront.net/js/reach.js';
-                    (
-                        document.getElementsByTagName('head')[0] ||
-                        document.getElementsByTagName('body')[0]
-                    ).appendChild(s);
-                })();
-            }
-
-            isInitialized = true;
-
-            return 'Successfully initialized: ' + name;
-        } catch (e) {
-            return 'Failed to initialize: ' + name;
-        }
-    }
-
-    this.init = initForwarder;
-    this.process = processEvent;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        window.console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
-    }
-
-    if (!isobject(config)) {
-        window.console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isobject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    window.console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/taplytics/src/TaplyticsKit.js
+++ b/kits/taplytics/src/TaplyticsKit.js
@@ -15,298 +15,307 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var isobject = require('isobject');
+    var isobject = require('isobject');
 
-var name = 'Taplytics',
-    moduleId = 129,
-    MessageType = {
-        SessionStart: 1,
-        SessionEnd: 2,
-        PageView: 3,
-        PageEvent: 4,
-        CrashReport: 5,
-        OptOut: 6,
-        Commerce: 16,
-    };
+    var name = 'Taplytics',
+        moduleId = 129,
+        MessageType = {
+            SessionStart: 1,
+            SessionEnd: 2,
+            PageView: 3,
+            PageEvent: 4,
+            CrashReport: 5,
+            OptOut: 6,
+            Commerce: 16
+        };
 
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        reportingService,
-        eventQueue = [],
-        settings = {},
-        initUserAttributes = {},
-        initUserIdentities = [];
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            reportingService,
+            eventQueue = [],
+            settings = {},
+            initUserAttributes = {},
+            initUserIdentities = [];
 
-    self.name = name;
+        self.name = name;
 
-    function initForwarder(
-        forwarderSettings,
-        service,
-        testMode,
-        trackerId,
-        userAttributes,
-        userIdentities
-    ) {
-        reportingService = service;
-        settings = forwarderSettings;
-        initUserAttributes = userAttributes;
-        initUserIdentities = userIdentities;
+        function initForwarder(forwarderSettings, service, testMode, trackerId, userAttributes, userIdentities) {
+            reportingService = service;
+            settings = forwarderSettings;
+            initUserAttributes = userAttributes;
+            initUserIdentities = userIdentities;
 
-        try {
-            if (!testMode && !window.Taplytics) {
-                var taplyticsScript = document.createElement('script');
-                taplyticsScript.type = 'text/javascript';
-                taplyticsScript.async = true;
-                taplyticsScript.src = getTaplyticsSourceLink();
-                (
-                    document.getElementsByTagName('head')[0] ||
-                    document.getElementsByTagName('body')[0]
-                ).appendChild(taplyticsScript);
-                taplyticsScript.onload = function() {
+            try {
+                if (!testMode && !window.Taplytics) {
+                    var taplyticsScript = document.createElement('script');
+                    taplyticsScript.type = 'text/javascript';
+                    taplyticsScript.async = true;
+                    taplyticsScript.src = getTaplyticsSourceLink();
+                    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(taplyticsScript);
+                    taplyticsScript.onload = function() {
+                        isInitialized = true;
+
+                        // On load, if the clientsdk exists and there are events
+                        // in the eventQueue, process each event
+                        if (window.Taplytics && eventQueue.length > 0) {
+                            // Process any events that may have been queued up
+                            // while forwarder was being initialized.
+                            eventQueue.forEach(function(event) {
+                                processEvent(event);
+                            });
+
+                            eventQueue = [];
+                        }
+                    };
+                }
+                else {
                     isInitialized = true;
-
-                    // On load, if the clientsdk exists and there are events
-                    // in the eventQueue, process each event
-                    if (window.Taplytics && eventQueue.length > 0) {
-                        // Process any events that may have been queued up
-                        // while forwarder was being initialized.
-                        eventQueue.forEach(function(event) {
-                            processEvent(event);
-                        });
-
-                        eventQueue = [];
+                    if (testMode) {
+                        Taplytics.src = getTaplyticsSourceLink();
                     }
-                };
-            } else {
-                isInitialized = true;
-                if (testMode) {
-                    Taplytics.src = getTaplyticsSourceLink();
                 }
+
+                return 'Taplytics successfully loaded';
             }
-
-            return 'Taplytics successfully loaded';
-        } catch (e) {
-            return 'Failed to initialize: ' + e;
+            catch (e) {
+                return 'Failed to initialize: ' + e;
+            }
         }
-    }
 
-    /**
-     * Called whenever an event occurs. Used to log different types of events.
-     * @param event
-     * @returns {string}
-     */
-    function processEvent(event) {
-        var reportEvent = false;
-        if (isInitialized) {
-            try {
-                if (event.EventDataType === MessageType.PageView) {
-                    reportEvent = logPageView(event);
-                } else if (event.EventDataType === MessageType.Commerce) {
-                    if (
-                        event.EventCategory ===
-                        mParticle.CommerceEventType.ProductPurchase
-                    ) {
-                        reportEvent = logPurchaseEvent(event);
+        /**
+         * Called whenever an event occurs. Used to log different types of events.
+         * @param event
+         * @returns {string}
+         */
+        function processEvent(event) {
+            var reportEvent = false;
+            if (isInitialized) {
+                try {
+                    if (event.EventDataType === MessageType.PageView) {
+                        reportEvent = logPageView(event);
+                    } else if (event.EventDataType === MessageType.Commerce) {
+                        if (event.EventCategory === mParticle.CommerceEventType.ProductPurchase) {
+                            reportEvent = logPurchaseEvent(event);
+                        } else {
+                            reportEvent = logCommerceEvent(event);
+                        }
+                    } else if (event.EventDataType === MessageType.PageEvent) {
+                        reportEvent = logEvent(event);
+                    }
+
+                    // leave the below alone
+                    if (reportEvent === true && reportingService) {
+                        reportingService(self, event);
+                        return 'Successfully sent to ' + name;
                     } else {
-                        reportEvent = logCommerceEvent(event);
+                        return 'Error logging event or event type not supported - ' + reportEvent.error;
                     }
-                } else if (event.EventDataType === MessageType.PageEvent) {
-                    reportEvent = logEvent(event);
                 }
-
-                // leave the below alone
-                if (reportEvent === true && reportingService) {
-                    reportingService(self, event);
-                    return 'Successfully sent to ' + name;
-                } else {
-                    return (
-                        'Error logging event or event type not supported - ' +
-                        reportEvent.error
-                    );
+                catch (e) {
+                    return 'Failed to send to: ' + name + ' ' + e;
                 }
-            } catch (e) {
-                return 'Failed to send to: ' + name + ' ' + e;
             }
-        } else {
-            eventQueue.push(event);
-        }
-
-        return (
-            "Can't send to forwarder " +
-            name +
-            ', not initialized. Event added to queue.'
-        );
-    }
-
-    /**
-     * Helper method to check if object is empty
-     * @param obj
-     * @returns {boolean}
-     */
-    function isEmpty(obj) {
-        for (var prop in obj) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Helper method to merge obj 2 into obj1
-     * @param obj1
-     * @param obj2
-     */
-    function mergeObjects(obj1, obj2) {
-        var obj = {};
-        for (var key in obj1) {
-            if (obj1[key]) {
-                obj[key] = obj1[key];
+            else {
+                eventQueue.push(event);
             }
-        }
-        for (var key in obj2) {
-            if (obj2[key]) {
-                obj[key] = obj2[key];
-            }
-        }
-        return obj;
-    }
 
-    /**
-     * Helper method to clone an object
-     * @param {*} obj
-     */
-    function clone(obj) {
-        var copy = {};
-        for (var key in obj) {
-            if (obj.hasOwnProperty(key)) {
-                copy[key] = obj[key];
-            }
-        }
-        return copy;
-    }
-
-    /**
-     * tracks Taplytics events
-     * @param {*} event
-     * @param {*} revenue
-     * @param {*} attributes
-     */
-    function trackEvent(event, revenue, attributes) {
-        if (revenue) {
-            if (attributes && !isEmpty(attributes)) {
-                Taplytics.track(event, revenue, attributes);
-            } else {
-                Taplytics.track(event, revenue);
-            }
-        } else {
-            if (attributes && !isEmpty(attributes)) {
-                Taplytics.track(event, null, attributes);
-            } else {
-                Taplytics.track(event);
-            }
-        }
-    }
-
-    /**
-     * Construct Taplytics src link to load the SDK
-     * @returns {string}
-     */
-    function getTaplyticsSourceLink() {
-        var token = settings.apiKey;
-        var cookieDomain = settings.taplyticsOptionCookieDomain;
-        var timeout = settings.taplyticsOptionTimeout;
-
-        var src = 'https://js.taplytics.com/jssdk/' + token + '.min.js';
-        var query = '';
-
-        if (timeout) {
-            query = query + 'timeout=' + timeout;
+            return 'Can\'t send to forwarder ' + name + ', not initialized. Event added to queue.';
         }
 
-        if (cookieDomain) {
-            query = query + (query ? '&' : '') + 'cookieDomain=' + cookieDomain;
-        }
-
-        var userBucketing = settings.taplyticsOptionUserBucketing;
-
-        if (userBucketing === 'True') {
-            query = query + (query ? '&' : '') + 'user_bucketing=true';
-        }
-
-        var user_attributes = initUserAttributes || {};
-
-        if (initUserIdentities.length) {
-            var identity = initUserIdentities[0];
-            var type = identity.Type;
-            var id = identity.Identity;
-            switch (type) {
-                case 1:
-                    user_attributes['user_id'] = id;
-                    break;
-                case 7:
-                    user_attributes['email'] = id;
-                    break;
-            }
-        }
-
-        if (!isEmpty(user_attributes)) {
-            user_attributes = encodeURIComponent(
-                JSON.stringify(user_attributes)
-            );
-            query =
-                query +
-                (query ? '&' : '') +
-                'user_attributes=' +
-                user_attributes;
-        }
-
-        if (query) {
-            src = src + '?' + query;
-        }
-
-        return src;
-    }
-
-    /**
-     * Logs page view event to Taplytics
-     * @param event
-     * @returns {*}
-     */
-    function logPageView(event) {
-        // Details on the `event` object schema in the README
-        try {
-            if (event.EventAttributes) {
-                Taplytics.page(event.EventName, event.EventAttributes);
-            } else {
-                trackEvent(event.EventName);
-            }
+        /**
+         * Helper method to check if object is empty
+         * @param obj
+         * @returns {boolean}
+         */
+        function isEmpty(obj) {
+            for (var prop in obj) { return false; }
             return true;
-        } catch (e) {
-            return { error: e };
         }
-    }
 
-    /**
-     * Logs purchase events as revenue events to Taplytics
-     * @param event
-     * @returns {*}
-     */
-    function logPurchaseEvent(event) {
-        var reportEvent = false;
-        if (event.ProductAction.ProductList) {
+        /**
+         * Helper method to merge obj 2 into obj1
+         * @param obj1
+         * @param obj2
+         */
+        function mergeObjects(obj1, obj2) {
+            var obj = {};
+            for (var key in obj1) {
+                if (obj1[key]) {
+                    obj[key] = obj1[key];
+                }
+            }
+            for (var key in obj2) {
+                if (obj2[key]) {
+                    obj[key] = obj2[key];
+                }
+            }
+            return obj;
+        }
+
+        /**
+         * Helper method to clone an object
+         * @param {*} obj
+         */
+        function clone(obj) {
+            var copy = {};
+            for (var key in obj) {
+              if (obj.hasOwnProperty(key)) {
+                copy[key] = obj[key];
+              }
+            }
+            return copy;
+          }
+
+        /**
+         * tracks Taplytics events
+         * @param {*} event
+         * @param {*} revenue
+         * @param {*} attributes
+         */
+        function trackEvent(event, revenue, attributes) {
+            if (revenue) {
+                if (attributes && !isEmpty(attributes)) {
+                    Taplytics.track(event, revenue, attributes);
+                } else {
+                    Taplytics.track(event, revenue);
+                }
+            } else {
+                if (attributes && !isEmpty(attributes)) {
+                    Taplytics.track(event, null, attributes);
+                } else {
+                    Taplytics.track(event);
+                }
+            }
+        }
+
+        /**
+         * Construct Taplytics src link to load the SDK
+         * @returns {string}
+         */
+        function getTaplyticsSourceLink() {
+            var token = settings.apiKey;
+            var cookieDomain = settings.taplyticsOptionCookieDomain;
+            var timeout = settings.taplyticsOptionTimeout;
+
+            var src = 'https://js.taplytics.com/jssdk/' + token + '.min.js';
+            var query = '';
+
+            if (timeout) {
+                query = query + 'timeout=' + timeout;
+            }
+
+            if (cookieDomain) {
+                query = query + (query ? '&' : '') + 'cookieDomain=' + cookieDomain;
+            }
+
+            var userBucketing = settings.taplyticsOptionUserBucketing;
+
+            if (userBucketing === 'True') {
+                query = query + (query ? '&' : '') + 'user_bucketing=true';
+            }
+
+            var user_attributes = initUserAttributes || {};
+
+            if (initUserIdentities.length) {
+                var identity = initUserIdentities[0];
+                var type = identity.Type;
+                var id = identity.Identity;
+                switch (type) {
+                    case 1:
+                        user_attributes['user_id'] = id;
+                        break;
+                    case 7:
+                        user_attributes['email'] = id;
+                        break;
+                }
+            }
+
+            if (!isEmpty(user_attributes)) {
+                user_attributes = encodeURIComponent(JSON.stringify(user_attributes));
+                query = query + (query ? '&' : '') + 'user_attributes=' + user_attributes;
+            }
+
+            if (query) {
+                src = src + '?' + query;
+            }
+
+            return src;
+        }
+
+        /**
+         * Logs page view event to Taplytics
+         * @param event
+         * @returns {*}
+         */
+        function logPageView(event) {
+            // Details on the `event` object schema in the README
             try {
-                var productList = event.ProductAction.ProductList;
-                productList.forEach(function(product) {
-                    var product = product;
-                    var attributes = {};
-                    var productAttributes = product;
-                    if (product.Attributes) {
-                        productAttributes = mergeObjects(
-                            product.Attributes,
-                            product
-                        );
-                    }
+                if (event.EventAttributes) {
+                    Taplytics.page(event.EventName, event.EventAttributes);
+                }
+                else {
+                    trackEvent(event.EventName);
+                }
+                return true;
+            }
+            catch (e) {
+                return { error: e };
+            }
+        }
 
+        /**
+         * Logs purchase events as revenue events to Taplytics
+         * @param event
+         * @returns {*}
+         */
+        function logPurchaseEvent(event) {
+            var reportEvent = false;
+            if (event.ProductAction.ProductList) {
+                try {
+                    var productList = event.ProductAction.ProductList;
+                    productList.forEach(function(product) {
+                        var product = product;
+                        var attributes = {};
+                        var productAttributes = product;
+                        if (product.Attributes) {
+                            productAttributes = mergeObjects(product.Attributes, product);
+                        }
+
+                        if (event.EventAttributes) {
+                            attributes['EventAttributes'] = event.EventAttributes;
+                        }
+
+                        if (event.CurrencyCode) {
+                            attributes['CurrencyCode'] = event.CurrencyCode;
+                        }
+
+                        attributes['ProductAttributes'] = productAttributes;
+
+                        Taplytics.track(event.EventName, parseFloat(product.TotalAmount), attributes);
+                    });
+                    return true;
+                }
+                catch (e) {
+                    return {error: e};
+                }
+            }
+
+            return reportEvent;
+        }
+
+        /**
+         * Logs all other commerce events as regular events with metadata to Taplytics
+         * @param event
+         * @returns {*}
+         */
+        function logCommerceEvent(event) {
+            var reportEvent = false;
+
+            var attributes = {};
+
+            if (event) {
+                try {
                     if (event.EventAttributes) {
                         attributes['EventAttributes'] = event.EventAttributes;
                     }
@@ -315,293 +324,216 @@ var constructor = function() {
                         attributes['CurrencyCode'] = event.CurrencyCode;
                     }
 
-                    attributes['ProductAttributes'] = productAttributes;
+                    if (event.EventCategory === mParticle.CommerceEventType.PromotionClick) {
+                        var promotionList = event.PromotionAction.PromotionList;
+                        if (promotionList) {
+                            promotionList.forEach(function(promotion) {
+                                attributes["Promotion"] = promotion;
+                                trackEvent(event.EventName, null, attributes);
+                            });
+                        }
+                    } else if (event.EventCategory === mParticle.CommerceEventType.ProductImpression) {
+                        var impressions = event.ProductImpressions;
+                        if (impressions) {
+                            impressions.forEach(function(impression) {
+                                var productList = impression.ProductList;
+                                var impressionName = impression.ProductImpressionList;
+                                if (productList) {
+                                    productList.forEach(function(product) {
+                                        var productAttributes = product;
+                                        var attributeCopy = clone(attributes);
+                                        if (product.Attributes) {
+                                            productAttributes = mergeObjects(product, product.Attributes);
+                                        }
 
-                    Taplytics.track(
-                        event.EventName,
-                        parseFloat(product.TotalAmount),
-                        attributes
-                    );
-                });
+                                        attributeCopy["ProductImpression"] = impressionName;
+                                        attributeCopy["ProductImpressionProduct"] = productAttributes;
+                                        trackEvent(event.EventName, null, attributeCopy);
+                                    });
+                                }
+                            });
+                        }
+                    } else if (event.EventCategory === mParticle.CommerceEventType.ProductAddToCart ||
+                        event.EventCategory === mParticle.CommerceEventType.ProductRemoveFromCart ||
+                        event.ProductAction) {
+
+                        if (event.ProductAction.ProductList) {
+                            var productList = event.ProductAction.ProductList;
+                            productList.forEach(function(product) {
+                                var productAttributes = product;
+                                if (product.Attributes) {
+                                    productAttributes = mergeObjects(product, product.Attributes);
+                                }
+                                attributes["ProductAttributes"] = productAttributes;
+                                if (event.ShoppingCart && event.ShoppingCart.ProductList) {
+                                    attributes["ShoppingCart"] = event.ShoppingCart.ProductList;
+                                }
+                                trackEvent(event.EventName, null, attributes);
+                            });
+                        }
+                    } else {
+                        trackEvent(event.EventName, null, attributes);
+                    }
+
+                    return true;
+                }
+                catch (e) {
+                    return {error: e};
+                }
+            }
+
+            return reportEvent;
+		}
+
+        /**
+         * Log regular Taplytics events
+         * @param {*} event
+         */
+        function logEvent(event) {
+            try {
+                trackEvent(event.EventName, null, event.EventAttributes);
                 return true;
-            } catch (e) {
+            }
+            catch (e) {
                 return { error: e };
             }
         }
 
-        return reportEvent;
-    }
-
-    /**
-     * Logs all other commerce events as regular events with metadata to Taplytics
-     * @param event
-     * @returns {*}
-     */
-    function logCommerceEvent(event) {
-        var reportEvent = false;
-
-        var attributes = {};
-
-        if (event) {
-            try {
-                if (event.EventAttributes) {
-                    attributes['EventAttributes'] = event.EventAttributes;
-                }
-
-                if (event.CurrencyCode) {
-                    attributes['CurrencyCode'] = event.CurrencyCode;
-                }
-
-                if (
-                    event.EventCategory ===
-                    mParticle.CommerceEventType.PromotionClick
-                ) {
-                    var promotionList = event.PromotionAction.PromotionList;
-                    if (promotionList) {
-                        promotionList.forEach(function(promotion) {
-                            attributes['Promotion'] = promotion;
-                            trackEvent(event.EventName, null, attributes);
+        /**
+         * Identifies user id or email with Taplytics
+         * @param id
+         * @param type
+         * @returns {string}
+         */
+        function setUserIdentity(id, type) {
+            if (isInitialized) {
+                try {
+                    // Some integrations have primary ids that they use
+                    // (ie. CustomerId, or Email), you may have special methods
+                    // to call for these. mParticle allows for several other
+                    // types of userIds to be set. To view all user identity
+                    // types, navigate to - https://github.com/mParticle/mparticle-sdk-javascript/blob/master-v2/src/types.js#L88-L101
+                    if (type === window.mParticle.IdentityType.CustomerId) {
+                        Taplytics.identify({
+                            user_id: id
                         });
                     }
-                } else if (
-                    event.EventCategory ===
-                    mParticle.CommerceEventType.ProductImpression
-                ) {
-                    var impressions = event.ProductImpressions;
-                    if (impressions) {
-                        impressions.forEach(function(impression) {
-                            var productList = impression.ProductList;
-                            var impressionName =
-                                impression.ProductImpressionList;
-                            if (productList) {
-                                productList.forEach(function(product) {
-                                    var productAttributes = product;
-                                    var attributeCopy = clone(attributes);
-                                    if (product.Attributes) {
-                                        productAttributes = mergeObjects(
-                                            product,
-                                            product.Attributes
-                                        );
-                                    }
-
-                                    attributeCopy[
-                                        'ProductImpression'
-                                    ] = impressionName;
-                                    attributeCopy[
-                                        'ProductImpressionProduct'
-                                    ] = productAttributes;
-                                    trackEvent(
-                                        event.EventName,
-                                        null,
-                                        attributeCopy
-                                    );
-                                });
-                            }
+                    else if (type === window.mParticle.IdentityType.Email) {
+                        Taplytics.identify({
+                            email: id
                         });
                     }
-                } else if (
-                    event.EventCategory ===
-                        mParticle.CommerceEventType.ProductAddToCart ||
-                    event.EventCategory ===
-                        mParticle.CommerceEventType.ProductRemoveFromCart ||
-                    event.ProductAction
-                ) {
-                    if (event.ProductAction.ProductList) {
-                        var productList = event.ProductAction.ProductList;
-                        productList.forEach(function(product) {
-                            var productAttributes = product;
-                            if (product.Attributes) {
-                                productAttributes = mergeObjects(
-                                    product,
-                                    product.Attributes
-                                );
-                            }
-                            attributes['ProductAttributes'] = productAttributes;
-                            if (
-                                event.ShoppingCart &&
-                                event.ShoppingCart.ProductList
-                            ) {
-                                attributes['ShoppingCart'] =
-                                    event.ShoppingCart.ProductList;
-                            }
-                            trackEvent(event.EventName, null, attributes);
-                        });
-                    }
-                } else {
-                    trackEvent(event.EventName, null, attributes);
                 }
-
-                return true;
-            } catch (e) {
-                return { error: e };
+                catch (e) {
+                    return 'Failed to call setUserIdentity on ' + name + ' ' + e;
+                }
+            }
+            else {
+                return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
             }
         }
 
-        return reportEvent;
-    }
-
-    /**
-     * Log regular Taplytics events
-     * @param {*} event
-     */
-    function logEvent(event) {
-        try {
-            trackEvent(event.EventName, null, event.EventAttributes);
-            return true;
-        } catch (e) {
-            return { error: e };
-        }
-    }
-
-    /**
-     * Identifies user id or email with Taplytics
-     * @param id
-     * @param type
-     * @returns {string}
-     */
-    function setUserIdentity(id, type) {
-        if (isInitialized) {
-            try {
-                // Some integrations have primary ids that they use
-                // (ie. CustomerId, or Email), you may have special methods
-                // to call for these. mParticle allows for several other
-                // types of userIds to be set. To view all user identity
-                // types, navigate to - https://github.com/mParticle/mparticle-sdk-javascript/blob/master-v2/src/types.js#L88-L101
-                if (type === window.mParticle.IdentityType.CustomerId) {
-                    Taplytics.identify({
-                        user_id: id,
-                    });
-                } else if (type === window.mParticle.IdentityType.Email) {
-                    Taplytics.identify({
-                        email: id,
-                    });
+        /**
+         * Sets user attributes to Taplytics
+         * @param key
+         * @param value
+         * @returns {string}
+         */
+        function setUserAttribute(key, value) {
+            if (isInitialized) {
+                try {
+                    var attributes = {};
+                    attributes[key] = value;
+                    Taplytics.identify(attributes);
+                    return 'Successfully called setUserAttribute API on ' + name;
                 }
-            } catch (e) {
-                return 'Failed to call setUserIdentity on ' + name + ' ' + e;
+                catch (e) {
+                    return 'Failed to call SET setUserAttribute on ' + name + ' ' + e;
+                }
             }
-        } else {
-            return (
-                "Can't call setUserIdentity on forwarder " +
-                name +
-                ', not initialized'
-            );
+            else {
+                return 'Can\'t call setUserAttribute on forwarder ' + name + ', not initialized';
+            }
         }
-    }
 
-    /**
-     * Sets user attributes to Taplytics
-     * @param key
-     * @param value
-     * @returns {string}
-     */
-    function setUserAttribute(key, value) {
-        if (isInitialized) {
-            try {
+        /**
+         * Remove user attribute by setting it to null
+         * @param key
+         */
+        function removeUserAttribute(key) {
+            setUserAttribute(key, null);
+        }
+
+        /**
+         * V2 version of setting user identity
+         * @param user
+         * @returns {string}
+         */
+        function onUserIdentified(user) {
+            if (isInitialized) {
+                var identities = user.getUserIdentities().userIdentities;
                 var attributes = {};
-                attributes[key] = value;
-                Taplytics.identify(attributes);
-                return 'Successfully called setUserAttribute API on ' + name;
-            } catch (e) {
-                return (
-                    'Failed to call SET setUserAttribute on ' + name + ' ' + e
-                );
+                if (identities.customerid) {
+                    attributes.user_id = identities.customerid;
+                }
+                if (identities.email) {
+                    attributes.email = identities.email;
+                }
+                if (!isEmpty(attributes)) {
+                    Taplytics.identify(attributes);
+                }
             }
+            else {
+                return 'Can\'t call onUserIdentified on forwarder ' + name + ', not initialized';
+            }
+        }
+
+        this.init = initForwarder;
+        this.process = processEvent;
+        this.setUserIdentity = setUserIdentity;
+        this.setUserAttribute = setUserAttribute;
+        this.removeUserAttribute = removeUserAttribute;
+        this.onUserIdentified = onUserIdentified;
+    };
+
+    function getId() {
+        return moduleId;
+    }
+
+    function register(config) {
+        if (!config) {
+            console.log('You must pass a config object to register the kit ' + name);
+            return;
+        }
+
+        if (!isobject(config)) {
+            console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
+
+        if (isobject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
         } else {
-            return (
-                "Can't call setUserAttribute on forwarder " +
-                name +
-                ', not initialized'
-            );
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
         }
     }
 
-    /**
-     * Remove user attribute by setting it to null
-     * @param key
-     */
-    function removeUserAttribute(key) {
-        setUserAttribute(key, null);
-    }
-
-    /**
-     * V2 version of setting user identity
-     * @param user
-     * @returns {string}
-     */
-    function onUserIdentified(user) {
-        if (isInitialized) {
-            var identities = user.getUserIdentities().userIdentities;
-            var attributes = {};
-            if (identities.customerid) {
-                attributes.user_id = identities.customerid;
-            }
-            if (identities.email) {
-                attributes.email = identities.email;
-            }
-            if (!isEmpty(attributes)) {
-                Taplytics.identify(attributes);
-            }
-        } else {
-            return (
-                "Can't call onUserIdentified on forwarder " +
-                name +
-                ', not initialized'
-            );
-        }
-    }
-
-    this.init = initForwarder;
-    this.process = processEvent;
-    this.setUserIdentity = setUserIdentity;
-    this.setUserAttribute = setUserAttribute;
-    this.removeUserAttribute = removeUserAttribute;
-    this.onUserIdentified = onUserIdentified;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        console.log(
-            'You must pass a config object to register the kit ' + name
-        );
-        return;
-    }
-
-    if (!isobject(config)) {
-        console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isobject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };

--- a/kits/twitter/src/TwitterEventForwarder.js
+++ b/kits/twitter/src/TwitterEventForwarder.js
@@ -12,155 +12,149 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var name = 'Twitter',
-    moduleId = 43,
-    MessageType = {
-        PageView: 3,
-        PageEvent: 4,
-    };
+    var name = 'Twitter',
+        moduleId = 43,
+        MessageType = {
+            PageView    : 3,
+            PageEvent   : 4
+        };
 
-var constructor = function() {
-    var self = this,
-        isInitialized = false,
-        forwarderSettings = null,
-        reportingService = null,
-        isTesting = false,
-        eventQueue = [];
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            forwarderSettings = null,
+            reportingService = null,
+            isTesting = false,
+            eventQueue = [];
 
-    self.name = name;
+        self.name = name;
 
-    function initForwarder(settings, service, testMode) {
-        forwarderSettings = settings;
-        reportingService = service;
-        isTesting = testMode;
-        d = document;
+        function initForwarder(settings, service, testMode) {
+            forwarderSettings = settings;
+            reportingService  = service;
+            isTesting         = testMode;
+            d = document;
 
-        try {
-            if (!testMode) {
-                (function() {
-                    var w, d, s, e;
+            try {
+                if (!testMode) {
+                    (function() {
+                        var w, d, s, e;
 
-                    w = window;
+                        w = window;
 
-                    if (!w.twttr) {
-                        d = document;
-                        s = document.createElement('script');
-                        s.type = 'text/javascript';
-                        s.src = '//platform.twitter.com/oct.js';
-                        s.onload = function() {
-                            if (twttr && eventQueue.length > 0) {
-                                for (var i = 0; i < eventQueue.length; i++) {
-                                    processEvent(eventQueue[i]);
+                        if(!w.twttr) {
+                            d       = document;
+                            s       = document.createElement('script');
+                            s.type  = 'text/javascript';
+                            s.src   = '//platform.twitter.com/oct.js';
+                            s.onload = function () {
+                                if(twttr && eventQueue.length > 0) {
+                                    for (var i = 0; i < eventQueue.length; i++) {
+                                        processEvent(eventQueue[i]);
+                                    }
+
+                                    eventQueue = [];
                                 }
+                            };
 
-                                eventQueue = [];
-                            }
-                        };
+                            e       = d.getElementsByTagName('script')[0];
 
-                        e = d.getElementsByTagName('script')[0];
+                            e.parentNode.insertBefore(s, e);
+                        }
+                    })();
+                }
 
-                        e.parentNode.insertBefore(s, e);
-                    }
-                })();
+                isInitialized = true;
+
+                return 'Successfully initialized: ' + name;
+
+            } catch (e) {
+                return 'Can\'t initialize forwarder: '+ name +':' + e;
+            }
+        }
+
+        function processEvent(event) {
+            var reportEvent = false;
+
+            if(!isInitialized) {
+                return 'Can\'t send forwarder '+ name + ', not initialized';
             }
 
-            isInitialized = true;
+            if(!window.twttr) {
+                eventQueue.push(event);
+                return;
+            }
 
-            return 'Successfully initialized: ' + name;
-        } catch (e) {
-            return "Can't initialize forwarder: " + name + ':' + e;
+            try {
+                if (event.EventDataType === MessageType.PageView || event.EventDataType === MessageType.PageEvent) {
+                    reportEvent = true;
+                    logEvent(event);
+                }
+
+                if(reportEvent && reportingService) {
+                    reportingService(self, event);
+                }
+
+                return 'Successfully sent to forwarder ' + name;
+            } catch (error) {
+                return 'Can\'t send to forwarder: ' + name + ' ' + e;
+            }
         }
+
+        function logEvent(event) {
+            twttr.conversion.trackPid(forwarderSettings.pixelId);
+        }
+
+        this.init       = initForwarder;
+        this.process    = processEvent;
+    };
+
+    function getId() {
+        return moduleId;
     }
 
-    function processEvent(event) {
-        var reportEvent = false;
-
-        if (!isInitialized) {
-            return "Can't send forwarder " + name + ', not initialized';
-        }
-
-        if (!window.twttr) {
-            eventQueue.push(event);
+    function register(config) {
+        if (!config) {
+            window.console.log('You must pass a config object to register the kit ' + name);
             return;
         }
 
-        try {
-            if (
-                event.EventDataType === MessageType.PageView ||
-                event.EventDataType === MessageType.PageEvent
-            ) {
-                reportEvent = true;
-                logEvent(event);
-            }
+        if (!isObject(config)) {
+            window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
+            return;
+        }
 
-            if (reportEvent && reportingService) {
-                reportingService(self, event);
-            }
+        if (isObject(config.kits)) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        } else {
+            config.kits = {};
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+        window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
 
-            return 'Successfully sent to forwarder ' + name;
-        } catch (error) {
-            return "Can't send to forwarder: " + name + ' ' + e;
+    if (typeof window !== 'undefined') {
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
         }
     }
 
-    function logEvent(event) {
-        twttr.conversion.trackPid(forwarderSettings.pixelId);
-    }
-
-    this.init = initForwarder;
-    this.process = processEvent;
-};
-
-function getId() {
-    return moduleId;
-}
-
-function register(config) {
-    if (!config) {
-        window.console.log(
-            'You must pass a config object to register the kit ' + name
+    function isObject(val) {
+        return (
+            val != null &&
+            typeof val === 'object' &&
+            Array.isArray(val) === false
         );
-        return;
     }
 
-    if (!isObject(config)) {
-        window.console.log(
-            "'config' must be an object. You passed in a " + typeof config
-        );
-        return;
-    }
-
-    if (isObject(config.kits)) {
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    } else {
-        config.kits = {};
-        config.kits[name] = {
-            constructor: constructor,
-        };
-    }
-    window.console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
-    );
-}
-
-if (typeof window !== 'undefined') {
-    if (window && window.mParticle && window.mParticle.addForwarder) {
-        window.mParticle.addForwarder({
-            name: name,
-            constructor: constructor,
-            getId: getId,
-        });
-    }
-}
-
-function isObject(val) {
-    return (
-        val != null && typeof val === 'object' && Array.isArray(val) === false
-    );
-}
-
-module.exports = {
-    register: register,
-};
+    module.exports = {
+        register: register
+    };


### PR DESCRIPTION
## Background

This is a draft inspection PR for reviewing the 19 kits previously classified as `Major source drift` before generating first-release `dist/` files for the v3 monorepo track.

No generated `dist/**`, `node_modules/**`, or build artifacts are included.

## Kits Synced

1. Adwords — `kits/adwords` from `mparticle-javascript-integration-adwords` `master`
2. Criteo — `kits/criteo` from `mparticle-javascript-integration-criteo` `master`
3. Device Match — `kits/device-match` from `mparticle-javascript-integration-device-match` `master`
4. DoubleClick — `kits/doubleclick` from `mparticle-javascript-integration-doubleclick` `master`
5. Facebook — `kits/facebook` from `mparticle-javascript-integration-facebook` `master`
6. Heap — `kits/heap` from `mparticle-javascript-integration-heap` `main`
7. ID5 1 — `kits/id5/id5-1` from `mparticle-javascript-integration-id5` `main`
8. Inspectlet — `kits/inspectlet` from `mparticle-javascript-integration-inspectlet` `master`
9. Intercom — `kits/intercom` from `mparticle-javascript-integration-intercom` `master`
10. KissMetrics — `kits/kissmetrics` from `mparticle-javascript-integration-kissmetrics` `master`
11. Leanplum 1 — `kits/leanplum/leanplum-1` from `mparticle-javascript-integration-leanplum` `master`
12. Localytics 4 — `kits/localytics/localytics-4` from `mparticle-javascript-integration-localytics` `master`
13. OneTrust — `kits/onetrust` from `mparticle-javascript-integration-onetrust` `master`
14. Optimizely — `kits/optimizely` from `mparticle-javascript-integration-optimizely` `master`
15. SimpleReach — `kits/simplereach` from `mparticle-javascript-integration-simplereach` `master`
16. Taplytics — `kits/taplytics` from `mparticle-javascript-integration-taplytics` `master`
17. Twitter — `kits/twitter` from `mparticle-javascript-integration-twitter` `master`
18. Google Analytics 4 — `kits/google-analytics-4` from `mparticle-javascript-integration-google-analytics-4` `master`
19. Adobe — `kits/adobe` from `mparticle-javascript-integration-adobe` `master`

Excluded by request: Braze 6, Google Tag Manager, Rokt, and minor/formatting-only/identical kits.

## Diff Stats

- 52 tracked source files changed
- 3,143 insertions / 3,862 deletions
- Changes are scoped to kit `src/**` files, plus Adobe Heartbeat/AdobeClient/AdobeServer source package directories

## Monorepo Adaptation Notes

- Preserved existing monorepo package manifests and lockfiles, including repository metadata, nested kit package names, peer dependency model, root scripts, and package directory conventions.
- Did not copy standalone `.github`, release configs, semantic-release files, `dist`, `node_modules`, or build outputs.
- Did not copy Facebook test changes because the diff was whitespace-only after comparison.
- Did not copy the standalone Adobe server test change that removed `suffix: 'Server'`; this suffix is required by the monorepo test/config shape. Adobe source changes are included.
- Normalized trailing whitespace/line endings in copied source so `git diff --check` passes.

## Verification

Focused verification was run for the required representative set:

- `kits/adobe`: `npm ci`, `npm run build`, `npm test`
- `kits/google-analytics-4`: `npm ci`, `npm run build`, `npm test`
- `kits/kissmetrics`: `npm ci`, `npm run build`, `npm test`
- `kits/heap`: `npm ci`, `npm run build`, `npm test`
- `kits/adwords`: `npm ci`, `npm run build`, `npm test`
- `git diff --check`

Results:

- All final verification commands passed.
- Adobe `npm test` initially failed after copying the standalone test change that removed `suffix: 'Server'`; preserving the monorepo-specific suffix fixed the suite, and the rerun passed.
- GA4 tests emitted expected console error logs for invalid commerce-event test cases, but the test command exited successfully.

Not run due to PR size/time: install/build/test for the other 14 changed kits.