### PR TITLE
fix: correct kit package files metadata

### DIFF
--- a/kits/adobe-target/package.json
+++ b/kits/adobe-target/package.json
@@ -11,7 +11,7 @@
   "main": "dist/AdobeTarget-Kit.common.js",
   "browser": "dist/AdobeTarget-Kit.common.js",
   "files": [
-    "dist/AdobeTarget-Kit.common.jss"
+    "dist/AdobeTarget-Kit.common.js"
   ],
   "devDependencies": {
     "@mparticle/web-kit-wrapper": "^1.0.5",

--- a/kits/adwords/package.json
+++ b/kits/adwords/package.json
@@ -6,7 +6,7 @@
     "main": "dist/GoogleAdWordsEventForwarder.common.js",
     "browser": "dist/GoogleAdWordsEventForwarder.common.js",
     "files": [
-        "dist/GoogleAdWordsEventForwarder.common..js"
+        "dist/GoogleAdWordsEventForwarder.common.js"
     ],
     "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-adwords",
     "scripts": {

--- a/kits/google-analytics-4/packages/GA4Client/package.json
+++ b/kits/google-analytics-4/packages/GA4Client/package.json
@@ -6,7 +6,7 @@
     "main": "dist/GoogleAnalytics4EventForwarderClientSide-Kit.common.js",
     "browser": "dist/GoogleAnalytics4EventForwarderClientSide-Kit.common.js",
     "files": [
-        "dist/GoogleAnalyticsEvent4ForwarderClientSide-Kit.common.js"
+        "dist/GoogleAnalytics4EventForwarderClientSide-Kit.common.js"
     ],
     "scripts": {
         "build": "ENVIRONMENT=production rollup --config rollup.config.js",


### PR DESCRIPTION
## Summary
- Correct three kit package `files` entries so published package metadata points to the existing CommonJS bundle names.
- Align the `files` entries with each package's `main` and `browser` fields.

## Test plan
- Ran a lightweight Node JSON parse/alignment check for the three changed package files.
- No full build run; metadata-only package.json changes.