### PR TITLE
refactor: extract persistence helpers to reduce cognitive complexity

### DIFF
--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -27,21 +27,114 @@ export default function _Persistence(
         );
     };
 
+    function setFirstRunFromExistingData(
+        localStorageData: IPersistenceMinified | null,
+        cookies: IPersistenceMinified | null
+    ): void {
+        if (!localStorageData && !cookies) {
+            mpInstance._Store.isFirstRun = true;
+            (mpInstance._Store as Dictionary).mpid = 0;
+            return;
+        }
+        mpInstance._Store.isFirstRun = false;
+    }
+
+    function mergeStorageSources(
+        localStorageData: IPersistenceMinified | null,
+        cookies: IPersistenceMinified | null
+    ) {
+        if (localStorageData && cookies) {
+            // https://go.mparticle.com/work/SQDSDKS-6047
+            return Utils.extend(false, localStorageData, cookies);
+        }
+        return localStorageData || cookies;
+    }
+
+    // For migrating from localStorage to cookies -- If an instance switches from
+    // localStorage to cookies, then no mParticle cookie exists yet and there is
+    // localStorage. Get the localStorage, set them to cookies, then delete the
+    // localStorage item.
+    function migrateLocalStorageToCookies(
+        storage: Storage,
+        localStorageData: IPersistenceMinified | null,
+        cookies: IPersistenceMinified | null
+    ) {
+        let allData;
+        if (localStorageData) {
+            allData = mergeStorageSources(localStorageData, cookies);
+            storage.removeItem(mpInstance._Store.storageName);
+        } else if (cookies) {
+            allData = cookies;
+        }
+        self.storeDataInMemory(allData);
+        return allData;
+    }
+
+    // For migrating from cookie to localStorage -- If an instance is newly
+    // switching from cookies to localStorage, then no mParticle localStorage
+    // exists yet and there are cookies. Get the cookies, set them to
+    // localStorage, then delete the cookies.
+    function migrateCookiesToLocalStorage(
+        localStorageData: IPersistenceMinified | null,
+        cookies: IPersistenceMinified | null
+    ) {
+        if (!cookies) {
+            self.storeDataInMemory(localStorageData);
+            return;
+        }
+        const allData = mergeStorageSources(localStorageData, cookies);
+        self.storeDataInMemory(allData);
+        self.expireCookies(mpInstance._Store.storageName);
+        return allData;
+    }
+
+    function loadPersistenceIntoMemory(
+        localStorageData: IPersistenceMinified | null,
+        cookies: IPersistenceMinified | null
+    ) {
+        if (!mpInstance._Store.isLocalStorageAvailable) {
+            self.storeDataInMemory(cookies);
+            return;
+        }
+        if (mpInstance._Store.SDKConfig.useCookieStorage) {
+            return migrateLocalStorageToCookies(
+                window.localStorage,
+                localStorageData,
+                cookies
+            );
+        }
+        return migrateCookiesToLocalStorage(localStorageData, cookies);
+    }
+
+    function copyNonCurrentUserMpids(allData: IPersistenceMinified): void {
+        for (let key in allData) {
+            if (
+                allData.hasOwnProperty(key) &&
+                !SDKv2NonMPIDCookieKeys[key]
+            ) {
+                mpInstance._Store.nonCurrentUserMPIDs[key] = allData[key];
+            }
+        }
+    }
+
+    function clearCorruptStorage(): void {
+        if (
+            self.useLocalStorage() &&
+            mpInstance._Store.isLocalStorageAvailable
+        ) {
+            localStorage.removeItem(mpInstance._Store.storageName);
+            return;
+        }
+        self.expireCookies(mpInstance._Store.storageName);
+    }
+
     this.initializeStorage = function(): void {
         try {
-            let storage,
-                localStorageData = self.getLocalStorage(),
-                cookies = self.getCookie(),
-                allData;
+            const localStorageData = self.getLocalStorage();
+            const cookies = self.getCookie();
 
             // https://go.mparticle.com/work/SQDSDKS-6045
-            // Determine if there is any data in cookies or localStorage to figure out if it is the first time the browser is loading mParticle
-            if (!localStorageData && !cookies) {
-                mpInstance._Store.isFirstRun = true;
-                (mpInstance._Store as Dictionary).mpid = 0;
-            } else {
-                mpInstance._Store.isFirstRun = false;
-            }
+            setFirstRunFromExistingData(localStorageData, cookies);
 
             // https://go.mparticle.com/work/SQDSDKS-6045
             if (!mpInstance._Store.isLocalStorageAvailable) {
@@ -49,73 +142,16 @@ export default function _Persistence(
             }
 
             // https://go.mparticle.com/work/SQDSDKS-6046
-            if (mpInstance._Store.isLocalStorageAvailable) {
-                storage = window.localStorage;
-                if (mpInstance._Store.SDKConfig.useCookieStorage) {
-                    // For migrating from localStorage to cookies -- If an instance switches from localStorage to cookies, then
-                    // no mParticle cookie exists yet and there is localStorage. Get the localStorage, set them to cookies, then delete the localStorage item.
-                    if (localStorageData) {
-                        if (cookies) {
-                            // https://go.mparticle.com/work/SQDSDKS-6047
-                            allData = Utils.extend(
-                                false,
-                                localStorageData,
-                                cookies
-                            );
-                        } else {
-                            allData = localStorageData;
-                        }
-                        storage.removeItem(mpInstance._Store.storageName);
-                    } else if (cookies) {
-                        allData = cookies;
-                    }
-                    self.storeDataInMemory(allData);
-                } else {
-                    // For migrating from cookie to localStorage -- If an instance is newly switching from cookies to localStorage, then
-                    // no mParticle localStorage exists yet and there are cookies. Get the cookies, set them to localStorage, then delete the cookies.
-                    if (cookies) {
-                        if (localStorageData) {
-                            // https://go.mparticle.com/work/SQDSDKS-6047
-                            allData = Utils.extend(
-                                false,
-                                localStorageData,
-                                cookies
-                            );
-                        } else {
-                            allData = cookies;
-                        }
-                        self.storeDataInMemory(allData);
-                        self.expireCookies(mpInstance._Store.storageName);
-                    } else {
-                        self.storeDataInMemory(localStorageData);
-                    }
-                }
-            } else {
-                self.storeDataInMemory(cookies);
-            }
-
-            // https://go.mparticle.com/work/SQDSDKS-6046
-            // Stores all non-current user MPID information into the store
-            for (let key in allData) {
-                if (allData.hasOwnProperty(key)) {
-                    if (!SDKv2NonMPIDCookieKeys[key]) {
-                        mpInstance._Store.nonCurrentUserMPIDs[key] =
-                            allData[key];
-                    }
-                }
-            }
+            const allData = loadPersistenceIntoMemory(
+                localStorageData,
+                cookies
+            );
+            copyNonCurrentUserMpids(allData);
             self.update();
         } catch (e) {
             // If cookies or local storage is corrupt, we want to remove it
             // so that in the future, initializeStorage will work
-            if (
-                self.useLocalStorage() &&
-                mpInstance._Store.isLocalStorageAvailable
-            ) {
-                localStorage.removeItem(mpInstance._Store.storageName);
-            } else {
-                self.expireCookies(mpInstance._Store.storageName);
-            }
+            clearCorruptStorage();
             mpInstance.Logger.error('Error initializing storage: ' + e);
         }
     };
@@ -130,85 +166,93 @@ export default function _Persistence(
         }
     };
 
