### PR TITLE
chore(ci): prepare v2 legacy dist-tag

### DIFF
--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -90,7 +90,7 @@ jobs:
                           echo "development_branch=development" >> "$GITHUB_OUTPUT"
                           echo "staging_branch=staging" >> "$GITHUB_OUTPUT"
                           echo "release_branch=release/${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-                          echo "npm_dist_tag=latest" >> "$GITHUB_OUTPUT"
+                          echo "npm_dist_tag=legacy-v2-latest" >> "$GITHUB_OUTPUT"
                           ;;
                       v3)
                           echo "development_branch=v3-development" >> "$GITHUB_OUTPUT"
@@ -120,7 +120,7 @@ jobs:
                   set -eu
                   MAPPING="${TRACK}|${DEVELOPMENT_BRANCH}|${STAGING_BRANCH}|${RELEASE_BRANCH}|${NPM_DIST_TAG}"
                   case "$MAPPING" in
-                      "v2|development|staging|release/${GITHUB_RUN_NUMBER}|latest")
+                      "v2|development|staging|release/${GITHUB_RUN_NUMBER}|legacy-v2-latest")
                           EXPECTED_CONFIG_BRANCH="master"
                           ;;
                       "v3|v3-development|v3-staging|v3-release/${GITHUB_RUN_NUMBER}|latest")


### PR DESCRIPTION
## Summary

- Change the V2 npm dist-tag from the transitional `latest` mapping introduced by #1355 to `legacy-v2-latest`.
- Keep the V3 npm dist-tag mapped to `latest`.
- Update the approved V2 mapping assertion to match the future release behavior.

## Merge timing and rollout

This draft is intentionally **not for immediate merge**. It is stacked on #1355 and should be merged only at the V3 cutover, after #1355 and the current final V2 release have landed. After #1355 merges, retarget this PR to `master` before merging it at cutover.

Before moving `latest` to V3, manually assign the `legacy-v2-latest` npm dist-tag to the last already-published V2 version. This workflow change only affects future publishes and does not retroactively tag existing package versions.

After cutover, future V2 releases will publish under `legacy-v2-latest`, while consumers using compatible V2 semver ranges will continue resolving V2 releases normally.

The identical workflow change must eventually reach `main` for master/main workflow parity before real release workflows run.

## Validation

- YAML parsed successfully.
- All 26 embedded shell blocks passed `bash -n`.
- `git diff --check` passed.
- Confirmed the stacked diff changes exactly one file with only the two V2 mappings updated; V3 remains `latest`.
- npm's bundled semver parser returns `null` for `legacy-v2-latest`, confirming it is not a SemVer range and is acceptable as an npm dist-tag.

## Safety

- No package was published and no npm dist-tag was mutated.