### PR TITLE
ci: sync semantic tag release workflows to main

### DIFF
--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -1,28 +1,133 @@
 name: 'Staging Release - Step 1: Prepare CDN Pre-Release, Publish NPM'
+run-name: 'Staging Release - Step 1 [${{ inputs.track }}]'
 
 on:
     workflow_dispatch:
         inputs:
+            track:
+                description: 'Release track'
+                required: true
+                type: choice
+                options:
+                    - v2
+                    - v3
+                default: v2
             dryRun:
                 description: 'Do a dry run to preview instead of a real release [true/false]'
                 required: true
                 type: boolean
                 default: true
 
-jobs:
-    # SDK staging release must be done from the staging branch
-    confirm-staging-branch:
-        name: Confirm release is run on staging
-        runs-on: ubuntu-latest
-        steps:
-            - name: Git checkout
-              uses: actions/checkout@v6
+concurrency:
+    group: mparticle-web-sdk-release-publish
+    cancel-in-progress: false
 
-            - name: Branch Check
+jobs:
+    # SDK staging release is always performed from the resolved staging branch.
+    confirm-staging-branch:
+        name: Confirm ${{ inputs.track }} staging release state
+        runs-on: ubuntu-latest
+        outputs:
+            development_branch: ${{ steps.resolve.outputs.development_branch }}
+            staging_branch: ${{ steps.resolve.outputs.staging_branch }}
+            release_branch: ${{ steps.resolve.outputs.release_branch }}
+            release_config: ${{ steps.resolve.outputs.release_config }}
+            npm_dist_tag: ${{ steps.resolve.outputs.npm_dist_tag }}
+        steps:
+            - name: Checkout workflow source
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Validate workflow source
+              env:
+                  SOURCE_REF: ${{ github.ref }}
+                  DRY_RUN: ${{ github.event.inputs.dryRun }}
               run: |
-                  BRANCHNAME=${GITHUB_REF##*/}
-                  if [ $BRANCHNAME != "staging" ]; then
-                      echo "You can only run a staging release from the staging branch, you are trying to run it from ${BRANCHNAME}"
+                  set -eu
+                  case "$SOURCE_REF" in
+                      refs/heads/master|refs/heads/main) ;;
+                      *)
+                          echo "Release workflows require source ref refs/heads/master or refs/heads/main; received ${SOURCE_REF}"
+                          exit 1
+                          ;;
+                  esac
+
+                  if [ "$DRY_RUN" = "false" ]; then
+                      git fetch --no-tags --force origin \
+                          refs/heads/master:refs/remotes/origin/master \
+                          refs/heads/main:refs/remotes/origin/main
+                      for WORKFLOW in \
+                          .github/workflows/staging-step-1.yml \
+                          .github/workflows/staging-step-2.yml \
+                          .github/workflows/staging-step-3.yml; do
+                          if ! git diff --quiet \
+                              "refs/remotes/origin/master:${WORKFLOW}" \
+                              "refs/remotes/origin/main:${WORKFLOW}"; then
+                              echo "${WORKFLOW} differs between origin/master and origin/main"
+                              echo "Both paired workflow PRs must merge before a real release"
+                              exit 1
+                          fi
+                      done
+                  fi
+
+                  {
+                      printf '## Workflow source validation\n\n'
+                      printf -- '- Source ref: `%s`\n' "$SOURCE_REF"
+                      printf -- '- Dry run: `%s`\n' "$DRY_RUN"
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Resolve exact branch mapping
+              id: resolve
+              env:
+                  TRACK: ${{ inputs.track }}
+              run: |
+                  set -eu
+                  case "$TRACK" in
+                      v2)
+                          echo "development_branch=development" >> "$GITHUB_OUTPUT"
+                          echo "staging_branch=staging" >> "$GITHUB_OUTPUT"
+                          echo "release_branch=release/${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+                          echo "release_config=release.config.js" >> "$GITHUB_OUTPUT"
+                          echo "npm_dist_tag=v2" >> "$GITHUB_OUTPUT"
+                          ;;
+                      v3)
+                          echo "development_branch=v3-development" >> "$GITHUB_OUTPUT"
+                          echo "staging_branch=v3-staging" >> "$GITHUB_OUTPUT"
+                          echo "release_branch=v3-release/${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+                          echo "release_config=release.v3.config.js" >> "$GITHUB_OUTPUT"
+                          echo "npm_dist_tag=latest" >> "$GITHUB_OUTPUT"
+                          ;;
+                      *) exit 1 ;;
+                  esac
+
+            - name: Checkout ${{ steps.resolve.outputs.staging_branch }}
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+                  ref: ${{ steps.resolve.outputs.staging_branch }}
+
+            - name: Validate track mapping and checkout
+              env:
+                  TRACK: ${{ inputs.track }}
+                  DEVELOPMENT_BRANCH: ${{ steps.resolve.outputs.development_branch }}
+                  STAGING_BRANCH: ${{ steps.resolve.outputs.staging_branch }}
+                  RELEASE_BRANCH: ${{ steps.resolve.outputs.release_branch }}
+                  RELEASE_CONFIG: ${{ steps.resolve.outputs.release_config }}
+                  NPM_DIST_TAG: ${{ steps.resolve.outputs.npm_dist_tag }}
+              run: |
+                  set -eu
+                  MAPPING="${TRACK}|${DEVELOPMENT_BRANCH}|${STAGING_BRANCH}|${RELEASE_BRANCH}|${RELEASE_CONFIG}|${NPM_DIST_TAG}"
+                  case "$MAPPING" in
+                      "v2|development|staging|release/${GITHUB_RUN_NUMBER}|release.config.js|v2") ;;
+                      "v3|v3-development|v3-staging|v3-release/${GITHUB_RUN_NUMBER}|release.v3.config.js|latest") ;;
+                      *) exit 1 ;;
+                  esac
+                  test -f "$RELEASE_CONFIG"
+                  CHECKED_OUT_SHA="$(git rev-parse HEAD)"
+                  EXPECTED_SHA="$(git ls-remote --exit-code origin "refs/heads/${STAGING_BRANCH}" | awk 'NR == 1 { print $1 }')"
+                  if [ -z "$EXPECTED_SHA" ] || [ "$CHECKED_OUT_SHA" != "$EXPECTED_SHA" ]; then
+                      echo "Checkout does not match origin/${STAGING_BRANCH}"
                       exit 1
                   fi
 
@@ -34,7 +139,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
               with:
-                  ref: development
+                  ref: ${{ needs.confirm-staging-branch.outputs.development_branch }}
 
             - name: NPM install
               uses: actions/setup-node@v6
@@ -60,7 +165,7 @@ jobs:
               uses: actions/upload-artifact@v6
               if: failure()
               with:
-                  name: npm-logs-build-bundle
+                  name: npm-logs
                   path: ~/.npm/_logs
 
     # Currently, we're only using Jest to test TypeScript modules
@@ -68,12 +173,15 @@ jobs:
     test-jest:
         name: 'Test Jest'
         runs-on: 'ubuntu-latest'
+        needs: confirm-staging-branch
         strategy:
             matrix:
-                node-version: [18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x, 25.x]
+                node-version: [16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x, 25.x]
         steps:
             - name: Checkout
               uses: actions/checkout@v6
+              with:
+                  ref: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
 
             - name: NPM install
               uses: actions/setup-node@v6
@@ -90,7 +198,7 @@ jobs:
               uses: actions/upload-artifact@v6
               if: failure()
               with:
-                  name: npm-logs-test-jest-${{ matrix.node-version }}
+                  name: npm-logs
                   path: ~/.npm/_logs
 
     # Only Core test requires bundle, but we want to make sure
@@ -99,25 +207,29 @@ jobs:
         name: Core Tests
         uses: mParticle/mparticle-workflows/.github/workflows/web-run-test.yml@main
         needs:
+            - confirm-staging-branch
             - test-jest
             - build-bundle
         with:
             test_command_label: Core SDK Tests
             test_command: npm run test
             build_command: npm run build:iife
-            branch_name: ${{ github.sha }}
+            branch_name: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
 
     # Test Sub can be run independent of other tests
     test-stub:
         name: 'Test Stub'
         runs-on: ubuntu-latest
         needs:
+            - confirm-staging-branch
             - test-core
             - test-jest
             - build-bundle
         steps:
             - name: Checkout
               uses: actions/checkout@v6
+              with:
+                  ref: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
 
             - name: NPM install
               uses: actions/setup-node@v6
@@ -140,7 +252,7 @@ jobs:
               uses: actions/upload-artifact@v6
               if: failure()
               with:
-                  name: npm-logs-test-stub
+                  name: npm-logs
                   path: ~/.npm/_logs
 
     # Integration Tests run the same suite of tests against various build systems
@@ -150,131 +262,88 @@ jobs:
         name: 'Integration Tests: Require JS'
         uses: mParticle/mparticle-workflows/.github/workflows/web-run-test.yml@main
         needs:
+            - confirm-staging-branch
             - test-core
             - test-jest
             - build-bundle
         with:
             test_command_label: Require JS Test
             test_command: npm run test:requirejs
-            branch_name: ${{ github.sha }}
+            branch_name: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
 
     test-integrations-common-js-browserfy:
         name: 'Integration Tests: Browserfy Common JS'
         uses: mParticle/mparticle-workflows/.github/workflows/web-run-test.yml@main
         needs:
