### PR TITLE
ci: use continuous target-branch check for master

### DIFF
--- a/.github/workflows/reusable-workflows.yml
+++ b/.github/workflows/reusable-workflows.yml
@@ -10,9 +10,11 @@ jobs:
   pr-title-check:
     name: Check PR for semantic title
     uses: mParticle/mparticle-workflows/.github/workflows/pr-title-check.yml@stable
-  pr-branch-target-gitflow:
+  # This repo releases from master, so use the continuous (trunk-based) check.
+  # The gitflow variant only accepts main/build/ and fails on every PR here.
+  pr-branch-target-continuous:
     name: Check PR for semantic target branch
-    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@stable
+    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-continuous.yml@stable
   security-lint-checks:
     name: Security Lint Checks
     uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@stable


### PR DESCRIPTION
## Background

The `Check PR for semantic target branch` check fails on **every** pull request into `master`, including ones that were merged (#1274, #1254, and currently #1329).

The repo calls the **gitflow** variant of the shared check:

```yaml
uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@stable
```

That workflow only accepts `main`, `build/` and `chore/dependabot` branches, and takes no inputs, so `master` can never satisfy it:

```
master
Pull request target branch is not valid.
##[error]Process completed with exit code 1.
```

This repo's default branch is `master` and it releases from `master`, so the gitflow variant is simply the wrong one.

## What Has Changed

Switch to the **continuous** (trunk-based) variant that mParticle already publishes, which accepts `master` in addition to `main`, `build/` and `chore/dependabot`:

```yaml
uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-continuous.yml@stable
```

No other job is touched. Note the displayed check name changes from `Confirm that target branch for PR is main or build/` to `Confirm that target branch for PR is main or master`, so any branch-protection rule pinned to the old name would need updating — though since the old check has never passed on `master`, it cannot currently be a required check.

## Test plan

- [ ] This PR targets `master`, so the check on this PR is itself the test: it should now pass
- [ ] Confirm the other three reusable-workflow jobs still run (branch name, title, security lint)

## Screenshots/Video

- N/A