### PR TITLE
refactor: migrate events to TS

### DIFF
--- a/src/ecommerce.interfaces.ts
+++ b/src/ecommerce.interfaces.ts
@@ -165,14 +165,14 @@ export interface IECommerce extends IECommerceShared {
         promotionActionType: valueof<typeof PromotionActionType>
     ): number | null;
     calculateProductActionTotalAmount(
-        productAction: ProductAction | SDKProductAction
-    ): ProductAction | SDKProductAction;
+        productAction: SDKProductAction
+    ): SDKProductAction;
     convertTransactionAttributesToProductAction(
         transactionAttributes: TransactionAttributes,
-        productAction: ProductAction | SDKProductAction
+        productAction: SDKProductAction
     ): void;
     createCommerceEventObject(
-        customFlags?: SDKEventCustomFlags,
+        customFlags: SDKEventCustomFlags,
         options?: SDKEventOptions
     ): SDKEvent | null;
     expandProductAction(commerceEvent: CommerceEvent): SDKEvent[];

--- a/src/ecommerce.interfaces.ts
+++ b/src/ecommerce.interfaces.ts
@@ -13,15 +13,13 @@ import { valueof } from './utils';
 import {
     ProductActionType,
     PromotionActionType,
-    CommerceEventType,
-    EventType,
 } from './types';
 import {
     SDKEvent,
     SDKEventCustomFlags,
     SDKImpression,
     SDKProduct,
-    SDKProductImpression,
+    SDKProductAction,
     SDKPromotion,
 } from './sdkRuntimeModels';
 
