### PR TITLE
fix: do not resolve query-param keys that name inherited prototype members

### DIFF
--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -123,16 +123,16 @@ interface IPendingNavigation {
 export const allowedQueryParams = (href: string): Dictionary<string> =>
     queryStringParser(href, ALLOWED_QUERY_PARAMS);
 
-// The captured params, in allowlist order. Ordering comes from the constant rather
-// than a sort: it is deterministic without needing a comparator, and it does not
-// depend on the object's insertion order, so reordering the query string cannot
-// produce a different key.
+// The captured params, in allowlist order. Ordering comes from the constant
+// rather than a sort: it is deterministic without needing a comparator, and it
+// does not depend on the object's insertion order, so reordering the query string
+// cannot produce a different key.
 //
-// Membership is an own-property check, not `in`. `in` walks the prototype chain, so
-// a name matching an Object.prototype member reports as present on any plain
-// object. ALLOWED_QUERY_PARAMS contains no such name, which was the only thing
-// making `in` safe here — and it stops being a safe assumption the moment this
-// list can be extended from configuration.
+// Membership is an own-property check, not `in`. `in` walks the prototype
+// chain, so a name matching an Object.prototype member reports as present on
+// any plain object. ALLOWED_QUERY_PARAMS contains no such name, which was the
+// only thing making `in` safe here — and it stops being a safe assumption the
+// moment this list can be extended from configuration.
 const capturedNames = (params: Dictionary<string>): string[] =>
     ALLOWED_QUERY_PARAMS.filter(name => hasOwnProp(params, name));
 

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -1,7 +1,7 @@
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { BaseEvent } from './sdkRuntimeModels';
 import { EventType, MessageType } from './types';
-import { Dictionary, getHref, queryStringParser } from './utils';
+import { Dictionary, getHref, hasOwnProp, queryStringParser } from './utils';
 
 type HistoryStateMethod = History['pushState'];
 type HistoryMethodName = 'pushState' | 'replaceState';
@@ -123,12 +123,18 @@ interface IPendingNavigation {
 export const allowedQueryParams = (href: string): Dictionary<string> =>
     queryStringParser(href, ALLOWED_QUERY_PARAMS);
 
-// The captured params, in allowlist order. Ordering comes from the constant
-// rather than a sort: it is deterministic without needing a comparator, and it
-// does not depend on the object's insertion order, so reordering the query string
-// cannot produce a different key.
+// The captured params, in allowlist order. Ordering comes from the constant rather
+// than a sort: it is deterministic without needing a comparator, and it does not
+// depend on the object's insertion order, so reordering the query string cannot
+// produce a different key.
+//
+// Membership is an own-property check, not `in`. `in` walks the prototype chain, so
+// a name matching an Object.prototype member reports as present on any plain
+// object. ALLOWED_QUERY_PARAMS contains no such name, which was the only thing
+// making `in` safe here — and it stops being a safe assumption the moment this
+// list can be extended from configuration.
 const capturedNames = (params: Dictionary<string>): string[] =>
-    ALLOWED_QUERY_PARAMS.filter(name => name in params);
+    ALLOWED_QUERY_PARAMS.filter(name => hasOwnProp(params, name));
 
 // The dedup key: pathname plus the allowlisted params in a fixed order, so that
 // reordering the query string is not a new page. Params outside the allowlist

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -309,10 +309,8 @@ const mergeObjects = <T extends object>(...objects: T[]): T => {
 const moveElementToEnd = <T>(array: T[], index: number): T[] =>
     array.slice(0, index).concat(array.slice(index + 1), array[index]);
 
-// Own-property check that ignores inherited Object.prototype members. Needed
-// wherever a key is looked up by a name that did not come from the object itself:
-// `obj[name]` and `name in obj` both walk the prototype chain, so a name like
-// `constructor` resolves to something truthy on any plain object.
+// For keys that did not come from the object itself: `obj[name]` and `name in obj`
+// both walk the prototype chain, so `constructor` is truthy on any plain object.
 const hasOwnProp = (obj: object, key: string): boolean =>
     Object.prototype.hasOwnProperty.call(obj, key);
 
@@ -343,11 +341,7 @@ const queryStringParser = (
         keys.forEach(key => {
             const name = key.toLowerCase();
 
-            // The requested key may not have come from this URL — callers pass
-            // their own lists. Without the own-property guard, a key named
-            // `constructor` resolves to Object.prototype.constructor, passes the
-            // truthiness check below, and is copied out as if the URL had
-            // supplied it.
+            // Callers pass their own key list, so `name` may not be from this URL.
             if (!hasOwnProp(lowerCaseUrlParams, name)) {
                 return;
             }
@@ -390,12 +384,8 @@ const queryStringParserFallback = (url: string): URLSearchParamsFallback => {
         },
         forEach: function(callback: (value: string, key: string) => void) {
             for (var key in params) {
-                // Not `params.hasOwnProperty(key)`. The keys here come straight
-                // off the URL, so `?hasOwnProperty=1` gives `params` an own
-                // property shadowing the inherited method with the string `'1'`,
-                // and the next iteration calls it: `TypeError: params
-                // .hasOwnProperty is not a function`. That throws out of
-                // queryStringParser on the init path.
+                // Keys come straight off the URL, so `?hasOwnProperty=1` would
+                // shadow the method and `params.hasOwnProperty(key)` would throw.
                 if (hasOwnProp(params, key)) {
                     callback(params[key], key);
                 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -309,6 +309,13 @@ const mergeObjects = <T extends object>(...objects: T[]): T => {
 const moveElementToEnd = <T>(array: T[], index: number): T[] =>
     array.slice(0, index).concat(array.slice(index + 1), array[index]);
 
+// Own-property check that ignores inherited Object.prototype members. Needed
+// wherever a key is looked up by a name that did not come from the object itself:
+// `obj[name]` and `name in obj` both walk the prototype chain, so a name like
+// `constructor` resolves to something truthy on any plain object.
+const hasOwnProp = (obj: object, key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(obj, key);
+
 const queryStringParser = (
     url: string,
     keys: string[] = []
@@ -334,7 +341,18 @@ const queryStringParser = (
         return lowerCaseUrlParams;
     } else {
         keys.forEach(key => {
-            const value = lowerCaseUrlParams[key.toLowerCase()];
+            const name = key.toLowerCase();
+
+            // The requested key may not have come from this URL — callers pass
+            // their own lists. Without the own-property guard, a key named
+            // `constructor` resolves to Object.prototype.constructor, passes the
+            // truthiness check below, and is copied out as if the URL had
+            // supplied it.
+            if (!hasOwnProp(lowerCaseUrlParams, name)) {
+                return;
+            }
+
+            const value = lowerCaseUrlParams[name];
             if (value) {
                 results[key] = value;
             }
@@ -706,6 +724,7 @@ export {
     mergeObjects,
     moveElementToEnd,
     queryStringParser,
+    hasOwnProp,
     getCookies,
     getHref,
     replaceMPID,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -311,6 +311,11 @@ const moveElementToEnd = <T>(array: T[], index: number): T[] =>
 
 // For keys that did not come from the object itself: `obj[name]` and `name in obj`
 // both walk the prototype chain, so `constructor` is truthy on any plain object.
+//
+// Not `Object.hasOwn`, which Sonar recommends here (typescript:S6653). It is ES2022 and
+// does not compile under this project's `lib: ["es5", "es6", "dom"]`; widening that
+// would emit a call absent from every browser before 2021, and this same file still
+// carries a fallback for browsers with no URLSearchParams.
 const hasOwnProp = (obj: object, key: string): boolean =>
     Object.prototype.hasOwnProperty.call(obj, key);
 
@@ -342,13 +347,8 @@ const queryStringParser = (
             const name = key.toLowerCase();
 
             // Callers pass their own key list, so `name` may not be from this URL.
-            if (!hasOwnProp(lowerCaseUrlParams, name)) {
-                return;
-            }
-
-            const value = lowerCaseUrlParams[name];
-            if (value) {
-                results[key] = value;
+            if (hasOwnProp(lowerCaseUrlParams, name) && lowerCaseUrlParams[name]) {
+                results[key] = lowerCaseUrlParams[name];
             }
         });
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -390,7 +390,13 @@ const queryStringParserFallback = (url: string): URLSearchParamsFallback => {
         },
         forEach: function(callback: (value: string, key: string) => void) {
             for (var key in params) {
-                if (params.hasOwnProperty(key)) {
+                // Not `params.hasOwnProperty(key)`. The keys here come straight
+                // off the URL, so `?hasOwnProperty=1` gives `params` an own
+                // property shadowing the inherited method with the string `'1'`,
+                // and the next iteration calls it: `TypeError: params
+                // .hasOwnProperty is not a function`. That throws out of
+                // queryStringParser on the init path.
+                if (hasOwnProp(params, key)) {
                     callback(params[key], key);
                 }
             }

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -80,6 +80,18 @@ describe('pageViewTracker pure helpers', () => {
             expect(allowedQueryParams('')).toEqual({});
         });
 
+        // A URL is free to carry a param named after an Object.prototype member.
+        // It is not on the allowlist, so it is dropped like any other unlisted
+        // param — this asserts the drop, not the own-property guard in
+        // queryStringParser, which only bites when the KEY LIST names such a member.
+        it('should drop params named after Object.prototype members', () => {
+            expect(
+                allowedQueryParams(
+                    'https://example.com/?constructor=x&__proto__=y&toString=z&utm_source=google'
+                )
+            ).toEqual({ utm_source: 'google' });
+        });
+
         it('should keep every param on the allowlist', () => {
             const query = ALLOWED_QUERY_PARAMS.map(
                 name => `${name}=v-${name}`

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -115,8 +115,18 @@ describe('Utils', () => {
 
             // Callers supply their own key list, so a key may name an
             // Object.prototype member. Looking that up on a plain object resolves
-            // through the prototype chain to something truthy, which without an
-            // own-property guard gets copied out as though the URL supplied it.
+            // through the prototype chain, and without an own-property guard a
+            // truthy result gets copied out as though the URL supplied it.
+            //
+            // Only `constructor` actually exercises the guard. queryStringParser
+            // lowercases the key before the lookup, so `toString`, `valueOf` and
+            // `hasOwnProperty` become `tostring`/`valueof`/`hasownproperty` and
+            // resolve to undefined; `__proto__` resolves to Object.prototype but
+            // assigning it back onto `results` hits the setter rather than
+            // creating an own property. That makes the `.toLowerCase()` in
+            // queryStringParser load-bearing for five of these six names: remove
+            // it and they stop being inert. The other five are kept as
+            // documentation of the name class, not as independent coverage.
             it('does not resolve keys naming inherited Object.prototype members', () => {
                 const keys = [
                     'foo',
@@ -140,9 +150,11 @@ describe('Utils', () => {
             });
 
             it('returns a plain object so callers can call hasOwnProperty on it', () => {
-                // integrationCapture calls .hasOwnProperty() directly on the
-                // result, which is why the fix guards the lookup rather than
-                // dropping the returned object's prototype.
+                // integrationCapture#applyProcessors calls .hasOwnProperty() on
+                // its `clickIds` argument, and getQueryParams passes the return
+                // value of queryStringParser straight in — which is why the fix
+                // guards the lookup rather than dropping the returned object's
+                // prototype.
                 const result = queryStringParser(url, ['foo']);
 
                 expect(() => result.hasOwnProperty('foo')).not.toThrow();
@@ -229,6 +241,29 @@ describe('Utils', () => {
                 };
 
                 expect(queryStringParser(url, keys)).toEqual(expectedResult);
+            });
+
+            // The fallback builds its param map from the URL, so a param NAMED
+            // after a prototype method gives that map an own property shadowing
+            // the method with a string. Calling it on the next iteration threw
+            // `TypeError: params.hasOwnProperty is not a function` out of
+            // queryStringParser — and this needs no configuration, just a URL.
+            it('survives a query param named after a prototype method', () => {
+                expect(
+                    queryStringParser(
+                        'https://www.example.com?hasOwnProperty=1&foo=bar',
+                        ['foo']
+                    )
+                ).toEqual({ foo: 'bar' });
+            });
+
+            it('still returns a param named after a prototype method when asked for it', () => {
+                expect(
+                    queryStringParser(
+                        'https://www.example.com?hasOwnProperty=1&foo=bar',
+                        ['hasOwnProperty']
+                    )
+                ).toEqual({ hasOwnProperty: '1' });
             });
         });
     });

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -113,31 +113,19 @@ describe('Utils', () => {
                 expect(queryStringParser(url)).toEqual(expectedResult);
             });
 
-            // Callers supply their own key list, so a key may name an
-            // Object.prototype member. Looking that up on a plain object resolves
-            // through the prototype chain, and without an own-property guard a
-            // truthy result gets copied out as though the URL supplied it.
-            //
-            // Only `constructor` actually exercises the guard. queryStringParser
-            // lowercases the key before the lookup, so `toString`, `valueOf` and
-            // `hasOwnProperty` become `tostring`/`valueof`/`hasownproperty` and
-            // resolve to undefined; `__proto__` resolves to Object.prototype but
-            // assigning it back onto `results` hits the setter rather than
-            // creating an own property. That makes the `.toLowerCase()` in
-            // queryStringParser load-bearing for five of these six names: remove
-            // it and they stop being inert. The other five are kept as
-            // documentation of the name class, not as independent coverage.
-            it('does not resolve keys naming inherited Object.prototype members', () => {
-                const keys = [
-                    'foo',
-                    'constructor',
-                    '__proto__',
-                    'toString',
-                    'valueOf',
-                    'hasOwnProperty',
-                ];
+            it('does not resolve a key naming an inherited prototype member', () => {
+                expect(
+                    queryStringParser(url, ['foo', 'constructor', '__proto__'])
+                ).toEqual({ foo: 'bar' });
+            });
 
-                expect(queryStringParser(url, keys)).toEqual({ foo: 'bar' });
+            // Held inert by the lookup being lowercased (`toString` -> `tostring`),
+            // not by the own-property guard. Pinned so that making the lookup
+            // case-sensitive fails here rather than silently.
+            it('does not resolve mixed-case prototype member names either', () => {
+                expect(
+                    queryStringParser(url, ['foo', 'toString', 'valueOf', 'hasOwnProperty'])
+                ).toEqual({ foo: 'bar' });
             });
 
             it('still resolves a real query param sharing a prototype member name', () => {
@@ -150,11 +138,8 @@ describe('Utils', () => {
             });
 
             it('returns a plain object so callers can call hasOwnProperty on it', () => {
-                // integrationCapture#applyProcessors calls .hasOwnProperty() on
-                // its `clickIds` argument, and getQueryParams passes the return
-                // value of queryStringParser straight in — which is why the fix
-                // guards the lookup rather than dropping the returned object's
-                // prototype.
+                // integrationCapture#applyProcessors calls .hasOwnProperty() on this
+                // return value, so it must keep its prototype.
                 const result = queryStringParser(url, ['foo']);
 
                 expect(() => result.hasOwnProperty('foo')).not.toThrow();

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -112,6 +112,42 @@ describe('Utils', () => {
 
                 expect(queryStringParser(url)).toEqual(expectedResult);
             });
+
+            // Callers supply their own key list, so a key may name an
+            // Object.prototype member. Looking that up on a plain object resolves
+            // through the prototype chain to something truthy, which without an
+            // own-property guard gets copied out as though the URL supplied it.
+            it('does not resolve keys naming inherited Object.prototype members', () => {
+                const keys = [
+                    'foo',
+                    'constructor',
+                    '__proto__',
+                    'toString',
+                    'valueOf',
+                    'hasOwnProperty',
+                ];
+
+                expect(queryStringParser(url, keys)).toEqual({ foo: 'bar' });
+            });
+
+            it('still resolves a real query param sharing a prototype member name', () => {
+                expect(
+                    queryStringParser(
+                        'https://www.example.com?constructor=legitimate',
+                        ['constructor']
+                    )
+                ).toEqual({ constructor: 'legitimate' });
+            });
+
+            it('returns a plain object so callers can call hasOwnProperty on it', () => {
+                // integrationCapture calls .hasOwnProperty() directly on the
+                // result, which is why the fix guards the lookup rather than
+                // dropping the returned object's prototype.
+                const result = queryStringParser(url, ['foo']);
+
+                expect(() => result.hasOwnProperty('foo')).not.toThrow();
+                expect(result.hasOwnProperty('foo')).toBe(true);
+            });
         });
 
         describe('without URLSearchParams', () => {


### PR DESCRIPTION
## Summary

Two instances of the same bug class in `queryStringParser`, one latent and one reachable from a URL alone.

**1. Caller-supplied keys resolve through the prototype chain.** `queryStringParser` takes a caller-supplied list of keys and looks each one up on a plain object. `obj[name]` walks the prototype chain, so a key named `constructor` resolves to `Object.prototype.constructor`, passes the truthiness gate, and is copied into the result as though the URL had supplied it.

```js
queryStringParser('https://x.com?foo=bar', ['constructor'])
// before: { constructor: 'function Object() { [native code] }' }
// after:  {}
```

A real `?constructor=legitimate` in the URL still resolves — the guard is an own-property check, not a name ban. There is a test for that.

**2. `queryStringParserFallback` throws on a URL param named `hasOwnProperty`.** The fallback's returned `forEach` calls `params.hasOwnProperty(key)`, where `params`' keys come straight off the URL. `?hasOwnProperty=1` gives that map an own property shadowing the inherited method with the string `'1'`, and the next iteration invokes it.

```js
queryStringParser('https://x.com?hasOwnProperty=1&foo=bar', ['foo'])
// before: TypeError: params.hasOwnProperty is not a function
// after:  { foo: 'bar' }
```

That throws out of `queryStringParser`, through `allowedQueryParams` and `currentPage()`, and out of `IntegrationCapture.capture()` — **on the init path, from a URL alone, with no configuration required.** It is therefore strictly more reachable than (1), which needs a configurable key list to become input at all. The fallback is live code for browsers without `URL`/`URLSearchParams`, and the spec already exercises it (`describe('without URLSearchParams')`), which had no prototype-name coverage before this PR.

Both are fixed with one `hasOwnProp` helper.

## Reachability, stated plainly

- **(1) is not reachable in production today.** Both callers pass hardcoded key lists — `integrationCapture`'s click IDs and `pageViewTracker`'s `ALLOWED_QUERY_PARAMS` — and neither contains a prototype member name. It becomes reachable *input* the moment either list can be extended from configuration, which is the next PR.
- **(2) is reachable today**, on any browser taking the fallback path, from any URL carrying `?hasOwnProperty=`.

**`Object.prototype` is not polluted by any of this, before or after.** I verified. (1) is a data-hygiene and dedup-integrity bug and (2) is a crash — neither is a prototype-pollution vulnerability, and I would rather label them accurately than escalate.

## Why guard the lookup instead of `Object.create(null)`

`Object.create(null)` on the lookup map looks like the smaller fix and kills the whole class at the root. It is the wrong call here for two concrete reasons:

1. `queryStringParser` returns that same map **directly** when no keys are passed (`if (isEmpty(keys)) return lowerCaseUrlParams`), so the null prototype would escape to callers.
2. `integrationCapture.ts:336` — `applyProcessors` — calls `.hasOwnProperty()` on its `clickIds` argument, and `getQueryParams()` passes the return value of `queryStringParser` straight in. A null-prototype object throws there.

So the returned object stays plain, and a test pins that contract.

> Correction from the first revision of this description, which cited `integrationCapture.ts:289`. That line operates on `this.clickIds`, a fresh spread literal (`{...this.clickIds, ...queryParams, ...}`), so it is a plain object regardless of what `queryStringParser` returns. `:336` is the citation that actually holds. The same wrong claim was repeated in a test comment and is fixed there too.

## The other half, and its missing test

This also switches `pageViewTracker`'s `capturedNames()` from `in` to the same own-property check.

**That half has no test in this PR, deliberately.** `capturedNames()` only ever tests names drawn *from* `ALLOWED_QUERY_PARAMS`; with a hardcoded list containing no prototype member name, `in` and `hasOwnProperty` are unobservable through the public helpers.

> Correction: the first revision said the two "cannot be told apart by any test". That is false. `ALLOWED_QUERY_PARAMS` is a mutable export, so a test could push `'constructor'` onto it, assert `pageKey`, and pop it in a `finally`. The honest reason there is no test here is that the only possible one requires mutating an exported array that every other test in the file reads — shared mutable state in a suite that otherwise has none — and that was not worth the smell for one release. It gains a clean regression test in #1373, where the allowlist becomes configurable and the distinction is observable without touching module state.

## Test-quality corrections

The six-key prototype-member test (`['foo', 'constructor', '__proto__', 'toString', 'valueOf', 'hasOwnProperty']`) is **5/6 inert**, and its comment claimed otherwise. `queryStringParser` lowercases the key before the lookup, so:

| key | resolves to | exercises the guard? |
|---|---|---|
| `constructor` | `Object.prototype.constructor` (truthy) | **yes** |
| `__proto__` | `Object.prototype`, but assigning it back hits the setter rather than creating an own property | no |
| `toString` / `valueOf` / `hasOwnProperty` | `tostring` / `valueof` / `hasownproperty` → `undefined` | no |

The list is kept as documentation of the name class, with a comment that says which name does the work — and notes that the `.toLowerCase()` is therefore load-bearing for the other five, which was previously undocumented.

## Verification

Measured, not estimated:

- `jest` — **700 pass / 0 fail**, up from **694** on `origin/development` (+6: 4 from the original commit, 2 from the fallback fix)
- `karma` ChromeHeadless — **1089 pass / 0 fail**, 10 skipped
- `tsc -p . --noEmit` clean, `eslint src/ test/src/` clean

> Correction: the first revision said "+6 jest tests (from 692)". The original commit adds exactly 4 `it()` blocks and removes 0. The 698 total was right; the baseline was stale. Both numbers above are re-measured.

Mutation-checked — each fix deliberately broken, and the named test that catches it:

| mutation | test that fails |
|---|---|
| fallback guard reverted to `params.hasOwnProperty(key)` | `without URLSearchParams › survives a query param named after a prototype method` (and `› still returns a param named after a prototype method when asked for it`) |
| own-property guard deleted from `queryStringParser` | `with URLSearchParams › does not resolve keys naming inherited Object.prototype members` |
| guard replaced with a name ban (`name in Object.prototype`) | `with URLSearchParams › still resolves a real query param sharing a prototype member name` |

## Follow-ups, not fixed here

**Pre-existing full-harvest bug on `development`, unrelated to this PR.** `src/mp-instance.ts:~1546-1553` enables integration capture for any truthy `captureIntegrationSpecificIds.V2` value that is not `'none'`, but only assigns `captureMode` for `'all'` and `'roktonly'`. An unrecognised value leaves `captureMode` `undefined` → `getActiveIntegrationMapping()` returns `{}` → `queryStringParser(href, [])` takes the no-keys branch → **every query param on the page** is captured and forwarded. Verified structurally, not fixed here; it wants its own PR and its own risk assessment.

**Unsafe `obj.hasOwnProperty(...)` invocation elsewhere.** `src/utils.ts:47`, `:453`, `:502` and `src/integrationCapture.ts:289`/`:315`/`:336` all invoke `hasOwnProperty` as a method on an object whose keys may come from user data. A user attribute literally named `hasOwnProperty` throws at `utils.ts:453`. Same class as (2) above; a follow-up ticket rather than scope creep on this stack.

## Stack

Part 1 of 4 for customer-configurable APV query params:

1. **this PR** — hardening
2. #1373 — flag + union of `ALLOWED_QUERY_PARAMS` with a customer list
3. mPServer: `SettingTemplate` row
4. mPServer: Advanced Settings UI field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