+            - confirm-staging-branch
             - test-core
             - test-jest
             - build-bundle
         with:
             test_command_label: Browserfy CJS Test
             test_command: npm run test:integrations:cjs:browserfy
-            branch_name: ${{ github.sha }}
+            branch_name: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
             build_command: npm run build:npm && npm run build:test-bundle
 
     test-integrations-common-js-webpack:
         name: 'Integration Tests: webpack Common JS'
         uses: mParticle/mparticle-workflows/.github/workflows/web-run-test.yml@main
         needs:
+            - confirm-staging-branch
             - test-core
             - test-jest
             - build-bundle
         with:
             test_command_label: webpack CJS Test
             test_command: npm run test:integrations:cjs:webpack
-            branch_name: ${{ github.sha }}
+            branch_name: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
             build_command: npm run build:npm && npm run build:test-bundle
 
     test-integrations-common-js-rollup:
         name: 'Integration Tests: Rollup Common JS'
         uses: mParticle/mparticle-workflows/.github/workflows/web-run-test.yml@main
         needs:
+            - confirm-staging-branch
             - test-core
             - test-jest
             - build-bundle
         with:
             test_command_label: Rollup CJS Test
             test_command: npm run test:integrations:cjs:rollup
-            branch_name: ${{ github.sha }}
+            branch_name: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
             build_command: npm run build:npm && npm run build:test-bundle
 
     test-integrations-module-js-webpack:
         name: 'Integration Tests: webpack Module JS'
         uses: mParticle/mparticle-workflows/.github/workflows/web-run-test.yml@main
         needs:
+            - confirm-staging-branch
             - test-core
             - test-jest
             - build-bundle
         with:
             test_command_label: webpack Module Test
             test_command: npm run test:integrations:module:webpack
-            branch_name: ${{ github.sha }}
+            branch_name: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
             build_command: npm run build:esm && npm run build:test-bundle
 
     test-integrations-module-js-rollup:
         name: 'Integration Tests: Rollup Module JS'
         uses: mParticle/mparticle-workflows/.github/workflows/web-run-test.yml@main
         needs:
+            - confirm-staging-branch
             - test-core
             - test-jest
             - build-bundle
         with:
             test_command_label: Rollup Module Test
             test_command: npm run test:integrations:module:rollup
-            branch_name: ${{ github.sha }}
+            branch_name: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
             build_command: npm run build:esm && npm run build:test-bundle
-
-    load-kit-matrix:
-        name: Load Kit Matrix
-        runs-on: ubuntu-latest
-        outputs:
-            matrix: ${{ steps.set.outputs.matrix }}
-        steps:
-            - uses: actions/checkout@v6
-            - id: set
-              run: |
-                if [ -f kits/matrix.json ]; then
-                  echo "matrix=$(jq -c . kits/matrix.json)" >> "$GITHUB_OUTPUT"
-                else
-                  echo "matrix=[]" >> "$GITHUB_OUTPUT"
-                fi
-
-    run-kit-tests:
-        name: 'Kit Tests: ${{ matrix.kit.name }}'
-        needs:
-            - load-kit-matrix
-            - build-bundle
-            - test-jest
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                kit: ${{ fromJson(needs.load-kit-matrix.outputs.matrix) }}
-        steps:
-            - uses: actions/checkout@v6
-
-            - uses: actions/setup-node@v6
-              with:
-                  node-version: 24.x
-
-            - name: Install Firefox Latest
-              uses: browser-actions/setup-firefox@latest
-
-            - name: Install, build, and test kit
-              run: |
-                cd ${{ matrix.kit.local_path }}
-                npm ci
-                npm run build
-                npm test
-
-            - name: Archive npm failure logs
-              uses: actions/upload-artifact@v6
-              if: failure()
-              with:
-                  name: npm-logs-kit-${{ matrix.kit.name }}
-                  path: ~/.npm/_logs
 
     create-release-branch:
         name: Create release branch
+        if: ${{ github.event.inputs.dryRun == 'false' }}
         runs-on: ubuntu-latest
         needs:
             - test-core
@@ -285,28 +354,107 @@ jobs:
             - test-integrations-module-js-webpack
             - test-integrations-module-js-rollup
             - test-integrations-require-js
-            - load-kit-matrix
-            - run-kit-tests
             - confirm-staging-branch
         steps:
-            - name: Checkout development branch
+            - name: Checkout ${{ needs.confirm-staging-branch.outputs.development_branch }}
               uses: actions/checkout@v6
               with:
                   repository: mparticle/mparticle-web-sdk
-                  ref: development
+                  ref: ${{ needs.confirm-staging-branch.outputs.development_branch }}
 
             - name: Create and push release branch
+              env:
+                  RELEASE_BRANCH: ${{ needs.confirm-staging-branch.outputs.release_branch }}
               run: |
-                  git checkout -b release/${{ github.run_number }}
-                  git push origin release/${{ github.run_number }}
+                  set -eu
+                  git checkout -b "$RELEASE_BRANCH"
+                  git push origin "$RELEASE_BRANCH"
+
+    preview-release:
+        name: Preview Release Without Remote Mutation
+        if: ${{ github.event.inputs.dryRun == 'true' }}
+        runs-on: ubuntu-latest
+        needs:
+            - test-core
+            - test-stub
+            - test-integrations-common-js-browserfy
+            - test-integrations-common-js-webpack
+            - test-integrations-common-js-rollup
+            - test-integrations-module-js-webpack
+            - test-integrations-module-js-rollup
+            - test-integrations-require-js
+            - confirm-staging-branch
+        env:
+            TRACK: ${{ inputs.track }}
+            NPM_DIST_TAG: ${{ needs.confirm-staging-branch.outputs.npm_dist_tag }}
+            NPM_CONFIG_TAG: ${{ needs.confirm-staging-branch.outputs.npm_dist_tag }}
+        steps:
+            - name: Checkout ${{ needs.confirm-staging-branch.outputs.staging_branch }}
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+                  ref: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
+
+            - name: Combine staging and development locally
+              env:
+                  DEVELOPMENT_BRANCH: ${{ needs.confirm-staging-branch.outputs.development_branch }}
+              run: |
+                  set -eu
+                  git fetch --no-tags --force origin \
+                      "refs/heads/${DEVELOPMENT_BRANCH}:refs/remotes/origin/${DEVELOPMENT_BRANCH}"
+                  git merge --no-edit "refs/remotes/origin/${DEVELOPMENT_BRANCH}"
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24.x
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Verify npm dist-tag
+              run: |
+                  set -eu
+                  test "$(npm config get tag)" = "$NPM_DIST_TAG"
+
+            - name: Preview semantic-release
+              env:
+                  RELEASE_CONFIG: ${{ needs.confirm-staging-branch.outputs.release_config }}
+                  STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
+              run: |
+                  set -eu
+                  set -- --branches "$STAGING_BRANCH"
+                  case "$RELEASE_CONFIG" in
+                      release.config.js) ;;
+                      release.v3.config.js)
+                          set -- --extends "./${RELEASE_CONFIG}" "$@"
+                          ;;
+                      *) exit 1 ;;
+                  esac
+                  npx semantic-release "$@" --dry-run
+
+            - name: Write preview summary
+              env:
+                  SOURCE_REF: ${{ github.ref }}
+              run: |
+                  set -eu
+                  {
+                      printf '## Release preview only\n\n'
+                      printf -- '- Source ref: `%s`\n' "$SOURCE_REF"
+                      printf -- '- Track: `%s`\n' "$TRACK"
+                      printf -- '- npm dist-tag: `%s`\n' "$NPM_DIST_TAG"
+                      printf -- '- Remote mutations: `none`\n'
+                      printf -- '- Candidate tag: `not created`\n'
+                  } >> "$GITHUB_STEP_SUMMARY"
 
     release:
-        name: Determine Version and Perform Release
+        name: Perform Release
+        if: ${{ github.event.inputs.dryRun == 'false' }}
         runs-on: ubuntu-latest
         needs:
             - create-release-branch
-        outputs:
-            version: ${{ steps.get-version.outputs.version }}
+            - confirm-staging-branch
 
         # OIDC permissions for npm trusted publishing
         permissions:
@@ -321,13 +469,16 @@ jobs:
             GIT_AUTHOR_EMAIL: developers@mparticle.com
             GIT_COMMITTER_NAME: mparticle-automation
             GIT_COMMITTER_EMAIL: developers@mparticle.com
+            TRACK: ${{ inputs.track }}
+            NPM_DIST_TAG: ${{ needs.confirm-staging-branch.outputs.npm_dist_tag }}
+            NPM_CONFIG_TAG: ${{ needs.confirm-staging-branch.outputs.npm_dist_tag }}
 
         steps:
-            - name: Checkout staging branch
+            - name: Checkout ${{ needs.confirm-staging-branch.outputs.staging_branch }}
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-                  ref: staging
+                  ref: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
 
             - name: Import GPG Key
               uses: crazy-max/ghaction-import-gpg@e00cb83a68c1158b29afc5217dd0582cada6d172 #v4.4.0
@@ -338,8 +489,11 @@ jobs:
                   git_commit_gpgsign: true
 
             - name: Merge release branch into staging branch
