### PR TITLE
refactor(apv): encapsulate PageViewTracker so tests stop reaching into internals

### DIFF
--- a/src/mp-instance.ts
+++ b/src/mp-instance.ts
@@ -57,7 +57,12 @@ import { LoggingDispatcher } from './reporting/loggingDispatcher';
 import { IErrorReportingService, ILoggingService } from './reporting/types';
 import { logDeprecatedMethodUsage } from './reporting/deprecatedMethodLogger';
 import { normalizeRoktLauncherOptions } from './roktLauncherOptions';
-import { PageViewTracker } from './pageViewTracker';
+import {
+    hasInitialPageViewFired,
+    markInitialPageViewFired,
+    PageViewTracker,
+    resetPageViewTracking,
+} from './pageViewTracker';
 
 export interface IErrorLogMessage {
     message?: string;
@@ -298,12 +303,8 @@ export default function mParticleInstance(this: IMParticleWebSDKInstance, instan
         );
         instance._Events.stopTracking();
 
-        const instanceTracker = instance._PageViewTracker;
-        if (instanceTracker) {
-            instanceTracker.teardown();
-            instance._PageViewTracker = undefined;
-        }
-        PageViewTracker.resetWindowState(instanceTracker);
+        resetPageViewTracking();
+        instance._PageViewTracker = undefined;
 
         if (!keepPersistence) {
             instance._Persistence.resetPersistence();
@@ -1593,32 +1594,30 @@ function completeSDKInitialization(apiKey, config, mpInstance) {
         mpInstance._SessionManager.initialize();
         mpInstance._Events.logAST();
 
-        // Note: APV uses window-level singletons (WIN_TRACKER_KEY, WIN_INIT_PV_KEY)
-        // that assume a single active SDK instance. Multiple-instance support is
-        // out of scope
+        // Note: APV state (the active tracker and the initial-page-view flag) is
+        // window-scoped and assumes a single active SDK instance. Multiple-instance
+        // support is out of scope.
         if (getFeatureFlag(AutoLogPageView)) {
             if (!mpInstance._PageViewTracker) {
                 mpInstance.Logger.verbose(
                     'mParticle APV: [sdk-init] creating new PageViewTracker for this instance'
                 );
                 mpInstance._PageViewTracker = new PageViewTracker(mpInstance);
-
-                // Fire the initial page view once per page load (hard navigation).
-                // The flag survives module re-evaluation so repeated init() calls
-                // from SPA re-renders don't fire duplicate logPageView() events.
-                if (PageViewTracker.hasInitialPageViewFired()) {
-                    mpInstance.Logger.verbose(
-                        'mParticle APV: [sdk-init] initial page view already logged this page load, skipping'
-                    );
-                } else {
-                    PageViewTracker.markInitialPageViewFired();
-                    mpInstance._Events.logPageView();
-                }
-            } else {
-                mpInstance.Logger.verbose(
-                    'mParticle APV: [sdk-init] tracker already on this instance, skipping logPageView'
-                );
             }
+
+            // The initial page view fires once per hard page load, not once per
+            // init(): the window flag survives the module re-evaluation Next.js
+            // performs on every SPA navigation, so repeated init() calls from SPA
+            // re-renders don't fire duplicate logPageView() events.
+            if (hasInitialPageViewFired()) {
+                mpInstance.Logger.verbose(
+                    'mParticle APV: [sdk-init] initial page view already logged this page load, skipping'
+                );
+            } else {
+                markInitialPageViewFired();
+                mpInstance._Events.logPageView();
+            }
+
             mpInstance._PageViewTracker.init();
         } else if (mpInstance._PageViewTracker) {
             // AutoLogPageView was disabled on re-init: tear down the active tracker

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -1,7 +1,12 @@
 import { IMParticleWebSDKInstance } from './mp-instance';
+import { BaseEvent } from './sdkRuntimeModels';
 import { EventType, MessageType } from './types';
 
 type HistoryStateMethod = History['pushState'];
+type HistoryMethodName = 'pushState' | 'replaceState';
+type NavigationSource = HistoryMethodName | 'popstate';
+
+const HISTORY_METHODS: HistoryMethodName[] = ['pushState', 'replaceState'];
 
 const WRAPPED_MARKER = '__mpApvWrapped__';
 
@@ -9,374 +14,400 @@ type MarkedHistoryMethod = HistoryStateMethod & {
     [WRAPPED_MARKER]?: boolean;
 };
 
-// window key under which the single active tracker is stored.
-// Survives module re-evaluation (Next.js re-executes the bundle on every SPA
-// navigation, resetting all module-level state, but window persists for the
-// lifetime of the tab).
+// The window keys are the public debugging contract for APV: `window.__mpApvTracker__`
+// is what you inspect in a console to see whether tracking is live.
+//
+// APV state lives on `window` rather than in module scope because Next.js
+// re-executes the SDK bundle on every SPA navigation: module-level state is
+// reset each time, but `window` persists for the lifetime of the tab.
 export const WIN_TRACKER_KEY = '__mpApvTracker__';
 
 // Guards the initial page view so repeated mParticle.init() calls from SPA
 // re-renders don't fire duplicate logPageView() events for the same page.
 export const WIN_INIT_PV_KEY = '__mpApvInitPVLogged__' as const;
 
-export type WindowWithApvFlags = Window & {
+type WindowWithApvFlags = Window & {
     [WIN_TRACKER_KEY]?: PageViewTracker;
     [WIN_INIT_PV_KEY]?: boolean;
 };
 
-type NavigationSource = 'pushState' | 'replaceState' | 'popstate';
+interface IPageViewData {
+    hostname: string;
+    title: string;
+    path: string;
+}
+
+interface IPendingNavigation {
+    path: string;
+    timeoutId: ReturnType<typeof setTimeout>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers. No `this`, no globals, no side effects — callable and assertable
+// on their own, which is where the interesting rules live.
+// ---------------------------------------------------------------------------
+
+// Dedup keys on pathname only: a query-string- or hash-only change is the same
+// page and must not fire a view.
+export const isNewPage = (
+    lastPath: string | null,
+    candidatePath: string
+): boolean => candidatePath !== lastPath;
+
+export const supportsHistoryTracking = (win: Window | null): boolean =>
+    !!win &&
+    typeof win.history !== 'undefined' &&
+    typeof win.history.pushState === 'function' &&
+    typeof win.addEventListener === 'function';
+
+// Mirrors the event shape of the public mParticle.logPageView(), but carries the
+// path captured when the navigation was accepted rather than the live location.
+export const buildPageViewEvent = (data: IPageViewData): BaseEvent => ({
+    messageType: MessageType.PageView,
+    name: 'PageView',
+    data: { ...data },
+    eventType: EventType.Unknown,
+});
+
+// ---------------------------------------------------------------------------
+// Window-scoped APV state. Every read and write of the window flags goes through
+// these helpers, so neither the tracker nor mp-instance touches `window`
+// directly and `typeof window` is checked in exactly one place.
+// ---------------------------------------------------------------------------
+
+const apvWindow = (): WindowWithApvFlags | null =>
+    typeof window === 'undefined' ? null : (window as WindowWithApvFlags);
+
+// The tracker that currently owns the history patch, which may have been
+// registered by a module scope that no longer exists.
+export const getActiveTracker = (): PageViewTracker | undefined => {
+    const win = apvWindow();
+    return win ? win[WIN_TRACKER_KEY] : undefined;
+};
+
+export const hasInitialPageViewFired = (): boolean => {
+    const win = apvWindow();
+    return !!(win && win[WIN_INIT_PV_KEY]);
+};
+
+export const markInitialPageViewFired = (): void => {
+    const win = apvWindow();
+    if (win) {
+        win[WIN_INIT_PV_KEY] = true;
+    }
+};
+
+// Returns the page to its pre-APV state: stops the active tracker (restoring the
+// history methods it patched) and clears the window flags. The registry is the
+// authoritative handle, so this reaches trackers whose owning module is gone.
+export const resetPageViewTracking = (): void => {
+    const win = apvWindow();
+    if (!win) {
+        return;
+    }
+
+    const active = win[WIN_TRACKER_KEY];
+    if (active) {
+        active.teardown();
+    }
+
+    // teardown() clears WIN_TRACKER_KEY itself; delete unconditionally in case a
+    // tracker was registered by an older build whose teardown did not.
+    delete win[WIN_TRACKER_KEY];
+    delete win[WIN_INIT_PV_KEY];
+};
+
+const setActiveTracker = (tracker: PageViewTracker): void => {
+    const win = apvWindow();
+    if (win) {
+        win[WIN_TRACKER_KEY] = tracker;
+    }
+};
+
+const clearActiveTracker = (tracker: PageViewTracker): void => {
+    const win = apvWindow();
+    if (win && win[WIN_TRACKER_KEY] === tracker) {
+        delete win[WIN_TRACKER_KEY];
+    }
+};
+
+const currentPathname = (): string => window.location.pathname;
+
+// ---------------------------------------------------------------------------
+// History patching
+// ---------------------------------------------------------------------------
+
+// Wraps pushState/replaceState so `onNavigate` runs after the real method, and
+// returns the single function that undoes it — or null when nothing was
+// installed (history is already wrapped, or a frozen/sealed History rejected the
+// assignment). Handing back one undo closure keeps the wrapper and original
+// references out of the tracker entirely: there is no half-patched state for a
+// caller to inspect, and no way to restore the wrong pair.
+export const patchHistory = (
+    onNavigate: (source: NavigationSource) => void,
+    log: (message: string) => void
+): (() => void) | null => {
+    if ((window.history.pushState as MarkedHistoryMethod)[WRAPPED_MARKER]) {
+        log(
+            '[patch] history already wrapped, skipping to avoid double-wrap — STACKED WRAPPER DETECTED'
+        );
+        return null;
+    }
+
+    const originals = {} as Record<HistoryMethodName, HistoryStateMethod>;
+    const wrappers = {} as Record<HistoryMethodName, HistoryStateMethod>;
+
+    HISTORY_METHODS.forEach(name => {
+        const original = window.history[name];
+        originals[name] = original;
+
+        const wrapper = function(
+            this: History,
+            ...args: Parameters<HistoryStateMethod>
+        ): void {
+            const result = original.apply(this, args);
+            onNavigate(name);
+            return result;
+        };
+
+        Object.defineProperty(wrapper, WRAPPED_MARKER, {
+            value: true,
+            enumerable: false,
+        });
+
+        wrappers[name] = wrapper;
+    });
+
+    // Restore per method: a third party may have patched one of the two on top of
+    // ours after we installed. Clobbering theirs would break their tracking, so
+    // leave anything that is no longer ours in place.
+    const restore = (): void =>
+        HISTORY_METHODS.forEach(name => {
+            if (window.history[name] === wrappers[name]) {
+                window.history[name] = originals[name];
+                log(`[teardown] restored original ${name}`);
+            } else {
+                log(
+                    `[teardown] ${name} no longer ours; leaving in place, gating callback to no-op`
+                );
+            }
+        });
+
+    try {
+        HISTORY_METHODS.forEach(name => {
+            window.history[name] = wrappers[name];
+        });
+    } catch (e) {
+        log(
+            `[error] failed to patch history methods (frozen/sealed), rolling back: ${e}`
+        );
+        try {
+            restore();
+        } catch (restoreError) {
+            log(
+                `[error] failed to restore history methods after patch failure: ${restoreError}`
+            );
+        }
+        return null;
+    }
+
+    return restore;
+};
+
+// ---------------------------------------------------------------------------
+// Tracker
+// ---------------------------------------------------------------------------
 
 export class PageViewTracker {
-    static hasInitialPageViewFired(): boolean {
-        return !!(window as WindowWithApvFlags)[WIN_INIT_PV_KEY];
-    }
-
-    static markInitialPageViewFired(): void {
-        (window as WindowWithApvFlags)[WIN_INIT_PV_KEY] = true;
-    }
-
-    // Tears down any window-registered tracker that differs from instanceTracker
-    // (e.g. left by a previous module load), then clears both APV window flags.
-    // Call from _resetForTests after tearing down the instance-level tracker.
-    static resetWindowState(instanceTracker?: PageViewTracker): void {
-        const windowTracker = getWindowTracker();
-        if (windowTracker && windowTracker !== instanceTracker) {
-            windowTracker.teardown();
-        }
-        if (typeof window !== 'undefined') {
-            delete (window as WindowWithApvFlags)[WIN_INIT_PV_KEY];
-        }
-        setWindowTracker(undefined);
-    }
-
-    mpInstance: IMParticleWebSDKInstance;
+    private readonly mpInstance: IMParticleWebSDKInstance;
 
     private lastPath: string | null = null;
-    private _isActive = false;
+    private active = false;
+    private pendingNavigations: IPendingNavigation[] = [];
 
-    get isActive(): boolean {
-        return this._isActive;
-    }
-
-    private pendingNavigations: Array<{
-        path: string;
-        timeoutId: ReturnType<typeof setTimeout>;
-    }> = [];
-
-    private originalPushState: HistoryStateMethod | null = null;
-    private originalReplaceState: HistoryStateMethod | null = null;
-
-    private pushStateWrapper: HistoryStateMethod | null = null;
-    private replaceStateWrapper: HistoryStateMethod | null = null;
-
+    private undoHistoryPatch: (() => void) | null = null;
     private popStateListener: (() => void) | null = null;
 
     constructor(mpInstance: IMParticleWebSDKInstance) {
         this.mpInstance = mpInstance;
     }
 
-    private isSupportedEnvironment(): boolean {
-        return (
-            typeof window !== 'undefined' &&
-            typeof window.history !== 'undefined' &&
-            typeof window.history.pushState === 'function' &&
-            typeof window.addEventListener === 'function'
-        );
+    // True while this tracker owns the history patch and is listening for
+    // navigations. Flips to false on teardown, including the teardown a
+    // successor tracker performs during a handoff. Read-only, and the one thing
+    // worth checking on `window.__mpApvTracker__` from a console.
+    public get isActive(): boolean {
+        return this.active;
     }
 
     public init(): void {
-        this.mpInstance.Logger.verbose('mParticle APV: [init] PageViewTracker Init');
-        if (!this.isSupportedEnvironment()) {
-            this.mpInstance.Logger.verbose(
-                'mParticle APV: [init] unsupported environment (no History API), not starting'
+        this.log('[init] PageViewTracker Init');
+
+        if (!supportsHistoryTracking(apvWindow())) {
+            this.log(
+                '[init] unsupported environment (no History API), not starting'
             );
             return;
         }
 
-        // Tear down any tracker left over from a previous module load.
-        // window[WIN_TRACKER_KEY] outlives module re-evaluation; this is the
-        // only way to reach a tracker instance in a dead module scope.
-        // Transfer any pending navigations first so a route change that queued a
-        // deferred fire before module re-evaluation occurs is not silently dropped.
-        const prev = getWindowTracker();
-        let inheritedPaths: string[] = [];
-        if (prev && prev !== this) {
-            this.mpInstance.Logger.verbose(
-                'mParticle APV: [init] found stale tracker from previous module load — transferring pending navigations and tearing down'
-            );
-            inheritedPaths = prev.takePendingNavigations();
-            prev.teardown();
+        // Take over from whichever tracker is currently active: one left behind by
+        // a previous module load, or this same tracker on a repeat
+        // mParticle.init(). Their pending navigations are transferred rather than
+        // dropped — a route change may have queued a deferred fire that has not
+        // flushed yet, and dropping it loses a page view entirely.
+        const active = getActiveTracker();
+        let inheritedPaths = this.retire(active);
+        if (this.active && active !== this) {
+            inheritedPaths = inheritedPaths.concat(this.retire(this));
         }
 
-        if (this._isActive) {
-            this.mpInstance.Logger.verbose(
-                'mParticle APV: [init] starting (teardown-first for idempotency)'
-            );
-            // Preserve pending navigations through the self-teardown so a route
-            // change queued before mParticle.init() was called again is not lost.
-            inheritedPaths = [...inheritedPaths, ...this.takePendingNavigations()];
-            this.teardown();
-        }
+        this.active = true;
+        this.lastPath = currentPathname();
+        this.log(`[init] seeded lastPath: ${this.lastPath}`);
 
-        this._isActive = true;
-
-        this.lastPath = this.getCurrentKey();
-
-        this.mpInstance.Logger.verbose(
-            `mParticle APV: [init] seeded lastPath: ${this.lastPath}`
+        this.undoHistoryPatch = patchHistory(
+            source => this.safeHandleNavigation(source),
+            message => this.log(message)
         );
-
-        this.patchHistoryMethods();
-        this.addNavigationListeners();
-
-        setWindowTracker(this);
-
-        this.mpInstance.Logger.verbose(
-            'mParticle APV: [init] patched pushState/replaceState + listening for popstate'
-        );
-
-        // Re-fire navigations that the stale tracker had queued but not yet flushed
-        // when module re-evaluation occurred. Title is read at flush time so the
-        // router's post-navigation render commit still has a chance to update it.
-        inheritedPaths.forEach(path => {
-            const timeoutId = setTimeout(() => {
-                this.pendingNavigations = this.pendingNavigations.filter(
-                    p => p.timeoutId !== timeoutId
-                );
-                if (!this._isActive) return;
-                this.mpInstance._SessionManager.resetSessionTimer();
-                this.firePageView(path);
-            }, 0);
-            this.pendingNavigations.push({ path, timeoutId });
-        });
-    }
-
-    private patchHistoryMethods(): void {
-        const self = this;
-
-        const installed = window.history.pushState as MarkedHistoryMethod;
-        if (installed[WRAPPED_MARKER]) {
-            this.mpInstance.Logger.verbose(
-                'mParticle APV: [patch] history already wrapped, skipping to avoid double-wrap — STACKED WRAPPER DETECTED'
-            );
-            return;
-        }
-
-        const originalPushState = window.history.pushState;
-        const originalReplaceState = window.history.replaceState;
-        this.originalPushState = originalPushState;
-        this.originalReplaceState = originalReplaceState;
-
-        const pushStateWrapper = function(
-            this: History,
-            ...args: Parameters<HistoryStateMethod>
-        ): void {
-            const result = originalPushState.apply(this, args);
-            if (self._isActive) {
-                self.safeHandleNavigation('pushState');
-            }
-            return result;
-        };
-
-        const replaceStateWrapper = function(
-            this: History,
-            ...args: Parameters<HistoryStateMethod>
-        ): void {
-            const result = originalReplaceState.apply(this, args);
-            if (self._isActive) {
-                self.safeHandleNavigation('replaceState');
-            }
-            return result;
-        };
-
-        Object.defineProperty(pushStateWrapper, WRAPPED_MARKER, {
-            value: true,
-            enumerable: false,
-        });
-        Object.defineProperty(replaceStateWrapper, WRAPPED_MARKER, {
-            value: true,
-            enumerable: false,
-        });
-
-        this.pushStateWrapper = pushStateWrapper;
-        this.replaceStateWrapper = replaceStateWrapper;
-
-        try {
-            window.history.pushState = pushStateWrapper;
-            window.history.replaceState = replaceStateWrapper;
-        } catch (e) {
-            this.mpInstance.Logger.verbose(
-                `mParticle APV: [error] failed to patch history methods (frozen/sealed), rolling back: ${e}`
-            );
-            try {
-                if (window.history.pushState === pushStateWrapper) {
-                    window.history.pushState = originalPushState;
-                }
-                if (window.history.replaceState === replaceStateWrapper) {
-                    window.history.replaceState = originalReplaceState;
-                }
-            } catch (restoreError) {
-                this.mpInstance.Logger.verbose(
-                    `mParticle APV: [error] failed to restore history methods after patch failure: ${restoreError}`
-                );
-            }
-            this.pushStateWrapper = null;
-            this.replaceStateWrapper = null;
-            this.originalPushState = null;
-            this.originalReplaceState = null;
-        }
-    }
-
-    private addNavigationListeners(): void {
         this.popStateListener = () => this.safeHandleNavigation('popstate');
         window.addEventListener('popstate', this.popStateListener);
-    }
 
-    private safeHandleNavigation(source: NavigationSource): void {
-        try {
-            this.handleNavigation(source);
-        } catch (e) {
-            this.mpInstance.Logger.verbose(
-                `mParticle APV: [error] navigation handler threw (${source}), page view skipped: ${e}`
-            );
-        }
-    }
+        setActiveTracker(this);
 
-    private getCurrentKey(): string {
-        return window.location.pathname;
-    }
-
-    private handleNavigation(source: NavigationSource): void {
-        const candidatePath = this.getCurrentKey();
-
-        this.mpInstance.Logger.verbose(
-            `mParticle APV: [detect] navigation signal (source: ${source}, candidatePath: ${candidatePath}, lastPath: ${this.lastPath})`
+        this.log(
+            '[init] patched pushState/replaceState + listening for popstate'
         );
 
-        if (candidatePath === this.lastPath) {
-            this.mpInstance.Logger.verbose(
-                `mParticle APV: [dedupe] pathname unchanged, skipping (source: ${source}, path: ${candidatePath})`
-            );
-            return;
-        }
-
-        this.mpInstance.Logger.verbose(
-            `mParticle APV: [accept] pathname changed, scheduling fire (source: ${source}, from: ${this.lastPath}, to: ${candidatePath})`
-        );
-        this.lastPath = candidatePath;
-
-        // Snapshot the path now: it is already settled at this point, and a
-        // same-tick navigation would otherwise overwrite window.location
-        // before the deferred flush reads it. The title is intentionally read
-        // later (in the deferred flush) so the router's post-navigation render
-        // commit has a chance to update document.title first.
-        const capturedPath = candidatePath;
-
-        const timeoutId = setTimeout(() => {
-            this.pendingNavigations = this.pendingNavigations.filter(
-                p => p.timeoutId !== timeoutId
-            );
-            if (!this._isActive) {
-                this.mpInstance.Logger.verbose(
-                    'mParticle APV: [defer] fire aborted, tracker inactive (torn down before flush)'
-                );
-                return;
-            }
-
-            this.mpInstance._SessionManager.resetSessionTimer();
-            this.firePageView(capturedPath);
-        }, 0);
-        this.pendingNavigations.push({ path: capturedPath, timeoutId });
-    }
-
-    // Mirrors the event shape of the public mParticle.logPageView(), but carries
-    // the captured SPA path rather than reading the live location.
-    private firePageView(path: string): void {
-        const title = window.document.title;
-
-        this.mpInstance.Logger.verbose(
-            `mParticle APV: [fire] deferred flush -> _Events.logEvent(PageView) (path: ${path}, title: ${title})`
-        );
-
-        this.mpInstance._Events.logEvent({
-            messageType: MessageType.PageView,
-            name: 'PageView',
-            data: {
-                hostname: window.location.hostname,
-                title,
-                path,
-            },
-            eventType: EventType.Unknown,
-        });
-    }
-
-    // Cancels pending deferred fires and returns their captured paths so a
-    // successor tracker can re-schedule them. Call before teardown() during
-    // module-replacement handoff.
-    public takePendingNavigations(): string[] {
-        const paths = this.pendingNavigations.map(p => p.path);
-        this.pendingNavigations.forEach(p => clearTimeout(p.timeoutId));
-        this.pendingNavigations = [];
-        return paths;
-    }
-
-    private restoreHistoryMethod(
-        methodName: 'pushState' | 'replaceState',
-        original: HistoryStateMethod | null,
-        wrapper: HistoryStateMethod | null
-    ): void {
-        if (!original) return;
-        const stillOurs = wrapper !== null && window.history[methodName] === wrapper;
-        if (stillOurs) {
-            window.history[methodName] = original;
-            this.mpInstance.Logger.verbose(
-                `mParticle APV: [teardown] restored original ${methodName}`
-            );
-        } else {
-            this.mpInstance.Logger.verbose(
-                `mParticle APV: [teardown] ${methodName} no longer ours; leaving in place, gating callback to no-op`
-            );
-        }
+        inheritedPaths.forEach(path => this.scheduleFire(path));
     }
 
     public teardown(): void {
-        // Cancel any pending deferred fires (e.g. when the feature flag is
-        // disabled on re-init). For module-replacement, call takePendingNavigations()
-        // before teardown() instead so paths are transferred, not discarded.
-        this.pendingNavigations.forEach(p => clearTimeout(p.timeoutId));
-        this.pendingNavigations = [];
+        // Discard pending deferred fires (e.g. AutoLogPageView switched off on
+        // re-init). A handoff calls takePendingNavigations() first, so by this
+        // point those paths are already transferred rather than dropped.
+        this.takePendingNavigations();
 
         if (this.popStateListener) {
             window.removeEventListener('popstate', this.popStateListener);
             this.popStateListener = null;
         }
 
-        this.restoreHistoryMethod('pushState', this.originalPushState, this.pushStateWrapper);
-        this.originalPushState = null;
-        this.pushStateWrapper = null;
+        if (this.undoHistoryPatch) {
+            this.undoHistoryPatch();
+            this.undoHistoryPatch = null;
+        }
 
-        this.restoreHistoryMethod('replaceState', this.originalReplaceState, this.replaceStateWrapper);
-        this.originalReplaceState = null;
-        this.replaceStateWrapper = null;
+        this.active = false;
+        clearActiveTracker(this);
+    }
 
-        this._isActive = false;
-        if (getWindowTracker() === this) {
-            setWindowTracker(undefined);
+    // Stops the outgoing tracker and returns the paths it had queued so this
+    // tracker can re-schedule them once it is active. Private, but reachable
+    // across instances: the handoff protocol stays internal to the class.
+    private retire(outgoing: PageViewTracker | undefined): string[] {
+        if (!outgoing) {
+            return [];
+        }
+
+        this.log(
+            outgoing === this
+                ? '[init] retiring this tracker for a repeat mParticle.init() — transferring pending navigations and tearing down'
+                : '[init] retiring a tracker from a previous module load — transferring pending navigations and tearing down'
+        );
+
+        const paths = outgoing.takePendingNavigations();
+        outgoing.teardown();
+        return paths;
+    }
+
+    // Cancels this tracker's deferred fires and hands back their captured paths.
+    private takePendingNavigations(): string[] {
+        const pending = this.pendingNavigations;
+        this.pendingNavigations = [];
+        pending.forEach(p => clearTimeout(p.timeoutId));
+        return pending.map(p => p.path);
+    }
+
+    private safeHandleNavigation(source: NavigationSource): void {
+        // An orphaned wrapper still calls in: teardown can only restore a history
+        // method that is still ours, so one a third party patched over stays
+        // installed and keeps firing at a dead tracker. Bail before touching
+        // lastPath or queueing a fire the flush would just abort. Guarding here
+        // rather than at each wrapper also covers the popstate path.
+        if (!this.active) {
+            return;
+        }
+
+        try {
+            this.handleNavigation(source);
+        } catch (e) {
+            this.log(
+                `[error] navigation handler threw (${source}), page view skipped: ${e}`
+            );
         }
     }
-}
 
-function getWindowTracker(): PageViewTracker | undefined {
-    if (typeof window === 'undefined') return undefined;
-    return (window as WindowWithApvFlags)[WIN_TRACKER_KEY];
-}
+    private handleNavigation(source: NavigationSource): void {
+        const candidatePath = currentPathname();
 
-function setWindowTracker(tracker: PageViewTracker | undefined): void {
-    if (typeof window === 'undefined') return;
-    const win = window as WindowWithApvFlags;
-    if (tracker) {
-        win[WIN_TRACKER_KEY] = tracker;
-    } else {
-        delete win[WIN_TRACKER_KEY];
+        this.log(
+            `[detect] navigation signal (source: ${source}, candidatePath: ${candidatePath}, lastPath: ${this.lastPath})`
+        );
+
+        if (!isNewPage(this.lastPath, candidatePath)) {
+            this.log(
+                `[dedupe] pathname unchanged, skipping (source: ${source}, path: ${candidatePath})`
+            );
+            return;
+        }
+
+        this.log(
+            `[accept] pathname changed, scheduling fire (source: ${source}, from: ${this.lastPath}, to: ${candidatePath})`
+        );
+        this.lastPath = candidatePath;
+        this.scheduleFire(candidatePath);
+    }
+
+    // Deferred by a macrotask so the router's post-navigation render commit has a
+    // chance to update document.title before the event is built. The path is
+    // snapshotted now because it is already settled, whereas a same-tick
+    // navigation would overwrite window.location before the flush reads it.
+    private scheduleFire(path: string): void {
+        const timeoutId = setTimeout(() => {
+            this.pendingNavigations = this.pendingNavigations.filter(
+                p => p.timeoutId !== timeoutId
+            );
+
+            if (!this.active) {
+                this.log(
+                    '[defer] fire aborted, tracker inactive (torn down before flush)'
+                );
+                return;
+            }
+
+            this.mpInstance._SessionManager.resetSessionTimer();
+            this.firePageView(path);
+        }, 0);
+
+        this.pendingNavigations.push({ path, timeoutId });
+    }
+
+    private firePageView(path: string): void {
+        const title = window.document.title;
+        const event = buildPageViewEvent({
+            hostname: window.location.hostname,
+            title,
+            path,
+        });
+
+        this.log(
+            `[fire] deferred flush -> _Events.logEvent(PageView) (path: ${path}, title: ${title})`
+        );
+
+        this.mpInstance._Events.logEvent(event);
+    }
+
+    private log(message: string): void {
+        this.mpInstance.Logger.verbose(`mParticle APV: ${message}`);
     }
 }

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -14,21 +14,31 @@ type MarkedHistoryMethod = HistoryStateMethod & {
     [WRAPPED_MARKER]?: boolean;
 };
 
-// The window keys are the public debugging contract for APV: `window.__mpApvTracker__`
-// is what you inspect in a console to see whether tracking is live.
+// All APV state hangs off one window key, and it is the public debugging
+// contract: `window.__mpApv__` is what you inspect in a console to see whether
+// tracking is live.
 //
-// APV state lives on `window` rather than in module scope because Next.js
-// re-executes the SDK bundle on every SPA navigation: module-level state is
-// reset each time, but `window` persists for the lifetime of the tab.
-export const WIN_TRACKER_KEY = '__mpApvTracker__';
+// It lives on `window` rather than in module scope because Next.js re-executes
+// the SDK bundle on every SPA navigation: module-level state is reset each time,
+// but `window` persists for the lifetime of the tab.
+//
+// One object rather than a key per flag, so resetting is a single reassignment.
+// Nothing has to be deleted, and there is no ordering in which half the state
+// survives the reset.
+export const WIN_APV_KEY = '__mpApv__';
 
-// Guards the initial page view so repeated mParticle.init() calls from SPA
-// re-renders don't fire duplicate logPageView() events for the same page.
-export const WIN_INIT_PV_KEY = '__mpApvInitPVLogged__' as const;
+interface IApvState {
+    // The tracker that currently owns the history patch. May have been
+    // registered by a module scope that no longer exists.
+    tracker?: PageViewTracker;
 
-type WindowWithApvFlags = Window & {
-    [WIN_TRACKER_KEY]?: PageViewTracker;
-    [WIN_INIT_PV_KEY]?: boolean;
+    // Guards the initial page view so repeated mParticle.init() calls from SPA
+    // re-renders don't fire duplicate logPageView() events for the same page.
+    initialPageViewFired: boolean;
+}
+
+type WindowWithApv = Window & {
+    [WIN_APV_KEY]?: IApvState;
 };
 
 interface IPageViewData {
@@ -56,7 +66,7 @@ export const isNewPage = (
 
 export const supportsHistoryTracking = (win: Window | null): boolean =>
     !!win &&
-    typeof win.history !== 'undefined' &&
+    win.history !== undefined &&
     typeof win.history.pushState === 'function' &&
     typeof win.addEventListener === 'function';
 
@@ -70,35 +80,55 @@ export const buildPageViewEvent = (data: IPageViewData): BaseEvent => ({
 });
 
 // ---------------------------------------------------------------------------
-// Window-scoped APV state. Every read and write of the window flags goes through
-// these helpers, so neither the tracker nor mp-instance touches `window`
-// directly and `typeof window` is checked in exactly one place.
+// Window-scoped APV state. Every read and write goes through these helpers, so
+// neither the tracker nor mp-instance touches `window` directly and
+// `typeof window` is checked in exactly one place.
 // ---------------------------------------------------------------------------
 
-const apvWindow = (): WindowWithApvFlags | null =>
-    typeof window === 'undefined' ? null : (window as WindowWithApvFlags);
+const apvWindow = (): WindowWithApv | null =>
+    typeof window === 'undefined' ? null : (window as WindowWithApv);
 
-// The tracker that currently owns the history patch, which may have been
-// registered by a module scope that no longer exists.
-export const getActiveTracker = (): PageViewTracker | undefined => {
+const freshState = (): IApvState => ({ initialPageViewFired: false });
+
+// Reads tolerate absent state, so a read never mutates `window`. Only the
+// writers below create it.
+const readState = (): IApvState | undefined => {
     const win = apvWindow();
-    return win ? win[WIN_TRACKER_KEY] : undefined;
+    return win ? win[WIN_APV_KEY] : undefined;
+};
+
+const writeState = (): IApvState | null => {
+    const win = apvWindow();
+    if (!win) {
+        return null;
+    }
+
+    if (!win[WIN_APV_KEY]) {
+        win[WIN_APV_KEY] = freshState();
+    }
+
+    return win[WIN_APV_KEY];
+};
+
+export const getActiveTracker = (): PageViewTracker | undefined => {
+    const state = readState();
+    return state ? state.tracker : undefined;
 };
 
 export const hasInitialPageViewFired = (): boolean => {
-    const win = apvWindow();
-    return !!(win && win[WIN_INIT_PV_KEY]);
+    const state = readState();
+    return !!(state && state.initialPageViewFired);
 };
 
 export const markInitialPageViewFired = (): void => {
-    const win = apvWindow();
-    if (win) {
-        win[WIN_INIT_PV_KEY] = true;
+    const state = writeState();
+    if (state) {
+        state.initialPageViewFired = true;
     }
 };
 
 // Returns the page to its pre-APV state: stops the active tracker (restoring the
-// history methods it patched) and clears the window flags. The registry is the
+// history methods it patched), then swaps in fresh state. The state object is the
 // authoritative handle, so this reaches trackers whose owning module is gone.
 export const resetPageViewTracking = (): void => {
     const win = apvWindow();
@@ -106,28 +136,27 @@ export const resetPageViewTracking = (): void => {
         return;
     }
 
-    const active = win[WIN_TRACKER_KEY];
+    const active = getActiveTracker();
     if (active) {
         active.teardown();
     }
 
-    // teardown() clears WIN_TRACKER_KEY itself; delete unconditionally in case a
-    // tracker was registered by an older build whose teardown did not.
-    delete win[WIN_TRACKER_KEY];
-    delete win[WIN_INIT_PV_KEY];
+    // One reassignment replaces every flag at once, so nothing can be left behind
+    // whatever shape the previous state was in.
+    win[WIN_APV_KEY] = freshState();
 };
 
 const setActiveTracker = (tracker: PageViewTracker): void => {
-    const win = apvWindow();
-    if (win) {
-        win[WIN_TRACKER_KEY] = tracker;
+    const state = writeState();
+    if (state) {
+        state.tracker = tracker;
     }
 };
 
 const clearActiveTracker = (tracker: PageViewTracker): void => {
-    const win = apvWindow();
-    if (win && win[WIN_TRACKER_KEY] === tracker) {
-        delete win[WIN_TRACKER_KEY];
+    const state = readState();
+    if (state && state.tracker === tracker) {
+        state.tracker = undefined;
     }
 };
 
@@ -235,7 +264,7 @@ export class PageViewTracker {
     // True while this tracker owns the history patch and is listening for
     // navigations. Flips to false on teardown, including the teardown a
     // successor tracker performs during a handoff. Read-only, and the one thing
-    // worth checking on `window.__mpApvTracker__` from a console.
+    // worth checking on `window.__mpApv__.tracker` from a console.
     public get isActive(): boolean {
         return this.active;
     }

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -8,8 +8,7 @@ import {
     patchHistory,
     resetPageViewTracking,
     supportsHistoryTracking,
-    WIN_INIT_PV_KEY,
-    WIN_TRACKER_KEY,
+    WIN_APV_KEY,
 } from '../../src/pageViewTracker';
 import { IMParticleWebSDKInstance } from '../../src/mp-instance';
 import { EventType, MessageType } from '../../src/types';
@@ -918,18 +917,37 @@ describe('PageViewTracker', () => {
             expect(() => resetPageViewTracking()).not.toThrow();
         });
 
-        // The window keys are a debugging contract: `window.__mpApvTracker__` is
-        // what you inspect in a console to see whether APV is live. Renaming
-        // either of them silently breaks that, so pin the literals.
-        it('should expose its state under the documented window keys', () => {
+        // The window key is a debugging contract: `window.__mpApv__` is what you
+        // inspect in a console to see whether APV is live. Renaming it silently
+        // breaks that, so pin the literal and the shape.
+        it('should expose all its state under one documented window key', () => {
             const tracker = createTracker();
             tracker.init();
             markInitialPageViewFired();
 
-            expect(WIN_TRACKER_KEY).toBe('__mpApvTracker__');
-            expect(WIN_INIT_PV_KEY).toBe('__mpApvInitPVLogged__');
-            expect((window as any).__mpApvTracker__).toBe(tracker);
-            expect((window as any).__mpApvInitPVLogged__).toBe(true);
+            expect(WIN_APV_KEY).toBe('__mpApv__');
+            expect((window as any).__mpApv__).toEqual({
+                tracker,
+                initialPageViewFired: true,
+            });
+        });
+
+        // The point of one object over two loose keys: reset is a single
+        // reassignment, so there is no ordering in which half the state survives.
+        it('should replace the whole state object on reset', () => {
+            const tracker = createTracker();
+            tracker.init();
+            markInitialPageViewFired();
+            const before = (window as any).__mpApv__;
+
+            resetPageViewTracking();
+
+            const after = (window as any).__mpApv__;
+            expect(after).not.toBe(before);
+            expect(after).toEqual({
+                tracker: undefined,
+                initialPageViewFired: false,
+            });
         });
     });
 });

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -1,6 +1,18 @@
-import { PageViewTracker, WIN_TRACKER_KEY } from '../../src/pageViewTracker';
+import {
+    buildPageViewEvent,
+    getActiveTracker,
+    hasInitialPageViewFired,
+    isNewPage,
+    markInitialPageViewFired,
+    PageViewTracker,
+    patchHistory,
+    resetPageViewTracking,
+    supportsHistoryTracking,
+    WIN_INIT_PV_KEY,
+    WIN_TRACKER_KEY,
+} from '../../src/pageViewTracker';
 import { IMParticleWebSDKInstance } from '../../src/mp-instance';
-import { MessageType } from '../../src/types';
+import { EventType, MessageType } from '../../src/types';
 
 // Capture the genuinely-native history methods at import time, before any
 // tracker has a chance to monkey-patch them. Used to reset state between tests
@@ -10,31 +22,249 @@ const NATIVE_REPLACE_STATE = window.history.replaceState;
 
 const WRAPPED_MARKER = '__mpApvWrapped__';
 
+// A wrapper installed by a third party (or an older SDK build) that already
+// carries the marker, so our patch must decline to wrap on top of it.
+const markedForeignWrapper = (): History['pushState'] => {
+    const wrapper = function() {
+        /* someone else's wrapper */
+    } as History['pushState'];
+    Object.defineProperty(wrapper, WRAPPED_MARKER, {
+        value: true,
+        enumerable: false,
+    });
+    return wrapper;
+};
+
+const unmarkedForeignWrapper = (): History['pushState'] =>
+    function() {
+        /* someone else's wrapper */
+    } as History['pushState'];
+
+// ---------------------------------------------------------------------------
+// The pure helpers carry the interesting rules and need no DOM, no timers, and
+// no tracker instance to assert.
+// ---------------------------------------------------------------------------
+
+describe('pageViewTracker pure helpers', () => {
+    describe('#isNewPage', () => {
+        it('should treat a different pathname as a new page', () => {
+            expect(isNewPage('/a', '/b')).toBe(true);
+        });
+
+        it('should treat an identical pathname as the same page', () => {
+            expect(isNewPage('/a', '/a')).toBe(false);
+        });
+
+        // The caller passes pathnames only, so query strings and hashes never
+        // reach here — which is exactly why they cannot trigger a page view.
+        it('should treat the first navigation after construction as new', () => {
+            expect(isNewPage(null, '/a')).toBe(true);
+        });
+    });
+
+    describe('#supportsHistoryTracking', () => {
+        it('should reject a missing window (SSR)', () => {
+            expect(supportsHistoryTracking(null)).toBe(false);
+        });
+
+        it('should reject a window with no History API', () => {
+            expect(supportsHistoryTracking(({} as unknown) as Window)).toBe(
+                false
+            );
+        });
+
+        it('should reject a window whose pushState is not callable', () => {
+            const win = ({
+                history: { pushState: undefined },
+                addEventListener: () => undefined,
+            } as unknown) as Window;
+
+            expect(supportsHistoryTracking(win)).toBe(false);
+        });
+
+        it('should reject a window that cannot register listeners', () => {
+            const win = ({
+                history: { pushState: () => undefined },
+            } as unknown) as Window;
+
+            expect(supportsHistoryTracking(win)).toBe(false);
+        });
+
+        it('should accept a browser window', () => {
+            expect(supportsHistoryTracking(window)).toBe(true);
+        });
+    });
+
+    describe('#buildPageViewEvent', () => {
+        it('should build a PageView event from the supplied data alone', () => {
+            const event = buildPageViewEvent({
+                hostname: 'example.com',
+                title: 'Cart',
+                path: '/cart',
+            });
+
+            expect(event).toEqual({
+                messageType: MessageType.PageView,
+                name: 'PageView',
+                eventType: EventType.Unknown,
+                data: {
+                    hostname: 'example.com',
+                    title: 'Cart',
+                    path: '/cart',
+                },
+            });
+        });
+
+        it('should not alias the caller data into the event', () => {
+            const data = { hostname: 'example.com', title: 'Cart', path: '/cart' };
+            const event = buildPageViewEvent(data);
+
+            data.path = '/mutated-after-the-fact';
+
+            expect(event.data.path).toBe('/cart');
+        });
+    });
+});
+
+describe('#patchHistory', () => {
+    let onNavigate: jest.Mock;
+    let log: jest.Mock;
+
+    beforeEach(() => {
+        onNavigate = jest.fn();
+        log = jest.fn();
+    });
+
+    afterEach(() => {
+        window.history.pushState = NATIVE_PUSH_STATE;
+        window.history.replaceState = NATIVE_REPLACE_STATE;
+        NATIVE_REPLACE_STATE.call(window.history, {}, '', '/');
+    });
+
+    it('should notify with the method that navigated, after it has run', () => {
+        const undo = patchHistory(onNavigate, log);
+
+        window.history.pushState({}, '', '/pushed');
+        expect(onNavigate).toHaveBeenLastCalledWith('pushState');
+        // The real method already ran by the time we are notified.
+        expect(window.location.pathname).toBe('/pushed');
+
+        window.history.replaceState({}, '', '/replaced');
+        expect(onNavigate).toHaveBeenLastCalledWith('replaceState');
+        expect(window.location.pathname).toBe('/replaced');
+
+        undo();
+    });
+
+    it('should restore the native methods when undone', () => {
+        const undo = patchHistory(onNavigate, log);
+        undo();
+
+        expect(window.history.pushState).toBe(NATIVE_PUSH_STATE);
+        expect(window.history.replaceState).toBe(NATIVE_REPLACE_STATE);
+    });
+
+    it('should decline to wrap history that is already wrapped', () => {
+        const foreignWrapper = markedForeignWrapper();
+        window.history.pushState = foreignWrapper;
+
+        expect(patchHistory(onNavigate, log)).toBeNull();
+        expect(window.history.pushState).toBe(foreignWrapper);
+        expect(log).toHaveBeenCalledWith(
+            expect.stringContaining('already wrapped')
+        );
+    });
+
+    // A third party may patch one of the two methods on top of ours. Undo must
+    // decide per method: leave theirs in place, still restore ours.
+    it('should leave a foreign wrapper in place but restore its own', () => {
+        const undo = patchHistory(onNavigate, log);
+
+        const foreignWrapper = unmarkedForeignWrapper();
+        window.history.pushState = foreignWrapper;
+
+        undo();
+
+        expect(window.history.pushState).toBe(foreignWrapper);
+        expect(window.history.replaceState).toBe(NATIVE_REPLACE_STATE);
+    });
+
+    it('should roll back and report null when assignment is rejected', () => {
+        // A frozen/sealed History makes the assignment throw in strict mode.
+        Object.defineProperty(window.history, 'pushState', {
+            value: NATIVE_PUSH_STATE,
+            writable: false,
+            configurable: true,
+        });
+
+        try {
+            expect(patchHistory(onNavigate, log)).toBeNull();
+            expect(window.history.pushState).toBe(NATIVE_PUSH_STATE);
+            expect(window.history.replaceState).toBe(NATIVE_REPLACE_STATE);
+            expect(log).toHaveBeenCalledWith(
+                expect.stringContaining('failed to patch history methods')
+            );
+        } finally {
+            Object.defineProperty(window.history, 'pushState', {
+                value: NATIVE_PUSH_STATE,
+                writable: true,
+                configurable: true,
+            });
+        }
+    });
+
+    // The rejection can land on the second assignment, leaving one wrapper
+    // installed and one not. The rollback has to be per method or it either
+    // leaks the pushState wrapper or restores a method it never replaced.
+    it('should roll back the half that was installed when the second is rejected', () => {
+        Object.defineProperty(window.history, 'replaceState', {
+            value: NATIVE_REPLACE_STATE,
+            writable: false,
+            configurable: true,
+        });
+
+        try {
+            expect(patchHistory(onNavigate, log)).toBeNull();
+            expect(window.history.pushState).toBe(NATIVE_PUSH_STATE);
+            expect(window.history.replaceState).toBe(NATIVE_REPLACE_STATE);
+
+            // Nothing is left listening, so a navigation is not reported twice
+            // (or at all) by a wrapper the caller believes it rolled back.
+            NATIVE_PUSH_STATE.call(window.history, {}, '', '/after-rollback');
+            expect(onNavigate).not.toHaveBeenCalled();
+        } finally {
+            Object.defineProperty(window.history, 'replaceState', {
+                value: NATIVE_REPLACE_STATE,
+                writable: true,
+                configurable: true,
+            });
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The tracker itself, asserted only through its public surface: init(),
+// teardown(), isActive, the registry helpers, and the events it logs.
+// ---------------------------------------------------------------------------
+
 describe('PageViewTracker', () => {
     let mpInstance: IMParticleWebSDKInstance;
     let logEvent: jest.Mock;
     let resetSessionTimer: jest.Mock;
     let verbose: jest.Mock;
 
-    // Every tracker built during a test is registered here so afterEach can
-    // tear it down. Trackers add global window listeners in init(); without
-    // teardown those listeners leak across tests and fire on later navigations.
-    let trackers: PageViewTracker[];
-
-    const createTracker = (): PageViewTracker => {
-        const tracker = new PageViewTracker(mpInstance);
-        trackers.push(tracker);
-        return tracker;
-    };
+    const createTracker = (): PageViewTracker => new PageViewTracker(mpInstance);
 
     // Change the URL without triggering the tracker's patched pushState.
     const navigateNatively = (path: string): void => {
         NATIVE_PUSH_STATE.call(window.history, {}, '', path);
     };
 
+    const loggedPaths = (): string[] =>
+        logEvent.mock.calls.map(([event]) => event.data.path);
+
     beforeEach(() => {
         jest.useFakeTimers();
-        trackers = [];
 
         logEvent = jest.fn();
         resetSessionTimer = jest.fn();
@@ -48,23 +278,16 @@ describe('PageViewTracker', () => {
     });
 
     afterEach(() => {
-        // Tear down every tracker so its window listeners don't leak into the
-        // next test. Swallow errors from trackers whose mocks were rigged to
-        // throw.
-        trackers.forEach(tracker => {
-            try {
-                tracker.teardown();
-            } catch (e) {
-                /* ignore */
-            }
-        });
+        // One call tears down whichever tracker is active and clears the window
+        // flags — the same entry point the SDK uses, so the tests exercise it
+        // rather than reaching around it.
+        resetPageViewTracking();
 
         // Restore the native history methods and reset the URL so each test
         // starts from a clean `http://localhost/` (jsdom's default origin).
         window.history.pushState = NATIVE_PUSH_STATE;
         window.history.replaceState = NATIVE_REPLACE_STATE;
         NATIVE_REPLACE_STATE.call(window.history, {}, '', '/');
-        delete (window as any)[WIN_TRACKER_KEY];
 
         jest.clearAllTimers();
         jest.useRealTimers();
@@ -72,16 +295,24 @@ describe('PageViewTracker', () => {
     });
 
     describe('#constructor', () => {
-        it('should be side-effect free and store the mpInstance', () => {
+        it('should be side-effect free', () => {
             const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
 
             const tracker = createTracker();
 
-            expect(tracker.mpInstance).toBe(mpInstance);
-            expect(tracker['isActive']).toBe(false);
-            expect(tracker['lastPath']).toBeNull();
+            expect(tracker.isActive).toBe(false);
             expect(addEventListenerSpy).not.toHaveBeenCalled();
             expect(window.history.pushState).toBe(NATIVE_PUSH_STATE);
+            expect(getActiveTracker()).toBeUndefined();
+        });
+
+        it('should not log page views before init()', () => {
+            createTracker();
+
+            window.history.pushState({}, '', '/never-tracked');
+            jest.runAllTimers();
+
+            expect(logEvent).not.toHaveBeenCalled();
         });
     });
 
@@ -98,7 +329,8 @@ describe('PageViewTracker', () => {
             const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
 
             expect(() => tracker.init()).not.toThrow();
-            expect(tracker['isActive']).toBe(false);
+            expect(tracker.isActive).toBe(false);
+            expect(getActiveTracker()).toBeUndefined();
             expect(addEventListenerSpy).not.toHaveBeenCalled();
 
             // Restore for afterEach cleanup.
@@ -111,14 +343,29 @@ describe('PageViewTracker', () => {
     });
 
     describe('#init', () => {
-        it('should seed lastPath with the pathname only at init time', () => {
+        it('should become active and register itself', () => {
+            const tracker = createTracker();
+            tracker.init();
+
+            expect(tracker.isActive).toBe(true);
+            expect(getActiveTracker()).toBe(tracker);
+        });
+
+        // The seed is the pathname alone, so a query-string change against the
+        // landing URL is still the same page.
+        it('should seed the current page by pathname only', () => {
             navigateNatively('/dashboard?tab=1#section');
 
             const tracker = createTracker();
             tracker.init();
 
-            expect(tracker['lastPath']).toBe('/dashboard');
-            expect(tracker['isActive']).toBe(true);
+            window.history.replaceState({}, '', '/dashboard?tab=2');
+            jest.runAllTimers();
+            expect(logEvent).not.toHaveBeenCalled();
+
+            window.history.pushState({}, '', '/settings');
+            jest.runAllTimers();
+            expect(loggedPaths()).toEqual(['/settings']);
         });
 
         it('should patch pushState/replaceState and register listeners', () => {
@@ -145,38 +392,35 @@ describe('PageViewTracker', () => {
             tracker.init();
             const firstWrapper = window.history.pushState;
 
-            const teardownSpy = jest.spyOn(tracker, 'teardown');
             tracker.init();
 
-            expect(teardownSpy).toHaveBeenCalled();
             // After teardown-first + re-patch, the installed wrapper is a fresh
             // one wrapping the native method, never a wrapper wrapping a wrapper.
             expect(window.history.pushState).not.toBe(firstWrapper);
-            expect(tracker['originalPushState']).toBe(NATIVE_PUSH_STATE);
-        });
-    });
 
-    describe('#patchHistoryMethods', () => {
+            // Proof that the second patch captured the native method and not the
+            // first wrapper: tearing down leaves history exactly as it started.
+            tracker.teardown();
+            expect(window.history.pushState).toBe(NATIVE_PUSH_STATE);
+        });
+
         // Q9.5 - A second wrapper/instance already present skips patching.
-        it('should skip patching when history is already wrapped (marker guard)', () => {
-            const foreignWrapper = function() {
-                /* someone else's wrapper */
-            } as History['pushState'];
-            Object.defineProperty(foreignWrapper, WRAPPED_MARKER, {
-                value: true,
-                enumerable: false,
-            });
+        it('should not wrap history that another wrapper already owns', () => {
+            const foreignWrapper = markedForeignWrapper();
             window.history.pushState = foreignWrapper;
 
             const tracker = createTracker();
             tracker.init();
 
             expect(window.history.pushState).toBe(foreignWrapper);
-            expect(tracker['originalPushState']).toBeNull();
-            expect(tracker['pushStateWrapper']).toBeNull();
             expect(verbose).toHaveBeenCalledWith(
                 expect.stringContaining('already wrapped')
             );
+
+            // Having declined to patch, teardown must not clobber the wrapper it
+            // never owned.
+            tracker.teardown();
+            expect(window.history.pushState).toBe(foreignWrapper);
         });
 
         it('should mark its wrapper as non-enumerable', () => {
@@ -191,7 +435,7 @@ describe('PageViewTracker', () => {
 
         // Q9.8 - Frozen/sealed history throws on assignment, rolls back, and
         // init() doesn't escape while listeners still get added.
-        it('should roll back and not throw when history assignment fails', () => {
+        it('should still listen for popstate when history cannot be patched', () => {
             // Make pushState non-writable so assignment throws in strict mode.
             Object.defineProperty(window.history, 'pushState', {
                 value: NATIVE_PUSH_STATE,
@@ -207,14 +451,20 @@ describe('PageViewTracker', () => {
 
                 // Assignment failed, so the native method is left in place...
                 expect(window.history.pushState).toBe(NATIVE_PUSH_STATE);
-                expect(tracker['pushStateWrapper']).toBeNull();
-                expect(tracker['originalPushState']).toBeNull();
 
-                // ...but the navigation listener is still registered.
+                // ...but the navigation listener is still registered, so
+                // back/forward navigation is still tracked.
                 expect(addEventListenerSpy).toHaveBeenCalledWith(
                     'popstate',
                     expect.any(Function)
                 );
+
+                navigateNatively('/popstate-only');
+                window.dispatchEvent(new PopStateEvent('popstate'));
+                jest.runAllTimers();
+                expect(loggedPaths()).toEqual(['/popstate-only']);
+
+                expect(() => tracker.teardown()).not.toThrow();
             } finally {
                 // Restore writability so afterEach can reset.
                 Object.defineProperty(window.history, 'pushState', {
@@ -273,9 +523,14 @@ describe('PageViewTracker', () => {
             expect(logEvent).toHaveBeenCalledTimes(1);
         });
 
-        it('should update lastPath synchronously when a change is accepted', () => {
+        // The accepted path is recorded synchronously, so a return trip to the
+        // previous URL in the same tick is a fresh page view rather than a dedup.
+        it('should record the accepted path before the deferred fire', () => {
             window.history.pushState({}, '', '/products');
-            expect(tracker['lastPath']).toBe('/products');
+            window.history.pushState({}, '', '/');
+            jest.runAllTimers();
+
+            expect(loggedPaths()).toEqual(['/products', '/']);
         });
 
         it('should fire a view on popstate navigation', () => {
@@ -309,7 +564,7 @@ describe('PageViewTracker', () => {
         it('should fire one view per accepted change', () => {
             navigateNatively('/a');
             const tracker = createTracker();
-            tracker.init(); // seeds lastPath = '/a'
+            tracker.init(); // seeds the current page as '/a'
 
             window.history.pushState({}, '', '/b');
             window.history.pushState({}, '', '/c');
@@ -333,8 +588,7 @@ describe('PageViewTracker', () => {
 
             jest.runAllTimers();
 
-            const paths = logEvent.mock.calls.map(([event]) => event.data.path);
-            expect(paths).toEqual(['/b', '/c']);
+            expect(loggedPaths()).toEqual(['/b', '/c']);
         });
     });
 
@@ -359,6 +613,23 @@ describe('PageViewTracker', () => {
                     path: '/next',
                 },
             });
+        });
+
+        // The title is read at flush time, not when the navigation is accepted,
+        // so a router that sets document.title during its render commit is
+        // reflected in the event.
+        it('should read the title at flush time, not at navigation time', () => {
+            navigateNatively('/');
+            const tracker = createTracker();
+            tracker.init();
+
+            window.document.title = 'Before Render';
+            window.history.pushState({}, '', '/next');
+            window.document.title = 'After Render';
+
+            jest.runAllTimers();
+
+            expect(logEvent.mock.calls[0][0].data.title).toBe('After Render');
         });
     });
 
@@ -396,21 +667,17 @@ describe('PageViewTracker', () => {
             expect(resetSessionTimer).not.toHaveBeenCalled();
         });
 
-        // safeHandleNavigation isolates errors from the *synchronous* handler
-        // so a throwing handler never breaks the app's own pushState call.
-        it('should isolate synchronous errors from the navigation handler', () => {
-            jest.spyOn(
-                tracker as PageViewTracker & {
-                    handleNavigation: () => void;
-                },
-                'handleNavigation'
-            ).mockImplementation(() => {
+        // The navigation handler runs inside the host page's own pushState call,
+        // so a throwing collaborator must never propagate into the router.
+        it('should isolate errors from the navigation handler', () => {
+            verbose.mockImplementationOnce(() => {
                 throw new Error('boom');
             });
 
             expect(() =>
                 window.history.pushState({}, '', '/explode')
             ).not.toThrow();
+            expect(window.location.pathname).toBe('/explode');
             expect(verbose).toHaveBeenCalledWith(
                 expect.stringContaining('navigation handler threw')
             );
@@ -436,7 +703,7 @@ describe('PageViewTracker', () => {
                 'popstate',
                 expect.any(Function)
             );
-            expect(tracker['isActive']).toBe(false);
+            expect(tracker.isActive).toBe(false);
         });
 
         // Q9.7 - Teardown with another wrapper on top leaves the original in
@@ -451,58 +718,85 @@ describe('PageViewTracker', () => {
             tracker.init();
 
             // A third party patches pushState on top of ours after init.
-            const foreignWrapper = function() {
-                /* someone else's wrapper */
-            } as History['pushState'];
+            const foreignWrapper = unmarkedForeignWrapper();
             window.history.pushState = foreignWrapper;
 
             tracker.teardown();
 
             // Our wrapper is no longer installed, so we must not clobber the
-            // foreign one by restoring the native method.
+            // foreign one by restoring the native method. replaceState was never
+            // touched by them, so it still comes back.
             expect(window.history.pushState).toBe(foreignWrapper);
+            expect(window.history.replaceState).toBe(NATIVE_REPLACE_STATE);
             expect(removeEventListenerSpy).toHaveBeenCalledWith(
                 'popstate',
                 expect.any(Function)
             );
-            expect(tracker['isActive']).toBe(false);
+            expect(tracker.isActive).toBe(false);
         });
 
-        // A third party may patch only one of the two methods. Teardown must
-        // decide per-method: leave the foreign pushState in place while still
-        // restoring our untouched replaceState (otherwise it leaks, and a
-        // later re-init stacks a second wrapper on top of it).
-        it('should restore replaceState even when pushState is foreign', () => {
+        it('should deregister itself', () => {
             const tracker = createTracker();
             tracker.init();
-
-            const foreignWrapper = function() {
-                /* someone else's wrapper */
-            } as History['pushState'];
-            window.history.pushState = foreignWrapper;
+            expect(getActiveTracker()).toBe(tracker);
 
             tracker.teardown();
 
-            expect(window.history.pushState).toBe(foreignWrapper);
-            expect(window.history.replaceState).toBe(NATIVE_REPLACE_STATE);
-            expect(tracker['isActive']).toBe(false);
-        });
-
-        it('should clear window[WIN_TRACKER_KEY] after teardown', () => {
-            const tracker = createTracker();
-            tracker.init();
-
-            expect((window as any)[WIN_TRACKER_KEY]).toBe(tracker);
-
-            tracker.teardown();
-
-            expect((window as any)[WIN_TRACKER_KEY]).toBeUndefined();
+            expect(getActiveTracker()).toBeUndefined();
         });
 
         it('should be safe to call before init()', () => {
             const tracker = createTracker();
             expect(() => tracker.teardown()).not.toThrow();
-            expect(tracker['isActive']).toBe(false);
+            expect(tracker.isActive).toBe(false);
+        });
+
+        it('should be safe to call twice', () => {
+            const tracker = createTracker();
+            tracker.init();
+            tracker.teardown();
+
+            expect(() => tracker.teardown()).not.toThrow();
+            expect(window.history.pushState).toBe(NATIVE_PUSH_STATE);
+        });
+
+        // Teardown can only restore a history method that is still ours. If a
+        // third party wrapped *our* wrapper, ours stays reachable and keeps being
+        // called after teardown — an orphaned wrapper attached to a dead tracker.
+        //
+        // No event fires either way (the deferred flush aborts when inactive), so
+        // this asserts the stronger property: a dead tracker does no work at all.
+        // Without the guard it still walks the dedup path and queues a timer just
+        // to throw the result away.
+        it('should do no work when an orphaned wrapper still calls in', () => {
+            navigateNatively('/');
+            const tracker = createTracker();
+            tracker.init();
+
+            // A third party wraps ours, delegating to it.
+            const ourWrapper = window.history.pushState;
+            window.history.pushState = function(
+                this: History,
+                ...args: Parameters<History['pushState']>
+            ): void {
+                return ourWrapper.apply(this, args);
+            } as History['pushState'];
+
+            tracker.teardown();
+            verbose.mockClear();
+
+            window.history.pushState({}, '', '/orphaned');
+            jest.runAllTimers();
+
+            expect(logEvent).not.toHaveBeenCalled();
+            expect(resetSessionTimer).not.toHaveBeenCalled();
+            // Bailed before the dedup path, so nothing was accepted or deferred.
+            expect(verbose).not.toHaveBeenCalledWith(
+                expect.stringContaining('[accept]')
+            );
+            expect(verbose).not.toHaveBeenCalledWith(
+                expect.stringContaining('[defer]')
+            );
         });
 
         it('should stop firing page views after teardown', () => {
@@ -521,87 +815,28 @@ describe('PageViewTracker', () => {
 
     // Regression: Next.js re-evaluates the SDK module on each SPA navigation,
     // resetting all module-level state. Each fresh module creates a new
-    // PageViewTracker and calls init(). Without the singleton teardown, each
+    // PageViewTracker and calls init(). Without the registry handoff, each
     // init() stacks a new pushState wrapper on top of the previous one and fires
     // N page views per navigation after N module loads.
-    describe('window singleton / stale tracker teardown (module re-evaluation)', () => {
-        it('should register itself in window[WIN_TRACKER_KEY] after init()', () => {
-            const tracker = createTracker();
-            tracker.init();
-
-            expect((window as any)[WIN_TRACKER_KEY]).toBe(tracker);
-        });
-
-        it('should tear down a stale tracker from a previous module load on init()', () => {
-            // Simulate a tracker left behind by a previous module load:
-            // the old module is gone, so the only handle to it is window[WIN_TRACKER_KEY].
+    describe('handoff between module loads', () => {
+        it('should retire the tracker left by a previous module load', () => {
+            // Simulate a tracker left behind by a previous module load: the old
+            // module is gone, so the only handle to it is the registry.
             const staleTracker = createTracker();
             staleTracker.init();
-            const teardownSpy = jest.spyOn(staleTracker, 'teardown');
 
-            // A new module load creates a fresh tracker and calls init().
             const newTracker = createTracker();
             newTracker.init();
 
-            expect(teardownSpy).toHaveBeenCalled();
-            expect((window as any)[WIN_TRACKER_KEY]).toBe(newTracker);
-        });
-
-        // Regression: a navigation queued by the stale tracker (setTimeout not yet
-        // flushed) must be transferred to the replacement tracker via
-        // takePendingNavigations() so it is not silently dropped on module
-        // re-evaluation.
-        it('should transfer a pending page view from the stale tracker on module re-evaluation', () => {
-            const staleTracker = createTracker();
-            staleTracker.init(); // seeds lastPath = '/'
-
-            // Route change detected by the stale tracker — deferred fire queued.
-            window.history.pushState({}, '', '/route-a');
-            // Timer not yet flushed.
-
-            // Module re-evaluation: new tracker transfers pending navigations then
-            // tears down the stale one.
-            const newTracker = createTracker();
-            newTracker.init(); // takes '/route-a' from stale, tears it down
-
-            // Flush: '/route-a' fires via the new tracker, not the stale one.
-            jest.runAllTimers();
-            expect(logEvent).toHaveBeenCalledTimes(1);
-            expect(logEvent.mock.calls[0][0].data.path).toBe('/route-a');
-
-            // A subsequent navigation from the new tracker fires as normal.
-            logEvent.mockClear();
-            window.history.pushState({}, '', '/route-b');
-            jest.runAllTimers();
-            expect(logEvent).toHaveBeenCalledTimes(1);
-            expect(logEvent.mock.calls[0][0].data.path).toBe('/route-b');
-        });
-
-        // Regression: same-instance re-init (e.g. SPA framework calling
-        // mParticle.init() on navigation) must not drop a page view queued before
-        // the re-init call.
-        it('should preserve a pending page view when the same tracker re-inits', () => {
-            const tracker = createTracker();
-            tracker.init(); // seeds lastPath = '/'
-
-            // Route change queues a deferred fire — timer not yet flushed.
-            window.history.pushState({}, '', '/about');
-
-            // SPA framework calls mParticle.init() again before the timer fires.
-            tracker.init();
-
-            // The pending '/about' view should still fire.
-            jest.runAllTimers();
-            expect(logEvent).toHaveBeenCalledTimes(1);
-            expect(logEvent.mock.calls[0][0].data.path).toBe('/about');
+            expect(staleTracker.isActive).toBe(false);
+            expect(newTracker.isActive).toBe(true);
+            expect(getActiveTracker()).toBe(newTracker);
         });
 
         it('should not fire duplicate page views after a module re-evaluation', () => {
-            // First module load: tracker A installs its wrapper.
             const trackerA = createTracker();
             trackerA.init();
 
-            // Second module load: tracker B tears down A and installs its own wrapper.
             const trackerB = createTracker();
             trackerB.init();
 
@@ -610,6 +845,91 @@ describe('PageViewTracker', () => {
             jest.runAllTimers();
 
             expect(logEvent).toHaveBeenCalledTimes(1);
+        });
+
+        // Regression: a navigation queued by the stale tracker (setTimeout not
+        // yet flushed) must be transferred to the replacement tracker so it is
+        // not silently dropped on module re-evaluation.
+        it('should transfer a pending page view from the retired tracker', () => {
+            const staleTracker = createTracker();
+            staleTracker.init(); // seeds the current page as '/'
+
+            // Route change detected by the stale tracker — deferred fire queued,
+            // timer not yet flushed.
+            window.history.pushState({}, '', '/route-a');
+
+            // Module re-evaluation: the new tracker inherits the pending
+            // navigation and retires the stale one.
+            const newTracker = createTracker();
+            newTracker.init();
+
+            jest.runAllTimers();
+            expect(loggedPaths()).toEqual(['/route-a']);
+
+            // A subsequent navigation from the new tracker fires as normal.
+            logEvent.mockClear();
+            window.history.pushState({}, '', '/route-b');
+            jest.runAllTimers();
+            expect(loggedPaths()).toEqual(['/route-b']);
+        });
+
+        // Regression: same-instance re-init (e.g. a SPA framework calling
+        // mParticle.init() on navigation) must not drop a page view queued
+        // before the re-init call.
+        it('should preserve a pending page view when the same tracker re-inits', () => {
+            const tracker = createTracker();
+            tracker.init(); // seeds the current page as '/'
+
+            // Route change queues a deferred fire — timer not yet flushed.
+            window.history.pushState({}, '', '/about');
+
+            // SPA framework calls mParticle.init() again before the timer fires.
+            tracker.init();
+
+            jest.runAllTimers();
+            expect(loggedPaths()).toEqual(['/about']);
+        });
+    });
+
+    describe('window-scoped state', () => {
+        it('should not report an initial page view before one is marked', () => {
+            expect(hasInitialPageViewFired()).toBe(false);
+        });
+
+        it('should report the initial page view once marked', () => {
+            markInitialPageViewFired();
+            expect(hasInitialPageViewFired()).toBe(true);
+        });
+
+        it('should clear the tracker and the initial page view flag on reset', () => {
+            const tracker = createTracker();
+            tracker.init();
+            markInitialPageViewFired();
+
+            resetPageViewTracking();
+
+            expect(tracker.isActive).toBe(false);
+            expect(getActiveTracker()).toBeUndefined();
+            expect(hasInitialPageViewFired()).toBe(false);
+            expect(window.history.pushState).toBe(NATIVE_PUSH_STATE);
+        });
+
+        it('should be safe to reset when nothing is tracking', () => {
+            expect(() => resetPageViewTracking()).not.toThrow();
+        });
+
+        // The window keys are a debugging contract: `window.__mpApvTracker__` is
+        // what you inspect in a console to see whether APV is live. Renaming
+        // either of them silently breaks that, so pin the literals.
+        it('should expose its state under the documented window keys', () => {
+            const tracker = createTracker();
+            tracker.init();
+            markInitialPageViewFired();
+
+            expect(WIN_TRACKER_KEY).toBe('__mpApvTracker__');
+            expect(WIN_INIT_PV_KEY).toBe('__mpApvInitPVLogged__');
+            expect((window as any).__mpApvTracker__).toBe(tracker);
+            expect((window as any).__mpApvInitPVLogged__).toBe(true);
         });
     });
 });

--- a/test/src/tests-event-logging.ts
+++ b/test/src/tests-event-logging.ts
@@ -662,8 +662,8 @@ describe('event logging', function() {
             mParticle._resetForTests(MPConfig);
             window.mParticle.config.flags = { autoLogPageView: 'True' };
 
-            // First init — one page view fires; window.__mpApvInitPVLogged__ and
-            // window.__mpApvTracker__ are both set.
+            // First init — one page view fires; window.__mpApv__ now holds both
+            // the tracker and initialPageViewFired.
             mParticle.init(apiKey, window.mParticle.config);
             await waitForCondition(hasIdentifyReturned);
 
@@ -671,8 +671,8 @@ describe('event logging', function() {
             firstBatch.events.filter(e => e.event_type === 'screen_view').length.should.equal(1);
 
             // Simulate Next.js module re-evaluation: a fresh module creates a new
-            // SDK instance with no _PageViewTracker, while window.__mpApvTracker__
-            // and window.__mpApvInitPVLogged__ survive from the previous load.
+            // SDK instance with no _PageViewTracker, while window.__mpApv__ survives
+            // from the previous load.
             const staleTracker = mParticle.getInstance()._PageViewTracker;
             mParticle.getInstance()._PageViewTracker = undefined;
 


### PR DESCRIPTION
## Summary

Follow-up to the review thread on #1331 (["Why do we have a test helper in our code?"](https://github.com/mParticle/mparticle-web-sdk/pull/1331#discussion_r-mp-instance-286) and @crisryantan's suggestion to pull window access behind module-level helpers).

**Behaviour-preserving, with one deliberate widening.** This restructures `pageViewTracker.ts` so its tests can assert the contract instead of the implementation. #1331 has since merged, so this is rebased onto `development` and sits directly on top of it. The one behavioural delta against `development`: #1331's orphaned-wrapper guard moves from the two history wrappers into `safeHandleNavigation`, so it now also covers the popstate path.

The tracker had no observable surface, so the spec reached into privates in 21 places — `tracker['isActive']`, `tracker['lastPath']`, `tracker['originalPushState']`, `tracker['pushStateWrapper']`, `(window as any)[WIN_TRACKER_KEY]`, and a `jest.spyOn` on the private `handleNavigation`. Those assertions pin how the tracker is built, not what it guarantees, so the file could not be refactored without rewriting its tests.

## What changed

**Pure rules extracted as module functions** — `isNewPage`, `supportsHistoryTracking`, `buildPageViewEvent`. No `this`, no globals, no side effects. The dedup rule and the event shape are now assertable without a DOM, a timer, or a tracker instance.

**#1331's window helpers generalised into a full registry** — `getActiveTracker`, `hasInitialPageViewFired`, `markInitialPageViewFired`, `resetPageViewTracking`, superseding `getWindowTracker`/`setWindowTracker`. `typeof window` is checked in exactly one place, and neither the tracker nor `mp-instance` touches the flags directly.

**`PageViewTracker.resetWindowState(instanceTracker)` is gone.** It was a static whose docstring said "call from `_resetForTests`", and it required the caller to know the teardown ordering. `resetPageViewTracking()` takes no argument and resolves the tracker through the registry, which is the authoritative handle after a module re-evaluation. That also fixes the hazard raised in review: `_resetForTests` could clear `instance._PageViewTracker` while a *different*, still-patched tracker was the registered one, leaving its wrapper installed and unreachable.

```diff
-        const instanceTracker = instance._PageViewTracker;
-        if (instanceTracker) {
-            instanceTracker.teardown();
-            instance._PageViewTracker = undefined;
-        }
-        PageViewTracker.resetWindowState(instanceTracker);
+        resetPageViewTracking();
+        instance._PageViewTracker = undefined;
```

**#1331's orphaned-wrapper guard kept and tested.** Moved from the two history wrappers into `safeHandleNavigation`, so it also covers the popstate path. It had no test; it has one now. Worth noting what that test asserts: no event fires either way, because the deferred flush already aborts when inactive — so the guard's real effect is that a dead tracker does *no work* (no dedup walk, no queued timer), and that is what the test pins.

**Four history fields collapsed into one undo closure.** `patchHistory(onNavigate, log)` installs both wrappers and returns the function that undoes them, or `null` when it installed nothing (already wrapped, or a frozen `History` rejected the assignment). The tracker holds `undoHistoryPatch` and nothing else, so there is no half-patched state to inspect and no way to restore the wrong pair. The push/replace duplication (two near-identical wrapper definitions, two restore calls) goes with it.

**Deferred-fire duplication removed.** `init()` and `handleNavigation()` had two copies of the same `setTimeout` block; they now share `scheduleFire()`. The `init()` copy was missing the "aborted, tracker inactive" log, so inherited paths lost that diagnostic.

**Class surface narrowed** to `constructor` / `init()` / `teardown()` / `isActive`:

```diff
 export declare class PageViewTracker {
-    mpInstance: IMParticleWebSDKInstance;
-    static hasInitialPageViewFired(): boolean;
-    static markInitialPageViewFired(): void;
-    static resetWindowState(instanceTracker?: PageViewTracker): void;
+    private readonly mpInstance;
+    get isActive(): boolean;
     init(): void;
     teardown(): void;
-    takePendingNavigations(): string[];
+    private takePendingNavigations;
 }
```

`takePendingNavigations` is private but still reachable across instances (TypeScript scopes `private` to the class, not the instance), so the handoff protocol stays internal. `isActive` replaces the private field the integration test in #1331 was already reading.

**One redundant condition dropped in `completeSDKInitialization`.** The initial page view was guarded by *both* `!mpInstance._PageViewTracker` and the window flag. A tracker can only exist because a previous `init()` created it, and that `init()` either fired the page view or skipped because the flag was already set — so the flag is set in every path where a tracker exists. The nested branch could not change the outcome; the flag is the only real guard.

## Why this is better

- **The tests describe the contract.** 21 private reach-ins → 0. Every assertion is now something a consumer can observe: an event logged, a history method restored, `isActive`, or a registry helper. The next change to this file does not require rewriting its spec.
- **The interesting logic is reachable without a harness.** The dedup rule, the environment check, the event shape, and the history patch are each callable on their own. `patchHistory` has its own describe block with no tracker in sight.
- **Side effects are cornered.** `window` reads/writes live in five short functions at the top of the file; the class touches `window` only to add/remove its listener and to read `location`/`title` at flush time. Previously `window` was reached from eight places across the class and two more from `mp-instance`.
- **There is no test-only API on the tracker.** `resetPageViewTracking()` is a real lifecycle operation — it is what you call to return a page to its pre-APV state — that `_resetForTests` happens to use.
- **Less code doing the same thing.** Two wrapper definitions → one loop. Two deferred-fire blocks → one. Four state fields → one closure. Nine `'mParticle APV: '` prefixes → one `log()`.

## Test plan

- [x] `npx jest` — **658 passed, 0 failed**. `pageViewTracker.spec.ts` goes 33 → 57 tests.
- [x] `karma start test/karma.config.js --browsers ChromeHeadless` — **1089 passed, 0 failed** (`FirefoxHeadless` is not installed locally, so it was excluded; CI covers it).
- [x] `tsc -p .` — clean.
- [x] `eslint src/pageViewTracker.ts` — no new findings (the file was prettier-parseable before and still is; the pre-existing repo-wide `no-undef`/`no-unused-vars` noise from the non-TS-aware config is unchanged).
- [x] Mutation-checked the new spec rather than trusting the green: dropping the pending-navigation transfer, inverting the dedup rule, inverting the `isActive` guard on the deferred flush, reading the path live at flush time, and skipping the rollback on a rejected history patch each fail 1–12 tests. The last of those is caught by exactly one test, so the added rollback case is not redundant coverage.

## Not in this PR

`_resetForTests` itself still ships in `mp-instance.ts`. Removing it is a separate job — **104 call sites across 38 test files**, plus 7 references in `src/` — and it is the karma suite's only reset mechanism. This PR removes the tracker's *participation* in it; the helper's own removal needs its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
