### PR TITLE
refactor: address ecommerce review types without changing runtime

### DIFF
--- a/src/ecommerce.interfaces.ts
+++ b/src/ecommerce.interfaces.ts
@@ -1,19 +1,10 @@
 import {
-    ProductAction,
-    Product,
-    Promotion,
-    CommerceEvent,
-} from '@mparticle/event-models';
-import {
     SDKEventAttrs,
     SDKEventOptions,
     TransactionAttributes,
 } from '@mparticle/web-sdk';
 import { valueof } from './utils';
-import {
-    ProductActionType,
-    PromotionActionType,
-} from './types';
+import { ProductActionType, PromotionActionType } from './types';
 import {
     SDKEvent,
     SDKEventCustomFlags,
@@ -36,7 +27,7 @@ interface IECommerceShared {
         couponCode?: string,
         attributes?: SDKEventAttrs
     ): SDKProduct | null;
-    createImpression(name: string, product: Product): SDKImpression | null;
+    createImpression(name: string, product: SDKProduct): SDKImpression | null;
     createPromotion(
         id: string | number,
         creative?: string,
@@ -51,7 +42,7 @@ interface IECommerceShared {
         shipping?: string | number,
         tax?: number
     ): TransactionAttributes | null;
-    expandCommerceEvent(event: CommerceEvent): SDKEvent[] | null;
+    expandCommerceEvent(event: SDKEvent): SDKEvent[] | null;
 }
 
 export interface SDKCart {
@@ -84,7 +75,7 @@ export interface SDKECommerceAPI extends IECommerceShared {
     ): void;
     logPromotion(
         type: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion,
+        promotion: SDKPromotion | SDKPromotion[],
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions
@@ -175,26 +166,26 @@ export interface IECommerce extends IECommerceShared {
         customFlags: SDKEventCustomFlags,
         options?: SDKEventOptions
     ): SDKEvent | null;
-    expandProductAction(commerceEvent: CommerceEvent): SDKEvent[];
-    expandProductImpression(commerceEvent: CommerceEvent): SDKEvent[];
-    expandPromotionAction(commerceEvent: CommerceEvent): SDKEvent[];
+    expandProductAction(commerceEvent: SDKEvent): SDKEvent[];
+    expandProductImpression(commerceEvent: SDKEvent): SDKEvent[];
+    expandPromotionAction(commerceEvent: SDKEvent): SDKEvent[];
     extractActionAttributes(
         attributes: ExtractedActionAttributes,
-        productAction: ProductAction
+        productAction: SDKProductAction
     ): void;
     extractProductAttributes(
         attributes: ExtractedProductAttributes,
-        product: Product
+        product: SDKProduct
     ): void;
     extractPromotionAttributes(
         attributes: ExtractedPromotionAttributes,
-        promotion: Promotion
+        promotion: SDKPromotion
     ): void;
     extractTransactionId(
         attributes: ExtractedTransactionId,
-        productAction: ProductAction
+        productAction: SDKProductAction
     ): void;
-    generateExpandedEcommerceName(eventName: string, plusOne: boolean): string;
+    generateExpandedEcommerceName(eventName: string, plusOne?: boolean): string;
     getProductActionEventName(
         productActionType: valueof<typeof ProductActionType>
     ): string;

--- a/src/ecommerce.interfaces.ts
+++ b/src/ecommerce.interfaces.ts
@@ -14,6 +14,13 @@ import {
     SDKPromotion,
 } from './sdkRuntimeModels';
 
+export interface ProductActionTransactionAttributes
+    extends Omit<Partial<TransactionAttributes>, 'Shipping'> {
+    Step?: number;
+    Option?: string;
+    Shipping?: string | number;
+}
+
 interface IECommerceShared {
     createProduct(
         name: string,
@@ -70,12 +77,12 @@ export interface SDKECommerceAPI extends IECommerceShared {
         product: SDKProduct | SDKProduct[],
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
-        transactionAttributes?: TransactionAttributes,
+        transactionAttributes?: ProductActionTransactionAttributes,
         eventOptions?: SDKEventOptions
     ): void;
     logPromotion(
         type: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion | SDKPromotion[],
+        promotion: SDKPromotion | Array<SDKPromotion>,
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions
@@ -110,38 +117,6 @@ export interface SDKECommerceAPI extends IECommerceShared {
     ): void;
 }
 
-interface ExtractedActionAttributes {
-    Affiliation?: string;
-    'Coupon Code'?: string;
-    'Total Amount'?: number;
-    'Shipping Amount'?: number;
-    'Tax Amount'?: number;
-    'Checkout Option'?: string;
-    'Checkout Step'?: number;
-    'Transaction ID'?: string;
-}
-interface ExtractedProductAttributes {
-    'Coupon Code'?: string;
-    Brand?: string;
-    Category?: string;
-    Name?: string;
-    Id?: string;
-    'Item Price'?: number;
-    Quantity?: number;
-    Position?: number;
-    Variant?: string;
-    'Total Product Amount': number;
-}
-interface ExtractedPromotionAttributes {
-    Id?: string;
-    Creative?: string;
-    Name?: string;
-    Position?: number;
-}
-interface ExtractedTransactionId {
-    'Transaction ID'?: string;
-}
-
 // Used for the private `_Ecommerce` namespace
 export interface IECommerce extends IECommerceShared {
     buildProductList(
@@ -159,7 +134,7 @@ export interface IECommerce extends IECommerceShared {
         productAction: SDKProductAction
     ): SDKProductAction;
     convertTransactionAttributesToProductAction(
-        transactionAttributes: TransactionAttributes,
+        transactionAttributes: ProductActionTransactionAttributes,
         productAction: SDKProductAction
     ): void;
     createCommerceEventObject(
@@ -170,19 +145,19 @@ export interface IECommerce extends IECommerceShared {
     expandProductImpression(commerceEvent: SDKEvent): SDKEvent[];
     expandPromotionAction(commerceEvent: SDKEvent): SDKEvent[];
     extractActionAttributes(
-        attributes: ExtractedActionAttributes,
+        attributes: SDKEventAttrs,
         productAction: SDKProductAction
     ): void;
     extractProductAttributes(
-        attributes: ExtractedProductAttributes,
+        attributes: SDKEventAttrs,
         product: SDKProduct
     ): void;
     extractPromotionAttributes(
-        attributes: ExtractedPromotionAttributes,
+        attributes: SDKEventAttrs,
         promotion: SDKPromotion
     ): void;
     extractTransactionId(
-        attributes: ExtractedTransactionId,
+        attributes: SDKEventAttrs,
         productAction: SDKProductAction
     ): void;
     generateExpandedEcommerceName(eventName: string, plusOne?: boolean): string;

--- a/src/ecommerce.interfaces.ts
+++ b/src/ecommerce.interfaces.ts
@@ -117,6 +117,38 @@ export interface SDKECommerceAPI extends IECommerceShared {
     ): void;
 }
 
+interface ExtractedActionAttributes {
+    Affiliation?: string;
+    'Coupon Code'?: string;
+    'Total Amount'?: number;
+    'Shipping Amount'?: number;
+    'Tax Amount'?: number;
+    'Checkout Option'?: string;
+    'Checkout Step'?: number;
+    'Transaction ID'?: string;
+}
+export interface ExtractedProductAttributes {
+    'Coupon Code'?: string;
+    Brand?: string;
+    Category?: string;
+    Name?: string;
+    Id?: string;
+    'Item Price'?: number;
+    Quantity?: number;
+    Position?: number;
+    Variant?: string;
+    'Total Product Amount': number;
+}
+interface ExtractedPromotionAttributes {
+    Id?: string;
+    Creative?: string;
+    Name?: string;
+    Position?: number;
+}
+interface ExtractedTransactionId {
+    'Transaction ID'?: string;
+}
+
 // Used for the private `_Ecommerce` namespace
 export interface IECommerce extends IECommerceShared {
     buildProductList(
@@ -145,19 +177,19 @@ export interface IECommerce extends IECommerceShared {
     expandProductImpression(commerceEvent: SDKEvent): SDKEvent[];
     expandPromotionAction(commerceEvent: SDKEvent): SDKEvent[];
     extractActionAttributes(
-        attributes: SDKEventAttrs,
+        attributes: ExtractedActionAttributes,
         productAction: SDKProductAction
     ): void;
     extractProductAttributes(
-        attributes: SDKEventAttrs,
+        attributes: ExtractedProductAttributes,
         product: SDKProduct
     ): void;
     extractPromotionAttributes(
-        attributes: SDKEventAttrs,
+        attributes: ExtractedPromotionAttributes,
         promotion: SDKPromotion
     ): void;
     extractTransactionId(
-        attributes: SDKEventAttrs,
+        attributes: ExtractedTransactionId,
         productAction: SDKProductAction
     ): void;
     generateExpandedEcommerceName(eventName: string, plusOne?: boolean): string;

--- a/src/ecommerce.ts
+++ b/src/ecommerce.ts
@@ -2,7 +2,10 @@ import Types, { ProductActionType, PromotionActionType } from './types';
 import Constants from './constants';
 import { extend, parseNumber, valueof } from './utils';
 import { IMParticleWebSDKInstance } from './mp-instance';
-import { IECommerce } from './ecommerce.interfaces';
+import {
+    IECommerce,
+    ProductActionTransactionAttributes,
+} from './ecommerce.interfaces';
 import {
     SDKEvent,
     SDKEventCustomFlags,
@@ -27,10 +30,7 @@ export default function Ecommerce(
 
     // https://go.mparticle.com/work/SQDSDKS-4801
     this.convertTransactionAttributesToProductAction = function(
-        transactionAttributes: TransactionAttributes & {
-            Step?: number;
-            Option?: string;
-        },
+        transactionAttributes: ProductActionTransactionAttributes,
         productAction: SDKProductAction
     ): void {
         if (transactionAttributes.hasOwnProperty('Id')) {
@@ -236,7 +236,7 @@ export default function Ecommerce(
 
     // https://go.mparticle.com/work/SQDSDKS-4801
     this.extractProductAttributes = function(
-        attributes: { [key: string]: any },
+        attributes: SDKEventAttrs,
         product: SDKProduct
     ): void {
         if (product.CouponCode) {
@@ -271,7 +271,7 @@ export default function Ecommerce(
 
     // https://go.mparticle.com/work/SQDSDKS-4801
     this.extractTransactionId = function(
-        attributes: { [key: string]: any },
+        attributes: SDKEventAttrs,
         productAction: SDKProductAction
     ): void {
         if (productAction.TransactionId) {
@@ -280,11 +280,11 @@ export default function Ecommerce(
     };
 
     // https://go.mparticle.com/work/SQDSDKS-4801
-    this.extractActionAttributes = function(
-        attributes: { [key: string]: any },
+    this.extractActionAttributes = (
+        attributes: SDKEventAttrs,
         productAction: SDKProductAction
-    ): void {
-        self.extractTransactionId(attributes, productAction);
+    ): void => {
+        this.extractTransactionId(attributes, productAction);
 
         if (productAction.Affiliation) {
             attributes['Affiliation'] = productAction.Affiliation;
@@ -317,7 +317,7 @@ export default function Ecommerce(
 
     // https://go.mparticle.com/work/SQDSDKS-4801
     this.extractPromotionAttributes = function(
-        attributes: { [key: string]: any },
+        attributes: SDKEventAttrs,
         promotion: SDKPromotion
     ): void {
         if (promotion.Id) {

--- a/src/ecommerce.ts
+++ b/src/ecommerce.ts
@@ -1,19 +1,40 @@
-import Types from './types';
+import Types, { ProductActionType, PromotionActionType } from './types';
 import Constants from './constants';
-import { extend, parseNumber } from './utils';
+import { extend, parseNumber, valueof } from './utils';
+import { IMParticleWebSDKInstance } from './mp-instance';
+import { IECommerce } from './ecommerce.interfaces';
+import {
+    SDKEvent,
+    SDKEventCustomFlags,
+    SDKImpression,
+    SDKProduct,
+    SDKProductAction,
+    SDKPromotion,
+} from './sdkRuntimeModels';
+import {
+    SDKEventAttrs,
+    SDKEventOptions,
+    TransactionAttributes,
+} from '@mparticle/web-sdk';
 
-var Messages = Constants.Messages;
+const { Messages } = Constants;
 
-export default function Ecommerce(mpInstance) {
-    var self = this;
+export default function Ecommerce(
+    this: IECommerce,
+    mpInstance: IMParticleWebSDKInstance
+): void {
+    const self = this;
 
     // https://go.mparticle.com/work/SQDSDKS-4801
     this.convertTransactionAttributesToProductAction = function(
-        transactionAttributes,
-        productAction
-    ) {
+        transactionAttributes: TransactionAttributes & {
+            Step?: number;
+            Option?: string;
+        },
+        productAction: SDKProductAction
+    ): void {
         if (transactionAttributes.hasOwnProperty('Id')) {
-            productAction.TransactionId = transactionAttributes.Id;
+            productAction.TransactionId = transactionAttributes.Id as unknown as string;
         }
         if (transactionAttributes.hasOwnProperty('Affiliation')) {
             productAction.Affiliation = transactionAttributes.Affiliation;
@@ -51,7 +72,9 @@ export default function Ecommerce(mpInstance) {
     // transactionAttributes.Revenue, derive it from the product list
     // (quantity * price) plus shipping and tax. A total that the caller provided
     // (including 0) is never overwritten.
-    this.calculateProductActionTotalAmount = function(productAction) {
+    this.calculateProductActionTotalAmount = function(
+        productAction: SDKProductAction
+    ): SDKProductAction {
         if (!productAction || productAction.TotalAmount != null) {
             return productAction;
         }
@@ -74,7 +97,9 @@ export default function Ecommerce(mpInstance) {
         return productAction;
     };
 
-    this.getProductActionEventName = function(productActionType) {
+    this.getProductActionEventName = function(
+        productActionType: valueof<typeof ProductActionType>
+    ): string {
         switch (productActionType) {
             case Types.ProductActionType.AddToCart:
                 return 'AddToCart';
@@ -118,7 +143,9 @@ export default function Ecommerce(mpInstance) {
         }
     };
 
-    this.getPromotionActionEventName = function(promotionActionType) {
+    this.getPromotionActionEventName = function(
+        promotionActionType: valueof<typeof PromotionActionType>
+    ): string {
         switch (promotionActionType) {
             case Types.PromotionActionType.PromotionClick:
                 return 'PromotionClick';
@@ -129,7 +156,9 @@ export default function Ecommerce(mpInstance) {
         }
     };
 
-    this.convertProductActionToEventType = function(productActionType) {
+    this.convertProductActionToEventType = function(
+        productActionType: valueof<typeof ProductActionType>
+    ): number | null {
         switch (productActionType) {
             case Types.ProductActionType.AddToCart:
                 return Types.CommerceEventType.ProductAddToCart;
@@ -178,7 +207,9 @@ export default function Ecommerce(mpInstance) {
         }
     };
 
-    this.convertPromotionActionToEventType = function(promotionActionType) {
+    this.convertPromotionActionToEventType = function(
+        promotionActionType: valueof<typeof PromotionActionType>
+    ): number | null {
         switch (promotionActionType) {
             case Types.PromotionActionType.PromotionClick:
                 return Types.CommerceEventType.PromotionClick;
@@ -194,14 +225,20 @@ export default function Ecommerce(mpInstance) {
         }
     };
 
-    this.generateExpandedEcommerceName = function(eventName, plusOne) {
+    this.generateExpandedEcommerceName = function(
+        eventName: string,
+        plusOne?: boolean
+    ): string {
         return (
             'eCommerce - ' + eventName + ' - ' + (plusOne ? 'Total' : 'Item')
         );
     };
 
     // https://go.mparticle.com/work/SQDSDKS-4801
-    this.extractProductAttributes = function(attributes, product) {
+    this.extractProductAttributes = function(
+        attributes: { [key: string]: any },
+        product: SDKProduct
+    ): void {
         if (product.CouponCode) {
             attributes['Coupon Code'] = product.CouponCode;
         }
@@ -233,14 +270,20 @@ export default function Ecommerce(mpInstance) {
     };
 
     // https://go.mparticle.com/work/SQDSDKS-4801
-    this.extractTransactionId = function(attributes, productAction) {
+    this.extractTransactionId = function(
+        attributes: { [key: string]: any },
+        productAction: SDKProductAction
+    ): void {
         if (productAction.TransactionId) {
             attributes['Transaction Id'] = productAction.TransactionId;
         }
     };
 
     // https://go.mparticle.com/work/SQDSDKS-4801
-    this.extractActionAttributes = function(attributes, productAction) {
+    this.extractActionAttributes = function(
+        attributes: { [key: string]: any },
+        productAction: SDKProductAction
+    ): void {
         self.extractTransactionId(attributes, productAction);
 
         if (productAction.Affiliation) {
@@ -273,7 +316,10 @@ export default function Ecommerce(mpInstance) {
     };
 
     // https://go.mparticle.com/work/SQDSDKS-4801
-    this.extractPromotionAttributes = function(attributes, promotion) {
+    this.extractPromotionAttributes = function(
+        attributes: { [key: string]: any },
+        promotion: SDKPromotion
+    ): void {
         if (promotion.Id) {
             attributes['Id'] = promotion.Id;
         }
@@ -291,7 +337,10 @@ export default function Ecommerce(mpInstance) {
         }
     };
 
-    this.buildProductList = function(event, product) {
+    this.buildProductList = function(
+        event: SDKEvent,
+        product: SDKProduct | SDKProduct[]
+    ): SDKProduct[] {
         if (product) {
             if (Array.isArray(product)) {
                 return product;
@@ -304,17 +353,17 @@ export default function Ecommerce(mpInstance) {
     };
 
     this.createProduct = function(
-        name,
-        sku,
-        price,
-        quantity,
-        variant,
-        category,
-        brand,
-        position,
-        couponCode,
-        attributes
-    ) {
+        name: string,
+        sku: string | number,
+        price: string | number,
+        quantity?: string | number,
+        variant?: string,
+        category?: string,
+        brand?: string,
+        position?: number,
+        couponCode?: string,
+        attributes?: SDKEventAttrs
+    ): SDKProduct | null {
         attributes = mpInstance._Helpers.sanitizeAttributes(attributes, name);
 
         if (typeof name !== 'string') {
@@ -342,7 +391,7 @@ export default function Ecommerce(mpInstance) {
             mpInstance.Logger.error(
                 'Position must be a number, it will be set to null.'
             );
-            position = null;
+            position = null as unknown as number;
         }
 
         if (!mpInstance._Helpers.Validators.isStringOrNumber(quantity)) {
@@ -353,34 +402,42 @@ export default function Ecommerce(mpInstance) {
 
         return {
             Name: name,
-            Sku: sku,
-            Price: price,
-            Quantity: quantity,
+            Sku: sku as unknown as string,
+            Price: price as number,
+            Quantity: quantity as number,
             Brand: brand,
             Variant: variant,
             Category: category,
             Position: position,
             CouponCode: couponCode,
-            TotalAmount: quantity * price,
+            TotalAmount: (quantity as number) * (price as number),
             Attributes: attributes,
         };
     };
 
-    this.createPromotion = function(id, creative, name, position) {
+    this.createPromotion = function(
+        id: string | number,
+        creative?: string,
+        name?: string,
+        position?: number
+    ): SDKPromotion | null {
         if (!mpInstance._Helpers.Validators.isStringOrNumber(id)) {
             mpInstance.Logger.error(Messages.ErrorMessages.PromotionIdRequired);
             return null;
         }
 
         return {
-            Id: id,
+            Id: id as unknown as string,
             Creative: creative,
             Name: name,
-            Position: position,
+            Position: position as unknown as string,
         };
     };
 
-    this.createImpression = function(name, product) {
+    this.createImpression = function(
+        name: string,
+        product: SDKProduct
+    ): SDKImpression | null {
         if (typeof name !== 'string') {
             mpInstance.Logger.error(
                 'Name is required when creating an impression.'
@@ -402,13 +459,13 @@ export default function Ecommerce(mpInstance) {
     };
 
     this.createTransactionAttributes = function(
-        id,
-        affiliation,
-        couponCode,
-        revenue,
-        shipping,
-        tax
-    ) {
+        id: string | number,
+        affiliation?: string,
+        couponCode?: string,
+        revenue?: string | number,
+        shipping?: string | number,
+        tax?: number
+    ): TransactionAttributes | null {
         if (!mpInstance._Helpers.Validators.isStringOrNumber(id)) {
             mpInstance.Logger.error(
                 Messages.ErrorMessages.TransactionIdRequired
@@ -420,14 +477,16 @@ export default function Ecommerce(mpInstance) {
             Id: id,
             Affiliation: affiliation,
             CouponCode: couponCode,
-            Revenue: revenue,
-            Shipping: shipping,
+            Revenue: revenue as number,
+            Shipping: shipping as string,
             Tax: tax,
         };
     };
 
-    this.expandProductImpression = function(commerceEvent) {
-        var appEvents = [];
+    this.expandProductImpression = function(
+        commerceEvent: SDKEvent
+    ): SDKEvent[] {
+        const appEvents = [];
         if (!commerceEvent.ProductImpressions) {
             return appEvents;
         }
@@ -450,7 +509,7 @@ export default function Ecommerce(mpInstance) {
                         attributes['Product Impression List'] =
                             productImpression.ProductImpressionList;
                     }
-                    var appEvent = mpInstance._ServerModel.createEventObject({
+                    const appEvent = mpInstance._ServerModel.createEventObject({
                         messageType: Types.MessageType.PageEvent,
                         name: self.generateExpandedEcommerceName('Impression'),
                         data: attributes,
@@ -464,7 +523,9 @@ export default function Ecommerce(mpInstance) {
         return appEvents;
     };
 
-    this.expandCommerceEvent = function(event) {
+    this.expandCommerceEvent = function(
+        event: SDKEvent
+    ): SDKEvent[] | null {
         if (!event) {
             return null;
         }
@@ -474,21 +535,23 @@ export default function Ecommerce(mpInstance) {
             .concat(self.expandProductImpression(event));
     };
 
-    this.expandPromotionAction = function(commerceEvent) {
-        var appEvents = [];
+    this.expandPromotionAction = function(
+        commerceEvent: SDKEvent
+    ): SDKEvent[] {
+        const appEvents = [];
         if (!commerceEvent.PromotionAction) {
             return appEvents;
         }
-        var promotions = commerceEvent.PromotionAction.PromotionList;
+        const promotions = commerceEvent.PromotionAction.PromotionList;
         promotions.forEach(function(promotion) {
             let attributes = extend(false, {}, commerceEvent.EventAttributes);
             self.extractPromotionAttributes(attributes, promotion);
 
-            var appEvent = mpInstance._ServerModel.createEventObject({
+            const appEvent = mpInstance._ServerModel.createEventObject({
                 messageType: Types.MessageType.PageEvent,
                 name: self.generateExpandedEcommerceName(
                     Types.PromotionActionType.getExpansionName(
-                        commerceEvent.PromotionAction.PromotionActionType
+                        commerceEvent.PromotionAction.PromotionActionType as unknown as number
                     )
                 ),
                 data: attributes,
@@ -499,12 +562,14 @@ export default function Ecommerce(mpInstance) {
         return appEvents;
     };
 
-    this.expandProductAction = function(commerceEvent) {
-        var appEvents = [];
+    this.expandProductAction = function(
+        commerceEvent: SDKEvent
+    ): SDKEvent[] {
+        const appEvents = [];
         if (!commerceEvent.ProductAction) {
             return appEvents;
         }
-        var shouldExtractActionAttributes = false;
+        let shouldExtractActionAttributes = false;
         if (
             commerceEvent.ProductAction.ProductActionType ===
                 Types.ProductActionType.Purchase ||
@@ -523,11 +588,11 @@ export default function Ecommerce(mpInstance) {
             if (commerceEvent.CurrencyCode) {
                 attributes['Currency Code'] = commerceEvent.CurrencyCode;
             }
-            var plusOneEvent = mpInstance._ServerModel.createEventObject({
+            const plusOneEvent = mpInstance._ServerModel.createEventObject({
                 messageType: Types.MessageType.PageEvent,
                 name: self.generateExpandedEcommerceName(
                     Types.ProductActionType.getExpansionName(
-                        commerceEvent.ProductAction.ProductActionType
+                        commerceEvent.ProductAction.ProductActionType as number
                     ),
                     true
                 ),
@@ -539,7 +604,7 @@ export default function Ecommerce(mpInstance) {
             shouldExtractActionAttributes = true;
         }
 
-        var products = commerceEvent.ProductAction.ProductList;
+        const products = commerceEvent.ProductAction.ProductList;
 
         if (!products) {
             return appEvents;
@@ -564,11 +629,11 @@ export default function Ecommerce(mpInstance) {
             }
             self.extractProductAttributes(attributes, product);
 
-            var productEvent = mpInstance._ServerModel.createEventObject({
+            const productEvent = mpInstance._ServerModel.createEventObject({
                 messageType: Types.MessageType.PageEvent,
                 name: self.generateExpandedEcommerceName(
                     Types.ProductActionType.getExpansionName(
-                        commerceEvent.ProductAction.ProductActionType
+                        commerceEvent.ProductAction.ProductActionType as number
                     )
                 ),
                 data: attributes,
@@ -580,10 +645,13 @@ export default function Ecommerce(mpInstance) {
         return appEvents;
     };
 
-    this.createCommerceEventObject = function(customFlags, options) {
-        var baseEvent;
+    this.createCommerceEventObject = function(
+        customFlags?: SDKEventCustomFlags,
+        options?: SDKEventOptions
+    ): SDKEvent | null {
+        let baseEvent;
         // https://go.mparticle.com/work/SQDSDKS-4801
-        var { extend } = mpInstance._Helpers;
+        const { extend } = mpInstance._Helpers;
 
         mpInstance.Logger.verbose(
             Messages.InformationMessages.StartingLogCommerceEvent
@@ -611,9 +679,12 @@ export default function Ecommerce(mpInstance) {
     };
 
     // sanitizes any non number, non string value to 0
-    this.sanitizeAmount = function(amount, category) {
+    this.sanitizeAmount = function(
+        amount: string | number,
+        category: string
+    ): number {
         if (!mpInstance._Helpers.Validators.isStringOrNumber(amount)) {
-            var message = [
+            const message = [
                 category,
                 'must be of type number. A',
                 typeof amount,

--- a/src/ecommerce.ts
+++ b/src/ecommerce.ts
@@ -3,6 +3,7 @@ import Constants from './constants';
 import { extend, parseNumber, valueof } from './utils';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import {
+    ExtractedProductAttributes,
     IECommerce,
     ProductActionTransactionAttributes,
 } from './ecommerce.interfaces';
@@ -236,7 +237,7 @@ export default function Ecommerce(
 
     // https://go.mparticle.com/work/SQDSDKS-4801
     this.extractProductAttributes = function(
-        attributes: SDKEventAttrs,
+        attributes: ExtractedProductAttributes,
         product: SDKProduct
     ): void {
         if (product.CouponCode) {

--- a/src/events.interfaces.ts
+++ b/src/events.interfaces.ts
@@ -62,7 +62,7 @@ export interface IEvents {
     ): void;
     logPromotionEvent(
         promotionType: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion,
+        promotion: SDKPromotion | SDKPromotion[],
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions

--- a/src/events.interfaces.ts
+++ b/src/events.interfaces.ts
@@ -12,6 +12,7 @@ import {
     SDKProduct,
     SDKPromotion,
 } from './sdkRuntimeModels';
+import { ProductActionTransactionAttributes } from './ecommerce.interfaces';
 import { valueof } from './utils';
 import { EventType, ProductActionType, PromotionActionType } from './types';
 
@@ -57,12 +58,12 @@ export interface IEvents {
         product: SDKProduct | SDKProduct[],
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
-        transactionAttributes?: TransactionAttributes,
+        transactionAttributes?: ProductActionTransactionAttributes,
         eventOptions?: SDKEventOptions
     ): void;
     logPromotionEvent(
         promotionType: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion | SDKPromotion[],
+        promotion: SDKPromotion | Array<SDKPromotion>,
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions

--- a/src/events.ts
+++ b/src/events.ts
@@ -5,6 +5,7 @@ import Types, {
 } from './types';
 import Constants from './constants';
 import { IEvents } from './events.interfaces';
+import { ProductActionTransactionAttributes } from './ecommerce.interfaces';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import {
     BaseEvent,
@@ -196,7 +197,7 @@ export default function Events(
         product: SDKProduct | SDKProduct[],
         customAttrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
-        transactionAttributes?: TransactionAttributes,
+        transactionAttributes?: ProductActionTransactionAttributes,
         options?: SDKEventOptions
     ): void {
         const event = mpInstance._Ecommerce.createCommerceEventObject(
@@ -342,7 +343,7 @@ export default function Events(
 
     this.logPromotionEvent = function(
         promotionType: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion | SDKPromotion[],
+        promotion: SDKPromotion | Array<SDKPromotion>,
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions

--- a/src/events.ts
+++ b/src/events.ts
@@ -342,7 +342,7 @@ export default function Events(
 
     this.logPromotionEvent = function(
         promotionType: valueof<typeof PromotionActionType>,
-        promotion: SDKPromotion,
+        promotion: SDKPromotion | SDKPromotion[],
         attrs?: SDKEventAttrs,
         customFlags?: SDKEventCustomFlags,
         eventOptions?: SDKEventOptions

--- a/test/src/tests-eCommerce.ts
+++ b/test/src/tests-eCommerce.ts
@@ -14,7 +14,7 @@ import {
     SDKProductAction,
 } from '../../src/sdkRuntimeModels';
 import { IMockForwarder } from './tests-forwarders';
-import { TransactionAttributes } from '@mparticle/web-sdk';
+import { ProductActionTransactionAttributes } from '../../src/ecommerce.interfaces';
 
 const { waitForCondition, fetchMockSuccess, hasIdentifyReturned } = Utils;
 
@@ -142,9 +142,12 @@ describe('eCommerce', function() {
                 'iPhone',
                 '12345',
                 '400');
+        const invalidProductActionType = 'Typo' as unknown as Parameters<
+            typeof mParticle.eCommerce.logProductAction
+        >[0];
 
         mParticle.eCommerce.logProductAction(
-            (mParticle.ProductActionType as any).Typo, // <------ will result in a null when converting the product action type as this is not a real value
+            invalidProductActionType,
             [product]
         );
         fetchMock.calls().length.should.equal(0);
@@ -159,7 +162,7 @@ describe('eCommerce', function() {
                 'Plus',
                 'Phones',
                 'Apple',
-                '1-foo' as any,
+                '1-foo' as unknown as number,
                 'my-coupon-code',
                 { customkey: 'customvalue' }
             ),
@@ -169,7 +172,7 @@ describe('eCommerce', function() {
                 'coupon-code',
                 '44334-foo',
                 '600-foo',
-                '200-foo' as any
+                '200-foo' as unknown as number
             );
 
         await waitForCondition(hasIdentifyReturned);
@@ -647,7 +650,13 @@ describe('eCommerce', function() {
         const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999);
         const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799);
 
-        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Step: 4, Option: 'Visa'} as unknown as TransactionAttributes);
+        mParticle.eCommerce.logProductAction(
+            mParticle.ProductActionType.Checkout,
+            [product1, product2],
+            null,
+            null,
+            { Step: 4, Option: 'Visa' }
+        );
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
 
@@ -668,7 +677,13 @@ describe('eCommerce', function() {
         const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 2);
         const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
 
-        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Step: 4, Option: 'Visa'} as unknown as TransactionAttributes);
+        mParticle.eCommerce.logProductAction(
+            mParticle.ProductActionType.Checkout,
+            [product1, product2],
+            null,
+            null,
+            { Step: 4, Option: 'Visa' }
+        );
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
 
@@ -681,7 +696,13 @@ describe('eCommerce', function() {
         await waitForCondition(hasIdentifyReturned);
         const product = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
 
-        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product], null, null, {Shipping: 10, Tax: 5} as unknown as TransactionAttributes);
+        mParticle.eCommerce.logProductAction(
+            mParticle.ProductActionType.Checkout,
+            [product],
+            null,
+            null,
+            { Shipping: 10, Tax: 5 }
+        );
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
 
@@ -695,7 +716,13 @@ describe('eCommerce', function() {
         const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
         const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
 
-        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Revenue: 5} as TransactionAttributes);
+        mParticle.eCommerce.logProductAction(
+            mParticle.ProductActionType.Checkout,
+            [product1, product2],
+            null,
+            null,
+            { Revenue: 5 }
+        );
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
 
@@ -748,7 +775,11 @@ describe('eCommerce', function() {
     });
 
     it('should fail to create product if name not a string', () => {
-        const createProduct = mParticle.eCommerce.createProduct as any;
+        const createProduct = mParticle.eCommerce.createProduct as unknown as (
+            name?: unknown,
+            sku?: unknown,
+            price?: unknown
+        ) => ReturnType<typeof mParticle.eCommerce.createProduct>;
         const product = createProduct(null);
         const product2 = createProduct(undefined);
         const product3 = createProduct(['product']);
@@ -763,11 +794,13 @@ describe('eCommerce', function() {
     });
 
     it('should fail to create product if sku not a string or a number', () => {
-        const createProduct = mParticle.eCommerce.createProduct as any;
+        const createProduct = mParticle.eCommerce.createProduct as unknown as (
+            name?: unknown,
+            sku?: unknown,
+            price?: unknown
+        ) => ReturnType<typeof mParticle.eCommerce.createProduct>;
         const product = createProduct('test', null);
-        const product2 = createProduct('test', {
-            key: 'value',
-        });
+        const product2 = createProduct('test', { key: 'value' });
         const product3 = createProduct('test', []);
         const product4 = createProduct('test', undefined);
 
@@ -790,13 +823,23 @@ describe('eCommerce', function() {
     });
 
     it('should fail to create impression if name is not specified', () => {
-        const impression = (mParticle.eCommerce.createImpression as any)(null);
+        const createImpression = mParticle.eCommerce
+            .createImpression as unknown as (
+            name?: unknown,
+            product?: unknown
+        ) => ReturnType<typeof mParticle.eCommerce.createImpression>;
+        const impression = createImpression(null);
 
         Should(impression).not.be.ok();
     });
 
     it('should fail to create impression if product is not specified', () => {
-        const impression = (mParticle.eCommerce.createImpression as any)('name', null);
+        const createImpression = mParticle.eCommerce
+            .createImpression as unknown as (
+            name?: unknown,
+            product?: unknown
+        ) => ReturnType<typeof mParticle.eCommerce.createImpression>;
+        const impression = createImpression('name', null);
 
         Should(impression).not.be.ok();
     });
@@ -1303,7 +1346,12 @@ describe('eCommerce', function() {
 
     it('should add customFlags to logCheckout events', async () => {
         await waitForCondition(hasIdentifyReturned);
-        mParticle.eCommerce.logCheckout(1, {} as any, {}, { interactionEvent: true });
+        mParticle.eCommerce.logCheckout(
+            1,
+            {} as unknown as string,
+            {},
+            { interactionEvent: true }
+        );
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
         checkoutEvent.data.custom_flags.interactionEvent.should.equal(true);
@@ -1458,7 +1506,7 @@ describe('eCommerce', function() {
         it('should be empty when transactionAttributes is empty', () => {
             const mparticle = mParticle.getInstance()
             const productAction = {} as SDKProductAction
-            mparticle._Ecommerce.convertTransactionAttributesToProductAction({} as TransactionAttributes, productAction)
+            mparticle._Ecommerce.convertTransactionAttributesToProductAction({}, productAction)
             Object.keys(productAction).length.should.equal(0);
         });
 
@@ -1483,7 +1531,10 @@ describe('eCommerce', function() {
             };
 
             const productAction = {} as SDKProductAction;
-            mparticle._Ecommerce.convertTransactionAttributesToProductAction(transactionAttributes as unknown as TransactionAttributes, productAction)
+            mparticle._Ecommerce.convertTransactionAttributesToProductAction(
+                transactionAttributes as unknown as ProductActionTransactionAttributes,
+                productAction
+            )
             productAction.TransactionId.should.equal("id")
             productAction.Affiliation.should.equal("affiliation")
             productAction.CouponCode.should.equal("couponCode")

--- a/test/src/tests-eCommerce.ts
+++ b/test/src/tests-eCommerce.ts
@@ -1,12 +1,35 @@
 import Utils from './config/utils';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock/esm/client';
-import { urls, apiKey, MPConfig, testMPID, ProductActionType, PromotionActionType } from './config/constants';
+import Should from 'should';
+import {
+    urls,
+    apiKey,
+    MPConfig,
+    testMPID,
+    PromotionActionType,
+} from './config/constants';
+import {
+    IMParticleInstanceManager,
+    SDKProductAction,
+} from '../../src/sdkRuntimeModels';
+import { IMockForwarder } from './tests-forwarders';
+import { TransactionAttributes } from '@mparticle/web-sdk';
+
 const { waitForCondition, fetchMockSuccess, hasIdentifyReturned } = Utils;
 
 const forwarderDefaultConfiguration = Utils.forwarderDefaultConfiguration,
     findEventFromRequest = Utils.findEventFromRequest,
     MockForwarder = Utils.MockForwarder;
+
+declare global {
+    interface Window {
+        mParticle: IMParticleInstanceManager;
+        MockForwarder1: IMockForwarder;
+    }
+}
+
+const mParticle = window.mParticle as IMParticleInstanceManager;
 
 describe('eCommerce', function() {
     beforeEach(function() {
@@ -121,7 +144,7 @@ describe('eCommerce', function() {
                 '400');
 
         mParticle.eCommerce.logProductAction(
-            mParticle.ProductActionType.Typo, // <------ will result in a null when converting the product action type as this is not a real value
+            (mParticle.ProductActionType as any).Typo, // <------ will result in a null when converting the product action type as this is not a real value
             [product]
         );
         fetchMock.calls().length.should.equal(0);
@@ -136,7 +159,7 @@ describe('eCommerce', function() {
                 'Plus',
                 'Phones',
                 'Apple',
-                '1-foo',
+                '1-foo' as any,
                 'my-coupon-code',
                 { customkey: 'customvalue' }
             ),
@@ -146,7 +169,7 @@ describe('eCommerce', function() {
                 'coupon-code',
                 '44334-foo',
                 '600-foo',
-                '200-foo'
+                '200-foo' as any
             );
 
         await waitForCondition(hasIdentifyReturned);
@@ -624,7 +647,7 @@ describe('eCommerce', function() {
         const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999);
         const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799);
 
-        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Step: 4, Option: 'Visa'});
+        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Step: 4, Option: 'Visa'} as unknown as TransactionAttributes);
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
 
@@ -645,7 +668,7 @@ describe('eCommerce', function() {
         const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 2);
         const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
 
-        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Step: 4, Option: 'Visa'});
+        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Step: 4, Option: 'Visa'} as unknown as TransactionAttributes);
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
 
@@ -658,7 +681,7 @@ describe('eCommerce', function() {
         await waitForCondition(hasIdentifyReturned);
         const product = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
 
-        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product], null, null, {Shipping: 10, Tax: 5});
+        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product], null, null, {Shipping: 10, Tax: 5} as unknown as TransactionAttributes);
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
 
@@ -672,7 +695,7 @@ describe('eCommerce', function() {
         const product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1);
         const product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1);
 
-        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Revenue: 5});
+        mParticle.eCommerce.logProductAction(mParticle.ProductActionType.Checkout, [product1, product2], null, null, {Revenue: 5} as TransactionAttributes);
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
 
@@ -685,7 +708,7 @@ describe('eCommerce', function() {
         const product = mParticle.eCommerce.createProduct('iPhone', '12345', 400);
 
         mParticle.eCommerce.logProductAction(
-            ProductActionType.CheckoutOption,
+            mParticle.ProductActionType.CheckoutOption,
             product,
             { color: 'blue' }
         );
@@ -710,7 +733,7 @@ describe('eCommerce', function() {
         const product = mParticle.eCommerce.createProduct('iPhone', '12345', 400);
 
         mParticle.eCommerce.logProductAction(
-            ProductActionType.ViewDetail,
+            mParticle.ProductActionType.ViewDetail,
             product
         );
 
@@ -725,11 +748,12 @@ describe('eCommerce', function() {
     });
 
     it('should fail to create product if name not a string', () => {
-        const product = mParticle.eCommerce.createProduct(null);
-        const product2 = mParticle.eCommerce.createProduct(undefined);
-        const product3 = mParticle.eCommerce.createProduct(['product']);
-        const product4 = mParticle.eCommerce.createProduct(123);
-        const product5 = mParticle.eCommerce.createProduct({ key: 'value' });
+        const createProduct = mParticle.eCommerce.createProduct as any;
+        const product = createProduct(null);
+        const product2 = createProduct(undefined);
+        const product3 = createProduct(['product']);
+        const product4 = createProduct(123);
+        const product5 = createProduct({ key: 'value' });
 
         Should(product).not.be.ok();
         Should(product2).not.be.ok();
@@ -739,12 +763,13 @@ describe('eCommerce', function() {
     });
 
     it('should fail to create product if sku not a string or a number', () => {
-        const product = mParticle.eCommerce.createProduct('test', null);
-        const product2 = mParticle.eCommerce.createProduct('test', {
+        const createProduct = mParticle.eCommerce.createProduct as any;
+        const product = createProduct('test', null);
+        const product2 = createProduct('test', {
             key: 'value',
         });
-        const product3 = mParticle.eCommerce.createProduct('test', []);
-        const product4 = mParticle.eCommerce.createProduct('test', undefined);
+        const product3 = createProduct('test', []);
+        const product4 = createProduct('test', undefined);
 
         Should(product).not.be.ok();
         Should(product2).not.be.ok();
@@ -765,13 +790,13 @@ describe('eCommerce', function() {
     });
 
     it('should fail to create impression if name is not specified', () => {
-        const impression = mParticle.eCommerce.createImpression(null);
+        const impression = (mParticle.eCommerce.createImpression as any)(null);
 
         Should(impression).not.be.ok();
     });
 
     it('should fail to create impression if product is not specified', () => {
-        const impression = mParticle.eCommerce.createImpression('name', null);
+        const impression = (mParticle.eCommerce.createImpression as any)('name', null);
 
         Should(impression).not.be.ok();
     });
@@ -1278,7 +1303,7 @@ describe('eCommerce', function() {
 
     it('should add customFlags to logCheckout events', async () => {
         await waitForCondition(hasIdentifyReturned);
-        mParticle.eCommerce.logCheckout(1, {}, {}, { interactionEvent: true });
+        mParticle.eCommerce.logCheckout(1, {} as any, {}, { interactionEvent: true });
 
         const checkoutEvent = findEventFromRequest(fetchMock.calls(), 'checkout');
         checkoutEvent.data.custom_flags.interactionEvent.should.equal(true);
@@ -1432,8 +1457,8 @@ describe('eCommerce', function() {
 
         it('should be empty when transactionAttributes is empty', () => {
             const mparticle = mParticle.getInstance()
-            const productAction = {}
-            mparticle._Ecommerce.convertTransactionAttributesToProductAction({}, productAction)
+            const productAction = {} as SDKProductAction
+            mparticle._Ecommerce.convertTransactionAttributesToProductAction({} as TransactionAttributes, productAction)
             Object.keys(productAction).length.should.equal(0);
         });
 
@@ -1457,8 +1482,8 @@ describe('eCommerce', function() {
                 Tax: "tax"
             };
 
-            const productAction = {};
-            mparticle._Ecommerce.convertTransactionAttributesToProductAction(transactionAttributes, productAction)
+            const productAction = {} as SDKProductAction;
+            mparticle._Ecommerce.convertTransactionAttributesToProductAction(transactionAttributes as unknown as TransactionAttributes, productAction)
             productAction.TransactionId.should.equal("id")
             productAction.Affiliation.should.equal("affiliation")
             productAction.CouponCode.should.equal("couponCode")
@@ -1477,7 +1502,7 @@ describe('eCommerce', function() {
                 ],
                 ShippingAmount: 10,
                 TaxAmount: 5,
-            };
+            } as SDKProductAction;
 
             mParticle
                 .getInstance()
@@ -1488,7 +1513,7 @@ describe('eCommerce', function() {
         });
 
         it('should default to zero when there are no products, shipping, or tax', () => {
-            const productAction = { ProductList: [] };
+            const productAction = { ProductList: [] } as SDKProductAction;
 
             mParticle
                 .getInstance()
@@ -1501,7 +1526,7 @@ describe('eCommerce', function() {
             const productAction = {
                 TotalAmount: 0,
                 ProductList: [{ Price: 100, Quantity: 1 }],
-            };
+            } as SDKProductAction;
 
             mParticle
                 .getInstance()


### PR DESCRIPTION
## Background
- Follow-up to the ecommerce JS→TS migrate. Review asked to drop any in tests and to stop casting valid checkout { Step, Option } through as unknown as TransactionAttributes.


## What Has Changed
- logProductAction now takes an internal ProductActionTransactionAttributes type that includes checkout Step/Option, so valid tests need no cast.
- Ecommerce tests no longer use any; invalid inputs still go through unknown.
- extractActionAttributes is an arrow function; promotion arrays use Array<SDKPromotion>.


## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- Repo-wide @typescript-eslint/no-explicit-any and a one-object createProduct API are out of scope.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