+              env:
+                  RELEASE_BRANCH: ${{ needs.confirm-staging-branch.outputs.release_branch }}
               run: |
-                  git pull origin release/${{ github.run_number }}
+                  set -eu
+                  git pull origin "$RELEASE_BRANCH"
 
             - name: Setup Node.js
               uses: actions/setup-node@v6
@@ -353,101 +507,112 @@ jobs:
             - name: Verify npm version
               run: npm --version
 
-            # Always dry-run first to determine the next version and validate
-            # the release config before making any permanent changes.
-            - name: Release --dry-run (determine version)
-              id: get-version
+            - name: Verify npm dist-tag
               run: |
-                  npx semantic-release --branches staging --dry-run 2>&1 | tee /tmp/sr-output.txt
-                  NEXT_VERSION=$(grep -oP '(?<=The next release version is )\S+' /tmp/sr-output.txt)
-                  if [ -z "$NEXT_VERSION" ]; then
-                      echo "ERROR: Failed to parse next release version from semantic-release output"
+                  set -eu
+                  CONFIGURED_TAG="$(npm config get tag)"
+                  if [ "$CONFIGURED_TAG" != "$NPM_DIST_TAG" ]; then
+                      echo "Expected npm dist-tag ${NPM_DIST_TAG}, received ${CONFIGURED_TAG}"
                       exit 1
                   fi
-                  echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
-            - name: Release
-              if: ${{ github.event.inputs.dryRun == 'false' }}
+            - name: Snapshot existing stable release tags
               run: |
-                  npx semantic-release --branches staging
+                  set -eu
+                  git ls-remote --tags --refs origin |
+                      awk '$2 ~ /^refs\/tags\/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/ {
+                          sub("^refs/tags/", "", $2)
+                          print $2
+                      }' > "$RUNNER_TEMP/stable-release-tags-before"
+
+            # NPM Publish happens here
+            - name: Release
+              env:
+                  RELEASE_CONFIG: ${{ needs.confirm-staging-branch.outputs.release_config }}
+                  STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
+              run: |
+                  set -eu
+                  set -- --branches "$STAGING_BRANCH"
+                  case "$RELEASE_CONFIG" in
+                      release.config.js) ;;
+                      release.v3.config.js)
+                          set -- --extends "./${RELEASE_CONFIG}" "$@"
+                          ;;
+                      *) exit 1 ;;
+                  esac
+                  npx semantic-release "$@"
 
             - name: Archive npm failure logs
               uses: actions/upload-artifact@v6
               if: failure()
               with:
-                  name: npm-logs-release
+                  name: npm-logs
                   path: ~/.npm/_logs
 
             - name: Push automated release commits to release branch
-              if: ${{ github.event.inputs.dryRun == 'false' }}
+              env:
+                  RELEASE_BRANCH: ${{ needs.confirm-staging-branch.outputs.release_branch }}
               run: |
-                  git push origin HEAD:release/${{ github.run_number }}
+                  set -eu
+                  git push origin "HEAD:${RELEASE_BRANCH}"
 
-    release-kits:
-        name: 'Publish Kit: ${{ matrix.kit.name }}'
-        needs:
-            - create-release-branch
-            - load-kit-matrix
-            - release
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                kit: ${{ fromJson(needs.load-kit-matrix.outputs.matrix) }}
-
-        # OIDC permissions for npm trusted publishing
-        permissions:
-            contents: write
-            issues: write
-            pull-requests: write
-            id-token: write
-
-        steps:
-            - name: Checkout staging branch
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-                  ref: staging
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24.x
-                  registry-url: 'https://registry.npmjs.org'
-
-            - name: Verify npm version
-              run: npm --version
-
-            - name: Publish kit
-              if: ${{ github.event.inputs.dryRun == 'false' }}
+            - name: Verify and report release candidate
               run: |
-                  cd ${{ matrix.kit.local_path }}
-                  npm ci
-                  npm run build
-                  npm publish
+                  set -eu
+                  CANDIDATE_SHA="$(git rev-parse HEAD)"
+                  git fetch --force --tags origin
 
-            - name: Archive npm failure logs
-              uses: actions/upload-artifact@v6
-              if: failure()
-              with:
-                  name: npm-logs-publish-${{ matrix.kit.name }}
-                  path: ~/.npm/_logs
+                  STABLE_TAGS="$(git tag --points-at "$CANDIDATE_SHA" |
+                      awk '/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/')"
+                  TAG_COUNT="$(printf '%s\n' "$STABLE_TAGS" |
+                      awk 'NF { count++ } END { print count + 0 }')"
+                  if [ "$TAG_COUNT" -ne 1 ]; then
+                      echo "Expected exactly one stable release tag at ${CANDIDATE_SHA}; found ${TAG_COUNT}"
+                      exit 1
+                  fi
+                  RELEASE_TAG="$(printf '%s\n' "$STABLE_TAGS" | awk 'NF { print; exit }')"
+                  if grep -Fqx "$RELEASE_TAG" "$RUNNER_TEMP/stable-release-tags-before"; then
+                      echo "Release tag ${RELEASE_TAG} existed before this workflow run"
+                      exit 1
+                  fi
 
-    cleanup:
-        name: Delete release branch
-        runs-on: ubuntu-latest
-        if: ${{ github.event.inputs.dryRun == 'false' }}
-        needs:
-            - release
-            - release-kits
-        env:
-            GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-        steps:
-            - name: Checkout staging branch
-              uses: actions/checkout@v6
-              with:
-                  ref: staging
+                  PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+                  if [ "v${PACKAGE_VERSION}" != "$RELEASE_TAG" ]; then
+                      echo "package.json version ${PACKAGE_VERSION} does not match ${RELEASE_TAG}"
+                      exit 1
+                  fi
+                  PACKAGE_MAJOR="${PACKAGE_VERSION%%.*}"
+                  case "${TRACK}|${PACKAGE_MAJOR}" in
+                      "v2|2"|"v3|3") ;;
+                      *)
+                          echo "Track ${TRACK} does not match release major ${PACKAGE_MAJOR}"
+                          exit 1
+                          ;;
+                  esac
 
-            - name: Delete release branch
-              run: |
-                  git push --delete origin release/${{ github.run_number }}
+                  REMOTE_TAG_REFS="$(git ls-remote --exit-code --tags origin \
+                      "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}")"
+                  REMOTE_TAG_SHA="$(printf '%s\n' "$REMOTE_TAG_REFS" |
+                      awk '$2 ~ /\^\{\}$/ { print $1; exit }')"
+                  if [ -z "$REMOTE_TAG_SHA" ]; then
+                      REMOTE_TAG_SHA="$(printf '%s\n' "$REMOTE_TAG_REFS" |
+                          awk '$2 !~ /\^\{\}$/ { print $1; exit }')"
+                  fi
+                  if [ "$REMOTE_TAG_SHA" != "$CANDIDATE_SHA" ]; then
+                      echo "Remote tag ${RELEASE_TAG} does not resolve to ${CANDIDATE_SHA}"
+                      exit 1
+                  fi
+
+                  {
+                      printf '## Release candidate ready\n\n'
+                      printf -- '- Track: `%s`\n' "$TRACK"
+                      printf -- '- Release tag: `%s`\n' "$RELEASE_TAG"
+                      printf -- '- Version: `%s`\n' "$PACKAGE_VERSION"
+                      printf -- '- Candidate SHA: `%s`\n' "$CANDIDATE_SHA"
+                      printf -- '- npm dist-tag: `%s`\n\n' "$NPM_DIST_TAG"
+                      printf 'Step 2 is optional and release-order A/B/C are unordered.\n\n'
+                      printf '### Next commands\n\n```sh\n'
+                      printf 'gh workflow run staging-step-2.yml -f releaseTag=%s -f releaseOrderBranch=release-order-a -f dryRun=true\n' "$RELEASE_TAG"
+                      printf 'gh workflow run staging-step-3.yml -f releaseTag=%s\n' "$RELEASE_TAG"
+                      printf '```\n'
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -198,7 +198,7 @@ jobs:
         needs: confirm-staging-branch
         strategy:
             matrix:
-                node-version: [16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x, 25.x]
+                node-version: [18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x, 25.x]
         steps:
             - name: Checkout
               uses: actions/checkout@v6

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -31,7 +31,6 @@ jobs:
             development_branch: ${{ steps.resolve.outputs.development_branch }}
             staging_branch: ${{ steps.resolve.outputs.staging_branch }}
             release_branch: ${{ steps.resolve.outputs.release_branch }}
-            release_config: ${{ steps.resolve.outputs.release_config }}
             npm_dist_tag: ${{ steps.resolve.outputs.npm_dist_tag }}
         steps:
             - name: Checkout workflow source
@@ -90,14 +89,12 @@ jobs:
                           echo "development_branch=development" >> "$GITHUB_OUTPUT"
                           echo "staging_branch=staging" >> "$GITHUB_OUTPUT"
                           echo "release_branch=release/${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-                          echo "release_config=release.config.js" >> "$GITHUB_OUTPUT"
                           echo "npm_dist_tag=v2" >> "$GITHUB_OUTPUT"
                           ;;
                       v3)
                           echo "development_branch=v3-development" >> "$GITHUB_OUTPUT"
                           echo "staging_branch=v3-staging" >> "$GITHUB_OUTPUT"
                           echo "release_branch=v3-release/${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-                          echo "release_config=release.v3.config.js" >> "$GITHUB_OUTPUT"
                           echo "npm_dist_tag=latest" >> "$GITHUB_OUTPUT"
                           ;;
                       *) exit 1 ;;
