### PR TITLE
chore(release): prepare kits 3.0.0

### DIFF
--- a/kits/adobe-target/package.json
+++ b/kits/adobe-target/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "@mparticle/web-adobe-target-kit",
-  "version": "1.0.0",
-  "scripts": {
-    "test": "npm run testKarma",
-    "testKarma": "node test/boilerplate/test-karma.js",
-    "build": "ENVIRONMENT=production rollup --config rollup.config.js",
-    "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
-    "testEndToEnd": "ENVIRONMENT=endToEndTest rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
-  },
-  "main": "dist/AdobeTarget-Kit.common.js",
-  "browser": "dist/AdobeTarget-Kit.common.js",
-  "files": [
-    "dist/AdobeTarget-Kit.common.js"
-  ],
-  "devDependencies": {
-    "@mparticle/web-kit-wrapper": "^1.0.5",
-    "mocha": "^5.2.0",
-    "chai": "^4.2.0",
-    "karma": "^3.1.1",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^2.2.0",
-    "karma-edge-launcher": "^0.4.2",
-    "karma-firefox-launcher": "^1.1.0",
-    "karma-ie-launcher": "^1.0.0",
-    "karma-junit-reporter": "^1.2.0",
-    "karma-mocha": "^1.3.0",
-    "karma-safari-launcher": "^1.0.0",
-    "rollup": "^1.15.6",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.3",
-    "shelljs": "0.8.3",
-    "should": "13.2.3",
-    "watchify": "^3.11.0"
-  },
-  "dependencies": {
-    "@mparticle/web-sdk": "^2.11.3"
-  }
+    "name": "@mparticle/web-adobe-target-kit",
+    "version": "3.0.0",
+    "scripts": {
+        "test": "npm run testKarma",
+        "testKarma": "node test/boilerplate/test-karma.js",
+        "build": "ENVIRONMENT=production rollup --config rollup.config.js",
+        "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
+        "testEndToEnd": "ENVIRONMENT=endToEndTest rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
+    },
+    "main": "dist/AdobeTarget-Kit.common.js",
+    "browser": "dist/AdobeTarget-Kit.common.js",
+    "files": [
+        "dist/AdobeTarget-Kit.common.js"
+    ],
+    "devDependencies": {
+        "@mparticle/web-kit-wrapper": "^1.0.5",
+        "mocha": "^5.2.0",
+        "chai": "^4.2.0",
+        "karma": "^3.1.1",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-junit-reporter": "^1.2.0",
+        "karma-mocha": "^1.3.0",
+        "karma-safari-launcher": "^1.0.0",
+        "rollup": "^1.15.6",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.3",
+        "shelljs": "0.8.3",
+        "should": "13.2.3",
+        "watchify": "^3.11.0"
+    },
+    "dependencies": {
+        "@mparticle/web-sdk": "^3.0.0"
+    }
 }

--- a/kits/adobe/package.json
+++ b/kits/adobe/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@mparticle/web-adobe-kit",
-    "version": "2.0.1",
+    "version": "3.0.0",
+    "private": true,
     "description": "mParticle Adobe kit integration",
     "repository": {
         "type": "git",
@@ -31,7 +32,7 @@
     "devDependencies": {
         "@babel/core": "^7.5.5",
         "@babel/preset-env": "^7.5.5",
-        "@mparticle/web-sdk": "^2.23.0",
+        "@mparticle/web-sdk": "^3.0.0",
         "babel-jest": "^24.9.0",
         "jest": "^24.9.0",
         "lerna": "^3.16.4",

--- a/kits/adobe/packages/AdobeClient/package.json
+++ b/kits/adobe/packages/AdobeClient/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@mparticle/web-adobe-client-kit",
-  "version": "2.1.3",
-  "description": "mParticle integration sdk for Adobe (client side)",
-  "main": "dist/AdobeClientSideKit.common.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
-  "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mParticle/mparticle-web-sdk.git",
-    "directory": "kits/adobe/packages/AdobeClient"
-  }
+    "name": "@mparticle/web-adobe-client-kit",
+    "version": "3.0.0",
+    "description": "mParticle integration sdk for Adobe (client side)",
+    "main": "dist/AdobeClientSideKit.common.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
+    "license": "Apache-2.0",
+    "publishConfig": {
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mParticle/mparticle-web-sdk.git",
+        "directory": "kits/adobe/packages/AdobeClient"
+    }
 }

--- a/kits/adobe/packages/AdobeServer/package.json
+++ b/kits/adobe/packages/AdobeServer/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@mparticle/web-adobe-server-kit",
-  "version": "2.1.2",
-  "description": "mParticle integration sdk for Adobe (server side)",
-  "main": "dist/AdobeServerSideKit.common.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
-  "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mParticle/mparticle-web-sdk.git",
-    "directory": "kits/adobe/packages/AdobeServer"
-  }
+    "name": "@mparticle/web-adobe-server-kit",
+    "version": "3.0.0",
+    "description": "mParticle integration sdk for Adobe (server side)",
+    "main": "dist/AdobeServerSideKit.common.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
+    "license": "Apache-2.0",
+    "publishConfig": {
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mParticle/mparticle-web-sdk.git",
+        "directory": "kits/adobe/packages/AdobeServer"
+    }
 }

--- a/kits/adwords/package.json
+++ b/kits/adwords/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-adwords-kit",
-    "version": "2.3.2",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Google Adwords",
     "main": "dist/GoogleAdWordsEventForwarder.common.js",
