### PR TITLE
fix(apv): prevent duplicate page views on SPA re-init (stacked wrapper + init guard)

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -57,13 +57,7 @@ import { LoggingDispatcher } from './reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService } from './reporting/types';
 import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 import { normalizeRoktLauncherOptions } from './roktLauncherOptions';
-import { PageViewTracker, WIN_TRACKER_KEY } from './pageViewTracker';
-
-const WIN_INIT_PV_KEY = '__mpApvInitPVLogged__' as const;
-type WindowWithApvFlags = Window & {
-    [WIN_INIT_PV_KEY]?: boolean;
-    [WIN_TRACKER_KEY]?: PageViewTracker;
-};
+import { PageViewTracker, WIN_TRACKER_KEY, WIN_INIT_PV_KEY, WindowWithApvFlags } from './pageViewTracker';
 
 export interface IErrorLogMessage {
     message?: string;

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -304,11 +304,19 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
         );
         instance._Events.stopTracking();
 
-        if (instance._PageViewTracker) {
-            instance._PageViewTracker.teardown();
+        const instanceTracker = instance._PageViewTracker;
+        if (instanceTracker) {
+            instanceTracker.teardown();
             instance._PageViewTracker = undefined;
         }
         const win = window as WindowWithApvFlags;
+        // Tear down any window-registered tracker that differs from the instance
+        // tracker (e.g. left by a previous module load) before clearing the
+        // window flag, so its history wrappers and popstate listener are removed.
+        const windowTracker = win[WIN_TRACKER_KEY];
+        if (windowTracker && windowTracker !== instanceTracker) {
+            windowTracker.teardown();
+        }
         delete win[WIN_INIT_PV_KEY];
         delete win[WIN_TRACKER_KEY];
 
@@ -1600,6 +1608,9 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
         mpInstance._SessionManager.initialize();
         mpInstance._Events.logAST();
 
+        // Note: APV uses window-level singletons (WIN_TRACKER_KEY, WIN_INIT_PV_KEY)
+        // that assume a single active SDK instance. Multiple-instance support is
+        // out of scope for this Rokt/legacy APV feature.
         if (getFeatureFlag(AutoLogPageView)) {
             if (!mpInstance._PageViewTracker) {
                 mpInstance.Logger.verbose(
@@ -1627,6 +1638,8 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
             }
             mpInstance._PageViewTracker.init();
         } else if (mpInstance._PageViewTracker) {
+            // AutoLogPageView was disabled on re-init: tear down the active tracker
+            // so it stops listening. Re-created if the flag is re-enabled later.
             mpInstance._PageViewTracker.teardown();
         }
 

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -1595,7 +1595,7 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
 
         // Note: APV uses window-level singletons (WIN_TRACKER_KEY, WIN_INIT_PV_KEY)
         // that assume a single active SDK instance. Multiple-instance support is
-        // out of scope for this Rokt/legacy APV feature.
+        // out of scope
         if (getFeatureFlag(AutoLogPageView)) {
             if (!mpInstance._PageViewTracker) {
                 mpInstance.Logger.verbose(

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -57,7 +57,13 @@ import { LoggingDispatcher } from './reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService } from './reporting/types';
 import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 import { normalizeRoktLauncherOptions } from './roktLauncherOptions';
-import { PageViewTracker } from './pageViewTracker';
+import { PageViewTracker, WIN_TRACKER_KEY } from './pageViewTracker';
+
+const WIN_INIT_PV_KEY = '__mpApvInitPVLogged__' as const;
+type WindowWithApvFlags = Window & {
+    [WIN_INIT_PV_KEY]?: boolean;
+    [WIN_TRACKER_KEY]?: PageViewTracker;
+};
 
 export interface IErrorLogMessage {
     message?: string;
@@ -297,6 +303,15 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             window.localStorage
         );
         instance._Events.stopTracking();
+
+        if (instance._PageViewTracker) {
+            instance._PageViewTracker.teardown();
+            instance._PageViewTracker = undefined;
+        }
+        const win = window as WindowWithApvFlags;
+        delete win[WIN_INIT_PV_KEY];
+        delete win[WIN_TRACKER_KEY];
+
         if (!keepPersistence) {
             instance._Persistence.resetPersistence();
         }
@@ -1586,10 +1601,29 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
         mpInstance._Events.logAST();
 
         if (getFeatureFlag(AutoLogPageView)) {
-            mpInstance._Events.logPageView();
-
             if (!mpInstance._PageViewTracker) {
+                mpInstance.Logger.verbose(
+                    'mParticle APV: [sdk-init] creating new PageViewTracker for this instance'
+                );
                 mpInstance._PageViewTracker = new PageViewTracker(mpInstance);
+
+                // Fire the initial page view once per page load (hard navigation).
+                // window[WIN_INIT_PV_KEY] survives module re-evaluation so
+                // repeated mParticle.init() calls from SPA re-renders don't
+                // fire duplicate logPageView() events for the same page.
+                const win = window as WindowWithApvFlags;
+                if (win[WIN_INIT_PV_KEY]) {
+                    mpInstance.Logger.verbose(
+                        'mParticle APV: [sdk-init] initial page view already logged this page load, skipping'
+                    );
+                } else {
+                    win[WIN_INIT_PV_KEY] = true;
+                    mpInstance._Events.logPageView();
+                }
+            } else {
+                mpInstance.Logger.verbose(
+                    'mParticle APV: [sdk-init] tracker already on this instance, skipping logPageView'
+                );
             }
             mpInstance._PageViewTracker.init();
         } else if (mpInstance._PageViewTracker) {

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -57,7 +57,7 @@ import { LoggingDispatcher } from './reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService } from './reporting/types';
 import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 import { normalizeRoktLauncherOptions } from './roktLauncherOptions';
-import { PageViewTracker, WIN_TRACKER_KEY, WIN_INIT_PV_KEY, WindowWithApvFlags } from './pageViewTracker';
+import { PageViewTracker } from './pageViewTracker';
 
 export interface IErrorLogMessage {
     message?: string;
@@ -303,16 +303,7 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
             instanceTracker.teardown();
             instance._PageViewTracker = undefined;
         }
-        const win = window as WindowWithApvFlags;
-        // Tear down any window-registered tracker that differs from the instance
-        // tracker (e.g. left by a previous module load) before clearing the
-        // window flag, so its history wrappers and popstate listener are removed.
-        const windowTracker = win[WIN_TRACKER_KEY];
-        if (windowTracker && windowTracker !== instanceTracker) {
-            windowTracker.teardown();
-        }
-        delete win[WIN_INIT_PV_KEY];
-        delete win[WIN_TRACKER_KEY];
+        PageViewTracker.resetWindowState(instanceTracker);
 
         if (!keepPersistence) {
             instance._Persistence.resetPersistence();
@@ -1613,16 +1604,14 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
                 mpInstance._PageViewTracker = new PageViewTracker(mpInstance);
 
                 // Fire the initial page view once per page load (hard navigation).
-                // window[WIN_INIT_PV_KEY] survives module re-evaluation so
-                // repeated mParticle.init() calls from SPA re-renders don't
-                // fire duplicate logPageView() events for the same page.
-                const win = window as WindowWithApvFlags;
-                if (win[WIN_INIT_PV_KEY]) {
+                // The flag survives module re-evaluation so repeated init() calls
+                // from SPA re-renders don't fire duplicate logPageView() events.
+                if (PageViewTracker.hasInitialPageViewFired()) {
                     mpInstance.Logger.verbose(
                         'mParticle APV: [sdk-init] initial page view already logged this page load, skipping'
                     );
                 } else {
-                    win[WIN_INIT_PV_KEY] = true;
+                    PageViewTracker.markInitialPageViewFired();
                     mpInstance._Events.logPageView();
                 }
             } else {

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -9,6 +9,18 @@ type MarkedHistoryMethod = HistoryStateMethod & {
     [WRAPPED_MARKER]?: boolean;
 };
 
+// window key under which the single active tracker is stored.
+// Survives module re-evaluation (Next.js re-executes the bundle on every SPA
+// navigation, resetting all module-level state, but window persists for the
+// lifetime of the tab).
+export const WIN_TRACKER_KEY = '__mpApvTracker__';
+
+type WindowWithTracker = Window & {
+    [WIN_TRACKER_KEY]?: PageViewTracker;
+};
+
+type NavigationSource = 'pushState' | 'replaceState' | 'popstate';
+
 export class PageViewTracker {
     mpInstance: IMParticleWebSDKInstance;
 
@@ -37,14 +49,24 @@ export class PageViewTracker {
     }
 
     public init(): void {
-        this.mpInstance.Logger.verbose(
-            'mParticle APV: [init] PageViewTracker Init'
-        );
+        this.mpInstance.Logger.verbose('mParticle APV: [init] PageViewTracker Init');
         if (!this.isSupportedEnvironment()) {
             this.mpInstance.Logger.verbose(
                 'mParticle APV: [init] unsupported environment (no History API), not starting'
             );
             return;
+        }
+
+        // Tear down any tracker left over from a previous module load.
+        // window[WIN_TRACKER_KEY] outlives module re-evaluation; this is the
+        // only way to reach a tracker instance in a dead module scope.
+        const win = window as WindowWithTracker;
+        const prev = win[WIN_TRACKER_KEY];
+        if (prev && prev !== this) {
+            this.mpInstance.Logger.verbose(
+                'mParticle APV: [init] found stale tracker from previous module load — tearing down to prevent stacked wrappers'
+            );
+            prev.teardown();
         }
 
         if (this.isActive) {
@@ -65,6 +87,8 @@ export class PageViewTracker {
         this.patchHistoryMethods();
         this.addNavigationListeners();
 
+        (window as WindowWithTracker)[WIN_TRACKER_KEY] = this;
+
         this.mpInstance.Logger.verbose(
             'mParticle APV: [init] patched pushState/replaceState + listening for popstate'
         );
@@ -76,7 +100,7 @@ export class PageViewTracker {
         const installed = window.history.pushState as MarkedHistoryMethod;
         if (installed[WRAPPED_MARKER]) {
             this.mpInstance.Logger.verbose(
-                'mParticle APV: [patch] history already wrapped, skipping to avoid double-wrap'
+                'mParticle APV: [patch] history already wrapped, skipping to avoid double-wrap — STACKED WRAPPER DETECTED'
             );
             return;
         }
@@ -147,7 +171,7 @@ export class PageViewTracker {
         window.addEventListener('popstate', this.popStateListener);
     }
 
-    private safeHandleNavigation(source: string): void {
+    private safeHandleNavigation(source: NavigationSource): void {
         try {
             this.handleNavigation(source);
         } catch (e) {
@@ -161,7 +185,7 @@ export class PageViewTracker {
         return window.location.pathname;
     }
 
-    private handleNavigation(source: string): void {
+    private handleNavigation(source: NavigationSource): void {
         const candidatePath = this.getCurrentKey();
 
         this.mpInstance.Logger.verbose(
@@ -221,47 +245,43 @@ export class PageViewTracker {
         });
     }
 
+    private restoreHistoryMethod(
+        methodName: 'pushState' | 'replaceState',
+        original: HistoryStateMethod | null,
+        wrapper: HistoryStateMethod | null
+    ): void {
+        if (!original) return;
+        const stillOurs = wrapper !== null && window.history[methodName] === wrapper;
+        if (stillOurs) {
+            window.history[methodName] = original;
+            this.mpInstance.Logger.verbose(
+                `mParticle APV: [teardown] restored original ${methodName}`
+            );
+        } else {
+            this.mpInstance.Logger.verbose(
+                `mParticle APV: [teardown] ${methodName} no longer ours; leaving in place, gating callback to no-op`
+            );
+        }
+    }
+
     public teardown(): void {
         if (this.popStateListener) {
             window.removeEventListener('popstate', this.popStateListener);
             this.popStateListener = null;
         }
-        const pushStateStillOurs =
-            this.pushStateWrapper !== null &&
-            window.history.pushState === this.pushStateWrapper;
-        if (this.originalPushState) {
-            if (pushStateStillOurs) {
-                window.history.pushState = this.originalPushState;
-                this.mpInstance.Logger.verbose(
-                    'mParticle APV: [teardown] restored original pushState'
-                );
-            } else {
-                this.mpInstance.Logger.verbose(
-                    'mParticle APV: [teardown] pushState no longer ours; leaving in place, gating callback to no-op'
-                );
-            }
-            this.originalPushState = null;
-            this.pushStateWrapper = null;
-        }
 
-        const replaceStateStillOurs =
-            this.replaceStateWrapper !== null &&
-            window.history.replaceState === this.replaceStateWrapper;
-        if (this.originalReplaceState) {
-            if (replaceStateStillOurs) {
-                window.history.replaceState = this.originalReplaceState;
-                this.mpInstance.Logger.verbose(
-                    'mParticle APV: [teardown] restored original replaceState'
-                );
-            } else {
-                this.mpInstance.Logger.verbose(
-                    'mParticle APV: [teardown] replaceState no longer ours; leaving in place, gating callback to no-op'
-                );
-            }
-            this.originalReplaceState = null;
-            this.replaceStateWrapper = null;
-        }
+        this.restoreHistoryMethod('pushState', this.originalPushState, this.pushStateWrapper);
+        this.originalPushState = null;
+        this.pushStateWrapper = null;
+
+        this.restoreHistoryMethod('replaceState', this.originalReplaceState, this.replaceStateWrapper);
+        this.originalReplaceState = null;
+        this.replaceStateWrapper = null;
 
         this.isActive = false;
+        const win = window as WindowWithTracker;
+        if (win[WIN_TRACKER_KEY] === this) {
+            delete win[WIN_TRACKER_KEY];
+        }
     }
 }

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -108,6 +108,9 @@ export class PageViewTracker {
             this.mpInstance.Logger.verbose(
                 'mParticle APV: [init] starting (teardown-first for idempotency)'
             );
+            // Preserve pending navigations through the self-teardown so a route
+            // change queued before mParticle.init() was called again is not lost.
+            inheritedPaths = [...inheritedPaths, ...this.takePendingNavigations()];
             this.teardown();
         }
 

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -53,6 +53,11 @@ export class PageViewTracker {
     private lastPath: string | null = null;
     private isActive = false;
 
+    private pendingNavigations: Array<{
+        path: string;
+        timeoutId: ReturnType<typeof setTimeout>;
+    }> = [];
+
     private originalPushState: HistoryStateMethod | null = null;
     private originalReplaceState: HistoryStateMethod | null = null;
 
@@ -86,20 +91,17 @@ export class PageViewTracker {
         // Tear down any tracker left over from a previous module load.
         // window[WIN_TRACKER_KEY] outlives module re-evaluation; this is the
         // only way to reach a tracker instance in a dead module scope.
+        // Transfer any pending navigations first so a route change that queued a
+        // deferred fire before module re-evaluation occurs is not silently dropped.
         const win = window as WindowWithApvFlags;
         const prev = win[WIN_TRACKER_KEY];
+        let inheritedPaths: string[] = [];
         if (prev && prev !== this) {
             this.mpInstance.Logger.verbose(
-                'mParticle APV: [init] found stale tracker from previous module load — tearing down to prevent stacked wrappers'
+                'mParticle APV: [init] found stale tracker from previous module load — transferring pending navigations and tearing down'
             );
+            inheritedPaths = prev.takePendingNavigations();
             prev.teardown();
-            // Known limitation: if the previous tracker had already queued a
-            // deferred firePageView() via setTimeout, that callback will abort
-            // (isActive is now false) and the navigation will not be re-fired by
-            // this tracker (it seeds lastPath with the current pathname, so the
-            // destination is treated as already-seen). This sub-ms window is
-            // acceptable: stacking N wrappers after N reloads is worse than
-            // losing a single view on the overlap tick.
         }
 
         if (this.isActive) {
@@ -125,6 +127,21 @@ export class PageViewTracker {
         this.mpInstance.Logger.verbose(
             'mParticle APV: [init] patched pushState/replaceState + listening for popstate'
         );
+
+        // Re-fire navigations that the stale tracker had queued but not yet flushed
+        // when module re-evaluation occurred. Title is read at flush time so the
+        // router's post-navigation render commit still has a chance to update it.
+        inheritedPaths.forEach(path => {
+            const timeoutId = setTimeout(() => {
+                this.pendingNavigations = this.pendingNavigations.filter(
+                    p => p.timeoutId !== timeoutId
+                );
+                if (!this.isActive) return;
+                this.mpInstance._SessionManager.resetSessionTimer();
+                this.firePageView(path);
+            }, 0);
+            this.pendingNavigations.push({ path, timeoutId });
+        });
     }
 
     private patchHistoryMethods(): void {
@@ -244,7 +261,10 @@ export class PageViewTracker {
         // commit has a chance to update document.title first.
         const capturedPath = candidatePath;
 
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
+            this.pendingNavigations = this.pendingNavigations.filter(
+                p => p.timeoutId !== timeoutId
+            );
             if (!this.isActive) {
                 this.mpInstance.Logger.verbose(
                     'mParticle APV: [defer] fire aborted, tracker inactive (torn down before flush)'
@@ -255,6 +275,7 @@ export class PageViewTracker {
             this.mpInstance._SessionManager.resetSessionTimer();
             this.firePageView(capturedPath);
         }, 0);
+        this.pendingNavigations.push({ path: capturedPath, timeoutId });
     }
 
     // Mirrors the event shape of the public mParticle.logPageView(), but carries
@@ -278,6 +299,16 @@ export class PageViewTracker {
         });
     }
 
+    // Cancels pending deferred fires and returns their captured paths so a
+    // successor tracker can re-schedule them. Call before teardown() during
+    // module-replacement handoff.
+    public takePendingNavigations(): string[] {
+        const paths = this.pendingNavigations.map(p => p.path);
+        this.pendingNavigations.forEach(p => clearTimeout(p.timeoutId));
+        this.pendingNavigations = [];
+        return paths;
+    }
+
     private restoreHistoryMethod(
         methodName: 'pushState' | 'replaceState',
         original: HistoryStateMethod | null,
@@ -298,6 +329,12 @@ export class PageViewTracker {
     }
 
     public teardown(): void {
+        // Cancel any pending deferred fires (e.g. when the feature flag is
+        // disabled on re-init). For module-replacement, call takePendingNavigations()
+        // before teardown() instead so paths are transferred, not discarded.
+        this.pendingNavigations.forEach(p => clearTimeout(p.timeoutId));
+        this.pendingNavigations = [];
+
         if (this.popStateListener) {
             window.removeEventListener('popstate', this.popStateListener);
             this.popStateListener = null;

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -52,7 +52,11 @@ export class PageViewTracker {
     mpInstance: IMParticleWebSDKInstance;
 
     private lastPath: string | null = null;
-    private isActive = false;
+    private _isActive = false;
+
+    get isActive(): boolean {
+        return this._isActive;
+    }
 
     private pendingNavigations: Array<{
         path: string;
@@ -104,7 +108,7 @@ export class PageViewTracker {
             prev.teardown();
         }
 
-        if (this.isActive) {
+        if (this._isActive) {
             this.mpInstance.Logger.verbose(
                 'mParticle APV: [init] starting (teardown-first for idempotency)'
             );
@@ -114,7 +118,7 @@ export class PageViewTracker {
             this.teardown();
         }
 
-        this.isActive = true;
+        this._isActive = true;
 
         this.lastPath = this.getCurrentKey();
 
@@ -139,7 +143,7 @@ export class PageViewTracker {
                 this.pendingNavigations = this.pendingNavigations.filter(
                     p => p.timeoutId !== timeoutId
                 );
-                if (!this.isActive) return;
+                if (!this._isActive) return;
                 this.mpInstance._SessionManager.resetSessionTimer();
                 this.firePageView(path);
             }, 0);
@@ -268,7 +272,7 @@ export class PageViewTracker {
             this.pendingNavigations = this.pendingNavigations.filter(
                 p => p.timeoutId !== timeoutId
             );
-            if (!this.isActive) {
+            if (!this._isActive) {
                 this.mpInstance.Logger.verbose(
                     'mParticle APV: [defer] fire aborted, tracker inactive (torn down before flush)'
                 );
@@ -351,7 +355,7 @@ export class PageViewTracker {
         this.originalReplaceState = null;
         this.replaceStateWrapper = null;
 
-        this.isActive = false;
+        this._isActive = false;
         if (getWindowTracker() === this) {
             setWindowTracker(undefined);
         }

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -172,7 +172,9 @@ export class PageViewTracker {
             ...args: Parameters<HistoryStateMethod>
         ): void {
             const result = originalPushState.apply(this, args);
-            self.safeHandleNavigation('pushState');
+            if (self._isActive) {
+                self.safeHandleNavigation('pushState');
+            }
             return result;
         };
 
@@ -181,7 +183,9 @@ export class PageViewTracker {
             ...args: Parameters<HistoryStateMethod>
         ): void {
             const result = originalReplaceState.apply(this, args);
-            self.safeHandleNavigation('replaceState');
+            if (self._isActive) {
+                self.safeHandleNavigation('replaceState');
+            }
             return result;
         };
 

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -67,6 +67,13 @@ export class PageViewTracker {
                 'mParticle APV: [init] found stale tracker from previous module load — tearing down to prevent stacked wrappers'
             );
             prev.teardown();
+            // Known limitation: if the previous tracker had already queued a
+            // deferred firePageView() via setTimeout, that callback will abort
+            // (isActive is now false) and the navigation will not be re-fired by
+            // this tracker (it seeds lastPath with the current pathname, so the
+            // destination is treated as already-seen). This sub-ms window is
+            // acceptable: stacking N wrappers after N reloads is worse than
+            // losing a single view on the overlap tick.
         }
 
         if (this.isActive) {

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -15,9 +15,16 @@ type MarkedHistoryMethod = HistoryStateMethod & {
 // lifetime of the tab).
 export const WIN_TRACKER_KEY = '__mpApvTracker__';
 
-type WindowWithTracker = Window & {
+// Guards the initial page view so repeated mParticle.init() calls from SPA
+// re-renders don't fire duplicate logPageView() events for the same page.
+export const WIN_INIT_PV_KEY = '__mpApvInitPVLogged__' as const;
+
+export type WindowWithApvFlags = Window & {
     [WIN_TRACKER_KEY]?: PageViewTracker;
+    [WIN_INIT_PV_KEY]?: boolean;
 };
+
+type WindowWithTracker = WindowWithApvFlags;
 
 type NavigationSource = 'pushState' | 'replaceState' | 'popstate';
 

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -39,13 +39,14 @@ export class PageViewTracker {
     // (e.g. left by a previous module load), then clears both APV window flags.
     // Call from _resetForTests after tearing down the instance-level tracker.
     static resetWindowState(instanceTracker?: PageViewTracker): void {
-        const win = window as WindowWithApvFlags;
-        const windowTracker = win[WIN_TRACKER_KEY];
+        const windowTracker = getWindowTracker();
         if (windowTracker && windowTracker !== instanceTracker) {
             windowTracker.teardown();
         }
-        delete win[WIN_INIT_PV_KEY];
-        delete win[WIN_TRACKER_KEY];
+        if (typeof window !== 'undefined') {
+            delete (window as WindowWithApvFlags)[WIN_INIT_PV_KEY];
+        }
+        setWindowTracker(undefined);
     }
 
     mpInstance: IMParticleWebSDKInstance;
@@ -93,8 +94,7 @@ export class PageViewTracker {
         // only way to reach a tracker instance in a dead module scope.
         // Transfer any pending navigations first so a route change that queued a
         // deferred fire before module re-evaluation occurs is not silently dropped.
-        const win = window as WindowWithApvFlags;
-        const prev = win[WIN_TRACKER_KEY];
+        const prev = getWindowTracker();
         let inheritedPaths: string[] = [];
         if (prev && prev !== this) {
             this.mpInstance.Logger.verbose(
@@ -125,7 +125,7 @@ export class PageViewTracker {
         this.patchHistoryMethods();
         this.addNavigationListeners();
 
-        (window as WindowWithApvFlags)[WIN_TRACKER_KEY] = this;
+        setWindowTracker(this);
 
         this.mpInstance.Logger.verbose(
             'mParticle APV: [init] patched pushState/replaceState + listening for popstate'
@@ -352,9 +352,23 @@ export class PageViewTracker {
         this.replaceStateWrapper = null;
 
         this.isActive = false;
-        const win = window as WindowWithApvFlags;
-        if (win[WIN_TRACKER_KEY] === this) {
-            delete win[WIN_TRACKER_KEY];
+        if (getWindowTracker() === this) {
+            setWindowTracker(undefined);
         }
+    }
+}
+
+function getWindowTracker(): PageViewTracker | undefined {
+    if (typeof window === 'undefined') return undefined;
+    return (window as WindowWithApvFlags)[WIN_TRACKER_KEY];
+}
+
+function setWindowTracker(tracker: PageViewTracker | undefined): void {
+    if (typeof window === 'undefined') return;
+    const win = window as WindowWithApvFlags;
+    if (tracker) {
+        win[WIN_TRACKER_KEY] = tracker;
+    } else {
+        delete win[WIN_TRACKER_KEY];
     }
 }

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -29,6 +29,27 @@ type WindowWithTracker = WindowWithApvFlags;
 type NavigationSource = 'pushState' | 'replaceState' | 'popstate';
 
 export class PageViewTracker {
+    static hasInitialPageViewFired(): boolean {
+        return !!(window as WindowWithApvFlags)[WIN_INIT_PV_KEY];
+    }
+
+    static markInitialPageViewFired(): void {
+        (window as WindowWithApvFlags)[WIN_INIT_PV_KEY] = true;
+    }
+
+    // Tears down any window-registered tracker that differs from instanceTracker
+    // (e.g. left by a previous module load), then clears both APV window flags.
+    // Call from _resetForTests after tearing down the instance-level tracker.
+    static resetWindowState(instanceTracker?: PageViewTracker): void {
+        const win = window as WindowWithApvFlags;
+        const windowTracker = win[WIN_TRACKER_KEY];
+        if (windowTracker && windowTracker !== instanceTracker) {
+            windowTracker.teardown();
+        }
+        delete win[WIN_INIT_PV_KEY];
+        delete win[WIN_TRACKER_KEY];
+    }
+
     mpInstance: IMParticleWebSDKInstance;
 
     private lastPath: string | null = null;

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -24,8 +24,6 @@ export type WindowWithApvFlags = Window & {
     [WIN_INIT_PV_KEY]?: boolean;
 };
 
-type WindowWithTracker = WindowWithApvFlags;
-
 type NavigationSource = 'pushState' | 'replaceState' | 'popstate';
 
 export class PageViewTracker {
@@ -88,7 +86,7 @@ export class PageViewTracker {
         // Tear down any tracker left over from a previous module load.
         // window[WIN_TRACKER_KEY] outlives module re-evaluation; this is the
         // only way to reach a tracker instance in a dead module scope.
-        const win = window as WindowWithTracker;
+        const win = window as WindowWithApvFlags;
         const prev = win[WIN_TRACKER_KEY];
         if (prev && prev !== this) {
             this.mpInstance.Logger.verbose(
@@ -122,7 +120,7 @@ export class PageViewTracker {
         this.patchHistoryMethods();
         this.addNavigationListeners();
 
-        (window as WindowWithTracker)[WIN_TRACKER_KEY] = this;
+        (window as WindowWithApvFlags)[WIN_TRACKER_KEY] = this;
 
         this.mpInstance.Logger.verbose(
             'mParticle APV: [init] patched pushState/replaceState + listening for popstate'
@@ -314,7 +312,7 @@ export class PageViewTracker {
         this.replaceStateWrapper = null;
 
         this.isActive = false;
-        const win = window as WindowWithTracker;
+        const win = window as WindowWithApvFlags;
         if (win[WIN_TRACKER_KEY] === this) {
             delete win[WIN_TRACKER_KEY];
         }

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -548,10 +548,10 @@ describe('PageViewTracker', () => {
         });
 
         // Regression: a navigation queued by the stale tracker (setTimeout not yet
-        // flushed) must not fire after the new tracker takes over. The stale
-        // tracker's deferred callback checks isActive and aborts; the new tracker
-        // seeds lastPath with the destination so it is treated as already-seen.
-        it('should drop a pending page view from the stale tracker on module re-evaluation', () => {
+        // flushed) must be transferred to the replacement tracker via
+        // takePendingNavigations() so it is not silently dropped on module
+        // re-evaluation.
+        it('should transfer a pending page view from the stale tracker on module re-evaluation', () => {
             const staleTracker = createTracker();
             staleTracker.init(); // seeds lastPath = '/'
 
@@ -559,15 +559,18 @@ describe('PageViewTracker', () => {
             window.history.pushState({}, '', '/route-a');
             // Timer not yet flushed.
 
-            // Module re-evaluation: new tracker tears down the stale one.
+            // Module re-evaluation: new tracker transfers pending navigations then
+            // tears down the stale one.
             const newTracker = createTracker();
-            newTracker.init(); // seeds lastPath = '/route-a', tears down staleTracker
+            newTracker.init(); // takes '/route-a' from stale, tears it down
 
-            // Flush: stale tracker's callback aborts because isActive is false.
+            // Flush: '/route-a' fires via the new tracker, not the stale one.
             jest.runAllTimers();
-            expect(logEvent).not.toHaveBeenCalled();
+            expect(logEvent).toHaveBeenCalledTimes(1);
+            expect(logEvent.mock.calls[0][0].data.path).toBe('/route-a');
 
-            // A subsequent navigation from the new tracker fires normally.
+            // A subsequent navigation from the new tracker fires as normal.
+            logEvent.mockClear();
             window.history.pushState({}, '', '/route-b');
             jest.runAllTimers();
             expect(logEvent).toHaveBeenCalledTimes(1);

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -547,6 +547,33 @@ describe('PageViewTracker', () => {
             expect((window as any)[WIN_TRACKER_KEY]).toBe(newTracker);
         });
 
+        // Regression: a navigation queued by the stale tracker (setTimeout not yet
+        // flushed) must not fire after the new tracker takes over. The stale
+        // tracker's deferred callback checks isActive and aborts; the new tracker
+        // seeds lastPath with the destination so it is treated as already-seen.
+        it('should drop a pending page view from the stale tracker on module re-evaluation', () => {
+            const staleTracker = createTracker();
+            staleTracker.init(); // seeds lastPath = '/'
+
+            // Route change detected by the stale tracker — deferred fire queued.
+            window.history.pushState({}, '', '/route-a');
+            // Timer not yet flushed.
+
+            // Module re-evaluation: new tracker tears down the stale one.
+            const newTracker = createTracker();
+            newTracker.init(); // seeds lastPath = '/route-a', tears down staleTracker
+
+            // Flush: stale tracker's callback aborts because isActive is false.
+            jest.runAllTimers();
+            expect(logEvent).not.toHaveBeenCalled();
+
+            // A subsequent navigation from the new tracker fires normally.
+            window.history.pushState({}, '', '/route-b');
+            jest.runAllTimers();
+            expect(logEvent).toHaveBeenCalledTimes(1);
+            expect(logEvent.mock.calls[0][0].data.path).toBe('/route-b');
+        });
+
         it('should not fire duplicate page views after a module re-evaluation', () => {
             // First module load: tracker A installs its wrapper.
             const trackerA = createTracker();

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -1,4 +1,4 @@
-import { PageViewTracker } from '../../src/pageViewTracker';
+import { PageViewTracker, WIN_TRACKER_KEY } from '../../src/pageViewTracker';
 import { IMParticleWebSDKInstance } from '../../src/mp-instance';
 import { MessageType } from '../../src/types';
 
@@ -64,6 +64,7 @@ describe('PageViewTracker', () => {
         window.history.pushState = NATIVE_PUSH_STATE;
         window.history.replaceState = NATIVE_REPLACE_STATE;
         NATIVE_REPLACE_STATE.call(window.history, {}, '', '/');
+        delete (window as any)[WIN_TRACKER_KEY];
 
         jest.clearAllTimers();
         jest.useRealTimers();
@@ -487,6 +488,17 @@ describe('PageViewTracker', () => {
             expect(tracker['isActive']).toBe(false);
         });
 
+        it('should clear window[WIN_TRACKER_KEY] after teardown', () => {
+            const tracker = createTracker();
+            tracker.init();
+
+            expect((window as any)[WIN_TRACKER_KEY]).toBe(tracker);
+
+            tracker.teardown();
+
+            expect((window as any)[WIN_TRACKER_KEY]).toBeUndefined();
+        });
+
         it('should be safe to call before init()', () => {
             const tracker = createTracker();
             expect(() => tracker.teardown()).not.toThrow();
@@ -504,6 +516,51 @@ describe('PageViewTracker', () => {
             jest.runAllTimers();
 
             expect(logEvent).not.toHaveBeenCalled();
+        });
+    });
+
+    // Regression: Next.js re-evaluates the SDK module on each SPA navigation,
+    // resetting all module-level state. Each fresh module creates a new
+    // PageViewTracker and calls init(). Without the singleton teardown, each
+    // init() stacks a new pushState wrapper on top of the previous one and fires
+    // N page views per navigation after N module loads.
+    describe('window singleton / stale tracker teardown (module re-evaluation)', () => {
+        it('should register itself in window[WIN_TRACKER_KEY] after init()', () => {
+            const tracker = createTracker();
+            tracker.init();
+
+            expect((window as any)[WIN_TRACKER_KEY]).toBe(tracker);
+        });
+
+        it('should tear down a stale tracker from a previous module load on init()', () => {
+            // Simulate a tracker left behind by a previous module load:
+            // the old module is gone, so the only handle to it is window[WIN_TRACKER_KEY].
+            const staleTracker = createTracker();
+            staleTracker.init();
+            const teardownSpy = jest.spyOn(staleTracker, 'teardown');
+
+            // A new module load creates a fresh tracker and calls init().
+            const newTracker = createTracker();
+            newTracker.init();
+
+            expect(teardownSpy).toHaveBeenCalled();
+            expect((window as any)[WIN_TRACKER_KEY]).toBe(newTracker);
+        });
+
+        it('should not fire duplicate page views after a module re-evaluation', () => {
+            // First module load: tracker A installs its wrapper.
+            const trackerA = createTracker();
+            trackerA.init();
+
+            // Second module load: tracker B tears down A and installs its own wrapper.
+            const trackerB = createTracker();
+            trackerB.init();
+
+            // One navigation should produce exactly one page view.
+            window.history.pushState({}, '', '/next');
+            jest.runAllTimers();
+
+            expect(logEvent).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -577,6 +577,25 @@ describe('PageViewTracker', () => {
             expect(logEvent.mock.calls[0][0].data.path).toBe('/route-b');
         });
 
+        // Regression: same-instance re-init (e.g. SPA framework calling
+        // mParticle.init() on navigation) must not drop a page view queued before
+        // the re-init call.
+        it('should preserve a pending page view when the same tracker re-inits', () => {
+            const tracker = createTracker();
+            tracker.init(); // seeds lastPath = '/'
+
+            // Route change queues a deferred fire — timer not yet flushed.
+            window.history.pushState({}, '', '/about');
+
+            // SPA framework calls mParticle.init() again before the timer fires.
+            tracker.init();
+
+            // The pending '/about' view should still fire.
+            jest.runAllTimers();
+            expect(logEvent).toHaveBeenCalledTimes(1);
+            expect(logEvent.mock.calls[0][0].data.path).toBe('/about');
+        });
+
         it('should not fire duplicate page views after a module re-evaluation', () => {
             // First module load: tracker A installs its wrapper.
             const trackerA = createTracker();

--- a/test/src/tests-event-logging.ts
+++ b/test/src/tests-event-logging.ts
@@ -657,6 +657,44 @@ describe('event logging', function() {
             );
             Should(reInitPageViewEvent).not.be.ok();
         });
+
+        it('should not log a duplicate page view when a fresh module replaces the tracker (Next.js module re-evaluation)', async () => {
+            mParticle._resetForTests(MPConfig);
+            window.mParticle.config.flags = { autoLogPageView: 'True' };
+
+            // First init — one page view fires; window.__mpApvInitPVLogged__ and
+            // window.__mpApvTracker__ are both set.
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const firstBatch = findBatch(fetchMock.calls(), 'screen_view');
+            firstBatch.events.filter(e => e.event_type === 'screen_view').length.should.equal(1);
+
+            // Simulate Next.js module re-evaluation: a fresh module creates a new
+            // SDK instance with no _PageViewTracker, while window.__mpApvTracker__
+            // and window.__mpApvInitPVLogged__ survive from the previous load.
+            const staleTracker = mParticle.getInstance()._PageViewTracker;
+            mParticle.getInstance()._PageViewTracker = undefined;
+
+            fetchMock.resetHistory();
+            fetchMock.post(urls.events, 200, { overwriteRoutes: true });
+            fetchMockSuccess(urls.identify, { mpid: testMPID, is_logged_in: false });
+
+            // Fresh-module init: should create a new tracker, tear down the stale
+            // one via the window singleton, and skip logPageView (flag already set).
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(() => mParticle.getInstance()?._Store?.identityCallInFlight === false);
+
+            // Stale tracker must have been torn down.
+            Should(staleTracker.isActive).not.be.ok();
+
+            // No duplicate page view from the fresh-module init.
+            const freshModulePageViewEvent = findEventFromRequest(
+                fetchMock.calls(),
+                'screen_view'
+            );
+            Should(freshModulePageViewEvent).not.be.ok();
+        });
     });
 
     it('should log opt out', async () => {

--- a/test/src/tests-event-logging.ts
+++ b/test/src/tests-event-logging.ts
@@ -626,6 +626,37 @@ describe('event logging', function() {
                 window.document.title
             );
         });
+
+        it('should not log a duplicate page view when init() is called again (SPA re-init)', async () => {
+            mParticle._resetForTests(MPConfig);
+            window.mParticle.config.flags = { autoLogPageView: 'True' };
+
+            // First init — one page view fires for the initial page load.
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(hasIdentifyReturned);
+
+            const firstInitPageViewBatch = findBatch(fetchMock.calls(), 'screen_view');
+            const firstInitPageViews = firstInitPageViewBatch.events.filter(
+                event => event.event_type === 'screen_view'
+            );
+            firstInitPageViews.length.should.equal(1);
+
+            // Simulate a SPA framework calling mParticle.init() again on navigation.
+            fetchMock.resetHistory();
+            fetchMock.post(urls.events, 200, { overwriteRoutes: true });
+            fetchMockSuccess(urls.identify, { mpid: testMPID, is_logged_in: false });
+
+            mParticle.init(apiKey, window.mParticle.config);
+            await waitForCondition(() => mParticle.getInstance()?._Store?.identityCallInFlight === false);
+
+            // No duplicate page view should fire — the PageViewTracker already
+            // owns navigation tracking after the first init.
+            const reInitPageViewEvent = findEventFromRequest(
+                fetchMock.calls(),
+                'screen_view'
+            );
+            Should(reInitPageViewEvent).not.be.ok();
+        });
     });
 
     it('should log opt out', async () => {


### PR DESCRIPTION
## Summary

- Adds a `window.__mpApvTracker__` singleton so that when Next.js re-evaluates the SDK module on each SPA navigation, the new module's tracker tears down the previous module's tracker before patching `pushState`. This eliminates stacked wrappers (N page views per navigation).
- Guards `logPageView()` in `completeSDKInitialization` behind `window.__mpApvInitPVLogged__` so the initial page view fires only once per hard page load, not on every `mParticle.init()` call.
- Fixes `_resetForTests` to tear down any active `PageViewTracker` and clear both APV window flags between tests, preventing stale state from leaking across test cases.

## Test plan

- [ ] Verify a single page view is logged on hard load with `AutoLogPageView: True`
- [ ] Verify SPA navigation (pushState) logs exactly one page view per route change
- [ ] Verify calling `mParticle.init()` again on re-navigation does not fire a duplicate initial page view
- [ ] `npm test` passes (2176 tests, 0 failures)

## Notes

The companion PR for kit double-registration via `configuredForwarders` accumulation is being reviewed separately as a draft.