@@ -115,19 +112,39 @@ jobs:
                   DEVELOPMENT_BRANCH: ${{ steps.resolve.outputs.development_branch }}
                   STAGING_BRANCH: ${{ steps.resolve.outputs.staging_branch }}
                   RELEASE_BRANCH: ${{ steps.resolve.outputs.release_branch }}
-                  RELEASE_CONFIG: ${{ steps.resolve.outputs.release_config }}
                   NPM_DIST_TAG: ${{ steps.resolve.outputs.npm_dist_tag }}
               run: |
                   # Verify the selected track uses approved release settings and
                   # the checkout matches the current remote staging commit.
                   set -eu
-                  MAPPING="${TRACK}|${DEVELOPMENT_BRANCH}|${STAGING_BRANCH}|${RELEASE_BRANCH}|${RELEASE_CONFIG}|${NPM_DIST_TAG}"
+                  MAPPING="${TRACK}|${DEVELOPMENT_BRANCH}|${STAGING_BRANCH}|${RELEASE_BRANCH}|${NPM_DIST_TAG}"
                   case "$MAPPING" in
-                      "v2|development|staging|release/${GITHUB_RUN_NUMBER}|release.config.js|v2") ;;
-                      "v3|v3-development|v3-staging|v3-release/${GITHUB_RUN_NUMBER}|release.v3.config.js|latest") ;;
+                      "v2|development|staging|release/${GITHUB_RUN_NUMBER}|v2")
+                          EXPECTED_CONFIG_BRANCH="master"
+                          ;;
+                      "v3|v3-development|v3-staging|v3-release/${GITHUB_RUN_NUMBER}|latest")
+                          EXPECTED_CONFIG_BRANCH="v3-staging"
+                          ;;
                       *) exit 1 ;;
                   esac
-                  test -f "$RELEASE_CONFIG"
+                  if [ ! -f release.config.js ]; then
+                      echo "release.config.js is required on ${STAGING_BRANCH}"
+                      exit 1
+                  fi
+                  EXPECTED_CONFIG_BRANCH="$EXPECTED_CONFIG_BRANCH" node <<'NODE'
+                  const config = require('./release.config.js');
+                  const expected = process.env.EXPECTED_CONFIG_BRANCH;
+                  if (
+                      !Array.isArray(config.branches) ||
+                      config.branches.length !== 1 ||
+                      config.branches[0] !== expected
+                  ) {
+                      console.error(
+                          `release.config.js must declare branches: ['${expected}']`
+                      );
+                      process.exit(1);
+                  }
+                  NODE
                   CHECKED_OUT_SHA="$(git rev-parse HEAD)"
                   EXPECTED_SHA="$(git ls-remote --exit-code origin "refs/heads/${STAGING_BRANCH}" | awk 'NR == 1 { print $1 }')"
                   if [ -z "$EXPECTED_SHA" ] || [ "$CHECKED_OUT_SHA" != "$EXPECTED_SHA" ]; then
@@ -443,19 +460,10 @@ jobs:
             - name: Release --dry-run
               if: ${{ github.event.inputs.dryRun == 'true' }}
               env:
-                  RELEASE_CONFIG: ${{ needs.confirm-staging-branch.outputs.release_config }}
                   STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
               run: |
                   set -eu
-                  set -- --branches "$STAGING_BRANCH"
-                  case "$RELEASE_CONFIG" in
-                      release.config.js) ;;
-                      release.v3.config.js)
-                          set -- --extends "./${RELEASE_CONFIG}" "$@"
-                          ;;
-                      *) exit 1 ;;
-                  esac
-                  npx semantic-release "$@" --dry-run
+                  npx semantic-release --branches "$STAGING_BRANCH" --dry-run
 
             - name: Snapshot existing stable release tags
               if: ${{ github.event.inputs.dryRun == 'false' }}
@@ -471,19 +479,10 @@ jobs:
             - name: Release
               if: ${{ github.event.inputs.dryRun == 'false' }}
               env:
-                  RELEASE_CONFIG: ${{ needs.confirm-staging-branch.outputs.release_config }}
                   STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
               run: |
                   set -eu
-                  set -- --branches "$STAGING_BRANCH"
-                  case "$RELEASE_CONFIG" in
-                      release.config.js) ;;
-                      release.v3.config.js)
-                          set -- --extends "./${RELEASE_CONFIG}" "$@"
-                          ;;
-                      *) exit 1 ;;
-                  esac
-                  npx semantic-release "$@"
+                  npx semantic-release --branches "$STAGING_BRANCH"
 
             - name: Archive npm failure logs
               uses: actions/upload-artifact@v6

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -363,10 +363,119 @@ jobs:
             branch_name: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
             build_command: npm run build:esm && npm run build:test-bundle
 
+    load-kit-matrix:
+        name: Load V3 kit test matrix
+        if: ${{ inputs.track == 'v3' }}
+        runs-on: ubuntu-latest
+        needs: confirm-staging-branch
+        outputs:
+            matrix: ${{ steps.load.outputs.matrix }}
+        steps:
+            - name: Checkout ${{ needs.confirm-staging-branch.outputs.development_branch }}
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ needs.confirm-staging-branch.outputs.development_branch }}
+
+            - name: Validate and load kit test matrix
+              id: load
+              run: |
+                  set -eu
+                  MATRIX_FILE="kits/matrix.json"
+                  if [ ! -f "$MATRIX_FILE" ]; then
+                      echo "${MATRIX_FILE} is required for V3 kit testing"
+                      exit 1
+                  fi
+                  if ! jq -e '
+                      type == "array" and
+                      length > 0 and
+                      all(.[];
+                          type == "object" and
+                          (.name | type == "string" and length > 0) and
+                          (.local_path | type == "string" and length > 0)
+                      )
+                  ' "$MATRIX_FILE" > /dev/null; then
+                      echo "${MATRIX_FILE} must be a non-empty JSON array whose entries have non-empty string name and local_path fields"
+                      exit 1
+                  fi
+                  echo "matrix=$(jq -c . "$MATRIX_FILE")" >> "$GITHUB_OUTPUT"
+
+    run-kit-tests:
+        name: 'Kit Tests: ${{ matrix.kit.name }}'
+        if: ${{ inputs.track == 'v3' }}
+        needs:
+            - confirm-staging-branch
+            - load-kit-matrix
+            - build-bundle
+            - test-jest
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                kit: ${{ fromJson(needs.load-kit-matrix.outputs.matrix) }}
+        steps:
+            - name: Checkout ${{ needs.confirm-staging-branch.outputs.development_branch }}
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ needs.confirm-staging-branch.outputs.development_branch }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24.x
+
+            - name: Install Firefox Latest
+              uses: browser-actions/setup-firefox@latest
+
+            - name: Install, build, and test kit
+              working-directory: ${{ matrix.kit.local_path }}
+              run: |
+                  set -eu
+                  npm ci
+                  npm run build
+                  npm test
+
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v6
+              if: failure()
+              with:
+                  name: npm-logs-kit-${{ strategy.job-index }}
+                  path: ~/.npm/_logs
+
     create-release-branch:
         name: Create release branch
         runs-on: ubuntu-latest
+        # always() lets V2 continue past intentionally skipped kit jobs while
+        # exact result checks prevent failed, cancelled, or unexpected skips.
+        if: >-
+            ${{
+                always() &&
+                needs.confirm-staging-branch.result == 'success' &&
+                needs.build-bundle.result == 'success' &&
+                needs.test-jest.result == 'success' &&
+                needs.test-core.result == 'success' &&
+                needs.test-stub.result == 'success' &&
+                needs.test-integrations-common-js-browserfy.result == 'success' &&
+                needs.test-integrations-common-js-webpack.result == 'success' &&
+                needs.test-integrations-common-js-rollup.result == 'success' &&
+                needs.test-integrations-module-js-webpack.result == 'success' &&
+                needs.test-integrations-module-js-rollup.result == 'success' &&
+                needs.test-integrations-require-js.result == 'success' &&
+                (
+                    (
+                        inputs.track == 'v2' &&
+                        needs.load-kit-matrix.result == 'skipped' &&
+                        needs.run-kit-tests.result == 'skipped'
+                    ) ||
+                    (
+                        inputs.track == 'v3' &&
+                        needs.load-kit-matrix.result == 'success' &&
+                        needs.run-kit-tests.result == 'success'
+                    )
+                )
+            }}
         needs:
+            - build-bundle
+            - test-jest
             - test-core
             - test-stub
             - test-integrations-common-js-browserfy
@@ -375,6 +484,8 @@ jobs:
             - test-integrations-module-js-webpack
             - test-integrations-module-js-rollup
             - test-integrations-require-js
+            - load-kit-matrix
+            - run-kit-tests
             - confirm-staging-branch
         steps:
             - name: Checkout ${{ needs.confirm-staging-branch.outputs.development_branch }}

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -53,6 +53,8 @@ jobs:
                           ;;
                   esac
 