+    function applyEmptyPersistenceDefaults(): void {
+        mpInstance.Logger.verbose(
+            Messages.InformationMessages.CookieNotFound
+        );
+        mpInstance._Store.clientId =
+            mpInstance._Store.clientId ||
+            mpInstance._Helpers.generateUniqueId();
+        mpInstance._Store.deviceId =
+            mpInstance._Store.deviceId ||
+            mpInstance._Helpers.generateUniqueId();
+    }
+
+    function hydrateStoreFromPersistence(
+        obj: IPersistenceMinified,
+        currentMPID?: MPID
+    ): void {
+        // Set MPID first, then change object to match MPID data
+        if (currentMPID) {
+            (mpInstance._Store as Dictionary).mpid = currentMPID;
+        } else {
+            (mpInstance._Store as Dictionary).mpid = obj.cu || 0;
+        }
+
+        obj.gs = obj.gs || ({} as IPersistenceMinified['gs']);
+
+        mpInstance._Store.sessionId =
+            obj.gs.sid || mpInstance._Store.sessionId;
+        mpInstance._Store.isEnabled =
+            typeof obj.gs.ie !== 'undefined'
+                ? obj.gs.ie
+                : mpInstance._Store.isEnabled;
+        mpInstance._Store.sessionAttributes =
+            obj.gs.sa || mpInstance._Store.sessionAttributes;
+        mpInstance._Store.localSessionAttributes =
+            obj.gs.lsa || mpInstance._Store.localSessionAttributes;
+        mpInstance._Store.serverSettings =
+            obj.gs.ss || mpInstance._Store.serverSettings;
+        mpInstance._Store.devToken =
+            mpInstance._Store.devToken || obj.gs.dt;
+        mpInstance._Store.SDKConfig.appVersion =
+            mpInstance._Store.SDKConfig.appVersion || obj.gs.av;
+        mpInstance._Store.clientId =
+            obj.gs.cgid ||
+            mpInstance._Store.clientId ||
+            mpInstance._Helpers.generateUniqueId();
+
+        // For most persistence values, we prioritize localstorage/cookie values over
+        // Store. However, we allow device ID to be overriden via a config value and
+        // thus the priority of the deviceId value is
+        // 1. value passed via config.deviceId
+        // 2. previous value in persistence
+        // 3. generate new guid
+        mpInstance._Store.deviceId =
+            mpInstance._Store.deviceId ||
+            obj.gs.das ||
+            mpInstance._Helpers.generateUniqueId();
+
+        mpInstance._Store.integrationAttributes = obj.gs.ia || {};
+        mpInstance._Store.context = obj.gs.c || mpInstance._Store.context;
+        mpInstance._Store.currentSessionMPIDs =
+            obj.gs.csm || mpInstance._Store.currentSessionMPIDs;
+
+        mpInstance._Store.isLoggedIn = obj.l === true;
+
+        if (obj.gs.les) {
+            mpInstance._Store.dateLastEventSent = new Date(obj.gs.les);
+        }
+
+        mpInstance._Store.sessionStartDate = obj.gs.ssd
+            ? new Date(obj.gs.ssd)
+            : new Date();
+
+        if (currentMPID) {
+            obj = obj[currentMPID];
+        } else {
+            obj = obj[obj.cu];
+        }
+    }
+
     // https://go.mparticle.com/work/SQDSDKS-6045
     this.storeDataInMemory = function(obj: IPersistenceMinified, currentMPID?: MPID): void {
         try {
             if (!obj) {
-                mpInstance.Logger.verbose(
-                    Messages.InformationMessages.CookieNotFound
-                );
-                mpInstance._Store.clientId =
-                    mpInstance._Store.clientId ||
-                    mpInstance._Helpers.generateUniqueId();
-                mpInstance._Store.deviceId =
-                    mpInstance._Store.deviceId ||
-                    mpInstance._Helpers.generateUniqueId();
-            } else {
-                // Set MPID first, then change object to match MPID data
-                if (currentMPID) {
-                    (mpInstance._Store as Dictionary).mpid = currentMPID;
-                } else {
-                    (mpInstance._Store as Dictionary).mpid = obj.cu || 0;
-                }
-
-                obj.gs = obj.gs || ({} as IPersistenceMinified['gs']);
-
-                mpInstance._Store.sessionId =
-                    obj.gs.sid || mpInstance._Store.sessionId;
-                mpInstance._Store.isEnabled =
-                    typeof obj.gs.ie !== 'undefined'
-                        ? obj.gs.ie
-                        : mpInstance._Store.isEnabled;
-                mpInstance._Store.sessionAttributes =
-                    obj.gs.sa || mpInstance._Store.sessionAttributes;
-                mpInstance._Store.localSessionAttributes =
-                    obj.gs.lsa || mpInstance._Store.localSessionAttributes;
-                mpInstance._Store.serverSettings =
-                    obj.gs.ss || mpInstance._Store.serverSettings;
-                mpInstance._Store.devToken =
-                    mpInstance._Store.devToken || obj.gs.dt;
-                mpInstance._Store.SDKConfig.appVersion =
-                    mpInstance._Store.SDKConfig.appVersion || obj.gs.av;
-                mpInstance._Store.clientId =
-                    obj.gs.cgid ||
-                    mpInstance._Store.clientId ||
-                    mpInstance._Helpers.generateUniqueId();
-
-                // For most persistence values, we prioritize localstorage/cookie values over
-                // Store. However, we allow device ID to be overriden via a config value and
-                // thus the priority of the deviceId value is
-                // 1. value passed via config.deviceId
-                // 2. previous value in persistence
-                // 3. generate new guid
-                mpInstance._Store.deviceId =
-                    mpInstance._Store.deviceId ||
-                    obj.gs.das ||
-                    mpInstance._Helpers.generateUniqueId();
-
-                mpInstance._Store.integrationAttributes = obj.gs.ia || {};
-                mpInstance._Store.context =
-                    obj.gs.c || mpInstance._Store.context;
-                mpInstance._Store.currentSessionMPIDs =
-                    obj.gs.csm || mpInstance._Store.currentSessionMPIDs;
-
-                mpInstance._Store.isLoggedIn = obj.l === true;
-
-                if (obj.gs.les) {
-                    mpInstance._Store.dateLastEventSent = new Date(obj.gs.les);
-                }
-
-                if (obj.gs.ssd) {
-                    mpInstance._Store.sessionStartDate = new Date(obj.gs.ssd);
-                } else {
-                    mpInstance._Store.sessionStartDate = new Date();
-                }
-
-                if (currentMPID) {
-                    obj = obj[currentMPID];
-                } else {
-                    obj = obj[obj.cu];
-                }
+                applyEmptyPersistenceDefaults();
+                return;
             }
+            hydrateStoreFromPersistence(obj, currentMPID);
         } catch (e) {
             mpInstance.Logger.error(Messages.ErrorMessages.CookieParseError);
         }
@@ -495,106 +539,190 @@ export default function _Persistence(
         b. Then remove MPIDs based on order in currentSessionMPIDs array, which
         stores MPIDs based on earliest login.
 */
+    function isEncodedCookieTooLarge(
+        encoded: string,
+        maxCookieSize: number
+    ): boolean {
+        return encoded.length > maxCookieSize;
+    }
+
+    function removeUnsessionedMpidsWhenOversized(
+        persistence: IPersistenceMinified,
+        expires: string,
+        domain: string,
+        maxCookieSize: number
+    ): string {
+        let encodedCookiesWithExpirationAndPath;
+        for (let key in persistence) {
+            if (!persistence.hasOwnProperty(key)) {
+                continue;
+            }
+            encodedCookiesWithExpirationAndPath = createFullEncodedCookie(
+                persistence,
+                expires,
+                domain
+            );
+            if (
+                !isEncodedCookieTooLarge(
+                    encodedCookiesWithExpirationAndPath,
+                    maxCookieSize
+                )
+            ) {
+                continue;
+            }
+            if (SDKv2NonMPIDCookieKeys[key] || key === persistence.cu) {
+                continue;
+            }
+            delete persistence[key];
+        }
+        return encodedCookiesWithExpirationAndPath;
+    }
+
+    function collectRemovableMpids(
+        persistence: IPersistenceMinified
+    ): Dictionary {
+        const MPIDsOnCookie: Dictionary = {};
+        for (let potentialMPID in persistence) {
+            if (!persistence.hasOwnProperty(potentialMPID)) {
+                continue;
+            }
+            if (
+                SDKv2NonMPIDCookieKeys[potentialMPID] ||
+                potentialMPID === persistence.cu
+            ) {
+                continue;
+            }
+            MPIDsOnCookie[potentialMPID] = 1;
+        }
+        return MPIDsOnCookie;
+    }
+
+    function removeMpidsNotInCurrentSession(
+        persistence: IPersistenceMinified,
+        MPIDsOnCookie: Dictionary,
+        currentSessionMPIDs: MPID[],
+        expires: string,
+        domain: string,
+        maxCookieSize: number
+    ): string {
+        let encodedCookiesWithExpirationAndPath;
+        for (let mpid in MPIDsOnCookie) {
+            encodedCookiesWithExpirationAndPath = createFullEncodedCookie(
+                persistence,
+                expires,
+                domain
+            );
+            if (
+                !isEncodedCookieTooLarge(
+                    encodedCookiesWithExpirationAndPath,
+                    maxCookieSize
+                )
+            ) {
+                continue;
+            }
+            if (!MPIDsOnCookie.hasOwnProperty(mpid)) {
+                continue;
+            }
+            if (currentSessionMPIDs.indexOf(mpid) === -1) {
+                delete persistence[mpid];
+            }
+        }
+        return encodedCookiesWithExpirationAndPath;
+    }
+
+    function logAndRemoveOversizedMpid(
+        persistence: IPersistenceMinified,
+        MPIDtoRemove: MPID,
+        maxCookieSize: number
+    ): void {
+        if (persistence[MPIDtoRemove]) {
+            mpInstance.Logger.verbose(
+                'Size of new encoded cookie is larger than maxCookieSize setting of ' +
+                    maxCookieSize +
+                    '. Removing from cookie the earliest logged in MPID containing: ' +
+                    JSON.stringify(
+                        persistence[MPIDtoRemove] as any,
+                        0 as any,
+                        2
+                    )
+            );
+            delete persistence[MPIDtoRemove];
+            return;
+        }
+        mpInstance.Logger.error(
+            'Unable to save MPID data to cookies because the resulting encoded cookie is larger than the maxCookieSize setting of ' +
+                maxCookieSize +
+                '. We recommend using a maxCookieSize of 1500.'
+        );
+    }
+
+    function removeCurrentSessionMpidsByAge(
+        persistence: IPersistenceMinified,
+        currentSessionMPIDs: MPID[],
+        expires: string,
+        domain: string,
+        maxCookieSize: number
+    ): string {
+        let encodedCookiesWithExpirationAndPath;
+        for (let i = 0; i < currentSessionMPIDs.length; i++) {
+            encodedCookiesWithExpirationAndPath = createFullEncodedCookie(
+                persistence,
+                expires,
+                domain
+            );
+            if (
+                !isEncodedCookieTooLarge(
+                    encodedCookiesWithExpirationAndPath,
+                    maxCookieSize
+                )
+            ) {
+                break;
+            }
+            logAndRemoveOversizedMpid(
+                persistence,
+                currentSessionMPIDs[i],
+                maxCookieSize
+            );
+        }
+        return encodedCookiesWithExpirationAndPath;
+    }
+
     this.reduceAndEncodePersistence = function(
         persistence: IPersistenceMinified,
         expires: string,
         domain: string,
         maxCookieSize: number
     ): string {
-        let encodedCookiesWithExpirationAndPath,
-            currentSessionMPIDs = persistence.gs.csm ? persistence.gs.csm : [];
-        // Comment 1 above
+        const currentSessionMPIDs = persistence.gs.csm
+            ? persistence.gs.csm
+            : [];
         if (!currentSessionMPIDs.length) {
-            for (let key in persistence) {
-                if (persistence.hasOwnProperty(key)) {
-                    encodedCookiesWithExpirationAndPath = createFullEncodedCookie(
-                        persistence,
-                        expires,
-                        domain
-                    );
-                    if (
-                        encodedCookiesWithExpirationAndPath.length >
-                        maxCookieSize
-                    ) {
-                        if (
-                            !SDKv2NonMPIDCookieKeys[key] &&
-                            key !== persistence.cu
-                        ) {
-                            delete persistence[key];
-                        }
-                    }
-                }
-            }
-        } else {
-            // Comment 2 above - First create an object of all MPIDs on the cookie
-            let MPIDsOnCookie = {};
-            for (let potentialMPID in persistence) {
-                if (persistence.hasOwnProperty(potentialMPID)) {
-                    if (
-                        !SDKv2NonMPIDCookieKeys[potentialMPID] &&
-                        potentialMPID !== persistence.cu
-                    ) {
-                        MPIDsOnCookie[potentialMPID] = 1;
-                    }
-                }
-            }
-            // Comment 2a above
-            if (Object.keys(MPIDsOnCookie).length) {
-                for (let mpid in MPIDsOnCookie) {
-                    encodedCookiesWithExpirationAndPath = createFullEncodedCookie(
-                        persistence,
-                        expires,
-                        domain
-                    );
-                    if (
-                        encodedCookiesWithExpirationAndPath.length >
-                        maxCookieSize
-                    ) {
-                        if (MPIDsOnCookie.hasOwnProperty(mpid)) {
-                            if (currentSessionMPIDs.indexOf(mpid) === -1) {
-                                delete persistence[mpid];
-                            }
-                        }
-                    }
-                }
-            }
-            // Comment 2b above
-            for (let i = 0; i < currentSessionMPIDs.length; i++) {
-                encodedCookiesWithExpirationAndPath = createFullEncodedCookie(
-                    persistence,
-                    expires,
-                    domain
-                );
-                if (
-                    encodedCookiesWithExpirationAndPath.length > maxCookieSize
-                ) {
-                    let MPIDtoRemove = currentSessionMPIDs[i];
-                    if (persistence[MPIDtoRemove]) {
-                        mpInstance.Logger.verbose(
-                            'Size of new encoded cookie is larger than maxCookieSize setting of ' +
-                                maxCookieSize +
-                                '. Removing from cookie the earliest logged in MPID containing: ' +
-                                JSON.stringify(
-                                    persistence[MPIDtoRemove] as any,
-                                    0 as any,
-                                    2
-                                )
-                        );
-                        delete persistence[MPIDtoRemove];
-                    } else {
-                        mpInstance.Logger.error(
-                            'Unable to save MPID data to cookies because the resulting encoded cookie is larger than the maxCookieSize setting of ' +
-                                maxCookieSize +
-                                '. We recommend using a maxCookieSize of 1500.'
-                        );
-                    }
-                } else {
-                    break;
-                }
-            }
+            return removeUnsessionedMpidsWhenOversized(
+                persistence,
+                expires,
+                domain,
+                maxCookieSize
+            );
         }
 
-        return encodedCookiesWithExpirationAndPath;
+        const MPIDsOnCookie = collectRemovableMpids(persistence);
+        if (Object.keys(MPIDsOnCookie).length) {
+            removeMpidsNotInCurrentSession(
+                persistence,
+                MPIDsOnCookie,
+                currentSessionMPIDs,
+                expires,
+                domain,
+                maxCookieSize
+            );
+        }
+        return removeCurrentSessionMpidsByAge(
+            persistence,
+            currentSessionMPIDs,
+            expires,
+            domain,
+            maxCookieSize
+        );
     };
 
     function createFullEncodedCookie(persistence: IPersistenceMinified, expires: string, domain: string): string {
@@ -607,99 +735,204 @@ export default function _Persistence(
         );
     }
 
-    this.findPrevCookiesBasedOnUI = function(identityApiData: IdentityApiData): void {
-        let persistence = mpInstance._Persistence.getPersistence();
-        let matchedUser;
-
-        if (identityApiData) {
-            for (let requestedIdentityType in identityApiData.userIdentities) {
-                if (persistence && Object.keys(persistence).length) {
-                    for (let key in persistence) {
-                        // any value in persistence that has an MPID key will be an MPID to search through
-                        // other keys on the cookie are currentSessionMPIDs and currentMPID which should not be searched
-                        if (persistence[key].mpid) {
-                            let cookieUIs = persistence[key].ui;
-                            for (let cookieUIType in cookieUIs) {
-                                if (
-                                    requestedIdentityType === cookieUIType &&
-                                    identityApiData.userIdentities[
-                                        requestedIdentityType
-                                    ] === cookieUIs[cookieUIType]
-                                ) {
-                                    matchedUser = key;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
+    function cookieUiMatchesRequestedIdentity(
+        cookieUIs,
+        requestedIdentityType: string,
+        requestedValue
+    ): boolean {
+        for (let cookieUIType in cookieUIs) {
+            if (
+                requestedIdentityType === cookieUIType &&
+                requestedValue === cookieUIs[cookieUIType]
+            ) {
+                return true;
             }
         }
+        return false;
+    }
 
+    function findMpidForRequestedIdentity(
+        persistence: IPersistenceMinified,
+        requestedIdentityType: string,
+        requestedValue
+    ) {
+        let matchedUser;
+        for (let key in persistence) {
+            // any value in persistence that has an MPID key will be an MPID to search through
+            // other keys on the cookie are currentSessionMPIDs and currentMPID which should not be searched
+            if (!persistence[key].mpid) {
+                continue;
+            }
+            if (
+                cookieUiMatchesRequestedIdentity(
+                    persistence[key].ui,
+                    requestedIdentityType,
+                    requestedValue
+                )
+            ) {
+                matchedUser = key;
+            }
+        }
+        return matchedUser;
+    }
+
+    function findMpidMatchingIdentities(
+        persistence: IPersistenceMinified | null,
+        identityApiData: IdentityApiData
+    ) {
+        let matchedUser;
+        for (let requestedIdentityType in identityApiData.userIdentities) {
+            if (!persistence || !Object.keys(persistence).length) {
+                continue;
+            }
+            const match = findMpidForRequestedIdentity(
+                persistence,
+                requestedIdentityType,
+                identityApiData.userIdentities[requestedIdentityType]
+            );
+            if (match) {
+                matchedUser = match;
+            }
+        }
+        return matchedUser;
+    }
+
+    this.findPrevCookiesBasedOnUI = function(identityApiData: IdentityApiData): void {
+        const persistence = mpInstance._Persistence.getPersistence();
+        if (!identityApiData) {
+            return;
+        }
+        const matchedUser = findMpidMatchingIdentities(
+            persistence,
+            identityApiData
+        );
         if (matchedUser) {
             self.storeDataInMemory(persistence, matchedUser);
         }
     };
 
+    function isNonEmptyArrayOrObject(value): boolean {
+        if (Array.isArray(value)) {
+            return value.length > 0;
+        }
+        if (!mpInstance._Helpers.isObject(value)) {
+            return false;
+        }
+        return Object.keys(value).length > 0;
+    }
+
+    function encodeGsBase64Field(gs, key: string): void {
+        if (!gs[key] || !isNonEmptyArrayOrObject(gs[key])) {
+            delete gs[key];
+            return;
+        }
+        gs[key] = Base64.encode(JSON.stringify(gs[key]));
+    }
+
+    function encodeGlobalSettings(gs): void {
+        for (let key in gs) {
+            if (!gs.hasOwnProperty(key)) {
+                continue;
+            }
+            if (Base64CookieKeys[key]) {
+                encodeGsBase64Field(gs, key);
+                continue;
+            }
+            if (key === 'ie') {
+                gs[key] = gs[key] ? 1 : 0;
+                continue;
+            }
+            if (!gs[key]) {
+                delete gs[key];
+            }
+        }
+    }
+
+    function encodeMpidBase64Field(container, key: string): void {
+        const value = container[key];
+        if (
+            mpInstance._Helpers.isObject(value) &&
+            Object.keys(value).length
+        ) {
+            container[key] = Base64.encode(JSON.stringify(value));
+            return;
+        }
+        delete container[key];
+    }
+
+    function encodeMpidRecord(record): void {
+        for (let key in record) {
+            if (!record.hasOwnProperty(key)) {
+                continue;
+            }
+            if (Base64CookieKeys[key]) {
+                encodeMpidBase64Field(record, key);
+            }
+        }
+    }
+
+    function encodeMpidRecords(persistence): void {
+        for (let mpid in persistence) {
+            if (!persistence.hasOwnProperty(mpid)) {
+                continue;
+            }
+            if (SDKv2NonMPIDCookieKeys[mpid]) {
+                continue;
+            }
+            encodeMpidRecord(persistence[mpid]);
+        }
+    }
+
     this.encodePersistence = function(persistenceString: string): string {
         const persistence: any = JSON.parse(persistenceString);
-        for (let key in persistence.gs) {
-            if (persistence.gs.hasOwnProperty(key)) {
-                if (Base64CookieKeys[key]) {
-                    if (persistence.gs[key]) {
-                        // base64 encode any value that is an object or Array in globalSettings
-                        if (
-                            (Array.isArray(persistence.gs[key]) &&
-                                persistence.gs[key].length) ||
-                            (mpInstance._Helpers.isObject(
-                                persistence.gs[key]
-                            ) &&
-                                Object.keys(persistence.gs[key]).length)
-                        ) {
-                            persistence.gs[key] = Base64.encode(
-                                JSON.stringify(persistence.gs[key])
-                            );
-                        } else {
-                            delete persistence.gs[key];
-                        }
-                    } else {
-                        delete persistence.gs[key];
-                    }
-                } else if (key === 'ie') {
-                    persistence.gs[key] = persistence.gs[key] ? 1 : 0;
-                } else if (!persistence.gs[key]) {
-                    delete persistence.gs[key];
-                }
-            }
-        }
-
-        for (let mpid in persistence) {
-            if (persistence.hasOwnProperty(mpid)) {
-                if (!SDKv2NonMPIDCookieKeys[mpid]) {
-                    for (let key in persistence[mpid]) {
-                        if (persistence[mpid].hasOwnProperty(key)) {
-                            if (Base64CookieKeys[key]) {
-                                if (
-                                    mpInstance._Helpers.isObject(
-                                        persistence[mpid][key]
-                                    ) &&
-                                    Object.keys(persistence[mpid][key]).length
-                                ) {
-                                    persistence[mpid][key] = Base64.encode(
-                                        JSON.stringify(persistence[mpid][key])
-                                    );
-                                } else {
-                                    delete persistence[mpid][key];
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        encodeGlobalSettings(persistence.gs);
+        encodeMpidRecords(persistence);
         return Utils.createCookieString(JSON.stringify(persistence));
     };
+
+    function decodeGlobalSettings(gs): void {
+        for (let key in gs) {
+            if (!gs.hasOwnProperty(key)) {
+                continue;
+            }
+            if (Base64CookieKeys[key]) {
+                gs[key] = JSON.parse(Base64.decode(gs[key]));
+                continue;
+            }
+            if (key === 'ie') {
+                gs[key] = Boolean(gs[key]);
+            }
+        }
+    }
+
+    function decodeMpidRecord(record): void {
+        for (let key in record) {
+            if (!record.hasOwnProperty(key)) {
+                continue;
+            }
+            if (!Base64CookieKeys[key]) {
+                continue;
+            }
+            if (record[key].length) {
+                record[key] = JSON.parse(Base64.decode(record[key]));
+            }
+        }
+    }
+
+    function decodeMpidRecords(persistence): void {
+        for (let mpid in persistence) {
+            if (!persistence.hasOwnProperty(mpid)) {
+                continue;
+            }
+            if (!SDKv2NonMPIDCookieKeys[mpid]) {
+                decodeMpidRecord(persistence[mpid]);
+                continue;
+            }
+            if (mpid === 'l') {
+                persistence[mpid] = Boolean(persistence[mpid]);
+            }
+        }
+    }
 
     // TODO: This should actually be decodePersistenceString or
     //       we should refactor this to take a string and return an object
@@ -707,55 +940,20 @@ export default function _Persistence(
         persistenceString: string
     ): string | void {
         try {
-            if (persistenceString) {
-                const persistence: any = JSON.parse(
-                    Utils.revertCookieString(persistenceString)
-                );
-                if (
-                    mpInstance._Helpers.isObject(persistence) &&
-                    Object.keys(persistence).length
-                ) {
-                    for (let key in persistence.gs) {
-                        if (persistence.gs.hasOwnProperty(key)) {
-                            if (Base64CookieKeys[key]) {
-                                persistence.gs[key] = JSON.parse(
-                                    Base64.decode(persistence.gs[key])
-                                );
-                            } else if (key === 'ie') {
-                                persistence.gs[key] = Boolean(
-                                    persistence.gs[key]
-                                );
-                            }
-                        }
-                    }
-
-                    for (let mpid in persistence) {
-                        if (persistence.hasOwnProperty(mpid)) {
-                            if (!SDKv2NonMPIDCookieKeys[mpid]) {
-                                for (let key in persistence[mpid]) {
-                                    if (persistence[mpid].hasOwnProperty(key)) {
-                                        if (Base64CookieKeys[key]) {
-                                            if (persistence[mpid][key].length) {
-                                                persistence[mpid][
-                                                    key
-                                                ] = JSON.parse(
-                                                    Base64.decode(
-                                                        persistence[mpid][key]
-                                                    )
-                                                );
-                                            }
-                                        }
-                                    }
-                                }
-                            } else if (mpid === 'l') {
-                                persistence[mpid] = Boolean(persistence[mpid]);
-                            }
-                        }
-                    }
-                }
-
-                return JSON.stringify(persistence);
+            if (!persistenceString) {
+                return;
             }
+            const persistence: any = JSON.parse(
+                Utils.revertCookieString(persistenceString)
+            );
+            if (
+                mpInstance._Helpers.isObject(persistence) &&
+                Object.keys(persistence).length
+            ) {
+                decodeGlobalSettings(persistence.gs);
+                decodeMpidRecords(persistence);
+            }
+            return JSON.stringify(persistence);
         } catch (e) {
             mpInstance.Logger.error(
                 'Problem with decoding cookie',

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -13,6 +13,10 @@ const Base64 = Polyfill.Base64,
     SDKv2NonMPIDCookieKeys = Constants.SDKv2NonMPIDCookieKeys,
     StorageNames = Constants.StorageNames;
 
+function removeLocalStorage(localStorageName: string): void {
+    localStorage.removeItem(localStorageName);
+}
+
 export default function _Persistence(
     this: IPersistence,
     mpInstance: IMParticleWebSDKInstance
@@ -380,10 +384,6 @@ export default function _Persistence(
 
         return null;
     };
-
-    function removeLocalStorage(localStorageName: string): void {
-        localStorage.removeItem(localStorageName);
-    }
 
     this.expireCookies = function(cookieName: string): void {
         let date = new Date(),
@@ -1186,7 +1186,7 @@ export default function _Persistence(
         self.expireCookies(StorageNames.cookieNameV4);
         self.expireCookies(mpInstance._Store.storageName);
 
-        if ((window as any).mParticle && (window as any).mParticle._isTestEnv) {
+        if ((window as any).mParticle?._isTestEnv) {
             let testWorkspaceToken = 'abcdef';
             removeLocalStorage(
                 mpInstance._Helpers.createMainStorageName(testWorkspaceToken)

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -13,10 +13,6 @@ const Base64 = Polyfill.Base64,
     SDKv2NonMPIDCookieKeys = Constants.SDKv2NonMPIDCookieKeys,
     StorageNames = Constants.StorageNames;
 
-function removeLocalStorage(localStorageName: string): void {
-    localStorage.removeItem(localStorageName);
-}
-
 export default function _Persistence(
     this: IPersistence,
     mpInstance: IMParticleWebSDKInstance
@@ -1188,7 +1184,7 @@ export default function _Persistence(
 
         if ((window as any).mParticle?._isTestEnv) {
             let testWorkspaceToken = 'abcdef';
-            removeLocalStorage(
+            localStorage.removeItem(
                 mpInstance._Helpers.createMainStorageName(testWorkspaceToken)
             );
             self.expireCookies(


### PR DESCRIPTION
## Background
- Sonar reports cognitive complexity failures on six methods in `persistence.ts`. The control flow is pre-existing from the JavaScript version; it is only being scored now because the persistence migration introduces the file as TypeScript. Keeping these refactors out of the migration PR keeps that diff limited to types.

## What Has Changed
- Extracted helpers so each of the following methods is at or under the allowed complexity of 15:
  - `initializeStorage` (was 38): first-run detection, localStorage/cookie merging, non-current-user MPID copying, and corrupt-storage cleanup are now separate functions.
  - `storeDataInMemory` (was 16): split into empty-persistence defaults and store hydration.
  - `reduceAndEncodePersistence` (was 59): the three MPID eviction strategies (no current session MPIDs, MPIDs outside the current session, then current session MPIDs by login order) are now separate functions.
  - `findPrevCookiesBasedOnUI` (was 31): identity matching split into per-MPID and per-identity-type helpers.
  - `encodePersistence` (was 55) and `decodePersistence` (was 61): global settings and per-MPID Base64 handling extracted into paired helpers.
- Cookie and localStorage merge order, MPID eviction priority, Base64 encode/decode, and identity cookie lookup results are unchanged.

## Screenshots/Video
- N/A. No user-facing or UI changes.

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- Stacked on the persistence migration PR. Please confirm the base branch is `refactor/SDKE-1107-update-persistence-to-TS` and not `development` before review.
- This is a structural refactor with no intended behavior change, so it relies on the existing persistence test coverage rather than adding tests.
- Verified locally with `npx tsc --noEmit --skipLibCheck` and the persistence Jest specs.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/SDKE-1107