### PR TITLE
feat(rokt): expose terminate on the window.mParticle.Rokt interface

### DIFF
--- a/src/roktManager.ts
+++ b/src/roktManager.ts
@@ -83,6 +83,9 @@ export interface IRoktKit {
     setExtensionData<T>(extensionData: IRoktPartnerExtensionData<T>): void;
     use: <T>(name: string) => Promise<T>;
     onShoppableAdsReady(callback: () => void): void;
+    // Optional because the Rokt Kit ships on its own release cadence; a kit
+    // published before terminate() existed will not implement it.
+    terminate?: () => Promise<void>;
     launcherOptions?: Dictionary<any>;
     settings?: IRoktKitSettings;
     integrationName?: string;
@@ -476,6 +479,40 @@ export default class RoktManager {
             return this.kit.use<T>(name);
         } catch (error) {
             return Promise.reject(error instanceof Error ? error : new Error('Error using extension: ' + name));
+        }
+    }
+
+    /**
+     * Tears down the current Rokt launcher and removes the placements it rendered.
+     *
+     * Intended for hosts that cannot simply destroy the container element —
+     * SPA route changes and confirmation pages, for example.
+     *
+     * Unlike the other proxied methods, a call made before the kit is ready is
+     * *not* queued. Replaying a teardown against a launcher created later would
+     * silently tear down placements the caller never asked to remove; with no
+     * launcher there is nothing to terminate, so this resolves as a no-op.
+     *
+     * @example
+     * await window.mParticle.Rokt.terminate();
+     *
+     * @returns {Promise<void>} Resolves once the launcher has torn down. Never rejects.
+     */
+    public async terminate(): Promise<void> {
+        if (!this.isReady()) {
+            this.logger?.verbose('mParticle.Rokt.terminate called before the Rokt kit was ready. Nothing to terminate.');
+            return;
+        }
+
+        if (!isFunction(this.kit.terminate)) {
+            this.logger?.error('mParticle.Rokt.terminate is not supported by the attached Rokt Kit version.');
+            return;
+        }
+
+        try {
+            await this.kit.terminate();
+        } catch (error) {
+            this.logger?.error(`Failed to terminate the Rokt launcher: ${getErrorMessage(error)}`);
         }
     }
 

--- a/test/jest/roktManager.spec.ts
+++ b/test/jest/roktManager.spec.ts
@@ -3007,6 +3007,106 @@ describe('RoktManager', () => {
         });
     });
 