+                  # Before a real release, confirm master and main use identical
+                  # copies of all three release workflows.
                   if [ "$DRY_RUN" = "false" ]; then
                       git fetch --no-tags --force origin \
                           refs/heads/master:refs/remotes/origin/master \
@@ -116,6 +118,8 @@ jobs:
                   RELEASE_CONFIG: ${{ steps.resolve.outputs.release_config }}
                   NPM_DIST_TAG: ${{ steps.resolve.outputs.npm_dist_tag }}
               run: |
+                  # Verify the selected track uses approved release settings and
+                  # the checkout matches the current remote staging commit.
                   set -eu
                   MAPPING="${TRACK}|${DEVELOPMENT_BRANCH}|${STAGING_BRANCH}|${RELEASE_BRANCH}|${RELEASE_CONFIG}|${NPM_DIST_TAG}"
                   case "$MAPPING" in
@@ -343,7 +347,6 @@ jobs:
 
     create-release-branch:
         name: Create release branch
-        if: ${{ github.event.inputs.dryRun == 'false' }}
         runs-on: ubuntu-latest
         needs:
             - test-core
@@ -370,87 +373,8 @@ jobs:
                   git checkout -b "$RELEASE_BRANCH"
                   git push origin "$RELEASE_BRANCH"
 
-    preview-release:
-        name: Preview Release Without Remote Mutation
-        if: ${{ github.event.inputs.dryRun == 'true' }}
-        runs-on: ubuntu-latest
-        needs:
-            - test-core
-            - test-stub
-            - test-integrations-common-js-browserfy
-            - test-integrations-common-js-webpack
-            - test-integrations-common-js-rollup
-            - test-integrations-module-js-webpack
-            - test-integrations-module-js-rollup
-            - test-integrations-require-js
-            - confirm-staging-branch
-        env:
-            TRACK: ${{ inputs.track }}
-            NPM_DIST_TAG: ${{ needs.confirm-staging-branch.outputs.npm_dist_tag }}
-            NPM_CONFIG_TAG: ${{ needs.confirm-staging-branch.outputs.npm_dist_tag }}
-        steps:
-            - name: Checkout ${{ needs.confirm-staging-branch.outputs.staging_branch }}
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-                  ref: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
-
-            - name: Combine staging and development locally
-              env:
-                  DEVELOPMENT_BRANCH: ${{ needs.confirm-staging-branch.outputs.development_branch }}
-              run: |
-                  set -eu
-                  git fetch --no-tags --force origin \
-                      "refs/heads/${DEVELOPMENT_BRANCH}:refs/remotes/origin/${DEVELOPMENT_BRANCH}"
-                  git merge --no-edit "refs/remotes/origin/${DEVELOPMENT_BRANCH}"
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24.x
-                  registry-url: 'https://registry.npmjs.org'
-
-            - name: Install dependencies
-              run: npm ci
-
-            - name: Verify npm dist-tag
-              run: |
-                  set -eu
-                  test "$(npm config get tag)" = "$NPM_DIST_TAG"
-
-            - name: Preview semantic-release
-              env:
-                  RELEASE_CONFIG: ${{ needs.confirm-staging-branch.outputs.release_config }}
-                  STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
-              run: |
-                  set -eu
-                  set -- --branches "$STAGING_BRANCH"
-                  case "$RELEASE_CONFIG" in
-                      release.config.js) ;;
-                      release.v3.config.js)
-                          set -- --extends "./${RELEASE_CONFIG}" "$@"
-                          ;;
-                      *) exit 1 ;;
-                  esac
-                  npx semantic-release "$@" --dry-run
-
-            - name: Write preview summary
-              env:
-                  SOURCE_REF: ${{ github.ref }}
-              run: |
-                  set -eu
-                  {
-                      printf '## Release preview only\n\n'
-                      printf -- '- Source ref: `%s`\n' "$SOURCE_REF"
-                      printf -- '- Track: `%s`\n' "$TRACK"
-                      printf -- '- npm dist-tag: `%s`\n' "$NPM_DIST_TAG"
-                      printf -- '- Remote mutations: `none`\n'
-                      printf -- '- Candidate tag: `not created`\n'
-                  } >> "$GITHUB_STEP_SUMMARY"
-
     release:
         name: Perform Release
-        if: ${{ github.event.inputs.dryRun == 'false' }}
         runs-on: ubuntu-latest
         needs:
             - create-release-branch
@@ -516,7 +440,25 @@ jobs:
                       exit 1
                   fi
 
+            - name: Release --dry-run
+              if: ${{ github.event.inputs.dryRun == 'true' }}
+              env:
+                  RELEASE_CONFIG: ${{ needs.confirm-staging-branch.outputs.release_config }}
+                  STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
+              run: |
+                  set -eu
+                  set -- --branches "$STAGING_BRANCH"
+                  case "$RELEASE_CONFIG" in
+                      release.config.js) ;;
+                      release.v3.config.js)
+                          set -- --extends "./${RELEASE_CONFIG}" "$@"
+                          ;;
+                      *) exit 1 ;;
+                  esac
+                  npx semantic-release "$@" --dry-run
+
             - name: Snapshot existing stable release tags
+              if: ${{ github.event.inputs.dryRun == 'false' }}
               run: |
                   set -eu
                   git ls-remote --tags --refs origin |
@@ -527,6 +469,7 @@ jobs:
 
             # NPM Publish happens here
             - name: Release
+              if: ${{ github.event.inputs.dryRun == 'false' }}
               env:
                   RELEASE_CONFIG: ${{ needs.confirm-staging-branch.outputs.release_config }}
                   STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
@@ -550,6 +493,7 @@ jobs:
                   path: ~/.npm/_logs
 
             - name: Push automated release commits to release branch
+              if: ${{ github.event.inputs.dryRun == 'false' }}
               env:
                   RELEASE_BRANCH: ${{ needs.confirm-staging-branch.outputs.release_branch }}
               run: |
@@ -557,6 +501,7 @@ jobs:
                   git push origin "HEAD:${RELEASE_BRANCH}"
 
             - name: Verify and report release candidate
+              if: ${{ github.event.inputs.dryRun == 'false' }}
               run: |
                   set -eu
                   CANDIDATE_SHA="$(git rev-parse HEAD)"

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -187,7 +187,7 @@ jobs:
               uses: actions/upload-artifact@v6
               if: failure()
               with:
-                  name: npm-logs
+                  name: npm-logs-build-bundle
                   path: ~/.npm/_logs
 
     # Currently, we're only using Jest to test TypeScript modules
@@ -220,7 +220,7 @@ jobs:
               uses: actions/upload-artifact@v6
               if: failure()
               with:
-                  name: npm-logs
+                  name: npm-logs-test-jest-${{ matrix.node-version }}
                   path: ~/.npm/_logs
 
     # Only Core test requires bundle, but we want to make sure
@@ -274,7 +274,7 @@ jobs:
               uses: actions/upload-artifact@v6
               if: failure()
               with:
-                  name: npm-logs
+                  name: npm-logs-test-stub
                   path: ~/.npm/_logs
 
     # Integration Tests run the same suite of tests against various build systems
@@ -489,7 +489,7 @@ jobs:
               uses: actions/upload-artifact@v6
               if: failure()
               with:
-                  name: npm-logs
+                  name: npm-logs-release
                   path: ~/.npm/_logs
 
             - name: Push automated release commits to release branch

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -542,6 +542,17 @@ jobs:
                   git_user_signingkey: true
                   git_commit_gpgsign: true
 
+            - name: Merge development into staging preview
+              if: ${{ github.event.inputs.dryRun == 'true' }}
+              env:
+                  DEVELOPMENT_BRANCH: ${{ needs.confirm-staging-branch.outputs.development_branch }}
+              run: |
+                  set -eu
+                  git fetch --no-tags --force origin \
+                      "refs/heads/${DEVELOPMENT_BRANCH}:refs/remotes/origin/${DEVELOPMENT_BRANCH}"
+                  git merge --no-edit \
+                      "refs/remotes/origin/${DEVELOPMENT_BRANCH}"
+
             - name: Merge release branch into staging branch
               if: ${{ github.event.inputs.dryRun == 'false' }}
               env:

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -5,7 +5,7 @@ on:
     workflow_dispatch:
         inputs:
             track:
-                description: 'Release track'
+                description: 'Release track (v2 promotes to master; v3 promotes to main)'
                 required: true
                 type: choice
                 options:

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -262,7 +262,7 @@ jobs:
               run: npm ci
 
             - name: Install Firefox Latest
-              uses: browser-actions/setup-firefox@latest
+              uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
 
             - name: Log Firefox Version
               run: firefox --version
@@ -424,7 +424,7 @@ jobs:
                   node-version: 24.x
 
             - name: Install Firefox Latest
-              uses: browser-actions/setup-firefox@latest
+              uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
 
             - name: Install, build, and test kit
               working-directory: ${{ matrix.kit.local_path }}
@@ -495,6 +495,7 @@ jobs:
                   ref: ${{ needs.confirm-staging-branch.outputs.development_branch }}
 
             - name: Create and push release branch