@@ -71,7 +69,7 @@ export interface SDKECommerceAPI extends IECommerceShared {
         customFlags?: SDKEventCustomFlags
     ): void;
     logImpression(
-        impression: SDKProductImpression,
+        impression: SDKImpression | SDKImpression[],
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions
@@ -155,20 +153,26 @@ interface ExtractedTransactionId {
 
 // Used for the private `_Ecommerce` namespace
 export interface IECommerce extends IECommerceShared {
-    buildProductList(event: SDKEvent, product: Product | Product[]): Product[];
+    buildProductList(
+        event: SDKEvent,
+        product: SDKProduct | SDKProduct[]
+    ): SDKProduct[];
     convertProductActionToEventType(
         productActionType: valueof<typeof ProductActionType>
     ): // https://go.mparticle.com/work/SQDSDKS-4801
-    typeof CommerceEventType | typeof EventType | null;
+    number | null;
     convertPromotionActionToEventType(
         promotionActionType: valueof<typeof PromotionActionType>
-    ): typeof CommerceEventType | null;
+    ): number | null;
+    calculateProductActionTotalAmount(
+        productAction: ProductAction | SDKProductAction
+    ): ProductAction | SDKProductAction;
     convertTransactionAttributesToProductAction(
         transactionAttributes: TransactionAttributes,
-        productAction: ProductAction
+        productAction: ProductAction | SDKProductAction
     ): void;
     createCommerceEventObject(
-        customFlags: SDKEventCustomFlags,
+        customFlags?: SDKEventCustomFlags,
         options?: SDKEventOptions
     ): SDKEvent | null;
     expandProductAction(commerceEvent: CommerceEvent): SDKEvent[];

--- a/src/events.interfaces.ts
+++ b/src/events.interfaces.ts
@@ -1,5 +1,4 @@
 import {
-    Callback,
     SDKEventAttrs,
     SDKEventOptions,
     TransactionAttributes,
@@ -8,8 +7,8 @@ import {
     BaseEvent,
     SDKEvent,
     SDKEventCustomFlags,
+    SDKImpression,
     SDKProduct,
-    SDKProductImpression,
     SDKPromotion,
 } from './sdkRuntimeModels';
 import { valueof } from './utils';
@@ -18,13 +17,20 @@ import { EventType, ProductActionType, PromotionActionType } from './types';
 // Supports wrapping event handlers functions that will ideally return a specific type
 type EventHandlerFunction<T> = (element: HTMLLinkElement | HTMLFormElement) => T;
 
+// Runtime may call with a position object or with no args (error / rejected path)
+export type TrackingCallback = (
+    location?: {
+        coords: { latitude: number | string; longitude: number | string };
+    }
+) => void;
+
 export interface IEvents {
     addEventHandler(
         domEvent: string,
         selector: string | Node,
         eventName: EventHandlerFunction<string> | string,
         data: EventHandlerFunction<SDKEventAttrs> | SDKEventAttrs,
-        eventType: valueof<typeof EventType>
+        eventType?: valueof<typeof EventType>
     ): void;
     logAST(): void;
     logCheckoutEvent(
@@ -45,11 +51,11 @@ export interface IEvents {
     ): void;
     logEvent(event: BaseEvent, eventOptions?: SDKEventOptions): void;
     logImpressionEvent(
-        impression: SDKProductImpression,
+        impression: SDKImpression | SDKImpression[],
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions
-    );
+    ): void;
     logOptOut(): void;
     logPageView(): void;
     logProductActionEvent(
@@ -62,7 +68,7 @@ export interface IEvents {
     ): void;
     logPromotionEvent(
         promotionType: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion,
+        promotion: SDKPromotion | SDKPromotion[],
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions
@@ -79,6 +85,6 @@ export interface IEvents {
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags
     ): void;
-    startTracking(callback: Callback): void;
+    startTracking(callback: TrackingCallback): void;
     stopTracking(): void;
 }

--- a/src/events.interfaces.ts
+++ b/src/events.interfaces.ts
@@ -1,4 +1,5 @@
 import {
+    Callback,
     SDKEventAttrs,
     SDKEventOptions,
     TransactionAttributes,
@@ -17,20 +18,13 @@ import { EventType, ProductActionType, PromotionActionType } from './types';
 // Supports wrapping event handlers functions that will ideally return a specific type
 type EventHandlerFunction<T> = (element: HTMLLinkElement | HTMLFormElement) => T;
 
-// Runtime may call with a position object or with no args (error / rejected path)
-export type TrackingCallback = (
-    location?: {
-        coords: { latitude: number | string; longitude: number | string };
-    }
-) => void;
-
 export interface IEvents {
     addEventHandler(
         domEvent: string,
         selector: string | Node,
         eventName: EventHandlerFunction<string> | string,
         data: EventHandlerFunction<SDKEventAttrs> | SDKEventAttrs,
-        eventType?: valueof<typeof EventType>
+        eventType: valueof<typeof EventType>
     ): void;
     logAST(): void;
     logCheckoutEvent(
@@ -68,7 +62,7 @@ export interface IEvents {
     ): void;
     logPromotionEvent(
         promotionType: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion | SDKPromotion[],
+        promotion: SDKPromotion,
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions
@@ -85,6 +79,6 @@ export interface IEvents {
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags
     ): void;
-    startTracking(callback: TrackingCallback): void;
+    startTracking(callback: Callback): void;
     stopTracking(): void;
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,16 +1,44 @@
 import Types from './types';
 import Constants from './constants';
+import { IEvents, TrackingCallback } from './events.interfaces';
+import { IMParticleWebSDKInstance } from './mp-instance';
+import {
+    BaseEvent,
+    SDKEvent,
+    SDKEventCustomFlags,
+    SDKImpression,
+    SDKProduct,
+    SDKProductActionType,
+    SDKPromotion,
+} from './sdkRuntimeModels';
+import {
+    SDKEventAttrs,
+    SDKEventOptions,
+    TransactionAttributes,
+} from '@mparticle/web-sdk';
+import { valueof } from './utils';
+import { EventType, ProductActionType, PromotionActionType } from './types';
 
-var Messages = Constants.Messages;
+interface DOMHandlerElement extends HTMLElement {
+    href?: string;
+    target?: string;
+    submit?: () => void;
+    attachEvent?: (event: string, handler: EventListener) => void;
+}
 
-export default function Events(mpInstance) {
-    var self = this;
-    this.logEvent = function(event, options) {
+const Messages = Constants.Messages;
+
+export default function Events(
+    this: IEvents,
+    mpInstance: IMParticleWebSDKInstance
+): void {
+    const self = this;
+    this.logEvent = function(event: BaseEvent, options?: SDKEventOptions): void {
         mpInstance.Logger.verbose(
             Messages.InformationMessages.StartingLogEvent + ': ' + event.name
         );
         if (mpInstance._Helpers.canLog()) {
-            var uploadObject = mpInstance._ServerModel.createEventObject(event);
+            const uploadObject = mpInstance._ServerModel.createEventObject(event);
             mpInstance._APIClient.sendEventToServer(uploadObject, options);
         } else {
             mpInstance.Logger.verbose(
@@ -19,7 +47,7 @@ export default function Events(mpInstance) {
         }
     };
 
-    this.startTracking = function(callback) {
+    this.startTracking = function(callback: TrackingCallback): void {
         if (!mpInstance._Store.isTracking) {
             if ('geolocation' in navigator) {
                 mpInstance._Store.watchPositionId = navigator.geolocation.watchPosition(
@@ -28,7 +56,7 @@ export default function Events(mpInstance) {
                 );
             }
         } else {
-            var position = {
+            const position = {
                 coords: {
                     latitude: mpInstance._Store.currentPosition.lat,
                     longitude: mpInstance._Store.currentPosition.lng,
@@ -37,7 +65,7 @@ export default function Events(mpInstance) {
             triggerCallback(callback, position);
         }
 
-        function successTracking(position) {
+        function successTracking(position: GeolocationPosition): void {
             mpInstance._Store.currentPosition = {
                 lat: position.coords.latitude,
                 lng: position.coords.longitude,
@@ -50,14 +78,22 @@ export default function Events(mpInstance) {
             mpInstance._Store.isTracking = true;
         }
 
-        function errorTracking() {
+        function errorTracking(): void {
             triggerCallback(callback);
             // prevents callback from being fired multiple times
             callback = null;
             mpInstance._Store.isTracking = false;
         }
 
-        function triggerCallback(callback, position) {
+        function triggerCallback(
+            callback: TrackingCallback | null,
+            position?: {
+                coords: {
+                    latitude: number | string;
+                    longitude: number | string;
+                };
+            } | GeolocationPosition
+        ): void {
             if (callback) {
                 try {
                     if (position) {
@@ -69,13 +105,13 @@ export default function Events(mpInstance) {
                     mpInstance.Logger.error(
                         'Error invoking the callback passed to startTrackingLocation.'
                     );
-                    mpInstance.Logger.error(e);
+                    mpInstance.Logger.error(e as string);
                 }
             }
         }
     };
 
-    this.stopTracking = function() {
+    this.stopTracking = function(): void {
         if (mpInstance._Store.isTracking) {
             navigator.geolocation.clearWatch(mpInstance._Store.watchPositionId);
             mpInstance._Store.currentPosition = null;
@@ -83,23 +119,23 @@ export default function Events(mpInstance) {
         }
     };
 
-    this.logOptOut = function() {
+    this.logOptOut = function(): void {
         mpInstance.Logger.verbose(
             Messages.InformationMessages.StartingLogOptOut
         );
 
-        var event = mpInstance._ServerModel.createEventObject({
+        const event = mpInstance._ServerModel.createEventObject({
             messageType: Types.MessageType.OptOut,
             eventType: Types.EventType.Other,
         });
         mpInstance._APIClient.sendEventToServer(event);
     };
 
-    this.logAST = function() {
+    this.logAST = function(): void {
         self.logEvent({ messageType: Types.MessageType.AppStateTransition });
     };
 
-    this.logPageView = function() {
+    this.logPageView = function(): void {
         self.logEvent({
             messageType: Types.MessageType.PageView,
             name: 'PageView',
@@ -111,8 +147,13 @@ export default function Events(mpInstance) {
         });
     };
 
-    this.logCheckoutEvent = function(step, option, attrs, customFlags) {
-        var event = mpInstance._Ecommerce.createCommerceEventObject(
+    this.logCheckoutEvent = function(
+        step: number,
+        option?: string,
+        attrs?: SDKEventAttrs,
+        customFlags?: SDKEventCustomFlags
+    ): void {
+        const event = mpInstance._Ecommerce.createCommerceEventObject(
             customFlags
         );
 
@@ -122,7 +163,8 @@ export default function Events(mpInstance) {
             );
             event.EventCategory = Types.CommerceEventType.ProductCheckout;
             event.ProductAction = {
-                ProductActionType: Types.ProductActionType.Checkout,
+                ProductActionType: Types.ProductActionType
+                    .Checkout as SDKProductActionType,
                 CheckoutStep: step,
                 CheckoutOptions: option,
                 ProductList: [],
@@ -133,19 +175,19 @@ export default function Events(mpInstance) {
     };
 
     this.logProductActionEvent = function(
-        productActionType,
-        product,
-        customAttrs,
-        customFlags,
-        transactionAttributes,
-        options
-    ) {
-        var event = mpInstance._Ecommerce.createCommerceEventObject(
+        productActionType: valueof<typeof ProductActionType>,
+        product: SDKProduct | SDKProduct[],
+        customAttrs?: SDKEventAttrs,
+        customFlags?: SDKEventCustomFlags,
+        transactionAttributes?: TransactionAttributes,
+        options?: SDKEventOptions
+    ): void {
+        const event = mpInstance._Ecommerce.createCommerceEventObject(
             customFlags,
             options
         );
 
-        var productList = Array.isArray(product) ? product : [product];
+        const productList = Array.isArray(product) ? product : [product];
 
         productList.forEach(function(product) {
             if (product.TotalAmount) {
@@ -182,15 +224,21 @@ export default function Events(mpInstance) {
                 productActionType
             );
             event.ProductAction = {
-                ProductActionType: productActionType,
+                ProductActionType: productActionType as SDKProductActionType,
                 ProductList: productList,
             };
 
-            if (Types.ProductActionType.isRoktCommerceType(productActionType)) {
+            if (
+                Types.ProductActionType.isRoktCommerceType(
+                    productActionType as number
+                )
+            ) {
                 event.CustomFlags = event.CustomFlags || {};
                 event.CustomFlags[
                     'Rokt.CommerceEventType'
-                ] = Types.ProductActionType.getExpansionName(productActionType);
+                ] = Types.ProductActionType.getExpansionName(
+                    productActionType as number
+                );
             }
 
             if (mpInstance._Helpers.isObject(transactionAttributes)) {
@@ -205,12 +253,12 @@ export default function Events(mpInstance) {
     };
 
     this.logPurchaseEvent = function(
-        transactionAttributes,
-        product,
-        attrs,
-        customFlags
-    ) {
-        var event = mpInstance._Ecommerce.createCommerceEventObject(
+        transactionAttributes: TransactionAttributes,
+        product: SDKProduct | SDKProduct[],
+        attrs?: SDKEventAttrs,
+        customFlags?: SDKEventCustomFlags
+    ): void {
+        const event = mpInstance._Ecommerce.createCommerceEventObject(
             customFlags
         );
 
@@ -220,7 +268,8 @@ export default function Events(mpInstance) {
             );
             event.EventCategory = Types.CommerceEventType.ProductPurchase;
             event.ProductAction = {
-                ProductActionType: Types.ProductActionType.Purchase,
+                ProductActionType: Types.ProductActionType
+                    .Purchase as SDKProductActionType,
             };
             event.ProductAction.ProductList = mpInstance._Ecommerce.buildProductList(
                 event,
@@ -237,17 +286,17 @@ export default function Events(mpInstance) {
     };
 
     this.logRefundEvent = function(
-        transactionAttributes,
-        product,
-        attrs,
-        customFlags
-    ) {
+        transactionAttributes: TransactionAttributes,
+        product: SDKProduct | SDKProduct[],
+        attrs?: SDKEventAttrs,
+        customFlags?: SDKEventCustomFlags
+    ): void {
         if (!transactionAttributes) {
             mpInstance.Logger.error(Messages.ErrorMessages.TransactionRequired);
             return;
         }
 
-        var event = mpInstance._Ecommerce.createCommerceEventObject(
+        const event = mpInstance._Ecommerce.createCommerceEventObject(
             customFlags
         );
 
@@ -257,7 +306,8 @@ export default function Events(mpInstance) {
             );
             event.EventCategory = Types.CommerceEventType.ProductRefund;
             event.ProductAction = {
-                ProductActionType: Types.ProductActionType.Refund,
+                ProductActionType: Types.ProductActionType
+                    .Refund as SDKProductActionType,
             };
             event.ProductAction.ProductList = mpInstance._Ecommerce.buildProductList(
                 event,
@@ -274,13 +324,13 @@ export default function Events(mpInstance) {
     };
 
     this.logPromotionEvent = function(
-        promotionType,
-        promotion,
-        attrs,
-        customFlags,
-        eventOptions
-    ) {
-        var event = mpInstance._Ecommerce.createCommerceEventObject(
+        promotionType: valueof<typeof PromotionActionType>,
+        promotion: SDKPromotion | SDKPromotion[],
+        attrs?: SDKEventAttrs,
+        customFlags?: SDKEventCustomFlags,
+        eventOptions?: SDKEventOptions
+    ): void {
+        const event = mpInstance._Ecommerce.createCommerceEventObject(
             customFlags
         );
 
@@ -292,7 +342,7 @@ export default function Events(mpInstance) {
                 promotionType
             );
             event.PromotionAction = {
-                PromotionActionType: promotionType,
+                PromotionActionType: promotionType as unknown as string,
                 PromotionList: Array.isArray(promotion)
                     ? promotion
                     : [promotion],
@@ -303,12 +353,12 @@ export default function Events(mpInstance) {
     };
 
     this.logImpressionEvent = function(
-        impression,
-        attrs,
-        customFlags,
-        options
-    ) {
-        var event = mpInstance._Ecommerce.createCommerceEventObject(
+        impression: SDKImpression | SDKImpression[],
+        attrs?: SDKEventAttrs,
+        customFlags?: SDKEventCustomFlags,
+        options?: SDKEventOptions
+    ): void {
+        const event = mpInstance._Ecommerce.createCommerceEventObject(
             customFlags
         );
 
@@ -334,7 +384,11 @@ export default function Events(mpInstance) {
         }
     };
 
-    this.logCommerceEvent = function(commerceEvent, attrs, options) {
+    this.logCommerceEvent = function(
+        commerceEvent: SDKEvent,
+        attrs?: SDKEventAttrs,
+        options?: SDKEventOptions
+    ): void {
         mpInstance.Logger.verbose(
             Messages.InformationMessages.StartingLogCommerceEvent
         );
@@ -353,7 +407,7 @@ export default function Events(mpInstance) {
             return;
         }
 
-        attrs = mpInstance._Helpers.sanitizeAttributes(
+        const sanitizedAttrs = mpInstance._Helpers.sanitizeAttributes(
             attrs,
             commerceEvent.EventName
         );
@@ -364,8 +418,8 @@ export default function Events(mpInstance) {
                 commerceEvent.ShoppingCart = {};
             }
 
-            if (attrs) {
-                commerceEvent.EventAttributes = attrs;
+            if (sanitizedAttrs) {
+                commerceEvent.EventAttributes = sanitizedAttrs;
             }
 
             // When no transaction total (Revenue) was provided, derive it from
@@ -388,15 +442,19 @@ export default function Events(mpInstance) {
     };
 
     this.addEventHandler = function(
-        domEvent,
-        selector,
-        eventName,
-        data,
-        eventType
-    ) {
-        var elements = [],
-            handler = function(e) {
-                var timeoutHandler = function() {
+        domEvent: string,
+        selector: string | Node,
+        eventName:
+            | ((element: HTMLLinkElement | HTMLFormElement) => string)
+            | string,
+        data:
+            | ((element: HTMLLinkElement | HTMLFormElement) => SDKEventAttrs)
+            | SDKEventAttrs,
+        eventType?: valueof<typeof EventType>
+    ): void {
+        let elements: ArrayLike<Element> | Element[] = [],
+            handler = function(e: Event): void {
+                const timeoutHandler = function(): void {
                     if (element.href) {
                         window.location.href = element.href;
                     } else if (element.submit) {
@@ -412,10 +470,13 @@ export default function Events(mpInstance) {
                     messageType: Types.MessageType.PageEvent,
                     name:
                         typeof eventName === 'function'
-                            ? eventName(element)
+                            ? eventName(element as HTMLLinkElement | HTMLFormElement)
                             : eventName,
-                    data: typeof data === 'function' ? data(element) : data,
-                    eventType: eventType || Types.EventType.Other,
+                    data:
+                        typeof data === 'function'
+                            ? data(element as HTMLLinkElement | HTMLFormElement)
+                            : data,
+                    eventType: (eventType || Types.EventType.Other) as number,
                 });
 
                 // TODO: Handle middle-clicks and special keys (ctrl, alt, etc)
@@ -428,7 +489,7 @@ export default function Events(mpInstance) {
                     if (e.preventDefault) {
                         e.preventDefault();
                     } else {
-                        e.returnValue = false;
+                        (e as any).returnValue = false;
                     }
 
                     setTimeout(
@@ -437,8 +498,8 @@ export default function Events(mpInstance) {
                     );
                 }
             },
-            element,
-            i;
+            element: DOMHandlerElement,
+            i: number;
 
         if (!selector) {
             mpInstance.Logger.error("Can't bind event, selector is required");
@@ -449,7 +510,7 @@ export default function Events(mpInstance) {
         if (typeof selector === 'string') {
             elements = document.querySelectorAll(selector);
         } else if (selector.nodeType) {
-            elements = [selector];
+            elements = [selector as Element];
         }
 
         if (elements.length) {
@@ -462,7 +523,7 @@ export default function Events(mpInstance) {
             );
 
             for (i = 0; i < elements.length; i++) {
-                element = elements[i];
+                element = elements[i] as DOMHandlerElement;
 
                 if (element.addEventListener) {
                     // Modern browsers
@@ -472,7 +533,7 @@ export default function Events(mpInstance) {
                     element.attachEvent('on' + domEvent, handler);
                 } else {
                     // All other browsers
-                    element['on' + domEvent] = handler;
+                    (element as any)['on' + domEvent] = handler;
                 }
             }
         } else {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,6 +1,6 @@
 import Types from './types';
 import Constants from './constants';
-import { IEvents, TrackingCallback } from './events.interfaces';
+import { IEvents } from './events.interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import {
     BaseEvent,
@@ -25,6 +25,12 @@ interface DOMHandlerElement extends HTMLElement {
     submit?: () => void;
     attachEvent?: (event: string, handler: EventListener) => void;
 }
+
+type TrackingCallback = (
+    location?: {
+        coords: { latitude: number | string; longitude: number | string };
+    }
+) => void;
 
 const Messages = Constants.Messages;
 
@@ -325,7 +331,7 @@ export default function Events(
 
     this.logPromotionEvent = function(
         promotionType: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion | SDKPromotion[],
+        promotion: SDKPromotion,
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions
@@ -450,7 +456,7 @@ export default function Events(
         data:
             | ((element: HTMLLinkElement | HTMLFormElement) => SDKEventAttrs)
             | SDKEventAttrs,
-        eventType?: valueof<typeof EventType>
+        eventType: valueof<typeof EventType>
     ): void {
         let elements: ArrayLike<Element> | Element[] = [],
             handler = function(e: Event): void {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,8 @@
-import Types from './types';
+import Types, {
+    EventType,
+    ProductActionType,
+    PromotionActionType,
+} from './types';
 import Constants from './constants';
 import { IEvents } from './events.interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
@@ -17,7 +21,6 @@ import {
     TransactionAttributes,
 } from '@mparticle/web-sdk';
 import { valueof } from './utils';
-import { EventType, ProductActionType, PromotionActionType } from './types';
 
 interface DOMHandlerElement extends HTMLElement {
     href?: string;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -340,6 +340,7 @@ export interface SDKInitConfig
     maxProducts?: number;
     requestConfig?: boolean;
     sessionTimeout?: number;
+    timeout?: number;
     useNativeSdk?: boolean;
     useCookieStorage?: boolean;
     v1SecureServiceUrl?: string;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -340,7 +340,6 @@ export interface SDKInitConfig
     maxProducts?: number;
     requestConfig?: boolean;
     sessionTimeout?: number;
-    timeout?: number;
     useNativeSdk?: boolean;
     useCookieStorage?: boolean;
     v1SecureServiceUrl?: string;

--- a/src/store.ts
+++ b/src/store.ts
@@ -87,6 +87,7 @@ export interface SDKConfig {
     maxProducts: number;
     requestConfig?: boolean;
     sessionTimeout?: number;
+    timeout?: number;
     useNativeSdk?: boolean;
     useCookieStorage?: boolean;
     v1SecureServiceUrl?: string;

--- a/test/src/tests-event-logging.ts
+++ b/test/src/tests-event-logging.ts
@@ -2,6 +2,7 @@ import Utils from './config/utils';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock/esm/client';
 import { expect } from 'chai';
+import Should from 'should';
 import {
     urls,
     apiKey,
@@ -9,8 +10,18 @@ import {
     MPConfig,
     MessageType,
 } from './config/constants';
+import { IMParticleInstanceManager } from '../../src/sdkRuntimeModels';
+import { TransactionAttributes } from '@mparticle/web-sdk';
 
 const { findEventFromRequest, findBatch, getIdentityEvent, waitForCondition, fetchMockSuccess, hasIdentifyReturned } = Utils;
+
+declare global {
+    interface Window {
+        mParticle: IMParticleInstanceManager;
+    }
+}
+
+const mParticle = window.mParticle as IMParticleInstanceManager;
 
 describe('event logging', function() {
     beforeEach(function() {
@@ -209,7 +220,7 @@ describe('event logging', function() {
     it('should log an error', async () => {
         await waitForCondition(hasIdentifyReturned);
 
-        mParticle.logError('my error');
+        mParticle.logError('my error' as any);
 
         const errorEvent = findEventFromRequest(fetchMock.calls(), 'my error');
 
@@ -269,10 +280,10 @@ describe('event logging', function() {
         await waitForCondition(hasIdentifyReturned);
 
         const bond = sinon.spy(mParticle.getInstance().Logger, 'warning');
-        mParticle.logError('my error', {
+        mParticle.logError('my error' as any, {
             invalid: ['my invalid attr'],
             valid: 10,
-        });
+        } as any);
 
         const errorEvent = findEventFromRequest(fetchMock.calls(), 'my error');
 
@@ -442,7 +453,7 @@ describe('event logging', function() {
     it('should not log a PageView event if there are invalid attrs', async () => {
         await waitForCondition(hasIdentifyReturned);
 
-        mParticle.logPageView('test1', 'invalid', null);
+        mParticle.logPageView('test1', 'invalid' as any, null);
         const pageViewEvent = findEventFromRequest(
             fetchMock.calls(),
             'test1'
@@ -454,7 +465,7 @@ describe('event logging', function() {
     it('should not log an event that has an invalid customFlags', async () => {
         await waitForCondition(hasIdentifyReturned);
 
-        mParticle.logPageView('test', null, 'invalid');
+        mParticle.logPageView('test', null, 'invalid' as any);
 
         const pageViewEvent = findEventFromRequest(
             fetchMock.calls(),
@@ -468,7 +479,7 @@ describe('event logging', function() {
 
         fetchMock.resetHistory();
 
-        mParticle.logPageView(null);
+        mParticle.logPageView(null as any);
         fetchMock.calls().length.should.equal(1);
         const pageViewEvent = findEventFromRequest(
             fetchMock.calls(),
@@ -477,7 +488,7 @@ describe('event logging', function() {
         pageViewEvent.data.screen_name.should.equal('PageView');
 
         fetchMock.resetHistory();
-        mParticle.logPageView({ test: 'test' });
+        mParticle.logPageView({ test: 'test' } as any);
         fetchMock.calls().length.should.equal(1);
         const pageViewEvent2 = findEventFromRequest(
             fetchMock.calls(),
@@ -486,7 +497,7 @@ describe('event logging', function() {
         pageViewEvent2.data.screen_name.should.equal('PageView');
 
         fetchMock.resetHistory();
-        mParticle.logPageView([1, 2, 3]);
+        mParticle.logPageView([1, 2, 3] as any);
         fetchMock.calls().length.should.equal(1);
         const pageViewEvent3 = findEventFromRequest(
             fetchMock.calls(),
@@ -576,7 +587,7 @@ describe('event logging', function() {
             const eventTypeSequence = fetchMock
                 .calls()
                 .filter((call) => call[1].method.toLowerCase() === 'post')
-                .map((call) => JSON.parse(call[1].body))
+                .map((call) => JSON.parse(call[1].body as string))
                 .filter((body) => body.events)
                 .flatMap((body) => body.events.map((event) => event.event_type));
 
@@ -628,7 +639,7 @@ describe('event logging', function() {
         await waitForCondition(hasIdentifyReturned);
 
         fetchMock.resetHistory();
-        mParticle.logEvent();
+        (mParticle.logEvent as any)();
         
         fetchMock.calls().should.have.lengthOf(0);
     });
@@ -638,7 +649,7 @@ describe('event logging', function() {
 
         fetchMock.resetHistory();
 
-        mParticle.logEvent('test', 100);
+        mParticle.logEvent('test', 100 as any);
 
         fetchMock.calls().should.have.lengthOf(0);
     });
@@ -646,7 +657,7 @@ describe('event logging', function() {
     it('event attributes must be object', async () => {
         await waitForCondition(hasIdentifyReturned);
 
-        mParticle.logEvent('Test Event', null, 1);
+        mParticle.logEvent('Test Event', null, 1 as any);
         
         const testEvent = findEventFromRequest(fetchMock.calls(), 'Test Event');
         
@@ -744,7 +755,7 @@ describe('event logging', function() {
         );
 
         expect(identityCalls.length).to.equal(1);
-        const data = JSON.parse(identityCalls[0][1].body);
+        const data = JSON.parse(identityCalls[0][1].body as string);
         data.should.have.properties(
             'client_sdk',
             'environment',
@@ -950,7 +961,7 @@ describe('event logging', function() {
         let successCallbackCalled = false;
         let numberTimesCalled = 0;
 
-        navigator.geolocation.shouldFail = true;
+        (navigator.geolocation as any).shouldFail = true;
 
         mParticle.startTrackingLocation(function() {
             numberTimesCalled += 1;
@@ -973,7 +984,7 @@ describe('event logging', function() {
         testEvent = findEventFromRequest(fetchMock.calls(), 'Test Event');
         Should(testEvent).not.be.ok();
 
-        navigator.geolocation.shouldFail = false;
+        (navigator.geolocation as any).shouldFail = false;
 
         clock.restore();
     });
@@ -992,7 +1003,7 @@ describe('event logging', function() {
             currentPosition = position;
         }
         const clock = sinon.useFakeTimers();
-        mParticle.startTrackingLocation(callback);
+        mParticle.startTrackingLocation(callback as any);
 
         // mock geo will successfully run after 1 second (geomock.js // navigator.geolocation.delay)
 
@@ -1025,7 +1036,7 @@ describe('event logging', function() {
             successCallbackCalled = true;
             mParticle.logEvent('Test Event');
         }
-        mParticle.startTrackingLocation(callback);
+        mParticle.startTrackingLocation(callback as any);
 
         // mock geo will successfully run after 1 second (geomock.js // navigator.geolocation.delay)
         clock.tick(1000);
@@ -1056,7 +1067,7 @@ describe('event logging', function() {
 
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
 
         batch.application_info.should.have.property(
             'application_name',
@@ -1078,7 +1089,7 @@ describe('event logging', function() {
             );
         })
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
         batch.events[0].data.should.have.property('is_first_run', true);
 
         await waitForCondition(() => {
@@ -1088,7 +1099,7 @@ describe('event logging', function() {
         })
 
         mParticle.init(apiKey, mParticle.config);
-        const batch2 = JSON.parse(fetchMock.lastOptions().body);
+        const batch2 = JSON.parse(fetchMock.lastOptions().body as unknown as string);
         batch2.events[0].data.should.have.property('is_first_run', false);
 
         delete window.mParticle.config.flags;
@@ -1110,7 +1121,7 @@ describe('event logging', function() {
         });
 
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
         batch.events[0].data.should.have.property('launch_referral');
         batch.events[0].data.launch_referral.should.startWith(
             'http://localhost'
@@ -1136,7 +1147,7 @@ describe('event logging', function() {
 
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
         batch.application_info.should.have.property(
             'application_name',
             'another name'
@@ -1165,7 +1176,7 @@ describe('event logging', function() {
         });
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
 
         batch.should.have.property('context');
         batch.context.should.have.property('data_plan');
@@ -1192,7 +1203,7 @@ describe('event logging', function() {
         });
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
 
         batch.should.have.property('context');
         batch.context.should.have.property('data_plan');
@@ -1219,7 +1230,7 @@ describe('event logging', function() {
         });
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
 
         batch.should.not.have.property('context');
 
@@ -1257,7 +1268,7 @@ describe('event logging', function() {
         errorMessage.should.equal(
             'Your data plan id must be a string and match the data plan slug format (i.e. under_case_slug)'
         );
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
         batch.should.not.have.property('context');
         delete window.mParticle.config.flags;
     });
@@ -1307,7 +1318,7 @@ describe('event logging', function() {
 
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
 
         batch.should.have.property('consent_state');
         batch.consent_state.should.have.properties(['gdpr', 'ccpa']);
@@ -1385,7 +1396,7 @@ describe('event logging', function() {
             Revenue: 'string',
             Tax: 'string',
             Shipping: 'string',
-        };
+        } as unknown as TransactionAttributes;
 
         const customAttributes = { sale: true };
         const customFlags = { 'Google.Category': 'travel' };
@@ -1398,7 +1409,7 @@ describe('event logging', function() {
             transactionAttributes
         );
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
 
         batch.events[0].data.product_action.total_amount.should.equal(0);
         batch.events[0].data.product_action.shipping_amount.should.equal(0);
@@ -1427,7 +1438,7 @@ describe('event logging', function() {
             'variant',
             'category',
             'brand',
-            'string',
+            'string' as any,
             'coupon'
         );
         const product2 = mParticle.eCommerce.createProduct(
@@ -1438,7 +1449,7 @@ describe('event logging', function() {
             'variant',
             'category',
             'brand',
-            'string',
+            'string' as any,
             'coupon'
         );
 
@@ -1447,7 +1458,7 @@ describe('event logging', function() {
             Revenue: 'string',
             Tax: 'string',
             Shipping: 'string',
-        };
+        } as unknown as TransactionAttributes;
 
         const customAttributes = { sale: true };
         const customFlags = { 'Google.Category': 'travel' };
@@ -1459,7 +1470,7 @@ describe('event logging', function() {
             transactionAttributes
         );
 
-        const batch = JSON.parse(fetchMock.lastOptions().body);
+        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
         (
             batch.events[0].data.product_action.products[0].position === null
         ).should.equal(true);

--- a/test/src/tests-event-logging.ts
+++ b/test/src/tests-event-logging.ts
@@ -23,6 +23,10 @@ declare global {
 
 const mParticle = window.mParticle as IMParticleInstanceManager;
 
+function parseFetchJson(body: unknown) {
+    return JSON.parse(body as string);
+}
+
 describe('event logging', function() {
     beforeEach(function() {
         mParticle._resetForTests(MPConfig);
@@ -587,7 +591,7 @@ describe('event logging', function() {
             const eventTypeSequence = fetchMock
                 .calls()
                 .filter((call) => call[1].method.toLowerCase() === 'post')
-                .map((call) => JSON.parse(call[1].body as string))
+                .map((call) => parseFetchJson(call[1].body))
                 .filter((body) => body.events)
                 .flatMap((body) => body.events.map((event) => event.event_type));
 
@@ -755,7 +759,7 @@ describe('event logging', function() {
         );
 
         expect(identityCalls.length).to.equal(1);
-        const data = JSON.parse(identityCalls[0][1].body as string);
+        const data = parseFetchJson(identityCalls[0][1].body);
         data.should.have.properties(
             'client_sdk',
             'environment',
@@ -1067,7 +1071,7 @@ describe('event logging', function() {
 
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
 
         batch.application_info.should.have.property(
             'application_name',
@@ -1089,7 +1093,7 @@ describe('event logging', function() {
             );
         })
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
         batch.events[0].data.should.have.property('is_first_run', true);
 
         await waitForCondition(() => {
@@ -1099,7 +1103,7 @@ describe('event logging', function() {
         })
 
         mParticle.init(apiKey, mParticle.config);
-        const batch2 = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch2 = parseFetchJson(fetchMock.lastOptions().body);
         batch2.events[0].data.should.have.property('is_first_run', false);
 
         delete window.mParticle.config.flags;
@@ -1121,7 +1125,7 @@ describe('event logging', function() {
         });
 
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
         batch.events[0].data.should.have.property('launch_referral');
         batch.events[0].data.launch_referral.should.startWith(
             'http://localhost'
@@ -1147,7 +1151,7 @@ describe('event logging', function() {
 
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
         batch.application_info.should.have.property(
             'application_name',
             'another name'
@@ -1176,7 +1180,7 @@ describe('event logging', function() {
         });
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
 
         batch.should.have.property('context');
         batch.context.should.have.property('data_plan');
@@ -1203,7 +1207,7 @@ describe('event logging', function() {
         });
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
 
         batch.should.have.property('context');
         batch.context.should.have.property('data_plan');
@@ -1230,7 +1234,7 @@ describe('event logging', function() {
         });
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
 
         batch.should.not.have.property('context');
 
@@ -1268,7 +1272,7 @@ describe('event logging', function() {
         errorMessage.should.equal(
             'Your data plan id must be a string and match the data plan slug format (i.e. under_case_slug)'
         );
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
         batch.should.not.have.property('context');
         delete window.mParticle.config.flags;
     });
@@ -1318,7 +1322,7 @@ describe('event logging', function() {
 
         window.mParticle.logEvent('Test Event');
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
 
         batch.should.have.property('consent_state');
         batch.consent_state.should.have.properties(['gdpr', 'ccpa']);
@@ -1409,7 +1413,7 @@ describe('event logging', function() {
             transactionAttributes
         );
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
 
         batch.events[0].data.product_action.total_amount.should.equal(0);
         batch.events[0].data.product_action.shipping_amount.should.equal(0);
@@ -1470,7 +1474,7 @@ describe('event logging', function() {
             transactionAttributes
         );
 
-        const batch = JSON.parse(fetchMock.lastOptions().body as unknown as string);
+        const batch = parseFetchJson(fetchMock.lastOptions().body);
         (
             batch.events[0].data.product_action.products[0].position === null
         ).should.equal(true);


### PR DESCRIPTION
## Background
- Continues the incremental JS → TS migration of the core SDK.

## What Has Changed
- Renamed `src/events.js` → `src/events.ts`. Added types; `var` → `let`/`const`. Kept `self = this` and `function()` style — no arrow rewrites.
- Interface fixes required to type-check (runtime already did this):
  - `logImpression` / `logImpressionEvent` take `SDKImpression | SDKImpression[]` (input is `{ Name, Product }` from `createImpression`, one or many). `SDKProductImpression` is the *outgoing* payload, not the argument.
  - `IECommerce`: declare `calculateProductActionTotalAmount`; `buildProductList` returns `SDKProduct[]`; `convert*ToEventType` returns `number | null`; `convertTransactionAttributesToProductAction` takes `SDKProductAction`.
  - `SDKConfig.timeout?: number` — already set from `DefaultConfig.timeout`, read by `addEventHandler`.
- Local `DOMHandlerElement` + `TrackingCallback` in `events.ts` only (geolocation callback is invoked with a position or with no args).
- A few `as SDKProductActionType` / `as number` casts remain because `valueof<typeof ProductActionType>` includes helper methods. Left for a follow-up, not `types.ts` here.

## Screenshots/Video
- N/A — no behavioral change.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/SDKE-1106