@@ -32,7 +32,7 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/amplitude/amplitude-8/package.json
+++ b/kits/amplitude/amplitude-8/package.json
@@ -1,55 +1,55 @@
 {
-  "name": "@mparticle/web-amplitude-kit",
-  "version": "2.3.0",
-  "author": "mParticle Developers (https://www.mparticle.com)",
-  "description": "mParticle integration SDK for Amplitude",
-  "main": "dist/Amplitude.common.js",
-  "module": "dist/Amplitude.esm.js",
-  "files": [
-    "dist/Amplitude.common.js",
-    "dist/Amplitude.esm.js",
-    "dist/Amplitude.iife.js"
-  ],
-  "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/amplitude/amplitude-8#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mParticle/mparticle-web-sdk.git",
-    "directory": "kits/amplitude/amplitude-8"
-  },
-  "scripts": {
-    "build": "rollup --config rollup.config.js",
-    "build:test": "rollup --config rollup.test.config.js",
-    "test": "npm run build && npm run build:test && cross-env DEBUG=false karma start test/karma.config.js",
-    "test:debug": "npm run build && npm run build:test && cross-env DEBUG=true karma start test/karma.config.js",
-    "watch": "rollup --config rollup.config.js -w",
-    "lint": "eslint src/"
-  },
-  "peerDependencies": {
-    "@mparticle/web-sdk": "^2.0.0"
-  },
-  "devDependencies": {
-    "@mparticle/web-sdk": "^2.58.0",
-    "chai": "^4.2.0",
-    "cross-env": "^7.0.3",
-    "eslint": "^8.36.0",
-    "eslint-config-prettier": "9.0.0",
-    "eslint-plugin-prettier": "3.4.1",
-    "karma": "^6.3.2",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-firefox-launcher": "^2.1.2",
-    "karma-mocha": "^2.0.1",
-    "mocha": "^9.0.0",
-    "prettier": "^2.2.1",
-    "rollup": "^2.75.7",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.1",
-    "should": "^7.1.1"
-  },
-  "license": "Apache-2.0",
-  "publishConfig": {
-      "access": "public",
-      "provenance": true,
-      "registry": "https://registry.npmjs.org"
-  }
+    "name": "@mparticle/web-amplitude-kit",
+    "version": "3.0.0",
+    "author": "mParticle Developers (https://www.mparticle.com)",
+    "description": "mParticle integration SDK for Amplitude",
+    "main": "dist/Amplitude.common.js",
+    "module": "dist/Amplitude.esm.js",
+    "files": [
+        "dist/Amplitude.common.js",
+        "dist/Amplitude.esm.js",
+        "dist/Amplitude.iife.js"
+    ],
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/amplitude/amplitude-8#readme",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mParticle/mparticle-web-sdk.git",
+        "directory": "kits/amplitude/amplitude-8"
+    },
+    "scripts": {
+        "build": "rollup --config rollup.config.js",
+        "build:test": "rollup --config rollup.test.config.js",
+        "test": "npm run build && npm run build:test && cross-env DEBUG=false karma start test/karma.config.js",
+        "test:debug": "npm run build && npm run build:test && cross-env DEBUG=true karma start test/karma.config.js",
+        "watch": "rollup --config rollup.config.js -w",
+        "lint": "eslint src/"
+    },
+    "peerDependencies": {
+        "@mparticle/web-sdk": "^3.0.0"
+    },
+    "devDependencies": {
+        "@mparticle/web-sdk": "^3.0.0",
+        "chai": "^4.2.0",
+        "cross-env": "^7.0.3",
+        "eslint": "^8.36.0",
+        "eslint-config-prettier": "9.0.0",
+        "eslint-plugin-prettier": "3.4.1",
+        "karma": "^6.3.2",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^2.1.2",
+        "karma-mocha": "^2.0.1",
+        "mocha": "^9.0.0",
+        "prettier": "^2.2.1",
+        "rollup": "^2.75.7",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.1",
+        "should": "^7.1.1"
+    },
+    "license": "Apache-2.0",
+    "publishConfig": {
+        "access": "public",
+        "provenance": true,
+        "registry": "https://registry.npmjs.org"
+    }
 }

--- a/kits/bingads/package.json
+++ b/kits/bingads/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-bing-ads-kit",
-    "version": "2.1.0",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Bing Ads",
     "main": "dist/BingAdsEventForwarder.common.js",
@@ -18,7 +18,6 @@
         "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js",
         "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
         "watch:tests": "ENVIRONMENT=production rollup --config rollup.test.config.js -w"