+              if: ${{ github.event.inputs.dryRun == 'false' }}
               env:
                   RELEASE_BRANCH: ${{ needs.confirm-staging-branch.outputs.release_branch }}
               run: |
@@ -542,6 +543,7 @@ jobs:
                   git_commit_gpgsign: true
 
             - name: Merge release branch into staging branch
+              if: ${{ github.event.inputs.dryRun == 'false' }}
               env:
                   RELEASE_BRANCH: ${{ needs.confirm-staging-branch.outputs.release_branch }}
               run: |
@@ -667,7 +669,7 @@ jobs:
                       printf -- '- Candidate SHA: `%s`\n' "$CANDIDATE_SHA"
                       printf -- '- npm dist-tag: `%s`\n\n' "$NPM_DIST_TAG"
                       printf 'Step 2 is optional and release-order A/B/C are unordered.\n\n'
-                      printf '### Next commands\n\n```sh\n'
+                      printf '### Preview commands\n\n```sh\n'
                       printf 'gh workflow run staging-step-2.yml -f releaseTag=%s -f releaseOrderBranch=release-order-a -f dryRun=true\n' "$RELEASE_TAG"
                       printf 'gh workflow run staging-step-3.yml -f releaseTag=%s\n' "$RELEASE_TAG"
                       printf '```\n'

--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -23,7 +23,8 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
-    # SDK staging release is always performed from the resolved staging branch.
+    # SDK staging release is performed on the mapped staging branch:
+    # v2 -> staging; v3 -> v3-staging.
     confirm-staging-branch:
         name: Confirm ${{ inputs.track }} staging release state
         runs-on: ubuntu-latest

--- a/.github/workflows/staging-step-2.yml
+++ b/.github/workflows/staging-step-2.yml
@@ -1,15 +1,20 @@
 name: 'Staging Release - Step 2: Publish SDK Release to Release Order Branch'
+run-name: 'Staging Release - Step 2 [${{ inputs.releaseTag }} → ${{ inputs.releaseOrderBranch }}]'
 
 on:
     workflow_dispatch:
         inputs:
+            releaseTag:
+                description: 'Semantic-release candidate tag (for example, v2.80.0 or v3.0.1)'
+                required: true
+                type: string
             dryRun:
-                description: 'Do a dry run to preview instead of a real release [true/false]'
+                description: 'Do a dry run to validate without pushing [true/false]'
                 required: true
                 type: boolean
                 default: true
             releaseOrderBranch:
-                description: 'Which Release Order Branch are you targeting? [release-order-a/release-order-b/release-order-c]'
+                description: 'Logical release-order destination'
                 required: true
                 type: choice
                 options:
@@ -18,21 +23,8 @@ on:
                     - release-order-c
 
 jobs:
-    verify-release-order-branch:
-        name: Verify Release Order Branch
-        runs-on: ubuntu-latest
-        steps:
-            # As a safe guard, if a valid release branch does not exist,
-            # this step will fail and throw an error
-            - name: Checkout Release Order (${{ github.event.inputs.releaseOrderBranch }})
-              uses: actions/checkout@v6
-              with:
-                  ref: ${{ github.event.inputs.releaseOrderBranch }}
-
-    push-release-branch:
-        name: Release staging to ${{ github.event.inputs.releaseOrderBranch}}
-        needs:
-            - verify-release-order-branch
+    promote-release-candidate:
+        name: Promote ${{ inputs.releaseTag }} to ${{ inputs.releaseOrderBranch }}
         runs-on: ubuntu-latest
         env:
             GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
@@ -40,16 +32,169 @@ jobs:
             GIT_AUTHOR_EMAIL: developers@mparticle.com
             GIT_COMMITTER_NAME: mparticle-automation
             GIT_COMMITTER_EMAIL: developers@mparticle.com
-
         steps:
-            - name: Checkout staging branch
+            - name: Checkout repository
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   repository: ${{ github.repository }}
-                  ref: staging
+                  token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
 
-            - name: Push to ${{ github.event.inputs.releaseOrderBranch }}
-              if: ${{ github.event.inputs.dryRun == 'false' }}
+            - name: Validate workflow source
+              env:
+                  SOURCE_REF: ${{ github.ref }}
+                  DRY_RUN: ${{ github.event.inputs.dryRun }}
               run: |
-                  git push origin HEAD:${{ github.event.inputs.releaseOrderBranch }}
+                  set -eu
+                  case "$SOURCE_REF" in
+                      refs/heads/master|refs/heads/main) ;;
+                      *)
+                          echo "Release workflows require source ref refs/heads/master or refs/heads/main; received ${SOURCE_REF}"
+                          exit 1
+                          ;;
+                  esac
+
+                  if [ "$DRY_RUN" = "false" ]; then
+                      git fetch --no-tags --force origin \
+                          refs/heads/master:refs/remotes/origin/master \
+                          refs/heads/main:refs/remotes/origin/main
+                      for WORKFLOW in \
+                          .github/workflows/staging-step-1.yml \
+                          .github/workflows/staging-step-2.yml \
+                          .github/workflows/staging-step-3.yml; do
+                          if ! git diff --quiet \
+                              "refs/remotes/origin/master:${WORKFLOW}" \
+                              "refs/remotes/origin/main:${WORKFLOW}"; then
+                              echo "${WORKFLOW} differs between origin/master and origin/main"
+                              echo "Both paired workflow PRs must merge before a real promotion"
+                              exit 1
+                          fi
+                      done
+                  fi
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24.x
+
+            - name: Resolve and validate release candidate
+              id: candidate
+              env:
+                  RELEASE_TAG: ${{ inputs.releaseTag }}
+                  RELEASE_ORDER_INPUT: ${{ inputs.releaseOrderBranch }}
+              run: |
+                  set -eu
+                  if ! printf '%s\n' "$RELEASE_TAG" |
+                      grep -Eq '^v(2|3)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+                      echo "Invalid stable release tag: $RELEASE_TAG"
+                      exit 1
+                  fi
+                  case "$RELEASE_ORDER_INPUT" in
+                      release-order-a|release-order-b|release-order-c) ;;
+                      *) exit 1 ;;
+                  esac
+
+                  git tag -d "$RELEASE_TAG" >/dev/null 2>&1 || true
+                  git fetch --no-tags --force origin \
+                      "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+                  CANDIDATE_SHA="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+
+                  REMOTE_TAG_REFS="$(git ls-remote --exit-code --tags origin \
+                      "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}")"
+                  REMOTE_TAG_SHA="$(printf '%s\n' "$REMOTE_TAG_REFS" |
+                      awk '$2 ~ /\^\{\}$/ { print $1; exit }')"
+                  if [ -z "$REMOTE_TAG_SHA" ]; then
+                      REMOTE_TAG_SHA="$(printf '%s\n' "$REMOTE_TAG_REFS" |
+                          awk '$2 !~ /\^\{\}$/ { print $1; exit }')"
+                  fi
+                  if [ "$REMOTE_TAG_SHA" != "$CANDIDATE_SHA" ]; then
+                      echo "Fetched tag does not match the remote peeled commit"
+                      exit 1
+                  fi
+
+                  git checkout --detach "$CANDIDATE_SHA"
+                  test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
+                  PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+                  if [ "v${PACKAGE_VERSION}" != "$RELEASE_TAG" ]; then
+                      echo "package.json version ${PACKAGE_VERSION} does not match ${RELEASE_TAG}"
+                      exit 1
+                  fi
+                  PACKAGE_MAJOR="${PACKAGE_VERSION%%.*}"
+                  case "$PACKAGE_MAJOR" in
+                      2)
+                          TRACK="v2"
+                          STAGING_BRANCH="staging"
+                          TARGET_BRANCH="$RELEASE_ORDER_INPUT"
+                          ;;
+                      3)
+                          TRACK="v3"
+                          STAGING_BRANCH="v3-staging"
+                          TARGET_BRANCH="v3-${RELEASE_ORDER_INPUT}"
+                          ;;
+                      *) exit 1 ;;
+                  esac
+                  case "${TRACK}|${STAGING_BRANCH}|${TARGET_BRANCH}" in
+                      "v2|staging|release-order-a"|"v2|staging|release-order-b"|"v2|staging|release-order-c") ;;
+                      "v3|v3-staging|v3-release-order-a"|"v3|v3-staging|v3-release-order-b"|"v3|v3-staging|v3-release-order-c") ;;
+                      *) exit 1 ;;
+                  esac
+
+                  STAGING_SHA="$(git ls-remote --exit-code origin \
+                      "refs/heads/${STAGING_BRANCH}" | awk 'NR == 1 { print $1 }')"
+                  if [ "$STAGING_SHA" != "$CANDIDATE_SHA" ]; then
+                      echo "${RELEASE_TAG} is stale: origin/${STAGING_BRANCH} is ${STAGING_SHA}"
+                      exit 1
+                  fi
+                  TARGET_SHA="$(git ls-remote --exit-code origin \
+                      "refs/heads/${TARGET_BRANCH}" | awk 'NR == 1 { print $1 }')"
+                  git fetch --no-tags --force origin \
+                      "refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+                  if [ "$TARGET_SHA" = "$CANDIDATE_SHA" ]; then
+                      PROMOTION_STATE="already current"
+                  elif git merge-base --is-ancestor "$TARGET_SHA" "$CANDIDATE_SHA"; then
+                      PROMOTION_STATE="fast-forward"
+                  else
+                      echo "origin/${TARGET_BRANCH} cannot fast-forward to ${RELEASE_TAG}"
+                      exit 1
+                  fi
+
+                  echo "track=$TRACK" >> "$GITHUB_OUTPUT"
+                  echo "candidate_sha=$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
+                  echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+                  echo "promotion_state=$PROMOTION_STATE" >> "$GITHUB_OUTPUT"
+
+            - name: Promote exact candidate
+              if: ${{ github.event.inputs.dryRun == 'false' }}
+              env:
+                  TARGET_BRANCH: ${{ steps.candidate.outputs.target_branch }}
+              run: |
+                  set -eu
+                  git push origin "HEAD:refs/heads/${TARGET_BRANCH}"
+
+            - name: Report promotion
+              env:
+                  RELEASE_TAG: ${{ inputs.releaseTag }}
+                  TRACK: ${{ steps.candidate.outputs.track }}
+                  CANDIDATE_SHA: ${{ steps.candidate.outputs.candidate_sha }}
+                  TARGET_BRANCH: ${{ steps.candidate.outputs.target_branch }}
+                  PROMOTION_STATE: ${{ steps.candidate.outputs.promotion_state }}
+                  DRY_RUN: ${{ github.event.inputs.dryRun }}
+                  SOURCE_REF: ${{ github.ref }}
+              run: |
+                  set -eu
+                  if [ "$DRY_RUN" = "true" ]; then
+                      ACTION="Would promote exact candidate"
+                  else
+                      ACTION="Promoted exact candidate"
+                  fi
+                  {
+                      printf '## Release-order promotion\n\n'
+                      printf -- '- Release tag: `%s`\n' "$RELEASE_TAG"
+                      printf -- '- Source ref: `%s`\n' "$SOURCE_REF"
+                      printf -- '- Track: `%s`\n' "$TRACK"
+                      printf -- '- Candidate SHA: `%s`\n' "$CANDIDATE_SHA"
+                      printf -- '- Destination: `%s`\n' "$TARGET_BRANCH"
+                      printf -- '- Validation: `%s`\n' "$PROMOTION_STATE"
+                      printf -- '- Dry run: `%s`\n' "$DRY_RUN"
+                      printf -- '- Action: `%s`\n' "$ACTION"
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/staging-step-3.yml
+++ b/.github/workflows/staging-step-3.yml
@@ -1,11 +1,22 @@
 name: "Staging Release - Step 3: Release to CDN and Synchronize Branches"
+run-name: 'Staging Release - Step 3 [${{ inputs.releaseTag }}]'
 
 on:
     workflow_dispatch:
+        inputs:
+            releaseTag:
+                description: 'Semantic-release candidate tag (for example, v2.80.0 or v3.0.1)'
+                required: true
+                type: string
+            dryRun:
+                description: 'Validate the atomic synchronization without pushing [true/false]'
+                required: true
+                type: boolean
+                default: true
 
 jobs:
     synchronize-branches:
-      name: Synchronize SDK to all branches
+      name: Synchronize exact candidate ${{ inputs.releaseTag }}
       runs-on: ubuntu-latest
       env:
         GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
@@ -15,24 +26,204 @@ jobs:
         GIT_COMMITTER_EMAIL: developers@mparticle.com
 
       steps:
-        - name: Checkout staging branch
+        - name: Checkout repository
           uses: actions/checkout@v6
           with:
             fetch-depth: 0
             repository: ${{ github.repository }}
             token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
-            ref: staging
 
-        - name: Push release commits to development
+        - name: Validate workflow source
+          env:
+            SOURCE_REF: ${{ github.ref }}
+            DRY_RUN: ${{ github.event.inputs.dryRun }}
           run: |
-            git push origin HEAD:development
+            set -eu
+            case "$SOURCE_REF" in
+              refs/heads/master|refs/heads/main) ;;
+              *)
+                echo "Release workflows require source ref refs/heads/master or refs/heads/main; received ${SOURCE_REF}"
+                exit 1
+                ;;
+            esac
 
