### PR TITLE
fix(ci): keep v2 releases on latest

### DIFF
--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -90,7 +90,7 @@ jobs:
                           echo "development_branch=development" >> "$GITHUB_OUTPUT"
                           echo "staging_branch=staging" >> "$GITHUB_OUTPUT"
                           echo "release_branch=release/${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-                          echo "npm_dist_tag=v2" >> "$GITHUB_OUTPUT"
+                          echo "npm_dist_tag=latest" >> "$GITHUB_OUTPUT"
                           ;;
                       v3)
                           echo "development_branch=v3-development" >> "$GITHUB_OUTPUT"
@@ -120,7 +120,7 @@ jobs:
                   set -eu
                   MAPPING="${TRACK}|${DEVELOPMENT_BRANCH}|${STAGING_BRANCH}|${RELEASE_BRANCH}|${NPM_DIST_TAG}"
                   case "$MAPPING" in
-                      "v2|development|staging|release/${GITHUB_RUN_NUMBER}|v2")
+                      "v2|development|staging|release/${GITHUB_RUN_NUMBER}|latest")
                           EXPECTED_CONFIG_BRANCH="master"
                           ;;
                       "v3|v3-development|v3-staging|v3-release/${GITHUB_RUN_NUMBER}|latest")


### PR DESCRIPTION
## Background

The real V2 Step 1 run [32491181905](https://github.com/mParticle/mparticle-web-sdk/actions/runs/32491181905) partially completed: semantic-release created Git tag `v2.79.1`, then npm publishing failed because the workflow supplied `NPM_CONFIG_TAG=v2`. npm's bundled SemVer parser interprets `v2` as the range `>=2.0.0 <3.0.0-0`, so npm rejects it as a dist-tag.

npm still has only `latest: 2.79.0`; version `2.79.1` was not published.

## What Has Changed

- Keep V2 releases publishing to npm dist-tag `latest` during the transition period.
- Update the approved V2 mapping assertion to require `latest`.
- Leave V3 mapped to `latest`; V3 will own that tag after cutover.
- Preserve all other release workflow behavior and fixes.

At V3 cutover, `legacy-v2` will be assigned to the final V2 version and `latest` will move to V3. This PR intentionally does not automate that cutover.

## Validation

- YAML parsing passed.
- `bash -n` passed for all 14 embedded shell blocks.
- `git diff --check` passed.
- V2 and V3 mappings both resolve to `latest`; no standalone invalid `v2` npm tag remains.
- npm's bundled SemVer parser reports `v2` as `>=2.0.0 <3.0.0-0` and `latest` as not a range, which makes `latest` valid for npm dist-tag use.
- Only `.github/workflows/staging-step-1.yml` changed.

## ⚠️ Pre-retry checklist

Do not rerun the failed workflow. Before dispatching another real release:

- [ ] Delete the partial remote Git tag `v2.79.1`.
- [ ] Delete or quarantine `release/177`.
- [ ] Confirm npm version `2.79.1` is absent.
- [ ] Synchronize this identical workflow change to `main`; real-release workflow parity validation requires exact files on `master` and `main`.
- [ ] Dispatch a fresh Step 1 run, not a rerun of the failed run.

No cleanup, publishing, cutover automation, `main` modification, or existing PR modification is performed by this PR.