-        
     },
     "devDependencies": {
         "@semantic-release/changelog": "^5.0.1",
@@ -44,7 +43,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/kits/braze/braze-3/package.json
+++ b/kits/braze/braze-3/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@mparticle/web-braze-kit-3",
-    "version": "3.0.9",
+    "version": "3.0.0",
+    "publishConfig": {
+        "access": "public"
+    },
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Braze",
     "main": "dist/BrazeKit.common.js",
@@ -35,7 +38,7 @@
     },
     "dependencies": {
         "@braze/web-sdk": "^3.5.0",
-        "@mparticle/web-sdk": "^2.23.0"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
     "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/braze/braze-3#readme"

--- a/kits/braze/braze-4/package.json
+++ b/kits/braze/braze-4/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@mparticle/web-braze-kit-4",
-    "version": "4.2.2",
+    "version": "3.0.0",
+    "publishConfig": {
+        "access": "public"
+    },
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Braze",
     "main": "dist/BrazeKit.common.js",
@@ -37,7 +40,7 @@
     },
     "dependencies": {
         "@braze/web-sdk": "^4.2.1",
-        "@mparticle/web-sdk": "^2.23.0"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
     "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/braze/braze-4#readme"

--- a/kits/braze/braze-5/package.json
+++ b/kits/braze/braze-5/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@mparticle/web-braze-kit-5",
-    "version": "5.0.3",
+    "version": "3.0.0",
+    "publishConfig": {
+        "access": "public"
+    },
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Braze",
     "main": "dist/BrazeKit.common.js",
@@ -39,7 +42,7 @@
     },
     "dependencies": {
         "@braze/web-sdk": "^5.5.0",
-        "@mparticle/web-sdk": "^2.23.0"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
     "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/braze/braze-5#readme"

--- a/kits/braze/braze-6/package.json
+++ b/kits/braze/braze-6/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@mparticle/web-braze-kit-6",
-    "version": "6.0.0",
+    "version": "3.0.0",
+    "publishConfig": {
+        "access": "public"
+    },
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Braze",
     "main": "dist/BrazeKit.common.js",
@@ -39,7 +42,7 @@
     },
     "dependencies": {
         "@braze/web-sdk": "^6.0.0",
-        "@mparticle/web-sdk": "^2.23.0"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
     "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/braze/braze-6#readme"

--- a/kits/criteo/package.json
+++ b/kits/criteo/package.json
@@ -1,37 +1,37 @@
 {
-  "name": "@mparticle/web-criteo-kit",
-  "version": "2.0.3",
-  "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
-  "description": "mParticle integration sdk for Criteo",
-  "browser": "dist/CriteoEventForwarder.common.js",
-  "main": "dist/CriteoEventForwarder.common.js",
-  "files": [
-    "dist/CriteoEventForwarder.common.js"
-  ],
-  "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-criteo",
-  "scripts": {
-    "build": "rollup --config rollup.config.js",
-    "watch": "rollup --config rollup.config.js -w",
-    "build:test": "rollup --config rollup.test.config.js",
-    "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
-    "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js"
-  },
-  "devDependencies": {
-    "@mparticle/web-sdk": "^2.23.6",
-    "@semantic-release/changelog": "^5.0.1",
-    "@semantic-release/exec": "^5.0.0",
-    "@semantic-release/git": "^9.0.0",
-    "chai": "^4.2.0",
-    "karma": "^5.1.0",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-firefox-launcher": "^1.3.0",
-    "karma-mocha": "^2.0.1",
-    "mocha": "^2.3.2",
-    "rollup": "^1.13.1",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.1",
-    "should": "^7.1.0"
-  },
-  "license": "Apache-2.0"
+    "name": "@mparticle/web-criteo-kit",
+    "version": "3.0.0",
+    "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
+    "description": "mParticle integration sdk for Criteo",
+    "browser": "dist/CriteoEventForwarder.common.js",
+    "main": "dist/CriteoEventForwarder.common.js",
+    "files": [
+        "dist/CriteoEventForwarder.common.js"
+    ],
+    "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-criteo",
+    "scripts": {
+        "build": "rollup --config rollup.config.js",
+        "watch": "rollup --config rollup.config.js -w",
+        "build:test": "rollup --config rollup.test.config.js",
+        "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
+        "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js"
+    },
+    "devDependencies": {
+        "@mparticle/web-sdk": "^3.0.0",
+        "@semantic-release/changelog": "^5.0.1",
+        "@semantic-release/exec": "^5.0.0",
+        "@semantic-release/git": "^9.0.0",
+        "chai": "^4.2.0",
+        "karma": "^5.1.0",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^1.3.0",
+        "karma-mocha": "^2.0.1",
+        "mocha": "^2.3.2",
+        "rollup": "^1.13.1",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.1",
+        "should": "^7.1.0"
+    },
+    "license": "Apache-2.0"
 }

--- a/kits/device-match/package.json
+++ b/kits/device-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-device-match-kit",
-    "version": "2.0.2",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Device Match",
     "main": "dist/DeviceMatchEventForwarder.common.js",
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/doubleclick/package.json
+++ b/kits/doubleclick/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-double-click-kit",
-    "version": "2.2.1",
+    "version": "3.0.0",
     "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-doubleclick",
     "main": "dist/DoubleClick-Kit.common.js",
     "browser": "dist/DoubleClick-Kit.common.js",
@@ -17,7 +17,7 @@
         "testEndToEnd": "browserify node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.js -v -o test/end-to-end-testapp/build/compilation.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
     },
     "devDependencies": {
-        "@mparticle/web-sdk": "^2.23.4",
+        "@mparticle/web-sdk": "^3.0.0",
         "@semantic-release/changelog": "^5.0.1",
         "@semantic-release/exec": "^5.0.0",
         "@semantic-release/git": "^9.0.0",

--- a/kits/dynamic-yield/package.json
+++ b/kits/dynamic-yield/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-dynamic-yield-kit",
-    "version": "2.0.4",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle Dynamic Yield kit integration",
     "main": "dist/DynamicYieldKit.common.js",
@@ -30,7 +30,7 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/facebook/package.json
+++ b/kits/facebook/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-facebook-kit",
-    "version": "2.3.0",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for facebook",
     "main": "dist/FacebookEventForwarder.common.js",
@@ -22,7 +22,7 @@
         "test": "node test/boilerplate/test-karma.js"
     },
     "devDependencies": {
-        "@mparticle/web-sdk": "^2.50.0",
+        "@mparticle/web-sdk": "^3.0.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",

--- a/kits/google-analytics-4/package.json
+++ b/kits/google-analytics-4/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@mparticle/web-google-analytics-4-kit",
-    "version": "1.0.0",
+    "version": "3.0.0",
+    "private": true,
     "description": "mParticle Google Analytics 4 kit integration",
     "repository": {
         "type": "git",

--- a/kits/google-analytics-4/packages/GA4Client/package.json
+++ b/kits/google-analytics-4/packages/GA4Client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-google-analytics-4-client-kit",
-    "version": "1.5.1",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Google Analytics",
     "main": "dist/GoogleAnalytics4EventForwarderClientSide-Kit.common.js",
@@ -53,7 +53,7 @@
         "watchify": "^3.11.0"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.58.0"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/google-analytics-4/packages/GA4Server/package.json
+++ b/kits/google-analytics-4/packages/GA4Server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-google-analytics-4-server-kit",
-    "version": "1.0.3",
+    "version": "3.0.0",
     "description": "mParticle integration sdk for Google Analytics (server side)",
     "main": "dist/GoogleAnalytics4EventForwarderServerSide-Kit.common.js",
     "browser": "dist/GoogleAnalytics4EventForwarderServerSide-Kit.common.js",
@@ -44,6 +44,6 @@
         "sinon": "^15.1.0"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.58.0"
+        "@mparticle/web-sdk": "^3.0.0"
     }
 }

