### PR TITLE
refactor: reduce filteredMparticleUser cognitive complexity for Sonar

### DIFF
--- a/src/filteredMparticleUser.ts
+++ b/src/filteredMparticleUser.ts
@@ -13,7 +13,7 @@ export interface IFilteredMparticleUser {
 }
 
 function isAttributeKeyAllowed(
-    kitBlocker?: KitBlocker,
+    kitBlocker: KitBlocker | undefined,
     key: string
 ): boolean {
     return !kitBlocker?.isAttributeKeyBlocked(key);

--- a/src/filteredMparticleUser.ts
+++ b/src/filteredMparticleUser.ts
@@ -31,8 +31,8 @@ function copyUserAttributeValue(value: unknown): unknown {
 }
 
 function buildUserAttributesCopy(
-    userAttributes: Dictionary | null | undefined,
-    kitBlocker: KitBlocker | undefined
+    userAttributes?: Dictionary,
+    kitBlocker?: KitBlocker
 ): Dictionary {
     const userAttributesCopy: Dictionary = {};
 

--- a/src/filteredMparticleUser.ts
+++ b/src/filteredMparticleUser.ts
@@ -1,6 +1,6 @@
 import Types from './types';
 import { IMParticleWebSDKInstance } from './mp-instance';
-import { MPID } from '@mparticle/web-sdk';
+import { MPID, UserIdentities } from '@mparticle/web-sdk';
 import { Dictionary } from './utils';
 import KitBlocker from './kitBlocking';
 import { MPForwarder } from './forwarders.interfaces';
@@ -12,6 +12,98 @@ export interface IFilteredMparticleUser {
     getAllUserAttributes(): Dictionary;
 }
 
+function isAttributeKeyAllowed(
+    kitBlocker: KitBlocker | undefined,
+    key: string
+): boolean {
+    return !kitBlocker || !kitBlocker.isAttributeKeyBlocked(key);
+}
+
+function isIdentityAllowed(
+    kitBlocker: KitBlocker | undefined,
+    identityName: string
+): boolean {
+    return !kitBlocker || !kitBlocker.isIdentityBlocked(identityName);
+}
+
+function copyUserAttributeValue(value: unknown): unknown {
+    return Array.isArray(value) ? (value as string[]).slice() : value;
+}
+
+function buildUserAttributesCopy(
+    userAttributes: Dictionary | null | undefined,
+    kitBlocker: KitBlocker | undefined
+): Dictionary {
+    const userAttributesCopy: Dictionary = {};
+
+    if (!userAttributes) {
+        return userAttributesCopy;
+    }
+
+    for (const prop in userAttributes) {
+        if (
+            !userAttributes.hasOwnProperty(prop) ||
+            !isAttributeKeyAllowed(kitBlocker, prop)
+        ) {
+            continue;
+        }
+
+        userAttributesCopy[prop] = copyUserAttributeValue(
+            userAttributes[prop]
+        );
+    }
+
+    return userAttributesCopy;
+}
+
+function buildUserAttributeLists(
+    userAttributes: Dictionary,
+    kitBlocker: KitBlocker | undefined
+): Dictionary<string[]> {
+    const userAttributesLists: Dictionary<string[]> = {};
+
+    for (const key in userAttributes) {
+        if (
+            !userAttributes.hasOwnProperty(key) ||
+            !Array.isArray(userAttributes[key]) ||
+            !isAttributeKeyAllowed(kitBlocker, key)
+        ) {
+            continue;
+        }
+
+        userAttributesLists[key] = userAttributes[key].slice();
+    }
+
+    return userAttributesLists;
+}
+
+function buildFilteredUserIdentities(
+    identities: UserIdentities,
+    kitBlocker: KitBlocker | undefined,
+    parseNumber: (value: string | number) => number
+): Dictionary<string> {
+    const currentUserIdentities: Dictionary<string> = {};
+    const identitiesByType = identities as Dictionary<string>;
+
+    for (const identityType in identitiesByType) {
+        if (!identitiesByType.hasOwnProperty(identityType)) {
+            continue;
+        }
+
+        const identityName = Types.IdentityType.getIdentityName(
+            parseNumber(identityType)
+        );
+
+        if (!isIdentityAllowed(kitBlocker, identityName)) {
+            continue;
+        }
+
+        currentUserIdentities[identityName] = identitiesByType[identityType];
+    }
+
+    return currentUserIdentities;
+}
+
 export default function filteredMparticleUser(
     mpid: MPID,
     forwarder: MPForwarder | { userAttributeFilters: number[] },
@@ -19,57 +111,24 @@ export default function filteredMparticleUser(
     kitBlocker?: KitBlocker
 ): IFilteredMparticleUser {
     function getAllUserAttributes(): Dictionary {
-        let userAttributesCopy: Dictionary = {};
-        const userAttributes = mpInstance._Store.getUserAttributes(mpid);
+        const userAttributesCopy = buildUserAttributesCopy(
+            mpInstance._Store.getUserAttributes(mpid),
+            kitBlocker
+        );
 
-        if (userAttributes) {
-            for (const prop in userAttributes) {
-                if (userAttributes.hasOwnProperty(prop)) {
-                    if (
-                        !kitBlocker ||
-                        (kitBlocker &&
-                            !kitBlocker.isAttributeKeyBlocked(prop))
-                    ) {
-                        if (Array.isArray(userAttributes[prop])) {
-                            userAttributesCopy[prop] = (userAttributes[
-                                prop
-                            ] as string[]).slice();
-                        } else {
-                            userAttributesCopy[prop] = userAttributes[prop];
-                        }
-                    }
-                }
-            }
-        }
-
-        userAttributesCopy = mpInstance._Helpers.filterUserAttributes(
+        return mpInstance._Helpers.filterUserAttributes(
             userAttributesCopy,
             (forwarder as MPForwarder).userAttributeFilters
         );
-
-        return userAttributesCopy;
     }
 
     return {
         getUserIdentities: function(): { userIdentities: Dictionary<string> } {
-            let currentUserIdentities: Dictionary<string> = {};
-            const identities = mpInstance._Store.getUserIdentities(mpid);
-
-            for (const identityType in identities) {
-                if (identities.hasOwnProperty(identityType)) {
-                    const identityName = Types.IdentityType.getIdentityName(
-                        mpInstance._Helpers.parseNumber(identityType)
-                    );
-                    if (
-                        !kitBlocker ||
-                        (kitBlocker &&
-                            !kitBlocker.isIdentityBlocked(identityName))
-                    )
-                        //if identity type is not blocked
-                        currentUserIdentities[identityName] =
-                            identities[identityType];
-                }
-            }
+            let currentUserIdentities = buildFilteredUserIdentities(
+                mpInstance._Store.getUserIdentities(mpid),
+                kitBlocker,
+                mpInstance._Helpers.parseNumber
+            );
 
             currentUserIdentities = mpInstance._Helpers.filterUserIdentitiesForForwarders(
                 currentUserIdentities,
@@ -86,30 +145,15 @@ export default function filteredMparticleUser(
         getUserAttributesLists: function(
             forwarder: MPForwarder
         ): Dictionary<string[]> {
-            let userAttributes: Dictionary;
-            let userAttributesLists: Dictionary<string[]> = {};
-
-            userAttributes = getAllUserAttributes();
-            for (const key in userAttributes) {
-                if (
-                    userAttributes.hasOwnProperty(key) &&
-                    Array.isArray(userAttributes[key])
-                ) {
-                    if (
-                        !kitBlocker ||
-                        (kitBlocker && !kitBlocker.isAttributeKeyBlocked(key))
-                    ) {
-                        userAttributesLists[key] = userAttributes[key].slice();
-                    }
-                }
-            }
-
-            userAttributesLists = mpInstance._Helpers.filterUserAttributes(
-                userAttributesLists,
-                forwarder.userAttributeFilters
+            const userAttributesLists = buildUserAttributeLists(
+                getAllUserAttributes(),
+                kitBlocker
             );
 
-            return userAttributesLists;
+            return mpInstance._Helpers.filterUserAttributes(
+                userAttributesLists,
+                forwarder.userAttributeFilters
+            ) as Dictionary<string[]>;
         },
         getAllUserAttributes: getAllUserAttributes,
     };

--- a/src/filteredMparticleUser.ts
+++ b/src/filteredMparticleUser.ts
@@ -13,7 +13,7 @@ export interface IFilteredMparticleUser {
 }
 
 function isAttributeKeyAllowed(
-    kitBlocker: KitBlocker | undefined,
+    kitBlocker?: KitBlocker,
     key: string
 ): boolean {
     return !kitBlocker?.isAttributeKeyBlocked(key);

--- a/src/filteredMparticleUser.ts
+++ b/src/filteredMparticleUser.ts
@@ -58,7 +58,7 @@ function buildUserAttributesCopy(
 
 function buildUserAttributeLists(
     userAttributes: Dictionary,
-    kitBlocker: KitBlocker | undefined
+    kitBlocker?: KitBlocker
 ): Dictionary<string[]> {
     const userAttributesLists: Dictionary<string[]> = {};
 

--- a/src/filteredMparticleUser.ts
+++ b/src/filteredMparticleUser.ts
@@ -16,14 +16,14 @@ function isAttributeKeyAllowed(
     kitBlocker: KitBlocker | undefined,
     key: string
 ): boolean {
-    return !kitBlocker || !kitBlocker.isAttributeKeyBlocked(key);
+    return !kitBlocker?.isAttributeKeyBlocked(key);
 }
 
 function isIdentityAllowed(
     kitBlocker: KitBlocker | undefined,
     identityName: string
 ): boolean {
-    return !kitBlocker || !kitBlocker.isIdentityBlocked(identityName);
+    return !kitBlocker?.isIdentityBlocked(identityName);
 }
 
 function copyUserAttributeValue(value: unknown): unknown {

--- a/test/jest/filteredMparticleUser.spec.ts
+++ b/test/jest/filteredMparticleUser.spec.ts
@@ -60,7 +60,7 @@ function createKitBlocker(options: {
 }
 
 describe('filteredMparticleUser', () => {
-    it('returns the MPID without constructing with new', () => {
+    it('should return the MPID without constructing with new', () => {
         const mpInstance = createMpInstance();
         const user = filteredMparticleUser(
             testMPID,
@@ -72,7 +72,7 @@ describe('filteredMparticleUser', () => {
     });
 
     describe('#getAllUserAttributes', () => {
-        it('returns {} when store attributes are missing', () => {
+        it('should return an empty object when store attributes are missing', () => {
             const mpInstance = createMpInstance({ userAttributes: null });
             const user = filteredMparticleUser(
                 testMPID,
@@ -83,7 +83,7 @@ describe('filteredMparticleUser', () => {
             expect(user.getAllUserAttributes()).toEqual({});
         });
 
-        it('copies list attributes so kits cannot mutate store values', () => {
+        it('should copy list attributes so kits cannot mutate store values', () => {
             const tags = ['a', 'b'];
             const mpInstance = createMpInstance({
                 userAttributes: { color: 'red', tags },
@@ -103,7 +103,7 @@ describe('filteredMparticleUser', () => {
             expect(tags).toEqual(['a', 'b']);
         });
 
-        it('omits kit-blocked attribute keys when no kit blocker is treated as allow-all', () => {
+        it('should omit kit-blocked attribute keys and allow all when kitBlocker is omitted', () => {
             const mpInstance = createMpInstance({
                 userAttributes: {
                     allowed: 'yes',
@@ -131,7 +131,7 @@ describe('filteredMparticleUser', () => {
             });
         });
 
-        it('applies forwarder userAttributeFilters after kit blocking', () => {
+        it('should apply forwarder userAttributeFilters after kit blocking', () => {
             const filteredKey = 'drop_me';
             const mpInstance = createMpInstance({
                 userAttributes: {
@@ -154,7 +154,7 @@ describe('filteredMparticleUser', () => {
     });
 
     describe('#getUserAttributesLists', () => {
-        it('returns only array attributes and copies them', () => {
+        it('should return only array attributes and copy them', () => {
             const tags = ['x'];
             const mpInstance = createMpInstance({
                 userAttributes: {
@@ -177,7 +177,7 @@ describe('filteredMparticleUser', () => {
             expect(lists.tags).not.toBe(tags);
         });
 
-        it('applies the method-argument forwarder filters to list keys', () => {
+        it('should apply the method-argument forwarder filters to list keys', () => {
             const mpInstance = createMpInstance({
                 userAttributes: {
                     tags: ['a'],
@@ -199,7 +199,7 @@ describe('filteredMparticleUser', () => {
             expect(lists).toEqual({ tags: ['a'] });
         });
 
-        it('does not include kit-blocked list attributes', () => {
+        it('should not include kit-blocked list attributes', () => {
             const mpInstance = createMpInstance({
                 userAttributes: {
                     tags: ['a'],
@@ -222,7 +222,7 @@ describe('filteredMparticleUser', () => {
     });
 
     describe('#getUserIdentities', () => {
-        it('maps store identity-type keys to names', () => {
+        it('should map store identity-type keys to names', () => {
             const mpInstance = createMpInstance();
             const user = filteredMparticleUser(
                 testMPID,
@@ -239,7 +239,7 @@ describe('filteredMparticleUser', () => {
             });
         });
 
-        it('omits kit-blocked identities and forwarder identity filters', () => {
+        it('should omit kit-blocked identities and forwarder identity filters', () => {
             const mpInstance = createMpInstance();
             const user = filteredMparticleUser(
                 testMPID,
@@ -258,7 +258,7 @@ describe('filteredMparticleUser', () => {
             });
         });
 
-        it('allows all identities when kitBlocker is omitted', () => {
+        it('should allow all identities when kitBlocker is omitted', () => {
             const mpInstance = createMpInstance();
             const user = filteredMparticleUser(
                 testMPID,

--- a/test/jest/filteredMparticleUser.spec.ts
+++ b/test/jest/filteredMparticleUser.spec.ts
@@ -9,9 +9,11 @@ import { Dictionary } from '../../src/utils';
 
 const testMPID = 'test-mpid';
 
-function createHelpers(mpInstance: IMParticleWebSDKInstance) {
-    return new Helpers(mpInstance);
-}
+const defaultIdentities: Dictionary<string> = {
+    [IdentityType.CustomerId]: 'cust-1',
+    [IdentityType.Email]: 'user@example.com',
+    [IdentityType.Google]: 'google-id',
+};
 
 function createMpInstance(options?: {
     userAttributes?: Dictionary | null;
@@ -20,15 +22,12 @@ function createMpInstance(options?: {
     const mockMPInstance = {
         _Store: {
             getUserAttributes: jest.fn(
-                () => options?.userAttributes ?? {}
+                () => (options && 'userAttributes' in options
+                    ? options.userAttributes
+                    : {})
             ),
             getUserIdentities: jest.fn(
-                () =>
-                    options?.userIdentities ?? {
-                        [IdentityType.CustomerId]: 'cust-1',
-                        [IdentityType.Email]: 'user@example.com',
-                        [IdentityType.Google]: 'google-id',
-                    }
+                () => options?.userIdentities ?? defaultIdentities
             ),
         },
         Logger: {
@@ -38,7 +37,7 @@ function createMpInstance(options?: {
         },
     } as unknown as IMParticleWebSDKInstance;
 
-    mockMPInstance._Helpers = createHelpers(mockMPInstance);
+    mockMPInstance._Helpers = new Helpers(mockMPInstance);
     return mockMPInstance;
 }
 
@@ -59,28 +58,40 @@ function createKitBlocker(options: {
     } as unknown as KitBlocker;
 }
 
+function createFilteredUser(
+    mpInstance: IMParticleWebSDKInstance,
+    forwarder: MPForwarder | { userAttributeFilters: number[] } = {
+        userAttributeFilters: [],
+    },
+    kitBlocker?: KitBlocker
+) {
+    return filteredMparticleUser(
+        testMPID,
+        forwarder,
+        mpInstance,
+        kitBlocker
+    );
+}
+
 describe('filteredMparticleUser', () => {
     it('should return the MPID without constructing with new', () => {
         const mpInstance = createMpInstance();
-        const user = filteredMparticleUser(
-            testMPID,
-            { userAttributeFilters: [] },
-            mpInstance
-        );
+        const user = createFilteredUser(mpInstance);
 
         expect(user.getMPID()).toBe(testMPID);
+        expect(mpInstance._Store.getUserAttributes).not.toHaveBeenCalled();
     });
 
     describe('#getAllUserAttributes', () => {
         it('should return an empty object when store attributes are missing', () => {
             const mpInstance = createMpInstance({ userAttributes: null });
-            const user = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [] },
-                mpInstance
-            );
 
-            expect(user.getAllUserAttributes()).toEqual({});
+            expect(
+                createFilteredUser(mpInstance).getAllUserAttributes()
+            ).toEqual({});
+            expect(mpInstance._Store.getUserAttributes).toHaveBeenCalledWith(
+                testMPID
+            );
         });
 
         it('should copy list attributes so kits cannot mutate store values', () => {
@@ -88,13 +99,8 @@ describe('filteredMparticleUser', () => {
             const mpInstance = createMpInstance({
                 userAttributes: { color: 'red', tags },
             });
-            const user = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [] },
-                mpInstance
-            );
+            const attrs = createFilteredUser(mpInstance).getAllUserAttributes();
 
-            const attrs = user.getAllUserAttributes();
             expect(attrs.color).toBe('red');
             expect(attrs.tags).toEqual(['a', 'b']);
             expect(attrs.tags).not.toBe(tags);
@@ -103,51 +109,50 @@ describe('filteredMparticleUser', () => {
             expect(tags).toEqual(['a', 'b']);
         });
 
-        it('should omit kit-blocked attribute keys and allow all when kitBlocker is omitted', () => {
+        it('should omit kit-blocked attribute keys', () => {
             const mpInstance = createMpInstance({
                 userAttributes: {
                     allowed: 'yes',
                     blocked_attr: 'no',
                 },
             });
-            const blockedUser = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [] },
+            const user = createFilteredUser(
                 mpInstance,
+                { userAttributeFilters: [] },
                 createKitBlocker({ blockedAttributes: ['blocked_attr'] })
             );
-            const unblockedUser = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [] },
-                mpInstance
-            );
 
-            expect(blockedUser.getAllUserAttributes()).toEqual({
-                allowed: 'yes',
+            expect(user.getAllUserAttributes()).toEqual({ allowed: 'yes' });
+        });
+
+        it('should allow all attributes when kitBlocker is omitted', () => {
+            const mpInstance = createMpInstance({
+                userAttributes: {
+                    allowed: 'yes',
+                    blocked_attr: 'no',
+                },
             });
-            expect(unblockedUser.getAllUserAttributes()).toEqual({
+
+            expect(
+                createFilteredUser(mpInstance).getAllUserAttributes()
+            ).toEqual({
                 allowed: 'yes',
                 blocked_attr: 'no',
             });
         });
 
-        it('should apply forwarder userAttributeFilters after kit blocking', () => {
-            const filteredKey = 'drop_me';
+        it('should apply factory forwarder userAttributeFilters', () => {
             const mpInstance = createMpInstance({
                 userAttributes: {
                     keep_me: '1',
                     drop_me: '2',
                 },
             });
-            const user = filteredMparticleUser(
-                testMPID,
-                {
-                    userAttributeFilters: [
-                        KitFilterHelper.hashUserAttribute(filteredKey),
-                    ],
-                } as MPForwarder,
-                mpInstance
-            );
+            const user = createFilteredUser(mpInstance, {
+                userAttributeFilters: [
+                    KitFilterHelper.hashUserAttribute('drop_me'),
+                ],
+            } as MPForwarder);
 
             expect(user.getAllUserAttributes()).toEqual({ keep_me: '1' });
         });
@@ -163,13 +168,9 @@ describe('filteredMparticleUser', () => {
                     empty: [],
                 },
             });
-            const user = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [] },
+            const lists = createFilteredUser(
                 mpInstance
-            );
-
-            const lists = user.getUserAttributesLists({
+            ).getUserAttributesLists({
                 userAttributeFilters: [],
             } as MPForwarder);
 
@@ -177,26 +178,27 @@ describe('filteredMparticleUser', () => {
             expect(lists.tags).not.toBe(tags);
         });
 
-        it('should apply the method-argument forwarder filters to list keys', () => {
+        it('should apply factory filters then method-argument forwarder filters', () => {
             const mpInstance = createMpInstance({
                 userAttributes: {
-                    tags: ['a'],
-                    secrets: ['s'],
+                    keep: ['a'],
+                    factory_drop: ['b'],
+                    method_drop: ['c'],
                 },
             });
-            const user = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [] },
-                mpInstance
-            );
-
-            const lists = user.getUserAttributesLists({
+            const user = createFilteredUser(mpInstance, {
                 userAttributeFilters: [
-                    KitFilterHelper.hashUserAttribute('secrets'),
+                    KitFilterHelper.hashUserAttribute('factory_drop'),
                 ],
             } as MPForwarder);
 
-            expect(lists).toEqual({ tags: ['a'] });
+            expect(
+                user.getUserAttributesLists({
+                    userAttributeFilters: [
+                        KitFilterHelper.hashUserAttribute('method_drop'),
+                    ],
+                } as MPForwarder)
+            ).toEqual({ keep: ['a'] });
         });
 
         it('should not include kit-blocked list attributes', () => {
@@ -206,10 +208,9 @@ describe('filteredMparticleUser', () => {
                     blocked_list: ['b'],
                 },
             });
-            const user = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [] },
+            const user = createFilteredUser(
                 mpInstance,
+                { userAttributeFilters: [] },
                 createKitBlocker({ blockedAttributes: ['blocked_list'] })
             );
 
@@ -222,13 +223,12 @@ describe('filteredMparticleUser', () => {
     });
 
     describe('#getUserIdentities', () => {
-        it('should map store identity-type keys to names', () => {
+        it('should map store identity-type keys to names when kitBlocker is omitted', () => {
             const mpInstance = createMpInstance();
-            const user = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [], userIdentityFilters: [] } as MPForwarder,
-                mpInstance
-            );
+            const user = createFilteredUser(mpInstance, {
+                userAttributeFilters: [],
+                userIdentityFilters: [],
+            } as MPForwarder);
 
             expect(user.getUserIdentities()).toEqual({
                 userIdentities: {
@@ -237,17 +237,29 @@ describe('filteredMparticleUser', () => {
                     google: 'google-id',
                 },
             });
+            expect(mpInstance._Store.getUserIdentities).toHaveBeenCalledWith(
+                testMPID
+            );
+        });
+
+        it('should return empty userIdentities when store identities are empty', () => {
+            const mpInstance = createMpInstance({ userIdentities: {} });
+            const user = createFilteredUser(mpInstance, {
+                userAttributeFilters: [],
+                userIdentityFilters: [],
+            } as MPForwarder);
+
+            expect(user.getUserIdentities()).toEqual({ userIdentities: {} });
         });
 
         it('should omit kit-blocked identities and forwarder identity filters', () => {
             const mpInstance = createMpInstance();
-            const user = filteredMparticleUser(
-                testMPID,
+            const user = createFilteredUser(
+                mpInstance,
                 {
                     userAttributeFilters: [],
                     userIdentityFilters: [IdentityType.Google],
                 } as MPForwarder,
-                mpInstance,
                 createKitBlocker({ blockedIdentities: ['email'] })
             );
 
@@ -258,13 +270,11 @@ describe('filteredMparticleUser', () => {
             });
         });
 
-        it('should allow all identities when kitBlocker is omitted', () => {
+        it('should not apply identity filters when the factory forwarder omits userIdentityFilters', () => {
             const mpInstance = createMpInstance();
-            const user = filteredMparticleUser(
-                testMPID,
-                { userAttributeFilters: [], userIdentityFilters: [] } as MPForwarder,
-                mpInstance
-            );
+            const user = createFilteredUser(mpInstance, {
+                userAttributeFilters: [],
+            });
 
             expect(user.getUserIdentities().userIdentities).toEqual({
                 customerid: 'cust-1',

--- a/test/jest/filteredMparticleUser.spec.ts
+++ b/test/jest/filteredMparticleUser.spec.ts
@@ -1,0 +1,276 @@
+import filteredMparticleUser from '../../src/filteredMparticleUser';
+import Helpers from '../../src/helpers';
+import KitFilterHelper from '../../src/kitFilterHelper';
+import KitBlocker from '../../src/kitBlocking';
+import { IdentityType } from '../../src/types';
+import { IMParticleWebSDKInstance } from '../../src/mp-instance';
+import { MPForwarder } from '../../src/forwarders.interfaces';
+import { Dictionary } from '../../src/utils';
+
+const testMPID = 'test-mpid';
+
+function createHelpers(mpInstance: IMParticleWebSDKInstance) {
+    return new Helpers(mpInstance);
+}
+
+function createMpInstance(options?: {
+    userAttributes?: Dictionary | null;
+    userIdentities?: Dictionary<string>;
+}): IMParticleWebSDKInstance {
+    const mockMPInstance = {
+        _Store: {
+            getUserAttributes: jest.fn(
+                () => options?.userAttributes ?? {}
+            ),
+            getUserIdentities: jest.fn(
+                () =>
+                    options?.userIdentities ?? {
+                        [IdentityType.CustomerId]: 'cust-1',
+                        [IdentityType.Email]: 'user@example.com',
+                        [IdentityType.Google]: 'google-id',
+                    }
+            ),
+        },
+        Logger: {
+            verbose: jest.fn(),
+            warning: jest.fn(),
+            error: jest.fn(),
+        },
+    } as unknown as IMParticleWebSDKInstance;
+
+    mockMPInstance._Helpers = createHelpers(mockMPInstance);
+    return mockMPInstance;
+}
+
+function createKitBlocker(options: {
+    blockedAttributes?: string[];
+    blockedIdentities?: string[];
+}): KitBlocker {
+    const blockedAttributes = new Set(options.blockedAttributes ?? []);
+    const blockedIdentities = new Set(options.blockedIdentities ?? []);
+
+    return {
+        isAttributeKeyBlocked: jest.fn((key: string) =>
+            blockedAttributes.has(key)
+        ),
+        isIdentityBlocked: jest.fn((identityName: string) =>
+            blockedIdentities.has(identityName)
+        ),
+    } as unknown as KitBlocker;
+}
+
+describe('filteredMparticleUser', () => {
+    it('returns the MPID without constructing with new', () => {
+        const mpInstance = createMpInstance();
+        const user = filteredMparticleUser(
+            testMPID,
+            { userAttributeFilters: [] },
+            mpInstance
+        );
+
+        expect(user.getMPID()).toBe(testMPID);
+    });
+
+    describe('#getAllUserAttributes', () => {
+        it('returns {} when store attributes are missing', () => {
+            const mpInstance = createMpInstance({ userAttributes: null });
+            const user = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [] },
+                mpInstance
+            );
+
+            expect(user.getAllUserAttributes()).toEqual({});
+        });
+
+        it('copies list attributes so kits cannot mutate store values', () => {
+            const tags = ['a', 'b'];
+            const mpInstance = createMpInstance({
+                userAttributes: { color: 'red', tags },
+            });
+            const user = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [] },
+                mpInstance
+            );
+
+            const attrs = user.getAllUserAttributes();
+            expect(attrs.color).toBe('red');
+            expect(attrs.tags).toEqual(['a', 'b']);
+            expect(attrs.tags).not.toBe(tags);
+
+            (attrs.tags as string[]).push('c');
+            expect(tags).toEqual(['a', 'b']);
+        });
+
+        it('omits kit-blocked attribute keys when no kit blocker is treated as allow-all', () => {
+            const mpInstance = createMpInstance({
+                userAttributes: {
+                    allowed: 'yes',
+                    blocked_attr: 'no',
+                },
+            });
+            const blockedUser = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [] },
+                mpInstance,
+                createKitBlocker({ blockedAttributes: ['blocked_attr'] })
+            );
+            const unblockedUser = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [] },
+                mpInstance
+            );
+
+            expect(blockedUser.getAllUserAttributes()).toEqual({
+                allowed: 'yes',
+            });
+            expect(unblockedUser.getAllUserAttributes()).toEqual({
+                allowed: 'yes',
+                blocked_attr: 'no',
+            });
+        });
+
+        it('applies forwarder userAttributeFilters after kit blocking', () => {
+            const filteredKey = 'drop_me';
+            const mpInstance = createMpInstance({
+                userAttributes: {
+                    keep_me: '1',
+                    drop_me: '2',
+                },
+            });
+            const user = filteredMparticleUser(
+                testMPID,
+                {
+                    userAttributeFilters: [
+                        KitFilterHelper.hashUserAttribute(filteredKey),
+                    ],
+                } as MPForwarder,
+                mpInstance
+            );
+
+            expect(user.getAllUserAttributes()).toEqual({ keep_me: '1' });
+        });
+    });
+
+    describe('#getUserAttributesLists', () => {
+        it('returns only array attributes and copies them', () => {
+            const tags = ['x'];
+            const mpInstance = createMpInstance({
+                userAttributes: {
+                    color: 'red',
+                    tags,
+                    empty: [],
+                },
+            });
+            const user = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [] },
+                mpInstance
+            );
+
+            const lists = user.getUserAttributesLists({
+                userAttributeFilters: [],
+            } as MPForwarder);
+
+            expect(lists).toEqual({ tags: ['x'], empty: [] });
+            expect(lists.tags).not.toBe(tags);
+        });
+
+        it('applies the method-argument forwarder filters to list keys', () => {
+            const mpInstance = createMpInstance({
+                userAttributes: {
+                    tags: ['a'],
+                    secrets: ['s'],
+                },
+            });
+            const user = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [] },
+                mpInstance
+            );
+
+            const lists = user.getUserAttributesLists({
+                userAttributeFilters: [
+                    KitFilterHelper.hashUserAttribute('secrets'),
+                ],
+            } as MPForwarder);
+
+            expect(lists).toEqual({ tags: ['a'] });
+        });
+
+        it('does not include kit-blocked list attributes', () => {
+            const mpInstance = createMpInstance({
+                userAttributes: {
+                    tags: ['a'],
+                    blocked_list: ['b'],
+                },
+            });
+            const user = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [] },
+                mpInstance,
+                createKitBlocker({ blockedAttributes: ['blocked_list'] })
+            );
+
+            expect(
+                user.getUserAttributesLists({
+                    userAttributeFilters: [],
+                } as MPForwarder)
+            ).toEqual({ tags: ['a'] });
+        });
+    });
+
+    describe('#getUserIdentities', () => {
+        it('maps store identity-type keys to names', () => {
+            const mpInstance = createMpInstance();
+            const user = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [], userIdentityFilters: [] } as MPForwarder,
+                mpInstance
+            );
+
+            expect(user.getUserIdentities()).toEqual({
+                userIdentities: {
+                    customerid: 'cust-1',
+                    email: 'user@example.com',
+                    google: 'google-id',
+                },
+            });
+        });
+
+        it('omits kit-blocked identities and forwarder identity filters', () => {
+            const mpInstance = createMpInstance();
+            const user = filteredMparticleUser(
+                testMPID,
+                {
+                    userAttributeFilters: [],
+                    userIdentityFilters: [IdentityType.Google],
+                } as MPForwarder,
+                mpInstance,
+                createKitBlocker({ blockedIdentities: ['email'] })
+            );
+
+            expect(user.getUserIdentities()).toEqual({
+                userIdentities: {
+                    customerid: 'cust-1',
+                },
+            });
+        });
+
+        it('allows all identities when kitBlocker is omitted', () => {
+            const mpInstance = createMpInstance();
+            const user = filteredMparticleUser(
+                testMPID,
+                { userAttributeFilters: [], userIdentityFilters: [] } as MPForwarder,
+                mpInstance
+            );
+
+            expect(user.getUserIdentities().userIdentities).toEqual({
+                customerid: 'cust-1',
+                email: 'user@example.com',
+                google: 'google-id',
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Background
- Follow-up to the `filteredMparticleUser` JS → TS migration PR.
- SonarQube flagged cognitive complexity on the migrated module; this PR addresses that without changing product behavior.

## What Has Changed
- Hoisted helper functions to module scope (`isAttributeKeyAllowed`, `buildUserAttributesCopy`, `buildFilteredUserIdentities`, etc.)
- Simplified control flow with early `continue` / helper extraction to satisfy Sonar cognitive complexity limits
- No intentional public API or functional changes

## Screenshots/Video
- N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- Stacked on `refactor/SDKE-1193-migrate-filteredMparticleUser-to-TS` (migration-only).
- Merge the migration PR first, then retarget this PR to `development` (or merge the stack in order).

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Relates to https://go/j/SDKE-1193