### PR TITLE
refactor: reduce helpers filterUserIdentities cognitive complexity

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -12,6 +12,55 @@ import { AliasUsersCallback, MPID } from '@mparticle/web-sdk';
 
 const StorageNames = Constants.StorageNames;
 
+function appendFilteredUserIdentity(
+    filteredUserIdentities: ISDKUserIdentity[],
+    identity: ISDKUserIdentity,
+    userIdentityType: number
+): void {
+    if (userIdentityType === Types.IdentityType.CustomerId) {
+        filteredUserIdentities.unshift(identity);
+    } else {
+        filteredUserIdentities.push(identity);
+    }
+}
+
+function buildFilteredUserIdentities(
+    userIdentitiesObject: utils.Dictionary<string> | null | undefined,
+    filterList: number[],
+    inArray: (items: any[], value: any) => boolean
+): ISDKUserIdentity[] {
+    const filteredUserIdentities: ISDKUserIdentity[] = [];
+
+    if (!userIdentitiesObject || !Object.keys(userIdentitiesObject).length) {
+        return filteredUserIdentities;
+    }
+
+    for (const userIdentityName in userIdentitiesObject) {
+        if (!userIdentitiesObject.hasOwnProperty(userIdentityName)) {
+            continue;
+        }
+
+        const userIdentityType = Types.IdentityType.getIdentityType(
+            userIdentityName
+        );
+
+        if (inArray(filterList, userIdentityType)) {
+            continue;
+        }
+
+        appendFilteredUserIdentity(
+            filteredUserIdentities,
+            {
+                Type: userIdentityType,
+                Identity: userIdentitiesObject[userIdentityName],
+            },
+            userIdentityType
+        );
+    }
+
+    return filteredUserIdentities;
+}
+
 export default function Helpers(
     this: SDKHelpersApi,
     mpInstance: IMParticleWebSDKInstance
@@ -165,32 +214,11 @@ export default function Helpers(
         userIdentitiesObject: Dictionary<string>,
         filterList: number[]
     ): ISDKUserIdentity[] {
-        const filteredUserIdentities: ISDKUserIdentity[] = [];
-
-        if (userIdentitiesObject && Object.keys(userIdentitiesObject).length) {
-            for (const userIdentityName in userIdentitiesObject) {
-                if (userIdentitiesObject.hasOwnProperty(userIdentityName)) {
-                    const userIdentityType = Types.IdentityType.getIdentityType(
-                        userIdentityName
-                    );
-                    if (!self.inArray(filterList, userIdentityType)) {
-                        const identity: ISDKUserIdentity = {
-                            Type: userIdentityType,
-                            Identity: userIdentitiesObject[userIdentityName],
-                        };
-                        if (
-                            userIdentityType === Types.IdentityType.CustomerId
-                        ) {
-                            filteredUserIdentities.unshift(identity);
-                        } else {
-                            filteredUserIdentities.push(identity);
-                        }
-                    }
-                }
-            }
-        }
-
-        return filteredUserIdentities;
+        return buildFilteredUserIdentities(
+            userIdentitiesObject,
+            filterList,
+            self.inArray
+        );
     };
 
     this.filterUserIdentitiesForForwarders =


### PR DESCRIPTION
## Background
- SonarQube flagged `filterUserIdentities` cognitive complexity (17 > 15).


## What Has Changed
-Extracted module-scoped helpers `buildFilteredUserIdentities` and `appendFilteredUserIdentity`.
- `filterUserIdentities` now delegates to those helpers.
- No intentional filtering / behavior change (same `inArray` checks, CustomerId unshift, etc.).


## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
