### PR TITLE
feat(rokt): type sessionId and sessionToken on launcherOptions

### DIFF
--- a/src/roktLauncherOptions.ts
+++ b/src/roktLauncherOptions.ts
@@ -5,6 +5,8 @@ export interface IRoktLauncherOptions extends Dictionary<any> {
     noDeviceID?: boolean;
     noFunctional?: boolean;
     noTargeting?: boolean;
+    sessionId?: string;
+    sessionToken?: string;
 }
 
 export function normalizeRoktLauncherOptions(

--- a/test/jest/roktLauncherOptions.spec.ts
+++ b/test/jest/roktLauncherOptions.spec.ts
@@ -45,4 +45,34 @@ describe('normalizeRoktLauncherOptions', () => {
         expect(launcherOptions.noFunctional).toBe(true);
         expect(launcherOptions.noTargeting).toBe(true);
     });
+
+    it('should preserve sessionId and sessionToken through normalization', () => {
+        const launcherOptions = {
+            sessionId: '0198c1a2-3b4c-7d5e-8f90-1a2b3c4d5e6f',
+            sessionToken: 'header.payload.signature',
+            noFunctional: false,
+        };
+
+        expect(normalizeRoktLauncherOptions(launcherOptions)).toEqual(
+            launcherOptions
+        );
+    });
+
+    it('should preserve sessionId and sessionToken when expanding noDeviceId', () => {
+        const launcherOptions = normalizeRoktLauncherOptions({
+            sessionId: '0198c1a2-3b4c-7d5e-8f90-1a2b3c4d5e6f',
+            sessionToken: 'header.payload.signature',
+            noDeviceId: true,
+            noFunctional: false,
+            noTargeting: false,
+        });
+
+        expect(launcherOptions.sessionId).toBe(
+            '0198c1a2-3b4c-7d5e-8f90-1a2b3c4d5e6f'
+        );
+        expect(launcherOptions.sessionToken).toBe('header.payload.signature');
+        expect(launcherOptions.noDeviceId).toBe(true);
+        expect(launcherOptions.noFunctional).toBe(true);
+        expect(launcherOptions.noTargeting).toBe(true);
+    });
 });

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -409,6 +409,29 @@ describe('RoktManager', () => {
             expect(roktManager['launcherOptions']).toEqual(expectedOptions);
         });
 
+        it('should preserve sessionId and sessionToken in launcher options', () => {
+            const launcherOptions = {
+                sessionId: '0198c1a2-3b4c-7d5e-8f90-1a2b3c4d5e6f',
+                sessionToken: 'header.payload.signature',
+            };
+
+            roktManager.init(
+                {} as IKitConfigs,
+                undefined,
+                mockMPInstance.Identity,
+                mockMPInstance._Store,
+                mockMPInstance.Logger,
+                {
+                    launcherOptions,
+                }
+            );
+
+            expect(roktManager['launcherOptions']).toEqual({
+                sandbox: false,
+                ...launcherOptions,
+            });
+        });
+
         it('should initialize the manager with default launcher options not provided', () => {
             roktManager.init(
                 {} as IKitConfigs,


### PR DESCRIPTION
Expose Rokt new-world session continuity fields on IRoktLauncherOptions so partners can seed createLauncher with a JWT alongside sessionId. normalize already spreads unknown keys; this makes the contract explicit and tested.

## Background
- Rokt TGW new-world session continuity requires partners to pass both `sessionId` and a short-lived JWT `sessionToken` into launcher creation so the first offers/events call can authorize with `Authorization: Bearer …`.
- Docs already describe seeding these via `mParticle.config.launcherOptions` / `createLauncher`, but `IRoktLauncherOptions` only typed privacy flags (`noDeviceID`, `noFunctional`, `noTargeting`).
- Runtime already preserves unknown keys through `normalizeRoktLauncherOptions` / RoktManager init; partners could pass the fields untyped. This PR makes the contract explicit in TypeScript and adds coverage so we don’t regress the handoff.

## What Has Changed
- Added optional `sessionId?: string` and `sessionToken?: string` to `IRoktLauncherOptions`.
- Added unit tests that `normalizeRoktLauncherOptions` preserves both fields (including when expanding `noDeviceId`).
- Added a RoktManager init test that `sessionId` / `sessionToken` from config survive into stored launcher options (alongside default `sandbox: false`).
- No runtime behavior change beyond typing + tests; kit passthrough of launcher options is unchanged.

## Screenshots/Video
- N/A (types + unit tests only)

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- Companion kit branch (test-only assert of passthrough): `feature/rokt-kit-launcher-session-token` on `mparticle-javascript-integration-rokt`.
- Aligns with Rokt Web SDK IL `sessionToken` support and documented `launcherOptions` / `createLauncher` contract (`sessionId` + `sessionToken`).
- Docs already cover the partner surface (rokt-docs); no mParticle docs change in this PR.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]