### PR TITLE
fix(ci): release checked-out staging candidate

### DIFF
--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -595,7 +595,13 @@ jobs:
                   STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
               run: |
                   set -eu
-                  npx semantic-release --branches "$STAGING_BRANCH" --dry-run
+                  CANDIDATE_SHA="$(git rev-parse HEAD)"
+                  # Dispatch metadata points at the canonical workflow branch;
+                  # semantic-release must evaluate the checked-out candidate.
+                  GITHUB_REF="refs/heads/${STAGING_BRANCH}" \
+                      GITHUB_REF_NAME="$STAGING_BRANCH" \
+                      GITHUB_SHA="$CANDIDATE_SHA" \
+                      npx semantic-release --branches "$STAGING_BRANCH" --dry-run
 
             - name: Snapshot existing stable release tags
               if: ${{ github.event.inputs.dryRun == 'false' }}
@@ -614,7 +620,13 @@ jobs:
                   STAGING_BRANCH: ${{ needs.confirm-staging-branch.outputs.staging_branch }}
               run: |
                   set -eu
-                  npx semantic-release --branches "$STAGING_BRANCH"
+                  CANDIDATE_SHA="$(git rev-parse HEAD)"
+                  # Dispatch metadata points at the canonical workflow branch;
+                  # semantic-release must evaluate the checked-out candidate.
+                  GITHUB_REF="refs/heads/${STAGING_BRANCH}" \
+                      GITHUB_REF_NAME="$STAGING_BRANCH" \
+                      GITHUB_SHA="$CANDIDATE_SHA" \
+                      npx semantic-release --branches "$STAGING_BRANCH"
 
             - name: Archive npm failure logs
               uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

- Fix semantic-release branch detection in both Step 1 release paths by passing the checked-out staging candidate's ref, ref name, and SHA directly to the semantic-release child process.
- Preserve the canonical `master`/`main` workflow-dispatch guard and the existing track-specific `--branches` argument.
- Keep preview and publishing behavior aligned: both evaluate the candidate checkout, while only the preview invocation uses `--dry-run`.

## Root cause

[Run 32488350865](https://github.com/mParticle/mparticle-web-sdk/actions/runs/32488350865/job/96791215387) reached `Release --dry-run`, but semantic-release reported that it was triggered on `master` while configured for `staging`.

Step 1 is intentionally dispatched from the canonical workflow branch and then checks out/builds a staging candidate. semantic-release 24 uses env-ci 11, which derives the GitHub branch from `GITHUB_REF`; passing `--branches staging` changes the allowed release branches but does not change the detected CI branch. The workflow now captures the candidate `HEAD` and overrides `GITHUB_REF`, `GITHUB_REF_NAME`, and `GITHUB_SHA` inline for each semantic-release child process.

`release.config.js` is intentionally unchanged because this is CI metadata detection, not release policy. The source-ref guard is also unchanged.

## Validation

- Parsed `.github/workflows/staging-step-1.yml` as YAML.
- Ran `bash -n` against all 26 embedded shell blocks.
- Ran `git diff --check` and confirmed only Step 1 changed.
- Verified both semantic-release invocations receive all three overrides and only preview has `--dry-run`.
- Installed locked dependencies with `npm ci`; confirmed semantic-release 24.2.9 uses env-ci 11.2.0.
- Proved env-ci resolves `refs/heads/staging` to `staging` and `refs/heads/v3-staging` to `v3-staging`, preserving the supplied candidate SHA.
- Stubbed `npx` for both release blocks to verify ref/name/SHA propagation and argument quoting without running semantic-release or publishing.

## Release workflow parity

This same workflow change must be applied to `main` before any real release. Step 1's existing real-release parity guard requires the release workflows on `master` and `main` to remain identical.