--- a/kits/google-tag-manager/package.json
+++ b/kits/google-tag-manager/package.json
@@ -1,44 +1,44 @@
 {
-  "name": "@mparticle/web-google-tag-manager-kit",
-  "version": "2.2.0",
-  "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-google-tag-manager",
-  "main": "dist/GoogleTagManager-Kit.common.js",
-  "browser": "dist/GoogleTagManager-Kit.common.js",
-  "files": [
-    "dist/GoogleTagManager-Kit.common.js"
-  ],
-  "scripts": {
-    "test": "npm run build && npm run test:karma",
-    "test:karma": "node test/test-karma.js",
-    "build": "ENVIRONMENT=production rollup --config rollup.config.js",
-    "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
-    "testEndToEnd": "browserify node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.js -v -o test/end-to-end-testapp/build/compilation.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
-  },
-  "dependencies": {
-    "@mparticle/web-sdk": "^2.11.1"
-  },
-  "devDependencies": {
-    "@mparticle/web-kit-wrapper": "^1.0.5",
-    "@semantic-release/changelog": "^5.0.1",
-    "@semantic-release/exec": "^5.0.0",
-    "@semantic-release/git": "^9.0.0",
-    "chai": "^4.3.4",
-    "karma": "^5.1.0",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^2.2.0",
-    "karma-edge-launcher": "^0.4.2",
-    "karma-firefox-launcher": "^1.1.0",
-    "karma-ie-launcher": "^1.0.0",
-    "karma-junit-reporter": "^1.2.0",
-    "karma-mocha": "^1.3.0",
-    "karma-safari-launcher": "^1.0.0",
-    "mocha": "^5.2.0",
-    "mparticle-sdk-javascript": "github:mparticle/mparticle-sdk-javascript",
-    "rollup": "^1.15.6",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.3",
-    "shelljs": "0.8.3",
-    "should": "13.2.3",
-    "watchify": "^3.11.0"
-  }
+    "name": "@mparticle/web-google-tag-manager-kit",
+    "version": "3.0.0",
+    "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-google-tag-manager",
+    "main": "dist/GoogleTagManager-Kit.common.js",
+    "browser": "dist/GoogleTagManager-Kit.common.js",
+    "files": [
+        "dist/GoogleTagManager-Kit.common.js"
+    ],
+    "scripts": {
+        "test": "npm run build && npm run test:karma",
+        "test:karma": "node test/test-karma.js",
+        "build": "ENVIRONMENT=production rollup --config rollup.config.js",
+        "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
+        "testEndToEnd": "browserify node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.js -v -o test/end-to-end-testapp/build/compilation.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
+    },
+    "dependencies": {
+        "@mparticle/web-sdk": "^3.0.0"
+    },
+    "devDependencies": {
+        "@mparticle/web-kit-wrapper": "^1.0.5",
+        "@semantic-release/changelog": "^5.0.1",
+        "@semantic-release/exec": "^5.0.0",
+        "@semantic-release/git": "^9.0.0",
+        "chai": "^4.3.4",
+        "karma": "^5.1.0",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-junit-reporter": "^1.2.0",
+        "karma-mocha": "^1.3.0",
+        "karma-safari-launcher": "^1.0.0",
+        "mocha": "^5.2.0",
+        "mparticle-sdk-javascript": "github:mparticle/mparticle-sdk-javascript",
+        "rollup": "^1.15.6",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.3",
+        "shelljs": "0.8.3",
+        "should": "13.2.3",
+        "watchify": "^3.11.0"
+    }
 }

