### PR TITLE
fix(ci): run release after skipped v2 kit jobs

### DIFF
--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -506,6 +506,13 @@ jobs:
     release:
         name: Perform Release
         runs-on: ubuntu-latest
+        if: >-
+            ${{
+                always() &&
+                !cancelled() &&
+                needs.create-release-branch.result == 'success' &&
+                needs.confirm-staging-branch.result == 'success'
+            }}
         needs:
             - create-release-branch
             - confirm-staging-branch


### PR DESCRIPTION
## Summary

- add an explicit `always() && !cancelled()` job gate so V2's intentionally skipped kit-test ancestors no longer trigger GitHub Actions' implicit job-level `success()` skip propagation
- require both direct prerequisites, `create-release-branch` and `confirm-staging-branch`, to succeed before `Perform Release` runs
- preserve the existing step-level `dryRun` conditions that select semantic-release preview versus publish

## Observed runs

- [Real run 32486722095](https://github.com/mParticle/mparticle-web-sdk/actions/runs/32486722095) pushed `release/174` but skipped `Perform Release`.
- [Dry run 32486245221](https://github.com/mParticle/mparticle-web-sdk/actions/runs/32486245221) also skipped `Perform Release`.

GitHub Actions implicitly applies `success()` to a job without a status-check condition. Because V2 intentionally skips the kit matrix jobs, that skip propagated through the dependency graph to `Perform Release`. The explicit gate overrides that behavior while still blocking failed, cancelled, or skipped direct prerequisites and workflow cancellation.

## Test plan

- [x] Parse `.github/workflows/staging-step-1.yml` as YAML
- [x] Extract and run `bash -n` on all 26 embedded shell blocks
- [x] Run `git diff --check`
- [x] Verify static gate truth cases: successful direct needs run despite skipped ancestors; failed, cancelled, or skipped direct needs and cancellation are blocked
- [x] Confirm only `.github/workflows/staging-step-1.yml` changed

## Follow-up

The same one-file change must be applied to `main` before a real release so the existing master/main workflow parity validation continues to pass. This PR intentionally targets only `master`.