### PR TITLE
refactor: migrate forwardingStatsUploader module to TS

### DIFF
--- a/src/forwardingStatsUploader.ts
+++ b/src/forwardingStatsUploader.ts
@@ -1,12 +1,25 @@
-export default function forwardingStatsUploader(mpInstance) {
-    this.startForwardingStatsTimer = function() {
-        mParticle._forwardingStatsTimer = setInterval(function() {
-            prepareAndSendForwardingStatsBatch();
-        }, mpInstance._Store.SDKConfig.forwarderStatsTimeout);
+import { IMParticleWebSDKInstance } from './mp-instance';
+import { Dictionary } from './utils';
+
+export interface IForwardingStatsUploader {
+    startForwardingStatsTimer(): void;
+}
+
+export default function forwardingStatsUploader(
+    this: IForwardingStatsUploader,
+    mpInstance: IMParticleWebSDKInstance
+): void {
+    this.startForwardingStatsTimer = function(): void {
+        (window.mParticle as Dictionary)._forwardingStatsTimer = setInterval(
+            function() {
+                prepareAndSendForwardingStatsBatch();
+            },
+            (mpInstance._Store.SDKConfig as Dictionary).forwarderStatsTimeout
+        );
     };
 
-    function prepareAndSendForwardingStatsBatch() {
-        var forwarderQueue = mpInstance._Forwarders.getForwarderStatsQueue(),
+    function prepareAndSendForwardingStatsBatch(): void {
+        const forwarderQueue = mpInstance._Forwarders.getForwarderStatsQueue(),
             uploadsTable =
                 mpInstance._Persistence.forwardingStatsBatches.uploadsTable,
             now = Date.now();
@@ -16,11 +29,11 @@ export default function forwardingStatsUploader(mpInstance) {
             mpInstance._Forwarders.setForwarderStatsQueue([]);
         }
 
-        for (var date in uploadsTable) {
-            (function(date) {
+        for (const date in uploadsTable) {
+            (function(date: string) {
                 if (uploadsTable.hasOwnProperty(date)) {
                     if (uploadsTable[date].uploading === false) {
-                        var xhrCallback = function() {
+                        const xhrCallback = function(): void {
                             if (xhr.readyState === 4) {
                                 if (xhr.status === 200 || xhr.status === 202) {
                                     mpInstance.Logger.verbose(
@@ -39,8 +52,8 @@ export default function forwardingStatsUploader(mpInstance) {
                             }
                         };
 
-                        var xhr = mpInstance._Helpers.createXHR(xhrCallback);
-                        var forwardingStatsData = uploadsTable[date].data;
+                        const xhr = mpInstance._Helpers.createXHR(xhrCallback);
+                        const forwardingStatsData = uploadsTable[date].data;
                         uploadsTable[date].uploading = true;
                         mpInstance._APIClient.sendBatchForwardingStatsToServer(
                             forwardingStatsData,

--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -30,7 +30,9 @@ import Persistence from './persistence';
 import Events from './events';
 import Forwarders from './forwarders';
 import ServerModel, { IServerModel } from './serverModel';
-import ForwardingStatsUploader from './forwardingStatsUploader';
+import ForwardingStatsUploader, {
+    IForwardingStatsUploader,
+} from './forwardingStatsUploader';
 import Identity from './identity';
 import Consent, { IConsent } from './consent';
 import KitBlocker from './kitBlocking';
@@ -82,7 +84,7 @@ export interface IMParticleWebSDKInstance extends MParticleWebSDK {
     _Ecommerce: IECommerce;
     _Events: IEvents;
     _Forwarders: any; // https://go.mparticle.com/work/SQDSDKS-5767
-    _ForwardingStatsUploader: ForwardingStatsUploader;
+    _ForwardingStatsUploader: IForwardingStatsUploader;
     _Helpers: SDKHelpersApi;
     _Identity: IIdentity;
     _IdentityAPIClient: typeof IdentityAPIClient;


### PR DESCRIPTION
## Background
- Continuing the effort to migrate remaining JavaScript modules in the mParticle Web SDK to TypeScript for improved type safety and developer experience. `forwardingStatsUploader.js` was one of the remaining JS modules.

## What Has Changed
- Converted `src/forwardingStatsUploader.js` to `src/forwardingStatsUploader.ts` with type annotations
- Added `IForwardingStatsUploader` interface and wired it in `src/mp-instance.ts`
- No intentional runtime behavior, public API, or functional changes

## Screenshots/Video
- N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/SDKE-1194