--- a/kits/heap/package.json
+++ b/kits/heap/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "@mparticle/web-heap-kit",
-  "version": "1.0.1",
-  "main": "dist/HeapKit.common.js",
-  "files": [
-    "dist/HeapKit.common.js"
-  ],
-  "scripts": {
-    "build": "ENVIRONMENT=production rollup --config rollup.config.js",
-    "build:test": "rollup --config rollup.test.config.js",
-    "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
-    "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
-    "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js",
-    "testEndToEnd": "ENVIRONMENT=testEndToEnd rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
-  },
-  "devDependencies": {
-    "@mparticle/web-kit-wrapper": "^1.0.5",
-    "@semantic-release/changelog": "^5.0.1",
-    "@semantic-release/exec": "^5.0.0",
-    "@semantic-release/git": "^9.0.0",
-    "mocha": "^5.2.0",
-    "chai": "^4.2.0",
-    "eslint": "^7.25.0",
-    "eslint-config-prettier": "8.3.0",
-    "eslint-plugin-prettier": "3.4.1",
-    "karma": "^5.1.0",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-firefox-launcher": "^2.1.0",
-    "karma-mocha": "^2.0.1",
-    "prettier": "^2.4.1",
-    "rollup": "^1.15.6",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.3",
-    "shelljs": "0.8.3",
-    "should": "13.2.3",
-    "watchify": "^3.11.0"
-  },
-  "dependencies": {
-    "@mparticle/web-sdk": "^2.20.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "license": "Apache-2.0"
+    "name": "@mparticle/web-heap-kit",
+    "version": "3.0.0",
+    "main": "dist/HeapKit.common.js",
+    "files": [
+        "dist/HeapKit.common.js"
+    ],
+    "scripts": {
+        "build": "ENVIRONMENT=production rollup --config rollup.config.js",
+        "build:test": "rollup --config rollup.test.config.js",
+        "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
+        "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
+        "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js",
+        "testEndToEnd": "ENVIRONMENT=testEndToEnd rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
+    },
+    "devDependencies": {
+        "@mparticle/web-kit-wrapper": "^1.0.5",
+        "@semantic-release/changelog": "^5.0.1",
+        "@semantic-release/exec": "^5.0.0",
+        "@semantic-release/git": "^9.0.0",
+        "mocha": "^5.2.0",
+        "chai": "^4.2.0",
+        "eslint": "^7.25.0",
+        "eslint-config-prettier": "8.3.0",
+        "eslint-plugin-prettier": "3.4.1",
+        "karma": "^5.1.0",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^2.1.0",
+        "karma-mocha": "^2.0.1",
+        "prettier": "^2.4.1",
+        "rollup": "^1.15.6",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.3",
+        "shelljs": "0.8.3",
+        "should": "13.2.3",
+        "watchify": "^3.11.0"
+    },
+    "dependencies": {
+        "@mparticle/web-sdk": "^3.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "license": "Apache-2.0"
 }

--- a/kits/id5/id5-1/package.json
+++ b/kits/id5/id5-1/package.json
@@ -1,55 +1,55 @@
 {
-  "name": "@mparticle/web-id5-kit",
-  "version": "1.0.4",
-  "main": "dist/ID5Kit.common.js",
-  "files": [
-    "dist/ID5Kit.common.js"
-  ],
-  "scripts": {
-    "build": "ENVIRONMENT=production rollup --config rollup.config.js",
-    "build:test": "rollup --config rollup.test.config.js",
-    "lint": "eslint src/ test/src/",
-    "lint:fix": "eslint src/ test/src/ --fix",
-    "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
-    "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
-    "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js",
-    "testEndToEnd": "ENVIRONMENT=testEndToEnd rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
-  },
-  "devDependencies": {
-    "@mparticle/eslint-config-sdks": "^0.0.4",
-    "@mparticle/web-kit-wrapper": "^1.0.5",
-    "@semantic-release/changelog": "^5.0.1",
-    "@semantic-release/exec": "^5.0.0",
-    "@semantic-release/git": "^9.0.0",
-    "chai": "^4.2.0",
-    "crypto-js": "^4.2.0",
-    "eslint": "^7.25.0",
-    "eslint-config-prettier": "9.1.0",
-    "karma": "^5.1.0",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-firefox-launcher": "^2.1.0",
-    "karma-mocha": "^2.0.1",
-    "mocha": "^5.2.0",
-    "prettier": "^2.4.1",
-    "rollup": "^1.15.6",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.3",
-    "shelljs": "0.8.3",
-    "should": "13.2.3",
-    "watchify": "^3.11.0"
-  },
-  "dependencies": {
-    "@mparticle/web-sdk": "^2.20.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/id5/id5-1#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mParticle/mparticle-web-sdk.git",
-    "directory": "kits/id5/id5-1"
-  }
+    "name": "@mparticle/web-id5-kit",
+    "version": "3.0.0",
+    "main": "dist/ID5Kit.common.js",
+    "files": [
+        "dist/ID5Kit.common.js"
+    ],
+    "scripts": {
+        "build": "ENVIRONMENT=production rollup --config rollup.config.js",
+        "build:test": "rollup --config rollup.test.config.js",
+        "lint": "eslint src/ test/src/",
+        "lint:fix": "eslint src/ test/src/ --fix",
+        "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
+        "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
+        "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js",
+        "testEndToEnd": "ENVIRONMENT=testEndToEnd rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
+    },
+    "devDependencies": {
+        "@mparticle/eslint-config-sdks": "^0.0.4",
+        "@mparticle/web-kit-wrapper": "^1.0.5",
+        "@semantic-release/changelog": "^5.0.1",
+        "@semantic-release/exec": "^5.0.0",
+        "@semantic-release/git": "^9.0.0",
+        "chai": "^4.2.0",
+        "crypto-js": "^4.2.0",
+        "eslint": "^7.25.0",
+        "eslint-config-prettier": "9.1.0",
+        "karma": "^5.1.0",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^2.1.0",
+        "karma-mocha": "^2.0.1",
+        "mocha": "^5.2.0",
+        "prettier": "^2.4.1",
+        "rollup": "^1.15.6",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.3",
+        "shelljs": "0.8.3",
+        "should": "13.2.3",
+        "watchify": "^3.11.0"
+    },
+    "dependencies": {
+        "@mparticle/web-sdk": "^3.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/id5/id5-1#readme",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mParticle/mparticle-web-sdk.git",
+        "directory": "kits/id5/id5-1"
+    }
 }

--- a/kits/inspectlet/package.json
+++ b/kits/inspectlet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-inspectlet-kit",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Inspectlet",
     "main": "dist/Inspectlet.common.js",
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/intercom/package.json
+++ b/kits/intercom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-intercom-kit",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Intercom",
     "main": "dist/IntercomEventForwarder.common.js",
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/kissmetrics/package.json
+++ b/kits/kissmetrics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-kissmetrics-kit",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Kissmetrics",
     "main": "dist/KissMetricsForwarder.common.js",
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/leanplum/leanplum-1/package.json
+++ b/kits/leanplum/leanplum-1/package.json
@@ -1,47 +1,47 @@
 {
-  "name": "@mparticle/web-leanplum-kit",
-  "version": "2.0.5",
-  "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
-  "description": "mParticle integration sdk for Leanplum",
-  "main": "dist/LeanplumAnalyticsEventForwarder.common.js",
-  "browser": "dist/LeanplumAnalyticsEventForwarder.common.js",
-  "files": [
-    "dist/LeanplumAnalyticsEventForwarder.common.js"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mParticle/mparticle-web-sdk.git",
-    "directory": "kits/leanplum/leanplum-1"
-  },
-  "scripts": {
-    "build": "rollup --config rollup.config.js",
-    "build:test": "rollup --config rollup.test.config.js",
-    "watch": "rollup --config rollup.config.js -w",
-    "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
-    "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js"
-  },
-  "devDependencies": {
-    "@semantic-release/changelog": "^5.0.1",
-    "@semantic-release/exec": "^5.0.0",
-    "@semantic-release/git": "^9.0.0",
-    "chai": "^4.2.0",
-    "karma": "^5.1.0",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-firefox-launcher": "^1.3.0",
-    "karma-mocha": "^2.0.1",
-    "mocha": "^2.5.3",
-    "rollup": "^1.13.1",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.1",
-    "shelljs": "^0.8.4",
-    "should": "^7.1.0",
-    "watchify": "^3.11.1"
-  },
-  "dependencies": {
-    "isobject": "^4.0.0",
-    "@mparticle/web-sdk": "^2.18.0"
-  },
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/leanplum/leanplum-1#readme"
+    "name": "@mparticle/web-leanplum-kit",
+    "version": "3.0.0",
+    "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
+    "description": "mParticle integration sdk for Leanplum",
+    "main": "dist/LeanplumAnalyticsEventForwarder.common.js",
+    "browser": "dist/LeanplumAnalyticsEventForwarder.common.js",
+    "files": [
+        "dist/LeanplumAnalyticsEventForwarder.common.js"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mParticle/mparticle-web-sdk.git",
+        "directory": "kits/leanplum/leanplum-1"
+    },
+    "scripts": {
+        "build": "rollup --config rollup.config.js",
+        "build:test": "rollup --config rollup.test.config.js",
+        "watch": "rollup --config rollup.config.js -w",
+        "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
+        "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js"
+    },
+    "devDependencies": {
+        "@semantic-release/changelog": "^5.0.1",
+        "@semantic-release/exec": "^5.0.0",
+        "@semantic-release/git": "^9.0.0",
+        "chai": "^4.2.0",
+        "karma": "^5.1.0",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^1.3.0",
+        "karma-mocha": "^2.0.1",
+        "mocha": "^2.5.3",
+        "rollup": "^1.13.1",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.1",
+        "shelljs": "^0.8.4",
+        "should": "^7.1.0",
+        "watchify": "^3.11.1"
+    },
+    "dependencies": {
+        "isobject": "^4.0.0",
+        "@mparticle/web-sdk": "^3.0.0"
+    },
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/leanplum/leanplum-1#readme"
 }

--- a/kits/localytics/localytics-4/package.json
+++ b/kits/localytics/localytics-4/package.json
@@ -1,42 +1,42 @@
 {
-  "name": "@mparticle/web-localytics-kit",
-  "version": "2.1.0",
-  "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
-  "description": "mParticle integration sdk for Localytics",
-  "main": "dist/LocalyticsEventForwarder.common.js",
-  "browser": "dist/LocalyticsEventForwarder.common.js",
-  "files": [
-    "dist/LocalyticsEventForwarder.common.js"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mParticle/mparticle-web-sdk.git",
-    "directory": "kits/localytics/localytics-4"
-  },
-  "scripts": {
-    "build": "rollup --config rollup.config.js",
-    "watch": "rollup --config rollup.config.js -w",
-    "test": "node test/boilerplate/test-karma.js"
-  },
-  "devDependencies": {
-    "chai": "^4.2.0",
-    "karma": "^5.1.0",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-firefox-launcher": "^1.3.0",
-    "karma-mocha": "^2.0.1",
-    "mocha": "^2.5.3",
-    "rollup": "^1.13.1",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.1",
-    "shelljs": "^0.8.4",
-    "should": "^7.1.0",
-    "watchify": "^3.11.1"
-  },
-  "dependencies": {
-    "isobject": "^4.0.0",
-    "@mparticle/web-sdk": "^2.11.1"
-  },
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/localytics/localytics-4#readme"
+    "name": "@mparticle/web-localytics-kit",
+    "version": "3.0.0",
+    "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
+    "description": "mParticle integration sdk for Localytics",
+    "main": "dist/LocalyticsEventForwarder.common.js",
+    "browser": "dist/LocalyticsEventForwarder.common.js",
+    "files": [
+        "dist/LocalyticsEventForwarder.common.js"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mParticle/mparticle-web-sdk.git",
+        "directory": "kits/localytics/localytics-4"
+    },
+    "scripts": {
+        "build": "rollup --config rollup.config.js",
+        "watch": "rollup --config rollup.config.js -w",
+        "test": "node test/boilerplate/test-karma.js"
+    },
+    "devDependencies": {
+        "chai": "^4.2.0",
+        "karma": "^5.1.0",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^1.3.0",
+        "karma-mocha": "^2.0.1",
+        "mocha": "^2.5.3",
+        "rollup": "^1.13.1",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.1",
+        "shelljs": "^0.8.4",
+        "should": "^7.1.0",
+        "watchify": "^3.11.1"
+    },
+    "dependencies": {
+        "isobject": "^4.0.0",
+        "@mparticle/web-sdk": "^3.0.0"
+    },
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/localytics/localytics-4#readme"
 }

--- a/kits/mixpanel/mixpanel-2/package.json
+++ b/kits/mixpanel/mixpanel-2/package.json
@@ -1,54 +1,54 @@
 {
-  "name": "@mparticle/web-mixpanel-kit",
-  "version": "2.2.0",
-  "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
-  "description": "mParticle integration sdk for Mixpanel",
-  "browser": "dist/MixpanelEventForwarder.common.js",
-  "files": [
-    "dist/MixpanelEventForwarder.common.js"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "provenance": true,
-    "registry": "https://registry.npmjs.org"
-  },
-  "main": "dist/MixpanelEventForwarder.common.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mParticle/mparticle-web-sdk.git",
-    "directory": "kits/mixpanel/mixpanel-2"
-  },
-  "scripts": {
-    "build": "rollup --config rollup.config.js",
-    "build:test": "rollup --config rollup.test.config.js",
-    "watch": "rollup --config rollup.config.js -w",
-    "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
-    "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js"
-  },
-  "devDependencies": {
-    "@mparticle/web-sdk": "^2.51.0",
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/exec": "^6.0.3",
-    "@semantic-release/git": "^10.0.1",
-    "@semantic-release/npm": "^13.1.2",
-    "semantic-release": "^24.2.0",
-    "chai": "^4.2.0",
-    "eslint-config-prettier": "9.0.0",
-    "eslint-plugin-prettier": "5.0.1",
-    "karma": "^5.1.0",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-firefox-launcher": "^1.3.0",
-    "karma-mocha": "^2.0.1",
-    "mocha": "^2.5.3",
-    "prettier": "^3.0.3",
-    "rollup": "^1.13.1",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.1",
-    "shelljs": "^0.8.4",
-    "should": "^7.1.0",
-    "watchify": "^3.11.1"
-  },
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/mixpanel/mixpanel-2#readme"
+    "name": "@mparticle/web-mixpanel-kit",
+    "version": "3.0.0",
+    "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
+    "description": "mParticle integration sdk for Mixpanel",
+    "browser": "dist/MixpanelEventForwarder.common.js",
+    "files": [
+        "dist/MixpanelEventForwarder.common.js"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true,
+        "registry": "https://registry.npmjs.org"
+    },
+    "main": "dist/MixpanelEventForwarder.common.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mParticle/mparticle-web-sdk.git",
+        "directory": "kits/mixpanel/mixpanel-2"
+    },
+    "scripts": {
+        "build": "rollup --config rollup.config.js",
+        "build:test": "rollup --config rollup.test.config.js",
+        "watch": "rollup --config rollup.config.js -w",
+        "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
+        "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js"
+    },
+    "devDependencies": {
+        "@mparticle/web-sdk": "^3.0.0",
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/exec": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/npm": "^13.1.2",
+        "semantic-release": "^24.2.0",
+        "chai": "^4.2.0",
+        "eslint-config-prettier": "9.0.0",
+        "eslint-plugin-prettier": "5.0.1",
+        "karma": "^5.1.0",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^1.3.0",
+        "karma-mocha": "^2.0.1",
+        "mocha": "^2.5.3",
+        "prettier": "^3.0.3",
+        "rollup": "^1.13.1",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.1",
+        "shelljs": "^0.8.4",
+        "should": "^7.1.0",
+        "watchify": "^3.11.1"
+    },
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/mixpanel/mixpanel-2#readme"
 }

