### PR TITLE
refactor: reduce helpers filterUserIdentities cognitive complexity

### DIFF
--- a/src/consent.ts
+++ b/src/consent.ts
@@ -90,7 +90,7 @@ export interface IConsentStateV2DTO {
 }
 
 export interface IConsentRulesValues {
-    consentPurpose: string;
+    consentPurpose: string | number;
     hasConsented: boolean;
 }
 export interface IConsentRules {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -279,7 +279,7 @@ export default function Helpers(
     this.isObject = utils.isObject;
     this.decoded = utils.decoded;
     this.parseStringOrNumber = utils.parseStringOrNumber;
-    this.generateHash = utils.generateHash as unknown as SDKHelpersApi['generateHash'];
+    this.generateHash = utils.generateHash;
     this.generateUniqueId = utils.generateUniqueId;
 
     // Imported Validators

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -12,6 +12,57 @@ import { EventType } from './types';
 
 const StorageNames = Constants.StorageNames;
 
+type FilteredUserIdentity = { Type: number; Identity: string };
+
+function appendFilteredUserIdentity(
+    filteredUserIdentities: FilteredUserIdentity[],
+    identity: FilteredUserIdentity,
+    userIdentityType: number
+): void {
+    if (userIdentityType === Types.IdentityType.CustomerId) {
+        filteredUserIdentities.unshift(identity);
+    } else {
+        filteredUserIdentities.push(identity);
+    }
+}
+
+function buildFilteredUserIdentities(
+    userIdentitiesObject: Dictionary<string> | null | undefined,
+    filterList: number[],
+    inArray: (items: any[], value: any) => boolean
+): FilteredUserIdentity[] {
+    const filteredUserIdentities: FilteredUserIdentity[] = [];
+
+    if (!userIdentitiesObject || !Object.keys(userIdentitiesObject).length) {
+        return filteredUserIdentities;
+    }
+
+    for (const userIdentityName in userIdentitiesObject) {
+        if (!userIdentitiesObject.hasOwnProperty(userIdentityName)) {
+            continue;
+        }
+
+        const userIdentityType = Types.IdentityType.getIdentityType(
+            userIdentityName
+        );
+
+        if (inArray(filterList, userIdentityType)) {
+            continue;
+        }
+
+        appendFilteredUserIdentity(
+            filteredUserIdentities,
+            {
+                Type: userIdentityType,
+                Identity: userIdentitiesObject[userIdentityName],
+            },
+            userIdentityType
+        );
+    }
+
+    return filteredUserIdentities;
+}
+
 export default function Helpers(
     this: SDKHelpersApi,
     mpInstance: IMParticleWebSDKInstance
@@ -163,35 +214,11 @@ export default function Helpers(
         userIdentitiesObject: Dictionary<string>,
         filterList: number[]
     ): Array<{ Type: number; Identity: string }> {
-        const filteredUserIdentities: Array<{
-            Type: number;
-            Identity: string;
-        }> = [];
-
-        if (userIdentitiesObject && Object.keys(userIdentitiesObject).length) {
-            for (const userIdentityName in userIdentitiesObject) {
-                if (userIdentitiesObject.hasOwnProperty(userIdentityName)) {
-                    const userIdentityType = Types.IdentityType.getIdentityType(
-                        userIdentityName
-                    );
-                    if (!self.inArray(filterList, userIdentityType)) {
-                        const identity = {
-                            Type: userIdentityType,
-                            Identity: userIdentitiesObject[userIdentityName],
-                        };
-                        if (
-                            userIdentityType === Types.IdentityType.CustomerId
-                        ) {
-                            filteredUserIdentities.unshift(identity);
-                        } else {
-                            filteredUserIdentities.push(identity);
-                        }
-                    }
-                }
-            }
-        }
-
-        return filteredUserIdentities;
+        return buildFilteredUserIdentities(
+            userIdentitiesObject,
+            filterList,
+            self.inArray
+        );
     };
 
     this.filterUserIdentitiesForForwarders =

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -265,7 +265,7 @@ export interface MParticleWebSDK {
     startTrackingLocation(callback?: Callback): void;
 
     stopTrackingLocation(): void;
-    generateHash(value: string): string;
+    generateHash(value: string): number;
     setIntegrationAttribute(
         integrationModuleId: number,
         attrs: IntegrationAttribute
@@ -375,7 +375,7 @@ export interface SDKHelpersApi {
     findKeyInObject?(obj: any, key: string): string;
     parseNumber?(value: string | number): number;
     generateUniqueId();
-    generateHash?(value: string): string;
+    generateHash?(value: string): number;
     // https://go.mparticle.com/work/SQDSDKS-6317
     getFeatureFlag?(feature: string): boolean | string; // TODO: Feature Constants should be converted to enum
     decoded?(s: string): string;


### PR DESCRIPTION
## Background
- Follow-up to the helpers JS → TS migration (#1273).
- SonarQube flagged `filterUserIdentities` cognitive complexity (17 > 15).
- Kept out of the migration PR so that stays migration-only.


## What Has Changed
-Extracted module-scoped helpers `buildFilteredUserIdentities` and `appendFilteredUserIdentity`.
- `filterUserIdentities` now delegates to those helpers.
- No intentional filtering / behavior change (same `inArray` checks, CustomerId unshift, etc.).


## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
