### PR TITLE
feat(apv): attach allowlisted query params to auto page views

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -20,7 +20,8 @@ import {
     SDKEventOptions,
     TransactionAttributes,
 } from '@mparticle/web-sdk';
-import { valueof } from './utils';
+import { getHref, valueof } from './utils';
+import { allowedQueryParams } from './pageViewTracker';
 
 interface DOMHandlerElement extends HTMLElement {
     href?: string;
@@ -144,11 +145,18 @@ export default function Events(
         self.logEvent({ messageType: Types.MessageType.AppStateTransition });
     };
 
+    // The auto page view for the landing page. The SPA navigations that follow it
+    // come from PageViewTracker instead, so both emitters attach the same
+    // allowlisted query params — and this is the one that matters for campaign
+    // attribution, since utm_*/gclid live on the entry URL.
     this.logPageView = function(): void {
         self.logEvent({
             messageType: Types.MessageType.PageView,
             name: 'PageView',
             data: {
+                // Params first so the core fields always win. See
+                // buildPageViewEvent, which does the same for SPA views.
+                ...allowedQueryParams(getHref()),
                 hostname: window.location.hostname,
                 title: window.document.title,
             },

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -165,17 +165,22 @@ export const supportsHistoryTracking = (win: Window | null): boolean =>
 // Mirrors the event shape of the public mParticle.logPageView(), but carries the
 // path and query params captured when the navigation was accepted rather than the
 // live location.
-export const buildPageViewEvent = (data: IPageViewData): BaseEvent => ({
+export const buildPageViewEvent = ({
+    params,
+    hostname,
+    title,
+    path,
+}: IPageViewData): BaseEvent => ({
     messageType: MessageType.PageView,
     name: 'PageView',
     // Params spread first, then the core fields by name, so a core field always
     // wins. No allowlist entry collides with hostname/title/path today; naming
     // them here is what keeps a later addition from silently overwriting one.
     data: {
-        ...data.params,
-        hostname: data.hostname,
-        title: data.title,
-        path: data.path,
+        ...params,
+        hostname,
+        title,
+        path,
     },
     eventType: EventType.Unknown,
 });

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -123,12 +123,18 @@ interface IPendingNavigation {
 export const allowedQueryParams = (href: string): Dictionary<string> =>
     queryStringParser(href, ALLOWED_QUERY_PARAMS);
 
-// The dedup key: pathname plus the allowlisted params, sorted so that reordering
-// the query string is not a new page. Params outside the allowlist never make it
-// into `page.params` and so cannot key a view — nor can the hash.
+// The captured params, in allowlist order. Ordering comes from the constant
+// rather than a sort: it is deterministic without needing a comparator, and it
+// does not depend on the object's insertion order, so reordering the query string
+// cannot produce a different key.
+const capturedNames = (params: Dictionary<string>): string[] =>
+    ALLOWED_QUERY_PARAMS.filter(name => name in params);
+
+// The dedup key: pathname plus the allowlisted params in a fixed order, so that
+// reordering the query string is not a new page. Params outside the allowlist
+// never make it into `page.params` and so cannot key a view — nor can the hash.
 export const pageKey = (page: IPageSnapshot): string => {
-    const query = Object.keys(page.params)
-        .sort()
+    const query = capturedNames(page.params)
         .map(name => `${name}=${page.params[name]}`)
         .join('&');
 
@@ -260,7 +266,7 @@ const describePage = (page: IPageSnapshot | null): string => {
         return 'null';
     }
 
-    const names = Object.keys(page.params).sort();
+    const names = capturedNames(page.params);
     return names.length ? `${page.path} (params: ${names.join()})` : page.path;
 };
 

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -1,6 +1,7 @@
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { BaseEvent } from './sdkRuntimeModels';
 import { EventType, MessageType } from './types';
+import { Dictionary, getHref, queryStringParser } from './utils';
 
 type HistoryStateMethod = History['pushState'];
 type HistoryMethodName = 'pushState' | 'replaceState';
@@ -41,14 +42,71 @@ type WindowWithApv = Window & {
     [WIN_APV_KEY]?: IApvState;
 };
 
-interface IPageViewData {
+// The query params an auto page view may carry. An allowlist, not a denylist:
+// partner URLs routinely hold order ids, email addresses and session tokens, and
+// none of those should reach the event stream because someone forgot to exclude
+// them. Anything absent from this list is dropped.
+//
+// SECURITY: `code`, `state` and `nonce` are the OAuth 2.0 / OIDC authorization
+// code and the CSRF/replay tokens. They are credentials until redeemed, and
+// attaching them here persists them in the event store and forwards them to
+// every configured kit. They are on the list by explicit product decision —
+// deleting that line is the whole of the fix if that decision is revisited.
+export const ALLOWED_QUERY_PARAMS: string[] = [
+    // Campaign attribution
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'utm_id',
+
+    // Ad-network click ids
+    'gclid',
+    'gbraid',
+    'wbraid',
+    'fbclid',
+    'msclkid',
+    'ttclid',
+    'twclid',
+    'li_fat_id',
+    'dclid',
+
+    // OAuth / OIDC — see the SECURITY note above
+    'client_id',
+    'redirect_uri',
+    'response_type',
+    'scope',
+    'state',
+    'code',
+    'nonce',
+
+    // Pagination and search
+    'page',
+    'limit',
+    'offset',
+    'cursor',
+    'per_page',
+    'q',
+    'search',
+
+    // Referral
+    'ref',
+    'referrer',
+];
+
+interface IPageSnapshot {
+    path: string;
+    params: Dictionary<string>;
+}
+
+interface IPageViewData extends IPageSnapshot {
     hostname: string;
     title: string;
-    path: string;
 }
 
 interface IPendingNavigation {
-    path: string;
+    page: IPageSnapshot;
     timeoutId: ReturnType<typeof setTimeout>;
 }
 
@@ -57,12 +115,33 @@ interface IPendingNavigation {
 // on their own, which is where the interesting rules live.
 // ---------------------------------------------------------------------------
 
-// Dedup keys on pathname only: a query-string- or hash-only change is the same
-// page and must not fire a view.
+// Pulls the allowlisted query params off a URL. Delegates to the SDK's own
+// parser, which lowercases keys (so `?UTM_Source=` and `?utm_source=` land on one
+// attribute), drops empty values, and carries the fallback for browsers without
+// URLSearchParams. Tolerates an empty href, so SSR yields no params rather than
+// throwing.
+export const allowedQueryParams = (href: string): Dictionary<string> =>
+    queryStringParser(href, ALLOWED_QUERY_PARAMS);
+
+// The dedup key: pathname plus the allowlisted params, sorted so that reordering
+// the query string is not a new page. Params outside the allowlist never make it
+// into `page.params` and so cannot key a view — nor can the hash.
+export const pageKey = (page: IPageSnapshot): string => {
+    const query = Object.keys(page.params)
+        .sort()
+        .map(name => `${name}=${page.params[name]}`)
+        .join('&');
+
+    return query ? `${page.path}?${query}` : page.path;
+};
+
+// Dedup keys on the pageKey above: a change to any captured param is a new page
+// (`?page=2` is a distinct pagination view), while a hash-only change, or a
+// change confined to params we do not capture, is the same page.
 export const isNewPage = (
-    lastPath: string | null,
-    candidatePath: string
-): boolean => candidatePath !== lastPath;
+    lastKey: string | null,
+    candidateKey: string
+): boolean => candidateKey !== lastKey;
 
 export const supportsHistoryTracking = (win: Window | null): boolean =>
     !!win &&
@@ -71,11 +150,18 @@ export const supportsHistoryTracking = (win: Window | null): boolean =>
     typeof win.addEventListener === 'function';
 
 // Mirrors the event shape of the public mParticle.logPageView(), but carries the
-// path captured when the navigation was accepted rather than the live location.
-export const buildPageViewEvent = (data: IPageViewData): BaseEvent => ({
+// path and query params captured when the navigation was accepted rather than the
+// live location.
+export const buildPageViewEvent = ({
+    params,
+    ...page
+}: IPageViewData): BaseEvent => ({
     messageType: MessageType.PageView,
     name: 'PageView',
-    data: { ...data },
+    // Params spread first so the core fields always win. No allowlist entry
+    // collides with hostname/title/path today; this ordering is what keeps a
+    // later addition from silently overwriting one.
+    data: { ...params, ...page },
     eventType: EventType.Unknown,
 });
 
@@ -160,7 +246,23 @@ const clearActiveTracker = (tracker: PageViewTracker): void => {
     }
 };
 
-const currentPathname = (): string => window.location.pathname;
+const currentPage = (): IPageSnapshot => ({
+    path: window.location.pathname,
+    params: allowedQueryParams(getHref()),
+});
+
+// Log-safe description of a page: the path, plus the NAMES of the captured
+// params. Values are deliberately omitted — verbose logging goes to the console,
+// and session-replay tooling ships console output off-domain, which is not a
+// place for an OAuth code or a consumer's search terms.
+const describePage = (page: IPageSnapshot | null): string => {
+    if (!page) {
+        return 'null';
+    }
+
+    const names = Object.keys(page.params).sort();
+    return names.length ? `${page.path} (params: ${names.join()})` : page.path;
+};
 
 // ---------------------------------------------------------------------------
 // History patching
@@ -250,7 +352,7 @@ export const patchHistory = (
 export class PageViewTracker {
     private readonly mpInstance: IMParticleWebSDKInstance;
 
-    private lastPath: string | null = null;
+    private lastPage: IPageSnapshot | null = null;
     private active = false;
     private pendingNavigations: IPendingNavigation[] = [];
 
@@ -285,14 +387,14 @@ export class PageViewTracker {
         // dropped — a route change may have queued a deferred fire that has not
         // flushed yet, and dropping it loses a page view entirely.
         const active = getActiveTracker();
-        let inheritedPaths = this.retire(active);
+        let inheritedPages = this.retire(active);
         if (this.active && active !== this) {
-            inheritedPaths = inheritedPaths.concat(this.retire(this));
+            inheritedPages = inheritedPages.concat(this.retire(this));
         }
 
         this.active = true;
-        this.lastPath = currentPathname();
-        this.log(`[init] seeded lastPath: ${this.lastPath}`);
+        this.lastPage = currentPage();
+        this.log(`[init] seeded lastPage: ${describePage(this.lastPage)}`);
 
         this.undoHistoryPatch = patchHistory(
             source => this.safeHandleNavigation(source),
@@ -307,7 +409,7 @@ export class PageViewTracker {
             '[init] patched pushState/replaceState + listening for popstate'
         );
 
-        inheritedPaths.forEach(path => this.scheduleFire(path));
+        inheritedPages.forEach(page => this.scheduleFire(page));
     }
 
     public teardown(): void {
@@ -330,10 +432,10 @@ export class PageViewTracker {
         clearActiveTracker(this);
     }
 
-    // Stops the outgoing tracker and returns the paths it had queued so this
+    // Stops the outgoing tracker and returns the pages it had queued so this
     // tracker can re-schedule them once it is active. Private, but reachable
     // across instances: the handoff protocol stays internal to the class.
-    private retire(outgoing: PageViewTracker | undefined): string[] {
+    private retire(outgoing: PageViewTracker | undefined): IPageSnapshot[] {
         if (!outgoing) {
             return [];
         }
@@ -344,17 +446,17 @@ export class PageViewTracker {
                 : '[init] retiring a tracker from a previous module load — transferring pending navigations and tearing down'
         );
 
-        const paths = outgoing.takePendingNavigations();
+        const pages = outgoing.takePendingNavigations();
         outgoing.teardown();
-        return paths;
+        return pages;
     }
 
-    // Cancels this tracker's deferred fires and hands back their captured paths.
-    private takePendingNavigations(): string[] {
+    // Cancels this tracker's deferred fires and hands back their captured pages.
+    private takePendingNavigations(): IPageSnapshot[] {
         const pending = this.pendingNavigations;
         this.pendingNavigations = [];
         pending.forEach(p => clearTimeout(p.timeoutId));
-        return pending.map(p => p.path);
+        return pending.map(p => p.page);
     }
 
     private safeHandleNavigation(source: NavigationSource): void {
@@ -377,31 +479,39 @@ export class PageViewTracker {
     }
 
     private handleNavigation(source: NavigationSource): void {
-        const candidatePath = currentPathname();
+        const candidate = currentPage();
+        const lastKey = this.lastPage ? pageKey(this.lastPage) : null;
 
         this.log(
-            `[detect] navigation signal (source: ${source}, candidatePath: ${candidatePath}, lastPath: ${this.lastPath})`
+            `[detect] navigation signal (source: ${source}, candidate: ${describePage(
+                candidate
+            )}, last: ${describePage(this.lastPage)})`
         );
 
-        if (!isNewPage(this.lastPath, candidatePath)) {
+        if (!isNewPage(lastKey, pageKey(candidate))) {
             this.log(
-                `[dedupe] pathname unchanged, skipping (source: ${source}, path: ${candidatePath})`
+                `[dedupe] page unchanged, skipping (source: ${source}, page: ${describePage(
+                    candidate
+                )})`
             );
             return;
         }
 
         this.log(
-            `[accept] pathname changed, scheduling fire (source: ${source}, from: ${this.lastPath}, to: ${candidatePath})`
+            `[accept] page changed, scheduling fire (source: ${source}, from: ${describePage(
+                this.lastPage
+            )}, to: ${describePage(candidate)})`
         );
-        this.lastPath = candidatePath;
-        this.scheduleFire(candidatePath);
+        this.lastPage = candidate;
+        this.scheduleFire(candidate);
     }
 
     // Deferred by a macrotask so the router's post-navigation render commit has a
-    // chance to update document.title before the event is built. The path is
-    // snapshotted now because it is already settled, whereas a same-tick
-    // navigation would overwrite window.location before the flush reads it.
-    private scheduleFire(path: string): void {
+    // chance to update document.title before the event is built. The path and
+    // query params are snapshotted now because they are already settled, whereas a
+    // same-tick navigation would overwrite window.location before the flush reads
+    // it.
+    private scheduleFire(page: IPageSnapshot): void {
         const timeoutId = setTimeout(() => {
             this.pendingNavigations = this.pendingNavigations.filter(
                 p => p.timeoutId !== timeoutId
@@ -415,22 +525,24 @@ export class PageViewTracker {
             }
 
             this.mpInstance._SessionManager.resetSessionTimer();
-            this.firePageView(path);
+            this.firePageView(page);
         }, 0);
 
-        this.pendingNavigations.push({ path, timeoutId });
+        this.pendingNavigations.push({ page, timeoutId });
     }
 
-    private firePageView(path: string): void {
+    private firePageView(page: IPageSnapshot): void {
         const title = window.document.title;
         const event = buildPageViewEvent({
+            ...page,
             hostname: window.location.hostname,
             title,
-            path,
         });
 
         this.log(
-            `[fire] deferred flush -> _Events.logEvent(PageView) (path: ${path}, title: ${title})`
+            `[fire] deferred flush -> _Events.logEvent(PageView) (page: ${describePage(
+                page
+            )}, title: ${title})`
         );
 
         this.mpInstance._Events.logEvent(event);

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -477,8 +477,8 @@ export class PageViewTracker {
     private takePendingNavigations(): IPageSnapshot[] {
         const pending = this.pendingNavigations;
         this.pendingNavigations = [];
-        pending.forEach(p => clearTimeout(p.timeoutId));
-        return pending.map(p => p.page);
+        pending.forEach(({ timeoutId }) => clearTimeout(timeoutId));
+        return pending.map(({ page }) => page);
     }
 
     private safeHandleNavigation(source: NavigationSource): void {

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -133,9 +133,16 @@ const capturedNames = (params: Dictionary<string>): string[] =>
 // The dedup key: pathname plus the allowlisted params in a fixed order, so that
 // reordering the query string is not a new page. Params outside the allowlist
 // never make it into `page.params` and so cannot key a view — nor can the hash.
+//
+// Values are re-encoded because queryStringParser hands them back DECODED. A
+// value holding the pair delimiters would otherwise serialize exactly like two
+// separate params — `{q: 'a&search=b'}` and `{q: 'a', search: 'b'}` both becoming
+// `q=a&search=b` — and dedup would treat a real navigation between them as the
+// same page and drop the view. `q`, `search` and `redirect_uri` carry `&` and `=`
+// routinely, so this is reachable rather than theoretical.
 export const pageKey = (page: IPageSnapshot): string => {
     const query = capturedNames(page.params)
-        .map(name => `${name}=${page.params[name]}`)
+        .map(name => `${name}=${encodeURIComponent(page.params[name])}`)
         .join('&');
 
     return query ? `${page.path}?${query}` : page.path;
@@ -158,16 +165,18 @@ export const supportsHistoryTracking = (win: Window | null): boolean =>
 // Mirrors the event shape of the public mParticle.logPageView(), but carries the
 // path and query params captured when the navigation was accepted rather than the
 // live location.
-export const buildPageViewEvent = ({
-    params,
-    ...page
-}: IPageViewData): BaseEvent => ({
+export const buildPageViewEvent = (data: IPageViewData): BaseEvent => ({
     messageType: MessageType.PageView,
     name: 'PageView',
-    // Params spread first so the core fields always win. No allowlist entry
-    // collides with hostname/title/path today; this ordering is what keeps a
-    // later addition from silently overwriting one.
-    data: { ...params, ...page },
+    // Params spread first, then the core fields by name, so a core field always
+    // wins. No allowlist entry collides with hostname/title/path today; naming
+    // them here is what keeps a later addition from silently overwriting one.
+    data: {
+        ...data.params,
+        hostname: data.hostname,
+        title: data.title,
+        path: data.path,
+    },
     eventType: EventType.Unknown,
 });
 
@@ -261,9 +270,11 @@ const currentPage = (): IPageSnapshot => ({
 // params. Values are deliberately omitted — verbose logging goes to the console,
 // and session-replay tooling ships console output off-domain, which is not a
 // place for an OAuth code or a consumer's search terms.
+// Only reachable before init() assigns lastPage, which is ahead of any navigation
+// handler being able to run, so this returns nothing rather than a sentinel.
 const describePage = (page: IPageSnapshot | null): string => {
     if (!page) {
-        return 'null';
+        return '';
     }
 
     const names = capturedNames(page.params);

--- a/test/jest/events-page-view.spec.ts
+++ b/test/jest/events-page-view.spec.ts
@@ -1,0 +1,85 @@
+import Events from '../../src/events';
+import { IEvents } from '../../src/events.interfaces';
+import { IMParticleWebSDKInstance } from '../../src/mp-instance';
+import { MessageType } from '../../src/types';
+
+// _Events.logPageView is the auto page view for the LANDING page — the SPA
+// navigations that follow it come from PageViewTracker instead. It is therefore
+// the emitter that carries campaign attribution, since utm_*/gclid live on the
+// entry URL, and it needs its own coverage for the query-param allowlist.
+describe('Events#logPageView', () => {
+    let events: IEvents;
+    let createEventObject: jest.Mock;
+    let originalUrl: string;
+
+    const loggedPageView = (): any => createEventObject.mock.calls[0][0];
+
+    beforeEach(() => {
+        originalUrl = window.location.pathname + window.location.search;
+
+        createEventObject = jest.fn(event => event);
+
+        const mpInstance = ({
+            Logger: { verbose: jest.fn() },
+            _Helpers: { canLog: () => true },
+            _ServerModel: { createEventObject },
+            _APIClient: { sendEventToServer: jest.fn() },
+        } as unknown) as IMParticleWebSDKInstance;
+
+        events = {} as IEvents;
+        Events.call(events, mpInstance);
+    });
+
+    afterEach(() => {
+        window.history.replaceState({}, '', originalUrl);
+    });
+
+    it('should log a PageView carrying hostname and title', () => {
+        window.document.title = 'Landing';
+
+        events.logPageView();
+
+        expect(loggedPageView()).toEqual({
+            messageType: MessageType.PageView,
+            name: 'PageView',
+            eventType: 0,
+            data: { hostname: 'localhost', title: 'Landing' },
+        });
+    });
+
+    it('should attach the allowlisted query params as flat attributes', () => {
+        window.document.title = 'Landing';
+        window.history.replaceState(
+            {},
+            '',
+            '/?utm_source=google&utm_medium=cpc&gclid=Cj0KC'
+        );
+
+        events.logPageView();
+
+        expect(loggedPageView().data).toEqual({
+            hostname: 'localhost',
+            title: 'Landing',
+            utm_source: 'google',
+            utm_medium: 'cpc',
+            gclid: 'Cj0KC',
+        });
+    });
+
+    // The allowlist is the point: a partner URL carrying an email or an order id
+    // must not leak into the event stream just because nobody excluded it.
+    it('should drop params that are not allowlisted', () => {
+        window.history.replaceState(
+            {},
+            '',
+            '/?utm_source=google&email=someone@example.com&order_id=42'
+        );
+
+        events.logPageView();
+
+        const { data } = loggedPageView();
+        expect(data.utm_source).toBe('google');
+        expect(data).not.toHaveProperty('email');
+        expect(data).not.toHaveProperty('order_id');
+    });
+});

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -1,9 +1,12 @@
 import {
+    ALLOWED_QUERY_PARAMS,
+    allowedQueryParams,
     buildPageViewEvent,
     getActiveTracker,
     hasInitialPageViewFired,
     isNewPage,
     markInitialPageViewFired,
+    pageKey,
     PageViewTracker,
     patchHistory,
     resetPageViewTracking,
@@ -45,17 +48,87 @@ const unmarkedForeignWrapper = (): History['pushState'] =>
 // ---------------------------------------------------------------------------
 
 describe('pageViewTracker pure helpers', () => {
+    describe('#allowedQueryParams', () => {
+        it('should keep an allowlisted param', () => {
+            expect(
+                allowedQueryParams('https://example.com/?utm_source=google')
+            ).toEqual({ utm_source: 'google' });
+        });
+
+        // The allowlist is the whole point: anything not named is dropped, so a
+        // partner URL carrying an order id or an email cannot leak through.
+        it('should drop a param that is not allowlisted', () => {
+            expect(
+                allowedQueryParams(
+                    'https://example.com/?utm_source=google&email=someone@example.com&order_id=42'
+                )
+            ).toEqual({ utm_source: 'google' });
+        });
+
+        it('should fold key casing onto the allowlisted name', () => {
+            expect(
+                allowedQueryParams('https://example.com/?UTM_Source=google')
+            ).toEqual({ utm_source: 'google' });
+        });
+
+        it('should return nothing for a URL with no query string', () => {
+            expect(allowedQueryParams('https://example.com/cart')).toEqual({});
+        });
+
+        // getHref() yields '' under SSR, so this is the path that must not throw.
+        it('should return nothing for an empty href', () => {
+            expect(allowedQueryParams('')).toEqual({});
+        });
+
+        it('should keep every param on the allowlist', () => {
+            const query = ALLOWED_QUERY_PARAMS.map(
+                name => `${name}=v-${name}`
+            ).join('&');
+
+            expect(
+                Object.keys(allowedQueryParams(`https://example.com/?${query}`))
+            ).toHaveLength(ALLOWED_QUERY_PARAMS.length);
+        });
+    });
+
+    describe('#pageKey', () => {
+        it('should be the pathname alone when no params are captured', () => {
+            expect(pageKey({ path: '/cart', params: {} })).toBe('/cart');
+        });
+
+        it('should include the captured params', () => {
+            expect(pageKey({ path: '/search', params: { q: 'shoes' } })).toBe(
+                '/search?q=shoes'
+            );
+        });
+
+        // Sorted, so a router that reorders the query string on an otherwise
+        // identical navigation does not produce a spurious second page view.
+        it('should be stable against param reordering', () => {
+            const a = pageKey({ path: '/s', params: { q: 'x', page: '2' } });
+            const b = pageKey({ path: '/s', params: { page: '2', q: 'x' } });
+
+            expect(a).toBe(b);
+        });
+
+        it('should distinguish two values of the same param', () => {
+            expect(pageKey({ path: '/s', params: { page: '1' } })).not.toBe(
+                pageKey({ path: '/s', params: { page: '2' } })
+            );
+        });
+    });
+
     describe('#isNewPage', () => {
-        it('should treat a different pathname as a new page', () => {
+        it('should treat a different key as a new page', () => {
             expect(isNewPage('/a', '/b')).toBe(true);
         });
 
-        it('should treat an identical pathname as the same page', () => {
+        it('should treat an identical key as the same page', () => {
             expect(isNewPage('/a', '/a')).toBe(false);
         });
 
-        // The caller passes pathnames only, so query strings and hashes never
-        // reach here — which is exactly why they cannot trigger a page view.
+        // The caller passes pageKey() output, so an unallowlisted param and the
+        // hash are already absent — which is why they cannot trigger a view.
         it('should treat the first navigation after construction as new', () => {
             expect(isNewPage(null, '/a')).toBe(true);
         });
@@ -100,6 +173,7 @@ describe('pageViewTracker pure helpers', () => {
                 hostname: 'example.com',
                 title: 'Cart',
                 path: '/cart',
+                params: {},
             });
 
             expect(event).toEqual({
@@ -114,13 +188,51 @@ describe('pageViewTracker pure helpers', () => {
             });
         });
 
+        it('should flatten the captured params alongside the core fields', () => {
+            const event = buildPageViewEvent({
+                hostname: 'example.com',
+                title: 'Cart',
+                path: '/cart',
+                params: { utm_source: 'google', gclid: 'Cj0KC' },
+            });
+
+            expect(event.data).toEqual({
+                hostname: 'example.com',
+                title: 'Cart',
+                path: '/cart',
+                utm_source: 'google',
+                gclid: 'Cj0KC',
+            });
+        });
+
+        // No allowlist entry collides with the core fields today; this asserts the
+        // spread ordering that keeps a later addition from overwriting one.
+        it('should not let a param overwrite a core field', () => {
+            const event = buildPageViewEvent({
+                hostname: 'example.com',
+                title: 'Cart',
+                path: '/cart',
+                params: { path: '/spoofed', hostname: 'evil.com' },
+            });
+
+            expect(event.data.path).toBe('/cart');
+            expect(event.data.hostname).toBe('example.com');
+        });
+
         it('should not alias the caller data into the event', () => {
-            const data = { hostname: 'example.com', title: 'Cart', path: '/cart' };
+            const data = {
+                hostname: 'example.com',
+                title: 'Cart',
+                path: '/cart',
+                params: { q: 'shoes' },
+            };
             const event = buildPageViewEvent(data);
 
             data.path = '/mutated-after-the-fact';
+            data.params.q = 'mutated-after-the-fact';
 
             expect(event.data.path).toBe('/cart');
+            expect(event.data.q).toBe('shoes');
         });
     });
 });
@@ -350,9 +462,9 @@ describe('PageViewTracker', () => {
             expect(getActiveTracker()).toBe(tracker);
         });
 
-        // The seed is the pathname alone, so a query-string change against the
-        // landing URL is still the same page.
-        it('should seed the current page by pathname only', () => {
+        // The seed is the pathname plus the allowlisted params, so a change to an
+        // unallowlisted param (`tab`) against the landing URL is the same page.
+        it('should seed the current page by path and allowlisted params only', () => {
             navigateNatively('/dashboard?tab=1#section');
 
             const tracker = createTracker();
@@ -365,6 +477,24 @@ describe('PageViewTracker', () => {
             window.history.pushState({}, '', '/settings');
             jest.runAllTimers();
             expect(loggedPaths()).toEqual(['/settings']);
+        });
+
+        // The seed includes the params, so arriving on `?page=2` and navigating to
+        // `?page=3` is a fresh view rather than a dedup against the landing URL.
+        it('should seed the allowlisted params so a change to one fires', () => {
+            navigateNatively('/dashboard?page=2');
+
+            const tracker = createTracker();
+            tracker.init();
+
+            window.history.pushState({}, '', '/dashboard?page=2');
+            jest.runAllTimers();
+            expect(logEvent).not.toHaveBeenCalled();
+
+            window.history.pushState({}, '', '/dashboard?page=3');
+            jest.runAllTimers();
+            expect(logEvent).toHaveBeenCalledTimes(1);
+            expect(logEvent.mock.calls[0][0].data.page).toBe('3');
         });
 
         it('should patch pushState/replaceState and register listeners', () => {
@@ -493,13 +623,30 @@ describe('PageViewTracker', () => {
             expect(logEvent).not.toHaveBeenCalled();
         });
 
-        // Dedup keys on pathname only, so a query-string-only change is treated
-        // as the same page and does not fire.
-        it('should not fire a view on a query-string-only change', () => {
+        // Dedup keys on the pathname plus the allowlisted params, so a change
+        // confined to a param we do not capture is the same page.
+        it('should not fire a view on an unallowlisted query-param change', () => {
             window.history.pushState({}, '', '/?tab=settings');
             jest.runAllTimers();
 
             expect(logEvent).not.toHaveBeenCalled();
+        });
+
+        // The counterpart: an allowlisted param IS part of the key, which is what
+        // makes pagination and search navigations visible at all.
+        it('should fire a view on an allowlisted query-param change', () => {
+            window.history.pushState({}, '', '/?q=shoes');
+            jest.runAllTimers();
+
+            expect(logEvent).toHaveBeenCalledTimes(1);
+
+            window.history.pushState({}, '', '/?q=boots');
+            jest.runAllTimers();
+
+            expect(logEvent).toHaveBeenCalledTimes(2);
+            expect(
+                logEvent.mock.calls.map(([event]) => event.data.q)
+            ).toEqual(['shoes', 'boots']);
         });
 
         // Hash support is deferred to a follow-up; a hash-only change leaves the
@@ -598,20 +745,79 @@ describe('PageViewTracker', () => {
             tracker.init();
 
             window.document.title = 'Next Page';
-            window.history.pushState({}, '', '/next?q=1#top');
+            window.history.pushState({}, '', '/next?tab=1#top');
             jest.runAllTimers();
 
             expect(logEvent).toHaveBeenCalledTimes(1);
             const [event] = logEvent.mock.calls[0];
-            expect(event).toMatchObject({
+            expect(event).toEqual({
                 messageType: MessageType.PageView,
                 name: 'PageView',
+                eventType: EventType.Unknown,
                 data: {
                     hostname: 'localhost',
                     title: 'Next Page',
                     path: '/next',
                 },
             });
+        });
+
+        it('should attach the allowlisted query params as flat attributes', () => {
+            navigateNatively('/');
+            const tracker = createTracker();
+            tracker.init();
+
+            window.document.title = 'Landing';
+            window.history.pushState(
+                {},
+                '',
+                '/promo?utm_source=google&utm_medium=cpc&gclid=Cj0KC&session_token=secret#top'
+            );
+            jest.runAllTimers();
+
+            expect(logEvent.mock.calls[0][0].data).toEqual({
+                hostname: 'localhost',
+                title: 'Landing',
+                path: '/promo',
+                utm_source: 'google',
+                utm_medium: 'cpc',
+                gclid: 'Cj0KC',
+            });
+        });
+
+        // Each deferred fire carries the params captured when its navigation was
+        // accepted, for the same reason as the path: a same-tick navigation would
+        // otherwise overwrite window.location before the flush reads it.
+        it('should capture the params at navigation time, not flush time', () => {
+            navigateNatively('/a');
+            const tracker = createTracker();
+            tracker.init();
+
+            window.history.pushState({}, '', '/b?utm_source=first');
+            window.history.pushState({}, '', '/c?utm_source=second');
+
+            jest.runAllTimers();
+
+            expect(
+                logEvent.mock.calls.map(([event]) => event.data.utm_source)
+            ).toEqual(['first', 'second']);
+        });
+
+        // Verbose logging goes to the console, and session-replay tooling ships
+        // console output off-domain. Param names are useful for debugging dedup;
+        // the values are not worth the exposure.
+        it('should log param names but never their values', () => {
+            navigateNatively('/');
+            const tracker = createTracker();
+            tracker.init();
+
+            window.history.pushState({}, '', '/callback?code=SECRET-AUTH-CODE');
+            jest.runAllTimers();
+
+            const logged = verbose.mock.calls.map(([message]) => message).join('\n');
+
+            expect(logged).toContain('code');
+            expect(logged).not.toContain('SECRET-AUTH-CODE');
         });
 
         // The title is read at flush time, not when the navigation is accepted,

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -92,6 +92,14 @@ describe('pageViewTracker pure helpers', () => {
     });
 
     describe('#pageKey', () => {
+        // Builds a snapshot the way currentPage() does, so a case can be stated
+        // as a URL and still exercise the real parser rather than a hand-made
+        // params object.
+        const pageFromHref = (href: string) => ({
+            path: new URL(href).pathname,
+            params: allowedQueryParams(href),
+        });
+
         it('should be the pathname alone when no params are captured', () => {
             expect(pageKey({ path: '/cart', params: {} })).toBe('/cart');
         });
@@ -115,6 +123,31 @@ describe('pageViewTracker pure helpers', () => {
             expect(pageKey({ path: '/s', params: { page: '1' } })).not.toBe(
                 pageKey({ path: '/s', params: { page: '2' } })
             );
+        });
+
+        // queryStringParser hands values back DECODED, so a value carrying the
+        // pair delimiters would serialize exactly like two separate params and
+        // dedup a real navigation away. `search` follows `q` in the allowlist, so
+        // the two below collide unless the value is re-encoded.
+        it('should not collide when a value contains the pair delimiters', () => {
+            const injected = pageKey({
+                path: '/s',
+                params: { q: 'a&search=b' },
+            });
+            const genuine = pageKey({
+                path: '/s',
+                params: { q: 'a', search: 'b' },
+            });
+
+            expect(injected).not.toBe(genuine);
+        });
+
+        // The same collision reached through the tracker rather than by hand:
+        // ?q=a%26search%3Db and ?q=a&search=b are different pages.
+        it('should fire a view between a colliding encoded and real pair', () => {
+            expect(
+                pageKey(pageFromHref('https://x.com/s?q=a%26search%3Db'))
+            ).not.toBe(pageKey(pageFromHref('https://x.com/s?q=a&search=b')));
         });
     });
 


### PR DESCRIPTION
## Summary

The auto page view carried `hostname`, `title` and — for SPA navigations — `path`. The query string was never read, so campaign attribution and pagination context were absent from every APV event.

Both APV emitters now attach an allowlisted set of query params as flat event attributes.

```js
// before
data: { hostname: 'shop.example.com', title: 'Shoes', path: '/search' }

// after
data: {
  hostname: 'shop.example.com',
  title:    'Shoes',
  path:     '/search',
  utm_source: 'google',
  utm_medium: 'cpc',
  gclid:      'Cj0KC...',
}
```

## There are two APV emitters, and only one is the tracker

This is the part worth reviewing carefully. The APV feature fires from two places:

| | emitter | fires on |
| :-- | :-- | :-- |
| Landing page view | `_Events.logPageView()` (`src/events.ts`) | `mParticle.init()` |
| SPA navigations | `PageViewTracker.firePageView()` | `pushState` / `replaceState` / `popstate` |

The **landing** view is the one that matters for campaign attribution, because `utm_*` and `gclid` live on the entry URL by definition. Patching only the tracker would have shipped a change that captured attribution params approximately never. Both are changed.

## Filtering reuses the existing parser

`utils.queryStringParser(url, keys)` already does allowlist matching, lowercases keys (so `?UTM_Source=` and `?utm_source=` land on one attribute), drops empty values, and carries the fallback for browsers without `URLSearchParams`. `integrationCapture.ts` already consumes it the same way. The new helper is one line:

```ts
export const allowedQueryParams = (href: string): Dictionary<string> =>
    queryStringParser(href, ALLOWED_QUERY_PARAMS);
```

It takes `getHref()`, which yields `''` under SSR, so that path returns no params rather than throwing.

## An allowlist, not a denylist

Partner URLs routinely hold order ids, email addresses and session tokens. None of those should reach the event stream because nobody remembered to exclude them, so anything absent from `ALLOWED_QUERY_PARAMS` is dropped. 31 params, grouped:

- **Campaign attribution** — `utm_source` `utm_medium` `utm_campaign` `utm_term` `utm_content` `utm_id`
- **Ad-network click ids** — `gclid` `gbraid` `wbraid` `fbclid` `msclkid` `ttclid` `twclid` `li_fat_id` `dclid`
- **OAuth / OIDC** — `client_id` `redirect_uri` `response_type` `scope` `state` `code` `nonce`
- **Pagination and search** — `page` `limit` `offset` `cursor` `per_page` `q` `search`
- **Referral** — `ref` `referrer`

Params are spread **before** the core fields, so a future allowlist addition cannot silently overwrite `hostname` / `title` / `path`. No current entry collides; the ordering and its test are what keep it that way.

## ⚠️ SECURITY: `code`, `state` and `nonce` are on the list by explicit product decision

These are the OAuth 2.0 / OIDC authorization code and the CSRF/replay tokens. They are credentials until redeemed. Attaching them means they are persisted in the event store and forwarded to every configured kit.

This was raised and the decision was to include them. A `SECURITY:` comment above `ALLOWED_QUERY_PARAMS` records that, so it reads as a decision rather than an accident, and removing those three entries is the whole of the rollback. Flagging here so reviewers see it rather than discover it.

`q` carries the same shape of risk at lower severity — free-text consumer search queries routinely contain PII.

## Behaviour change: dedup now keys on the params too

Dedup was `pathname` only. It is now `pathname` + the allowlisted params, sorted so that reordering the query string is not a new page.

- `?page=2` → `?page=3` **now fires** a page view. Without this, `page` / `limit` / `offset` / `cursor` / `per_page` / `q` would be captured only on navigations that also changed the path — i.e. almost never.
- `?tab=1` → `?tab=2` (unallowlisted) still fires nothing.
- A hash-only change still fires nothing.

**This raises APV event volume**, and reviewers should size that against their own traffic. The sharp edge is search: an SPA that pushes `?q=` per keystroke will emit a page view per keystroke. If that is unacceptable, dropping `q` from the allowlist (or reverting dedup to path-only) are both one-line changes.

## Verbose logs print param names, never values

Not requested, but console output is captured and shipped off-domain by session-replay tooling, which is not a place for an OAuth code or a consumer's search terms. `describePage()` emits `/callback (params: code)`, never the value. Asserted by a test.

## Verification

- `jest` — **692 pass / 0 fail** (was 679; +13)
- `karma` ChromeHeadless — **1089 pass / 0 fail**
- `tsc -p .` clean, `eslint src/ test/src/` clean
- **Mutation-checked.** Seven deliberate breakages, each caught by a named test: unsorted dedup key, params spread after the core fields, allowlist removed, `describePage` logging values, params re-read at flush time instead of navigation time, dedup reverted to path-only, and the spread dropped from `events.ts`.

New coverage: `#allowedQueryParams` (6), `#pageKey` (4), `#buildPageViewEvent` params + collision + aliasing, allowlisted-vs-unallowlisted dedup, capture-at-navigation-time, the log-safety assertion, and a new `test/jest/events-page-view.spec.ts` (3) for the landing-page emitter.

> The landing-page assertions are in a new jest spec rather than the karma suite deliberately. Asserting it in karma requires mutating `window.location` while a live `PageViewTracker` is patched into `history`, which queues deferred page views that land in the *next* test and broke two sibling APV tests. The jest spec drives `Events` against a stub instance instead — isolated, deterministic, no bundle rebuild.

## Out of scope, flagged for follow-up

1. **`serverModel.ts:357` sends `window.location.href` as `LaunchReferral`** on session start — the full URL, every param, unfiltered. That predates this PR and is a wider exposure than anything the allowlist governs. This PR does not touch it.
2. **The landing page view still has no `path` attribute** while SPA views do, so downstream cannot tell which page the entry view was for. One line to fix, but it changes the shape of an existing event, so it wants a data-plan decision first.
3. **New attribute keys need adding to consumers' mParticle data plans** before they will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