--- a/kits/onetrust/package.json
+++ b/kits/onetrust/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-onetrust-kit",
-    "version": "2.0.5",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for OneTrust",
     "browser": "dist/OneTrustKit.common.js",
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.15"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/optimizely/package.json
+++ b/kits/optimizely/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-optimizely-kit",
-    "version": "2.1.6",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Optimizely",
     "main": "dist/OptimizelyKit.common.js",
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/publish-matrix.json
+++ b/kits/publish-matrix.json
@@ -1,0 +1,136 @@
+[
+    {
+        "name": "@mparticle/web-adobe-target-kit",
+        "local_path": "kits/adobe-target"
+    },
+    {
+        "name": "@mparticle/web-adwords-kit",
+        "local_path": "kits/adwords"
+    },
+    {
+        "name": "@mparticle/web-amplitude-kit",
+        "local_path": "kits/amplitude/amplitude-8"
+    },
+    {
+        "name": "@mparticle/web-bing-ads-kit",
+        "local_path": "kits/bingads"
+    },
+    {
+        "name": "@mparticle/web-braze-kit-3",
+        "local_path": "kits/braze/braze-3"
+    },
+    {
+        "name": "@mparticle/web-braze-kit-4",
+        "local_path": "kits/braze/braze-4"
+    },
+    {
+        "name": "@mparticle/web-braze-kit-5",
+        "local_path": "kits/braze/braze-5"
+    },
+    {
+        "name": "@mparticle/web-braze-kit-6",
+        "local_path": "kits/braze/braze-6"
+    },
+    {
+        "name": "@mparticle/web-criteo-kit",
+        "local_path": "kits/criteo"
+    },
+    {
+        "name": "@mparticle/web-device-match-kit",
+        "local_path": "kits/device-match"
+    },
+    {
+        "name": "@mparticle/web-double-click-kit",
+        "local_path": "kits/doubleclick"
+    },
+    {
+        "name": "@mparticle/web-dynamic-yield-kit",
+        "local_path": "kits/dynamic-yield"
+    },
+    {
+        "name": "@mparticle/web-facebook-kit",
+        "local_path": "kits/facebook"
+    },
+    {
+        "name": "@mparticle/web-google-tag-manager-kit",
+        "local_path": "kits/google-tag-manager"
+    },
+    {
+        "name": "@mparticle/web-heap-kit",
+        "local_path": "kits/heap"
+    },
+    {
+        "name": "@mparticle/web-id5-kit",
+        "local_path": "kits/id5/id5-1"
+    },
+    {
+        "name": "@mparticle/web-inspectlet-kit",
+        "local_path": "kits/inspectlet"
+    },
+    {
+        "name": "@mparticle/web-intercom-kit",
+        "local_path": "kits/intercom"
+    },
+    {
+        "name": "@mparticle/web-kissmetrics-kit",
+        "local_path": "kits/kissmetrics"
+    },
+    {
+        "name": "@mparticle/web-leanplum-kit",
+        "local_path": "kits/leanplum/leanplum-1"
+    },
+    {
+        "name": "@mparticle/web-localytics-kit",
+        "local_path": "kits/localytics/localytics-4"
+    },
+    {
+        "name": "@mparticle/web-mixpanel-kit",
+        "local_path": "kits/mixpanel/mixpanel-2"
+    },
+    {
+        "name": "@mparticle/web-onetrust-kit",
+        "local_path": "kits/onetrust"
+    },
+    {
+        "name": "@mparticle/web-optimizely-kit",
+        "local_path": "kits/optimizely"
+    },
+    {
+        "name": "@mparticle/web-rokt-kit",
+        "local_path": "kits/rokt"
+    },
+    {
+        "name": "@mparticle/web-simplereach-kit",
+        "local_path": "kits/simplereach"
+    },
+    {
+        "name": "@mparticle/web-taplytics-kit",
+        "local_path": "kits/taplytics"
+    },
+    {
+        "name": "@mparticle/web-twitter-kit",
+        "local_path": "kits/twitter"
+    },
+    {
+        "name": "@mparticle/web-google-analytics-4-client-kit",
+        "local_path": "kits/google-analytics-4/packages/GA4Client"
+    },
+    {
+        "name": "@mparticle/web-google-analytics-4-server-kit",
+        "local_path": "kits/google-analytics-4/packages/GA4Server"
+    },
+    {
+        "name": "@mparticle/web-adobe-client-kit",
+        "local_path": "kits/adobe/packages/AdobeClient",
+        "build_path": "kits/adobe"
+    },
+    {
+        "name": "@mparticle/web-adobe-server-kit",
+        "local_path": "kits/adobe/packages/AdobeServer",
+        "build_path": "kits/adobe"
+    },
+    {
+        "name": "@mparticle/web-rokt-pay-plus-kit",
+        "local_path": "kits/roktpayplus"
+    }
+]