-        - name: Push release commits to master
-          run: |
-            git push origin HEAD:master
+            if [ "$DRY_RUN" = "false" ]; then
+              git fetch --no-tags --force origin \
+                refs/heads/master:refs/remotes/origin/master \
+                refs/heads/main:refs/remotes/origin/main
+              for WORKFLOW in \
+                .github/workflows/staging-step-1.yml \
+                .github/workflows/staging-step-2.yml \
+                .github/workflows/staging-step-3.yml; do
+                if ! git diff --quiet \
+                  "refs/remotes/origin/master:${WORKFLOW}" \
+                  "refs/remotes/origin/main:${WORKFLOW}"; then
+                  echo "${WORKFLOW} differs between origin/master and origin/main"
+                  echo "Both paired workflow PRs must merge before real synchronization"
+                  exit 1
+                fi
+              done
+            fi
 
-        - name: Push release commits to Release Order Branches
+        - name: Setup Node.js
+          uses: actions/setup-node@v6
+          with:
+            node-version: 24.x
+
+        - name: Resolve and preflight release candidate
+          id: candidate
+          env:
+            RELEASE_TAG: ${{ inputs.releaseTag }}
           run: |
-            git push origin HEAD:release-order-a
-            git push origin HEAD:release-order-b
-            git push origin HEAD:release-order-c
+            set -eu
+            if ! printf '%s\n' "$RELEASE_TAG" |
+                grep -Eq '^v(2|3)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+              echo "Invalid stable release tag: $RELEASE_TAG"
+              exit 1
+            fi
+
+            git tag -d "$RELEASE_TAG" >/dev/null 2>&1 || true
+            git fetch --no-tags --force origin \
+              "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            CANDIDATE_SHA="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+
+            REMOTE_TAG_REFS="$(git ls-remote --exit-code --tags origin \
+              "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}")"
+            REMOTE_TAG_SHA="$(printf '%s\n' "$REMOTE_TAG_REFS" |
+              awk '$2 ~ /\^\{\}$/ { print $1; exit }')"
+            if [ -z "$REMOTE_TAG_SHA" ]; then
+              REMOTE_TAG_SHA="$(printf '%s\n' "$REMOTE_TAG_REFS" |
+                awk '$2 !~ /\^\{\}$/ { print $1; exit }')"
+            fi
+            if [ "$REMOTE_TAG_SHA" != "$CANDIDATE_SHA" ]; then
+              echo "Fetched tag does not match the remote peeled commit"
+              exit 1
+            fi
+
+            git checkout --detach "$CANDIDATE_SHA"
+            test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
+            PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+            if [ "v${PACKAGE_VERSION}" != "$RELEASE_TAG" ]; then
+              echo "package.json version ${PACKAGE_VERSION} does not match ${RELEASE_TAG}"
+              exit 1
+            fi
+            PACKAGE_MAJOR="${PACKAGE_VERSION%%.*}"
+            case "$PACKAGE_MAJOR" in
+              2)
+                TRACK="v2"
+                STAGING_BRANCH="staging"
+                DEVELOPMENT_BRANCH="development"
+                TRUNK_BRANCH="master"
+                RELEASE_ORDER_A_BRANCH="release-order-a"
+                RELEASE_ORDER_B_BRANCH="release-order-b"
+                RELEASE_ORDER_C_BRANCH="release-order-c"
+                ;;
+              3)
+                TRACK="v3"
+                STAGING_BRANCH="v3-staging"
+                DEVELOPMENT_BRANCH="v3-development"
+                TRUNK_BRANCH="main"
+                RELEASE_ORDER_A_BRANCH="v3-release-order-a"
+                RELEASE_ORDER_B_BRANCH="v3-release-order-b"
+                RELEASE_ORDER_C_BRANCH="v3-release-order-c"
+                ;;
+              *) exit 1 ;;
+            esac
+            MAPPING="${TRACK}|${STAGING_BRANCH}|${DEVELOPMENT_BRANCH}|${TRUNK_BRANCH}|${RELEASE_ORDER_A_BRANCH}|${RELEASE_ORDER_B_BRANCH}|${RELEASE_ORDER_C_BRANCH}"
+            case "$MAPPING" in
+              "v2|staging|development|master|release-order-a|release-order-b|release-order-c") ;;
+              "v3|v3-staging|v3-development|main|v3-release-order-a|v3-release-order-b|v3-release-order-c") ;;
+              *) exit 1 ;;
+            esac
+
+            STAGING_SHA="$(git ls-remote --exit-code origin \
+              "refs/heads/${STAGING_BRANCH}" | awk 'NR == 1 { print $1 }')"
+            if [ "$STAGING_SHA" != "$CANDIDATE_SHA" ]; then
+              echo "${RELEASE_TAG} is stale: origin/${STAGING_BRANCH} is ${STAGING_SHA}"
+              exit 1
+            fi
+
+            for DESTINATION in \
+              "$DEVELOPMENT_BRANCH" \
+              "$TRUNK_BRANCH" \
+              "$RELEASE_ORDER_A_BRANCH" \
+              "$RELEASE_ORDER_B_BRANCH" \
+              "$RELEASE_ORDER_C_BRANCH"; do
+              DESTINATION_SHA="$(git ls-remote --exit-code origin \
+                "refs/heads/${DESTINATION}" | awk 'NR == 1 { print $1 }')"
+              git fetch --no-tags --force origin \
+                "refs/heads/${DESTINATION}:refs/remotes/origin/${DESTINATION}"
+              if [ "$DESTINATION_SHA" = "$CANDIDATE_SHA" ]; then
+                continue
+              fi
+              if ! git merge-base --is-ancestor "$DESTINATION_SHA" "$CANDIDATE_SHA"; then
+                echo "origin/${DESTINATION} cannot fast-forward to ${RELEASE_TAG}"
+                exit 1
+              fi
+            done
+
+            echo "track=$TRACK" >> "$GITHUB_OUTPUT"
+            echo "candidate_sha=$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
+            echo "development_branch=$DEVELOPMENT_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "trunk_branch=$TRUNK_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "release_order_a_branch=$RELEASE_ORDER_A_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "release_order_b_branch=$RELEASE_ORDER_B_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "release_order_c_branch=$RELEASE_ORDER_C_BRANCH" >> "$GITHUB_OUTPUT"
+
+        - name: Atomically synchronize all destinations
+          if: ${{ github.event.inputs.dryRun == 'false' }}
+          env:
+            DEVELOPMENT_BRANCH: ${{ steps.candidate.outputs.development_branch }}
+            TRUNK_BRANCH: ${{ steps.candidate.outputs.trunk_branch }}
+            RELEASE_ORDER_A_BRANCH: ${{ steps.candidate.outputs.release_order_a_branch }}
+            RELEASE_ORDER_B_BRANCH: ${{ steps.candidate.outputs.release_order_b_branch }}
+            RELEASE_ORDER_C_BRANCH: ${{ steps.candidate.outputs.release_order_c_branch }}
+          run: |
+            set -eu
+            git push --atomic origin \
+              "HEAD:refs/heads/${DEVELOPMENT_BRANCH}" \
+              "HEAD:refs/heads/${TRUNK_BRANCH}" \
+              "HEAD:refs/heads/${RELEASE_ORDER_A_BRANCH}" \
+              "HEAD:refs/heads/${RELEASE_ORDER_B_BRANCH}" \
+              "HEAD:refs/heads/${RELEASE_ORDER_C_BRANCH}"
+
+        - name: Report synchronized release
+          env:
+            RELEASE_TAG: ${{ inputs.releaseTag }}
+            TRACK: ${{ steps.candidate.outputs.track }}
+            CANDIDATE_SHA: ${{ steps.candidate.outputs.candidate_sha }}
+            DEVELOPMENT_BRANCH: ${{ steps.candidate.outputs.development_branch }}
+            TRUNK_BRANCH: ${{ steps.candidate.outputs.trunk_branch }}
+            RELEASE_ORDER_A_BRANCH: ${{ steps.candidate.outputs.release_order_a_branch }}
+            RELEASE_ORDER_B_BRANCH: ${{ steps.candidate.outputs.release_order_b_branch }}
+            RELEASE_ORDER_C_BRANCH: ${{ steps.candidate.outputs.release_order_c_branch }}
+            DRY_RUN: ${{ github.event.inputs.dryRun }}
+            SOURCE_REF: ${{ github.ref }}
+          run: |
+            set -eu
+            if [ "$DRY_RUN" = "true" ]; then
+              ACTION="Would run atomic push"
+            else
+              ACTION="Completed atomic push"
+            fi
+            {
+              printf '## Release synchronization\n\n'
+              printf -- '- Release tag: `%s`\n' "$RELEASE_TAG"
+              printf -- '- Source ref: `%s`\n' "$SOURCE_REF"
+              printf -- '- Track: `%s`\n' "$TRACK"
+              printf -- '- Candidate SHA: `%s`\n' "$CANDIDATE_SHA"
+              printf -- '- Dry run: `%s`\n' "$DRY_RUN"
+              printf -- '- Action: `%s`\n' "$ACTION"
+              printf -- '- Destinations: `%s`, `%s`, `%s`, `%s`, `%s`\n' \
+                "$DEVELOPMENT_BRANCH" "$TRUNK_BRANCH" \
+                "$RELEASE_ORDER_A_BRANCH" "$RELEASE_ORDER_B_BRANCH" \
+                "$RELEASE_ORDER_C_BRANCH"
+              printf '\n### Atomic command\n\n```sh\n'
+              printf 'git push --atomic origin \\\n'
+              printf '  HEAD:refs/heads/%s \\\n' "$DEVELOPMENT_BRANCH"
+              printf '  HEAD:refs/heads/%s \\\n' "$TRUNK_BRANCH"
+              printf '  HEAD:refs/heads/%s \\\n' "$RELEASE_ORDER_A_BRANCH"
+              printf '  HEAD:refs/heads/%s \\\n' "$RELEASE_ORDER_B_BRANCH"
+              printf '  HEAD:refs/heads/%s\n' "$RELEASE_ORDER_C_BRANCH"
+              printf '```\n'
+            } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- install the canonical semantic-tag release workflows on `main`, byte-for-byte matching the paired `master` proposal in [#1345](https://github.com/mParticle/mparticle-web-sdk/pull/1345)
- allow workflow source only from `master` or `main`, while keeping Step 1's V2/V3 dropdown as the only explicit track choice
- load semantic-release configuration from the explicitly selected staging branch instead of overriding an automatically discovered config
- restore V3 Step 1 testing for every kit root in `kits/matrix.json`, checked out from `v3-development`; V2 intentionally skips both kit jobs

## Release flow
```mermaid
flowchart LR
    S[Use workflow from master or main] --> A[Step 1: choose V2 or V3]
    A --> T{Track}
    T -->|V3| K[Load and test all kit roots from v3-development]
    T -->|V2| V[Skip kit jobs]
    K --> X[Checkout staging or v3-staging]
    V --> X
    X --> Y[Validate branch-local release.config.js marker]
    Y -->|stable releaseTag| B[Step 2: optional release-order promotion]
    Y -->|stable releaseTag| C[Step 3: final synchronization]
    B -. A/B/C are unordered .-> C
    C -->|dryRun=true| D[Preflight and print atomic push]
    C -->|dryRun=false| E[Atomic push to all five destinations]
```

- Step 1 gates release-branch creation on all core/integration tests and, for V3, all kit-root tests; failed, cancelled, or unexpectedly skipped required jobs block the release branch.
- Step 2 remains optional and release-order A/B/C are unordered.
- Steps 2 and 3 derive track only from the stable release tag and root package major.
- Step 3 defaults to `dryRun=true`; a real run performs one non-forced atomic push.

## V3 kit testing and publishing
- V3 loads the non-empty `kits/matrix.json` test/build-root matrix from `v3-development`, validates every `name` and `local_path`, and runs `npm ci`, `npm run build`, and `npm test` for every root with Node 24 and Firefox.
- V2 intentionally skips `load-kit-matrix` and `run-kit-tests`; the explicit release gate accepts those skips only for V2.
- This workflow does **not** publish kit packages. Kit publishing remains a separate V3 release-assets dependency using the leaf-package `kits/publish-matrix.json`, with its own resumable implementation.

## Branch-local release configuration
- both tracks invoke `npx semantic-release --branches <selected-staging>` and automatically load that branch's local `release.config.js`
- V2 requires exactly `branches: ['master']` on `staging`
- V3 requires exactly `branches: ['v3-staging']` on `v3-staging`
- the separate V3 release-assets PR must replace `main`'s `release.config.js` and propagate it to `v3-staging` before V3 Step 1 can run; the marker guard deliberately fails until then

## Source and synchronization safety
- every run, including dry runs, requires “Use workflow from” to be `master` or `main`
- all feature-branch and tag refs are intentionally rejected regardless of `dryRun`; supporting pre-merge workflow dispatch is deferred as a future optimization
- real runs fetch both trunks and require all three canonical workflow files to be byte-identical before mutation
- source ref never determines track; only Step 1's required dropdown does

## npm dist-tags
- V2 always publishes with `v2`
- V3 always publishes with `latest`

## Paired rollout
- Paired `master` PR: [#1345](https://github.com/mParticle/mparticle-web-sdk/pull/1345)
- Paired `main` PR: [#1346](https://github.com/mParticle/mparticle-web-sdk/pull/1346)
- **Both PRs must merge before any real release or promotion.**

## Validation
- [x] all three workflows parse as YAML and every embedded shell block passes `bash -n`
- [x] `git diff --check`
- [x] current `origin/main:kits/matrix.json` passes the production validator with 31 entries
- [x] V2 skipped-kit gate fixture passes; failed core tests are rejected
- [x] V3 all-success fixture passes; failed, cancelled, and skipped kit tests are rejected
- [x] no `release-kits` job or kit `npm publish` restored
- [x] no remaining `release.v3.config.js`, `--extends`, or release-config selector references
- [x] actual V2 marker accepted; planned V3 marker accepted; old V2 marker rejected for V3
- [x] source-ref guard: `master`/`main` accepted; feature branches and tags rejected for both dry and real runs, intentionally
- [x] semantic-tag, package-major, and fast-forward guard tests
- [x] byte comparison and matching SHA-256 hashes against the paired master worktree
- [ ] `actionlint` (not installed locally)