### PR TITLE
fix: correct generateHash typings

### DIFF
--- a/src/consent.ts
+++ b/src/consent.ts
@@ -90,7 +90,7 @@ export interface IConsentStateV2DTO {
 }
 
 export interface IConsentRulesValues {
-    consentPurpose: string;
+    consentPurpose: string | number;
     hasConsented: boolean;
 }
 export interface IConsentRules {

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -90,7 +90,7 @@ export interface IConsentStateV2DTO {
 }
 
 export interface IConsentRulesValues {
-    consentPurpose: string | number;
+    consentPurpose: string;
     hasConsented: boolean;
 }
 export interface IConsentRules {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -280,7 +280,7 @@ export default function Helpers(
     this.isObject = utils.isObject;
     this.decoded = utils.decoded;
     this.parseStringOrNumber = utils.parseStringOrNumber;
-    this.generateHash = utils.generateHash as unknown as SDKHelpersApi['generateHash'];
+    this.generateHash = utils.generateHash;
     this.generateUniqueId = utils.generateUniqueId;
 
     // Imported Validators

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -265,7 +265,7 @@ export interface MParticleWebSDK {
     startTrackingLocation(callback?: Callback): void;
 
     stopTrackingLocation(): void;
-    generateHash(value: string): string;
+    generateHash(value: string): number;
     setIntegrationAttribute(
         integrationModuleId: number,
         attrs: IntegrationAttribute
@@ -375,7 +375,7 @@ export interface SDKHelpersApi {
     findKeyInObject?(obj: any, key: string): string;
     parseNumber?(value: string | number): number;
     generateUniqueId();
-    generateHash?(value: string): string;
+    generateHash?(value: string): number;
     // https://go.mparticle.com/work/SQDSDKS-6317
     getFeatureFlag?(feature: string): boolean | string; // TODO: Feature Constants should be converted to enum
     decoded?(s: string): string;

--- a/test/src/tests-cookie-syncing.ts
+++ b/test/src/tests-cookie-syncing.ts
@@ -335,7 +335,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -367,7 +367,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -401,7 +401,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -435,7 +435,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -468,7 +468,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -501,7 +501,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -534,7 +534,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -567,7 +567,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -600,7 +600,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -632,7 +632,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -664,7 +664,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -696,7 +696,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -728,7 +728,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -760,7 +760,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -792,7 +792,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -823,7 +823,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -884,7 +884,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -945,7 +945,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -1007,7 +1007,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -1082,7 +1082,7 @@ describe('cookie syncing', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -1166,7 +1166,7 @@ describe('cookie syncing', function() {
         const createConsentRules = (purpose: string, consentType: '1' | '2' = '1') => ({
             includeOnMatch: true,
             values: [{
-                consentPurpose: mParticle.generateHash(consentType + purpose),
+                consentPurpose: mParticle.generateHash(consentType + purpose).toString(),
                 hasConsented: true,
             }],
         });

--- a/test/src/tests-forwarders.ts
+++ b/test/src/tests-forwarders.ts
@@ -665,7 +665,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -708,7 +708,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -749,7 +749,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -791,7 +791,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -833,7 +833,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -875,7 +875,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -917,7 +917,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -959,7 +959,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: consented,
                 },
             ],
@@ -1002,7 +1002,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consentPresent,
                 },
             ],
@@ -1047,7 +1047,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consentPresent,
                 },
             ],
@@ -1092,7 +1092,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consentPresent,
                 },
             ],
@@ -1138,7 +1138,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consentPresent,
                 },
             ],
@@ -1183,7 +1183,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consentPresent,
                 },
             ],
@@ -1228,7 +1228,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consentPresent,
                 },
             ],
@@ -1273,7 +1273,7 @@ describe('forwarders', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '2' + 'data_sale_opt_out'
-                    ),
+                    ).toString(),
                     hasConsented: consentPresent,
                 },
             ],

--- a/test/src/tests-identity.ts
+++ b/test/src/tests-identity.ts
@@ -660,7 +660,7 @@ describe('identity', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 1'
-                    ),
+                    ).toString(),
                     hasConsented: true,
                 },
             ],
@@ -676,7 +676,7 @@ describe('identity', function() {
                 {
                     consentPurpose: mParticle.generateHash(
                         '1' + 'foo purpose 2'
-                    ),
+                    ).toString(),
                     hasConsented: true,
                 },
             ],


### PR DESCRIPTION
## Background
- Follow-up to the helpers JS → TS migration (#1273).
- Keeps the migration PR minimal by moving known incorrect typings into this stacked change.

## What Has Changed
- `generateHash` return type: `string` → `number` on `MParticleWebSDK` and `SDKHelpersApi` (matches `utils.generateHash` and existing tests that assert `typeof … === 'number'`).
- Removes the temporary cast in `helpers.ts` now that the interface matches runtime.

## Screenshots/Video
- N/A

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- Fixing [Sonar Cloud Analysis](https://github.com/mParticle/mparticle-web-sdk/pull/1338/checks?check_run_id=96110363641) is a big refactor, will do in follow up PR

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