+    describe('#terminate', () => {
+        const makeKit = (): IRoktKit => ({
+            launcher: {
+                selectPlacements: jest.fn(),
+                hashAttributes: jest.fn(),
+                use: jest.fn(),
+            },
+            filters: undefined,
+            filteredUser: undefined,
+            userAttributes: undefined,
+            selectPlacements: jest.fn(),
+            hashAttributes: jest.fn(),
+            setExtensionData: jest.fn(),
+            use: jest.fn(),
+            onShoppableAdsReady: jest.fn(),
+            terminate: jest.fn().mockResolvedValue(undefined),
+        });
+
+        it('should call kit.terminate when a kit and launcher are attached', async () => {
+            const kit = makeKit();
+            roktManager.attachKit(kit);
+
+            await roktManager.terminate();
+
+            expect(kit.terminate).toHaveBeenCalledTimes(1);
+        });
+
+        it('should await the kit terminate promise before resolving', async () => {
+            const kit = makeKit();
+            let settled = false;
+            (kit.terminate as jest.Mock).mockImplementation(
+                () => new Promise<void>(resolve => setTimeout(() => {
+                    settled = true;
+                    resolve();
+                }, 0))
+            );
+            roktManager.attachKit(kit);
+
+            await roktManager.terminate();
+
+            expect(settled).toBe(true);
+        });
+
+        it('should resolve as a no-op and not queue when no kit is attached', async () => {
+            await expect(roktManager.terminate()).resolves.toBeUndefined();
+
+            expect(roktManager['kit']).toBeNull();
+            expect(roktManager['messageQueue'].size).toBe(0);
+            expect(mockMPInstance.Logger.verbose).toHaveBeenCalledWith(
+                'mParticle.Rokt.terminate called before the Rokt kit was ready. Nothing to terminate.'
+            );
+        });
+
+        it('should resolve as a no-op when a kit is attached without a launcher', async () => {
+            const kit = makeKit();
+            kit.launcher = null;
+            roktManager.attachKit(kit);
+
+            await expect(roktManager.terminate()).resolves.toBeUndefined();
+
+            expect(kit.terminate).not.toHaveBeenCalled();
+            expect(roktManager['messageQueue'].size).toBe(0);
+        });
+
+        it('should log an error when the attached kit predates terminate support', async () => {
+            const kit = makeKit();
+            delete kit.terminate;
+            roktManager.attachKit(kit);
+
+            await expect(roktManager.terminate()).resolves.toBeUndefined();
+
+            expect(mockMPInstance.Logger.error).toHaveBeenCalledWith(
+                'mParticle.Rokt.terminate is not supported by the attached Rokt Kit version.'
+            );
+        });
+
+        it('should log an error and resolve when kit.terminate rejects', async () => {
+            const kit = makeKit();
+            (kit.terminate as jest.Mock).mockRejectedValue(new Error('teardown failed'));
+            roktManager.attachKit(kit);
+
+            await expect(roktManager.terminate()).resolves.toBeUndefined();
+
+            expect(mockMPInstance.Logger.error).toHaveBeenCalledWith(
+                'Failed to terminate the Rokt launcher: teardown failed'
+            );
+        });
+
+        it('should stay ready so repeat calls keep reaching the kit', async () => {
+            const kit = makeKit();
+            roktManager.attachKit(kit);
+
+            await roktManager.terminate();
+            await roktManager.terminate();
+
+            expect(roktManager.isReady()).toBe(true);
+            expect(kit.terminate).toHaveBeenCalledTimes(2);
+        });
+    });
+
     describe('#onShoppableAdsReady', () => {
         const makeKit = (): IRoktKit => ({
             launcher: {


### PR DESCRIPTION
## Summary

Adds `RoktManager.terminate()`, exposing `window.mParticle.Rokt.terminate()` as a supported teardown path for partners who cannot simply destroy the container element — SPA route changes and confirmation pages in particular.

Today partners reach for the undocumented `window.Rokt.currentLauncher?.terminate()`. This routes the same call through the documented interface.

Pairs with mparticle-integrations/mparticle-javascript-integration-rokt#122, which adds the `terminate()` the manager delegates to. **That PR should merge and release first** — until a kit carrying it is on the page, this method logs that the attached kit version does not support terminate.

## Changes

- `RoktManager.terminate(): Promise<void>` — delegates to `this.kit.terminate()`, which forwards to the Rokt launcher.
- `IRoktKit.terminate` added as **optional**, guarded at the call site with `isFunction`. The Rokt Kit releases on its own cadence, so a kit published before this change genuinely will not implement it — version skew is real rather than theoretical.

`IRoktLauncher` is untouched: the manager only ever calls through the kit, and the kit owns the launcher-facing type.

## Behaviour

| State | Result |
|---|---|
| Kit + launcher attached | `await`s `kit.terminate()` |
| Nothing attached | Resolves as a no-op, logs verbose |
| Kit attached, no launcher | Resolves as a no-op |
| Kit predates `terminate` | Resolves, logs error |
| `kit.terminate()` rejects | Resolves, logs error |

`terminate()` never rejects — teardown should not be something callers have to defend against.

### A pre-ready call is not queued

Every other proxied method uses `deferredCall` when the kit isn't ready. `terminate` deliberately does not. Replaying a teardown against a launcher created *later* would silently tear down placements the caller never asked to remove; with no launcher there is nothing to terminate, so the call resolves as a no-op instead. This asymmetry is called out in the method's doc comment and pinned by tests.

## Also fixes a latent snippet bug

`terminate` is already in the snippet's `roktMethods` stub list (`snippet.js`), so a snippet-loaded page could queue `Rokt.terminate()` before init. At flush time `processPreloadedItem` hit an undefined method, threw, and `processReadyQueue` logged `Unable to compute proper mParticle function`. That path now dispatches correctly.

⚠️ **`getVersion` has the same latent gap** — it is in the snippet stub list but has no `RoktManager` implementation. Left out of scope here; happy to add it in a follow-up if wanted.

## Not included

`kits/rokt/` in this repo is a stale vendored snapshot of the Rokt kit (missing `storage.ts`, `utils.ts`, `pageViewStorage.ts`) and is not loaded by any build or test target, so it was intentionally left untouched. The live kit change is in the companion PR.

## Testing

- `npm run lint` — pass
- `npm run test:jest` — 632/632 across 26 suites
- Karma (ChromeHeadless) — 1087/1087

7 new `#terminate` cases in `test/jest/roktManager.spec.ts` cover each row of the behaviour table above, plus a case asserting the manager stays ready so repeat calls keep reaching the kit. The suite fails to compile against `development` without the source change.

> Note for reviewers running locally: Karma's default config includes `FirefoxHeadless` and aborts the whole run if Firefox isn't installed. Use `npx karma start test/karma.config.js --browsers ChromeHeadless`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
