### PR TITLE
fix: type leftover eCommerce tests after #1314 rebase

### DIFF
--- a/test/src/tests-eCommerce.ts
+++ b/test/src/tests-eCommerce.ts
@@ -985,7 +985,7 @@ describe('eCommerce', function() {
             product,
             eventAttributes,
             null,
-            { Step: 4, Option: 'Visa' }
+            { Step: 4, Option: 'Visa' } as unknown as TransactionAttributes
         );
         window.MockForwarder1.instance.receivedEvent.should.have.property(
             'ProductAction'
@@ -1246,8 +1246,8 @@ describe('eCommerce', function() {
 
     it('should be empty when transactionAttributes is empty', () => {
         const mparticle = mParticle.getInstance()
-        const productAction = {}
-        mparticle._Ecommerce.convertTransactionAttributesToProductAction({}, productAction)
+        const productAction = {} as SDKProductAction
+        mparticle._Ecommerce.convertTransactionAttributesToProductAction({} as TransactionAttributes, productAction)
         Object.keys(productAction).length.should.equal(0);
     });
 
@@ -1271,8 +1271,8 @@ describe('eCommerce', function() {
             Tax: "tax"
         };
 
-        const productAction = {};
-        mparticle._Ecommerce.convertTransactionAttributesToProductAction(transactionAttributes, productAction)
+        const productAction = {} as SDKProductAction;
+        mparticle._Ecommerce.convertTransactionAttributesToProductAction(transactionAttributes as unknown as TransactionAttributes, productAction)
         productAction.TransactionId.should.equal("id")
         productAction.Affiliation.should.equal("affiliation")
         productAction.CouponCode.should.equal("couponCode")
@@ -1291,7 +1291,7 @@ describe('eCommerce', function() {
             ],
             ShippingAmount: 10,
             TaxAmount: 5,
-        };
+        } as SDKProductAction;
 
         mParticle
             .getInstance()
@@ -1302,7 +1302,7 @@ describe('eCommerce', function() {
     });
 
     it('should default to zero when there are no products, shipping, or tax', () => {
-        const productAction = { ProductList: [] };
+        const productAction = { ProductList: [] } as SDKProductAction;
 
         mParticle
             .getInstance()
@@ -1315,7 +1315,7 @@ describe('eCommerce', function() {
         const productAction = {
             TotalAmount: 0,
             ProductList: [{ Price: 100, Quantity: 1 }],
-        };
+        } as SDKProductAction;
 
         mParticle
             .getInstance()


### PR DESCRIPTION
## Background
- Align checkout expand/sanitize tests with the existing logProductAction casts so rollup typecheck passes without restoring Cart or logCheckout.

## What Has Changed
- {Describe the changes introduced by this PR}

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
