### PR TITLE
feat: remove deprecated removeCCPAState method

### DIFF
--- a/src/consent.ts
+++ b/src/consent.ts
@@ -9,7 +9,6 @@ import KitFilterHelper from './kitFilterHelper';
 import Constants from './constants';
 import { IMParticleUser } from './identity-user-interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
-import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 
 const { CCPAPurpose } = Constants;
 

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -98,10 +98,7 @@ export interface IConsentRules {
     values: IConsentRulesValues[];
 }
 
-// TODO: Remove this if we can safely deprecate `removeCCPAState`
-export interface IConsentState extends ConsentState {
-    removeCCPAState: () => ConsentState;
-}
+export interface IConsentState extends ConsentState {}
 
 // Represents Actual Interface for Consent Module
 // TODO: Should eventually consolidate with SDKConsentStateApi
@@ -339,7 +336,6 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
                 consentState.getCCPAConsentState()
             );
 
-            // TODO: Remove casting once `removeCCPAState` is removed;
             return consentStateCopy as IConsentState;
         }
 
@@ -504,20 +500,6 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
             return this;
         }
 
-        // TODO: Can we remove this? It is deprecated.
-        function removeCCPAState(this: ConsentState) {
-            logDeprecatedMethodUsage(
-                {
-                    methodName: 'Consent.removeCCPAState',
-                    warningMessage: 'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead',
-                },
-                mpInstance.Logger,
-                mpInstance._ErrorReportingDispatcher
-            );
-            // @ts-ignore
-            return removeCCPAConsentState();
-        }
-
         return {
             setGDPRConsentState,
             addGDPRConsentState,
@@ -525,7 +507,6 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
             getCCPAConsentState,
             getGDPRConsentState,
             removeGDPRConsentState,
-            removeCCPAState, // TODO: Can we remove? This is deprecated
             removeCCPAConsentState,
         };
     };

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -98,8 +98,6 @@ export interface IConsentRules {
     values: IConsentRulesValues[];
 }
 
-export interface IConsentState extends ConsentState {}
-
 // Represents Actual Interface for Consent Module
 // TODO: Should eventually consolidate with SDKConsentStateApi
 export interface IConsent {
@@ -323,7 +321,7 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
     this.createConsentState = function(
         this: ConsentState,
         consentState?: ConsentState
-    ): IConsentState {
+    ): ConsentState {
         let gdpr = {};
         let ccpa = {};
 
@@ -336,7 +334,7 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
                 consentState.getCCPAConsentState()
             );
 
-            return consentStateCopy as IConsentState;
+            return consentStateCopy as ConsentState;
         }
 
         function canonicalizeForDeduplication(purpose: string): string {

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -334,7 +334,7 @@ export default function Consent(this: IConsent, mpInstance: IMParticleWebSDKInst
                 consentState.getCCPAConsentState()
             );
 
-            return consentStateCopy as ConsentState;
+            return consentStateCopy;
         }
 
         function canonicalizeForDeduplication(purpose: string): string {

--- a/test/src/tests-consent.ts
+++ b/test/src/tests-consent.ts
@@ -660,39 +660,4 @@ describe('Consent', function() {
         testEvent.consent_state.gdpr['test purpose'].should.have.property('hardware_id', 'hardware');
     });
 
-    // TODO: Deprecate in next major version
-    it('Should log deprecated message when using removeCCPAState', () => {
-        const bond = sinon.spy(mParticle.getInstance().Logger, 'warning');
-        const consentState = mParticle
-            .getInstance()
-            .Consent.createConsentState();
-        expect(consentState).to.be.ok;
-
-        consentState.setCCPAConsentState(
-            mParticle.Consent.createCCPAConsent(false)
-        );
-
-        expect(consentState.getCCPAConsentState()).to.have.property(
-            'Consented'
-        );
-        expect(consentState.getCCPAConsentState()).to.have.property(
-            'ConsentDocument'
-        );
-        expect(consentState.getCCPAConsentState()).to.have.property(
-            'HardwareId'
-        );
-        expect(consentState.getCCPAConsentState()).to.have.property('Location');
-        expect(consentState.getCCPAConsentState()).to.have.property(
-            'Timestamp'
-        );
-
-        // FIXME: Remove when deprecating removeCCPAState
-        ((consentState as unknown) as any).removeCCPAState();
-        (consentState.getCCPAConsentState() === undefined).should.equal(true);
-
-        bond.called.should.eql(true);
-        bond.getCalls()[0].args[0].should.eql(
-            'removeCCPAState is deprecated and will be removed in a future release; use removeCCPAConsentState instead'
-        );
-    });
 });


### PR DESCRIPTION
## Summary
- Removes deprecated `Consent.removeCCPAState` (use `removeCCPAConsentState`) from [#1237](https://github.com/mParticle/mparticle-web-sdk/pull/1237)
- Removes redundant `IConsentState` interface and related TODO cast cleanup

## Stack
Stacked on [#1314](https://github.com/mParticle/mparticle-web-sdk/pull/1314) (`breaking/remove-deprecated-commerce-apis`). Merge #1314 first, then this PR (base will retarget to `main` after #1314 merges, or retarget manually).

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] Jest passes
- [ ] Karma consent tests in CI