### PR TITLE
fix: align kit package names with published npm package names

### DIFF
--- a/kits/amplitude/amplitude-8/package.json
+++ b/kits/amplitude/amplitude-8/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mparticle/web-amplitude-kit-8",
+  "name": "@mparticle/web-amplitude-kit",
   "version": "2.3.0",
   "author": "mParticle Developers (https://www.mparticle.com)",
   "description": "mParticle integration SDK for Amplitude",

--- a/kits/id5/id5-1/package.json
+++ b/kits/id5/id5-1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mparticle/web-id5-kit-1",
+  "name": "@mparticle/web-id5-kit",
   "version": "1.0.4",
   "main": "dist/ID5Kit.common.js",
   "files": [

--- a/kits/leanplum/leanplum-1/package.json
+++ b/kits/leanplum/leanplum-1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mparticle/web-leanplum-kit-1",
+  "name": "@mparticle/web-leanplum-kit",
   "version": "2.0.5",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
   "description": "mParticle integration sdk for Leanplum",

--- a/kits/localytics/localytics-4/package.json
+++ b/kits/localytics/localytics-4/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mparticle/web-localytics-kit-4",
+  "name": "@mparticle/web-localytics-kit",
   "version": "2.1.0",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
   "description": "mParticle integration sdk for Localytics",

--- a/kits/mixpanel/mixpanel-2/package.json
+++ b/kits/mixpanel/mixpanel-2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mparticle/web-mixpanel-kit-2",
+  "name": "@mparticle/web-mixpanel-kit",
   "version": "2.2.0",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
   "description": "mParticle integration sdk for Mixpanel",


### PR DESCRIPTION
## Summary

These five kits were migrated into the monorepo with numeric-suffixed package names (carried over from their source repo folder names) that don't match the names actually published on npm. This normalizes the `name` field in each kit's `package.json` so the v3 lockstep release publishes to the existing npm packages instead of creating brand-new ones:

| Old (monorepo) name | Published npm name |
| --- | --- |
| `@mparticle/web-amplitude-kit-8` | `@mparticle/web-amplitude-kit` |
| `@mparticle/web-id5-kit-1` | `@mparticle/web-id5-kit` |
| `@mparticle/web-leanplum-kit-1` | `@mparticle/web-leanplum-kit` |
| `@mparticle/web-localytics-kit-4` | `@mparticle/web-localytics-kit` |
| `@mparticle/web-mixpanel-kit-2` | `@mparticle/web-mixpanel-kit` |

All five target names were verified to exist on the npm registry (`npm view <name> name`). Each kit's `package-lock.json` already uses the unsuffixed name, so this also resolves the package.json/lockfile name mismatch.

## Test plan

- [ ] `npm ci` succeeds in each of the five kit directories (name now matches lockfile)
- [ ] Release dry-run publishes to the existing npm package names