--- a/kits/rokt/package.json
+++ b/kits/rokt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-rokt-kit",
-    "version": "1.36.1",
+    "version": "3.0.0",
     "description": "mParticle integration kit for Rokt",
     "main": "dist/Rokt-Kit.common.js",
     "module": "dist/Rokt-Kit.esm.js",
@@ -39,7 +39,7 @@
         "@eslint/js": "^9.23.0",
         "@eslint/eslintrc": "^3.3.1",
         "@mparticle/event-models": "^1.1.9",
-        "@mparticle/web-sdk": "^2.73.1",
+        "@mparticle/web-sdk": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^8.28.0",
         "@typescript-eslint/parser": "^8.28.0",
         "@types/node": "^20.11.5",

--- a/kits/roktpayplus/package.json
+++ b/kits/roktpayplus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-rokt-pay-plus-kit",
-    "version": "1.1.0",
+    "version": "3.0.0",
     "description": "mParticle web kit that re-emits the events an advertiser already logs to the embedding Rokt Pay+ plugin via postMessage.",
     "main": "dist/RoktPayPlus-Kit.common.js",
     "module": "dist/RoktPayPlus-Kit.esm.js",
@@ -41,7 +41,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.23.0",
-        "@mparticle/web-sdk": "^2.73.1",
+        "@mparticle/web-sdk": "^3.0.0",
         "@types/node": "^20.11.5",
         "@typescript-eslint/eslint-plugin": "^8.28.0",
         "@typescript-eslint/parser": "^8.28.0",

--- a/kits/simplereach/package.json
+++ b/kits/simplereach/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-simplereach-kit",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for SimpleReach",
     "browser": "dist/SimpleReach.common.js",
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/taplytics/package.json
+++ b/kits/taplytics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-taplytics-kit",
-    "version": "2.0.2",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Taplytics",
     "main": "dist/TaplyticsKit.common.js",
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "isobject": "^4.0.0",
-        "@mparticle/web-sdk": "^2.11.1"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/kits/twitter/package.json
+++ b/kits/twitter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-twitter-kit",
-    "version": "2.0.2",
+    "version": "3.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Twitter",
     "browser": "dist/TwitterEventForwarder.common.js",
@@ -30,7 +30,7 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.11.0"
+        "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0"
 }


### PR DESCRIPTION
## BLOCKED — do not merge or release

This stage 2 bootstrap PR cannot pass kit CI and must be updated before merge or release. Core `@mparticle/web-sdk@3.0.0` is not yet available from npm; publish it first under the explicit non-latest `next` dist-tag, then regenerate kit lockfiles and version-sensitive dist bundles.

Do not publish kits, run release scripts, create tags, promote dist-tags, or allow any accidental `latest` promotion from this PR.

## What changed

- Adds the authoritative 33-leaf `kits/publish-matrix.json` inventory.
- Sets all 33 publishable leaf manifests to exact version `3.0.0`.
- Sets the Adobe and Google Analytics 4 build/test aggregator manifests to `3.0.0` and marks both `private: true`.
- Updates all 35 existing `@mparticle/web-sdk` dependency/devDependency/peerDependency references in the authoritative manifests to `^3.0.0`, preserving their sections.
- Adds `publishConfig.access: public` only to the four renamed Braze packages because current publish tooling uses plain `npm publish` and does not guarantee `--access public`.
- Leaves lockfiles and generated dist bundles intentionally unchanged; no fabricated resolutions or integrity values are included.

## Static validation completed

- 35/35 authoritative kit manifests changed to version `3.0.0`.
- 33/33 publish rows are unique by package name and local path and resolve to matching `3.0.0` manifests.
- Both aggregators are absent from the publish matrix and are private.
- All 35 existing core references are `^3.0.0`; no authoritative core reference remains on `^2`.
- No internal kit-to-kit dependency references exist.
- Package names are unchanged; no publishable leaf is private.
- All changed JSON parses and passes Prettier 1.18.2; `git diff --check` passes.
- Registry evidence: `npm view @mparticle/web-sdk@3.0.0 version` returns `E404 No match found for version 3.0.0`.
- Expected CI evidence: `npm ci --ignore-scripts` in `kits/braze/braze-3` returns `ETARGET No matching version found for @mparticle/web-sdk@^3.0.0`.

This is intentionally not CI-ready.

## Required follow-up after core publication

- [ ] Publish core `@mparticle/web-sdk@3.0.0` using the explicit `next` dist-tag; verify `latest` is unchanged.
- [ ] Pin npm to exactly `11.17.0` for lock regeneration and record Node/npm versions in the update.
- [ ] Regenerate all 34 relevant existing publishable/aggregator lockfiles; do not add a lock for AdobeServer and continue excluding the Heartbeat lock that has no manifest.
- [ ] Review every lockfile diff for expected core resolution/integrity changes and explain any unrelated dependency churn.
- [ ] Build all 32 unique matrix build roots (`build_path` when present, otherwise `local_path`).
- [ ] Commit all required version-sensitive generated dist, especially Rokt and Rokt Pay Plus output.
- [ ] Run the full test command for every kit/build root after lock regeneration.
- [ ] Run `npm pack --dry-run`/pack-content checks for all 33 publishable leaves and verify name, version, files, access, and dependency metadata.
- [ ] Re-run the 35-manifest/33-row static validations and `git diff --check`.
- [ ] Confirm this draft is updated and CI is green before requesting review or merge.

## External release blockers

- [ ] Complete first-publication setup for `@mparticle/web-braze-kit-3`, `@mparticle/web-braze-kit-4`, `@mparticle/web-braze-kit-5`, and `@mparticle/web-braze-kit-6`.
- [ ] Review npm trusted-publisher configuration and public-access behavior for every package, including the four Braze first publications.
- [ ] Complete the Rokt upstream parity check before regenerating/committing Rokt dist.
- [ ] Require explicit `next` tag usage for core and kit publication.
- [ ] Verify no command or workflow promotes `3.0.0` to `latest` accidentally.