### PR TITLE
feat: sync Rokt kit with upstream v1.36.1

### DIFF
--- a/kits/rokt/CHANGELOG.md
+++ b/kits/rokt/CHANGELOG.md
@@ -1,3 +1,84 @@
+## [1.36.1](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.36.0...v1.36.1) (2026-08-27)
+
+# [1.36.0](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.35.0...v1.36.0) (2026-08-27)
+
+
+### Features
+
+* forward terminate from the kit to the Rokt launcher ([#122](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/122)) ([87354d4](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/87354d4a05e428482e01829418effa6437c3457b)), closes [#terminate](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/terminate)
+
+# [1.35.0](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.34.1...v1.35.0) (2026-08-21)
+
+
+### Features
+
+* capture UTM params from page views and forward to selectPlacements ([#129](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/129)) ([e1f70d1](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/e1f70d132c06f30efd15a45dbd34285b51715457))
+
+## [1.34.1](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.34.0...v1.34.1) (2026-08-20)
+
+
+### Bug Fixes
+
+* retry page-view storage writes on quota failure and log eviction ([#126](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/126)) ([2e88327](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/2e88327d658e9adca21948ed736c81a9e74d262c))
+
+# [1.34.0](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.33.4...v1.34.0) (2026-08-19)
+
+
+### Features
+
+* send the mParticle device id as a selectPlacements attribute ([#121](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/121)) ([bb754ca](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/bb754ca5d4a313358c3cb9ec612ce98009a46724))
+
+## [1.33.4](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.33.3...v1.33.4) (2026-08-18)
+
+
+### Bug Fixes
+
+* stop retrying legacy page-view migration on every page load ([#118](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/118)) ([c4772f8](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/c4772f8c6b490acaf81f211ad369474bf683fc0b))
+
+## [1.33.3](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.33.2...v1.33.3) (2026-08-18)
+
+
+### Bug Fixes
+
+* limit page-view history to 25 most-recent records ([#123](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/123)) ([26f5a5b](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/26f5a5b1f1dc39ad02f896a2c8b6a900c24a56dd))
+
+## [1.33.2](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.33.1...v1.33.2) (2026-08-18)
+
+
+### Bug Fixes
+
+* add reason codes to PAGE_VIEW_CAPTURE_FAILED logs ([#119](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/119)) ([a4e5255](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/a4e5255ce5b749b406f0938cb8ad7acb5fc1bacc))
+
+## [1.33.1](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.33.0...v1.33.1) (2026-08-17)
+
+
+### Bug Fixes
+
+* read the mParticle session id from the public sessionManager facade ([#117](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/117)) ([ae19fd6](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/ae19fd690feafdfd7240ec296588008274370d9c))
+
+# [1.33.0](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.32.0...v1.33.0) (2026-08-17)
+
+
+### Features
+
+* send the current mParticle session id as a selectPlacements attribute ([#116](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/116)) ([b96ef4a](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/b96ef4a8474c4eb5cddfb9046c469cc666d6b648))
+
+# [1.32.0](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.31.0...v1.32.0) (2026-08-14)
+
+
+### Features
+
+* allow a full origin in domain so the launcher can load from a bundled extension ([#115](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/115)) ([c13e719](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/c13e719f051587a9e1a83e1f4a4c4c63bb37c743))
+
+# [1.31.0](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.30.2...v1.31.0) (2026-08-14)
+
+
+### Features
+
+* cap page-view storage by byte budget instead of fixed count ([#114](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/114)) ([4b041a5](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/4b041a5065a74c589640ec147fcd6b4d3a48b78f))
+* capture page title and canonical URL in page view events ([#112](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/112)) ([7b65606](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/7b6560624832e99f2e8f894a1257cd58df587e5a))
+* namespace page-view localStorage key and migrate legacy key ([#113](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/issues/113)) ([b428b15](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/commit/b428b15c101786885d462f3c27125113c558f534))
+
 ## [1.30.2](https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/compare/v1.30.1...v1.30.2) (2026-08-05)
 
 

--- a/kits/rokt/package-lock.json
+++ b/kits/rokt/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mparticle/web-rokt-kit",
-    "version": "1.30.2",
+    "version": "1.36.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mparticle/web-rokt-kit",
-            "version": "1.30.2",
+            "version": "1.36.1",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@eslint/eslintrc": "^3.3.1",

--- a/kits/rokt/package.json
+++ b/kits/rokt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-rokt-kit",
-    "version": "1.30.2",
+    "version": "1.36.1",
     "description": "mParticle integration kit for Rokt",
     "main": "dist/Rokt-Kit.common.js",
     "module": "dist/Rokt-Kit.esm.js",

--- a/kits/rokt/src/Rokt-Kit.ts
+++ b/kits/rokt/src/Rokt-Kit.ts
@@ -24,6 +24,33 @@ import {
   removeSelectPlacementsAttributePersistenceDeniedAttributes,
 } from './selectPlacementsAttributePersistence';
 
+import {
+  PageEvent,
+  PAGE_VIEWS_MAX_COUNT,
+  buildPageEvents,
+  loadPageViews,
+  writePageViews,
+  clearPageViews,
+  readCanonicalUrl,
+  captureUtmParams,
+  loadUtmParams,
+  clearUtmParams,
+} from './pageViewStorage';
+import { isLocalStorageAvailable } from './storage';
+
+import { isObject, isString, isEmpty, isFunction, sanitizeUrl } from './utils';
+import {
+  createLauncherAttachState,
+  markLauncherAttached,
+  markLauncherAttachFailed,
+  markLauncherTerminated,
+  rememberAttachContext,
+  recreateIfTerminated,
+  resetLauncherAttachState,
+  type LauncherAttachState,
+  type RoktLauncherOptions,
+} from './launcherAttachState';
+
 interface RoktKitSettings {
   accountId: string;
   roktExtensions?: string;
@@ -61,17 +88,6 @@ interface RoktExtensionEntry {
   value: string;
 }
 
-interface PageEvent {
-  pageUrl: string;
-  sourceMessageId: string;
-  timestamp: number;
-  activeTimeOnSite?: number;
-  // Derived at transmission not at capture based
-  // on the next page view's activeTimeOnSite,
-  // so it is absent on stored records.
-  activeTimeOnPage?: number;
-}
-
 interface RoktSelection {
   context?: {
     sessionId?: Promise<string>;
@@ -84,11 +100,12 @@ interface RoktLauncher {
   selectPlacements(options: Record<string, unknown>): RoktSelection | Promise<RoktSelection>;
   hashAttributes(attributes: Record<string, unknown>): Promise<Record<string, unknown>>;
   use(extensionName: string): Promise<unknown>;
+  terminate(): Promise<void>;
 }
 
 interface RoktGlobal {
-  createLauncher(options: Record<string, unknown>): Promise<RoktLauncher>;
-  createLocalLauncher(options: Record<string, unknown>): RoktLauncher;
+  createLauncher(options: RoktLauncherOptions): Promise<RoktLauncher>;
+  createLocalLauncher(options: RoktLauncherOptions): RoktLauncher;
   currentLauncher?: RoktLauncher;
   setExtensionData(data: Record<string, unknown>): void;
 }
@@ -160,7 +177,8 @@ interface MParticleExtended {
   logEvent(name: string, type: number, attrs?: Record<string, unknown>): void;
   EventType: { Other: number };
   getInstance(): MParticleInstance;
-  sessionManager?: { getSession(): string };
+  getDeviceId?(): string;
+  sessionManager?: { getSession?(): string; getSessionId?(): string };
   _getActiveForwarders(): Array<{ name: string }>;
   config?: { isLocalLauncherEnabled?: boolean; isLoggingEnabled?: boolean };
   captureTiming?(metricName: string): void;
@@ -189,6 +207,7 @@ interface TestHelpers {
   RateLimiter: typeof RateLimiter;
   ErrorCodes: typeof ErrorCodes;
   WSDKErrorSeverity: typeof WSDKErrorSeverity;
+  resetLauncherAttachState: () => void;
 }
 
 interface ForwarderRegistration {
@@ -257,16 +276,10 @@ const USER_IDENTIFIED_IN_WORKSPACE_KEY = 'userIdentifiedInWorkspace';
 
 const MESSAGE_TYPE_PAGE_VIEW = 3; // mParticle MessageType.PageView
 const MESSAGE_TYPE_SESSION_END = 2; // mParticle MessageType.SessionEnd
-// localStorage key under which captured page views are persisted (as a JSON
-// string). The kit owns this storage directly — separate from mParticle's
-// cookie/localStorage — so page-view capture does not affect mParticle
-// persistence or cookie sync. Distinct from PAGE_EVENTS_KEY, which is the
-// flattened wire shape sent to Rokt on selectPlacements.
-const LS_PAGE_VIEWS_KEY = 'mpPageViews';
-// Fixed cap on the number of persisted page views (oldest evicted first). Code
-// constant, not a kit setting — change it here.
-const PAGE_VIEWS_MAX_COUNT = 25;
 const PAGE_EVENTS_KEY = 'page_events';
+const PAGE_VIEW_ATTRIBUTES_KEY = 'page_view_attributes';
+const MPARTICLE_SESSION_ID_KEY = 'mparticle_session_id';
+const MPARTICLE_DEVICE_ID_KEY = 'mparticle_device_id';
 
 // Bound on how long selectPlacements will wait for an in-flight Workspace
 // IDSync search before proceeding without the userIdentifiedInWorkspace flag.
@@ -311,27 +324,6 @@ function mp(): MParticleExtended {
 // Module-level utility functions
 // ============================================================
 
-function readPageViewsStorage(): PageEvent[] {
-  try {
-    const stored = window.localStorage.getItem(LS_PAGE_VIEWS_KEY);
-    if (stored === null) {
-      return [];
-    }
-    const parsed = JSON.parse(stored);
-    return Array.isArray(parsed) ? (parsed as PageEvent[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function writePageViewsStorage(pageViews: PageEvent[]): void {
-  window.localStorage.setItem(LS_PAGE_VIEWS_KEY, JSON.stringify(pageViews));
-}
-
-function clearPageViewsStorage(): void {
-  window.localStorage.removeItem(LS_PAGE_VIEWS_KEY);
-}
-
 function generateLauncherScript(domain: string | undefined, extensions: string[]): string {
   const launcherPath = '/wsdk/integrations/launcher.js';
   const baseUrl = [generateBaseUrl(domain), launcherPath].join('');
@@ -349,6 +341,11 @@ function generateThankYouElementScript(domain: string | undefined) {
 
 function generateBaseUrl(domain: string | undefined) {
   const resolvedDomain = typeof domain !== 'undefined' ? domain : DEFAULT_ROKT_DOMAIN;
+
+  if (resolvedDomain.includes('://')) {
+    return resolvedDomain.replace(/\/+$/, '');
+  }
+
   const protocol = 'https://';
 
   return [protocol, resolvedDomain].join('');
@@ -362,7 +359,10 @@ function generateReportingUrl(configuredUrl: string | undefined, domain: string 
     return 'https://' + configuredUrl;
   }
 
-  return generateBaseUrl(domain) + endpoint;
+  const hasNonHttpScheme = domain?.includes('://') && !/^https?:\/\//i.test(domain);
+  const reportingDomain = hasNonHttpScheme ? undefined : domain;
+
+  return generateBaseUrl(reportingDomain) + endpoint;
 }
 
 function loadRoktScript(
@@ -383,10 +383,6 @@ function loadRoktScript(
   if (handlers?.onLoad) script.onload = handlers.onLoad;
   if (handlers?.onError) script.onerror = handlers.onError;
   target.appendChild(script);
-}
-
-function isObject(val: unknown): val is Record<string, unknown> {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
 }
 
 function parseSettingsString<T>(settingsString?: string): T[] {
@@ -480,34 +476,6 @@ function hashEventMessage(messageType: number, eventType: number, eventName: str
   return mp().generateHash([messageType, eventType, eventName].join(''));
 }
 
-function isEmpty(value: unknown): boolean {
-  if (value == null) return true;
-  if (typeof value === 'object') {
-    return Object.keys(value as object).length === 0;
-  }
-  if (Array.isArray(value)) {
-    return (value as unknown[]).length === 0;
-  }
-  return false;
-}
-
-function isString(value: unknown): value is string {
-  return typeof value === 'string';
-}
-
-// Strips the query string from a page-view URL before it is persisted and sent
-// to Rokt, since query params commonly carry PII (emails, tokens, order refs).
-// Returns the input unchanged if it can't be parsed as a URL.
-function sanitizeUrl(href: string): string {
-  try {
-    const url = new URL(href);
-    url.search = '';
-    return url.toString();
-  } catch {
-    return href;
-  }
-}
-
 function generateIntegrationName(customIntegrationName?: string): string {
   const coreSdkVersion = mp().getVersion();
   const kitVersion = process.env.PACKAGE_VERSION;
@@ -561,6 +529,10 @@ function sendAdBlockMeasurementSignals(domain: string | undefined, version: stri
     return;
   }
 
+  if (domain && domain.includes('://') && !/^https:\/\//i.test(domain)) {
+    return;
+  }
+
   const pageUrl = window.location.href.split('?')[0].split('#')[0];
   const params =
     'version=' +
@@ -570,8 +542,8 @@ function sendAdBlockMeasurementSignals(domain: string | undefined, version: stri
     '&pageUrl=' +
     encodeURIComponent(pageUrl);
 
-  const existingDomain = domain || 'apps.rokt.com';
-  createAutoRemovedIframe('https://' + existingDomain + '/v1/wsdk-init/index.html?' + params);
+  const existingBaseUrl = domain ? generateBaseUrl(domain) : 'https://apps.rokt.com';
+  createAutoRemovedIframe(existingBaseUrl + '/v1/wsdk-init/index.html?' + params);
 
   createAutoRemovedIframe(
     'https://' + ADBLOCK_CONTROL_DOMAIN + '/v1/wsdk-init/index.html?' + params + '&isControl=true',
@@ -759,6 +731,22 @@ class LoggingService {
   }
 }
 
+function buildPageEvent(event: SDKEvent): PageEvent {
+  const pageUrl = sanitizeUrl(window.location.href);
+  const pageTitle = event.EventAttributes?.title || document.title;
+  const canonicalUrl = readCanonicalUrl();
+  const activeTimeOnSite = event.ActiveTimeOnSite;
+
+  return {
+    pageUrl,
+    sourceMessageId: event.SourceMessageId,
+    timestamp: event.Timestamp,
+    ...(pageTitle ? { pageTitle } : {}),
+    ...(canonicalUrl !== undefined ? { canonicalUrl } : {}),
+    ...(Number.isFinite(activeTimeOnSite) ? { activeTimeOnSite } : {}),
+  };
+}
+
 // ============================================================
 // RoktKit class
 // ============================================================
@@ -811,6 +799,8 @@ class RoktKit implements KitInterface {
   // or any other identifier benefit from the same dedupe. Cleared on logout
   // so a re-login re-evaluates fresh.
   private _workspaceLastSearchedIdentitiesKey?: string;
+
+  private _launcherAttachState: LauncherAttachState = createLauncherAttachState();
 
   // ---- Private helpers ----
 
@@ -909,37 +899,36 @@ class RoktKit implements KitInterface {
     try {
       pageUrl = sanitizeUrl(window.location.href);
 
-      const pageViews = readPageViewsStorage();
-
-      const pageView: PageEvent = {
-        pageUrl,
-        sourceMessageId: event.SourceMessageId,
-        timestamp: event.Timestamp,
-      };
-
-      if (Number.isFinite(event.ActiveTimeOnSite)) {
-        pageView.activeTimeOnSite = event.ActiveTimeOnSite;
-      }
-
+      const pageViews = loadPageViews();
+      const pageView = buildPageEvent(event);
       pageViews.push(pageView);
 
-      while (pageViews.length > PAGE_VIEWS_MAX_COUNT) {
-        pageViews.shift();
+      const requested = Math.min(pageViews.length, PAGE_VIEWS_MAX_COUNT);
+      const stored = writePageViews(pageViews);
+      if (stored === 0) {
+        const reason = isLocalStorageAvailable() ? 'quota' : 'ls_unavailable';
+        this.loggingService?.log({
+          message: `Rokt Kit: Failed to persist page view for ${pageUrl} [reason: ${reason}]`,
+          code: 'PAGE_VIEW_CAPTURE_FAILED',
+        });
+      } else if (stored < requested) {
+        this.loggingService?.log({
+          message: `Rokt Kit: Page view storage reduced from ${requested} to ${stored} record(s) under quota pressure [reason: quota_eviction]`,
+          code: 'PAGE_VIEW_QUOTA_EVICTION',
+        });
       }
-
-      writePageViewsStorage(pageViews);
     } catch (err) {
-      this.errorReportingService?.report({
-        message: `Rokt Kit: Failed to capture page view for ${pageUrl}`,
+      const reason = isLocalStorageAvailable() ? 'exception' : 'ls_unavailable';
+      const errMessage = err instanceof Error ? err.message : String(err);
+      this.loggingService?.log({
+        message: `Rokt Kit: Failed to capture page view for ${pageUrl}: ${errMessage} [reason: ${reason}]`,
         code: 'PAGE_VIEW_CAPTURE_FAILED',
-        severity: WSDKErrorSeverity.INFO,
-        stackTrace: err instanceof Error ? err.stack : undefined,
       });
     }
   }
 
   private isLauncherReadyToAttach(): boolean {
-    return !!window.Rokt && typeof window.Rokt.createLauncher === 'function';
+    return !!window.Rokt && isFunction(window.Rokt.createLauncher);
   }
 
   /**
@@ -960,34 +949,6 @@ class RoktKit implements KitInterface {
       return {};
     }
     return mp().Rokt.getLocalSessionAttributes!();
-  }
-
-  private buildPageEvents(pageViews: PageEvent[]): PageEvent[] {
-    return pageViews.map((pageView, index) => {
-      const pageEvent: PageEvent = {
-        pageUrl: pageView.pageUrl,
-        sourceMessageId: pageView.sourceMessageId,
-        timestamp: pageView.timestamp,
-      };
-
-      const activeTimeOnSite = pageView.activeTimeOnSite;
-      const hasActiveTime = activeTimeOnSite !== undefined && Number.isFinite(activeTimeOnSite);
-      if (hasActiveTime) {
-        pageEvent.activeTimeOnSite = activeTimeOnSite;
-      }
-
-      const next = pageViews[index + 1];
-      const nextActiveTimeOnSite = next?.activeTimeOnSite;
-      const hasNextActiveTimeOnSite = nextActiveTimeOnSite !== undefined && Number.isFinite(nextActiveTimeOnSite);
-
-      if (hasActiveTime && hasNextActiveTimeOnSite) {
-        const diff = nextActiveTimeOnSite - activeTimeOnSite;
-        if (diff >= 0) {
-          pageEvent.activeTimeOnPage = diff;
-        }
-      }
-      return pageEvent;
-    });
   }
 
   private replaceOtherIdentityWithEmailsha256(userIdentities: IUserIdentities): Record<string, string> {
@@ -1023,7 +984,7 @@ class RoktKit implements KitInterface {
     }
     try {
       const mpInstance = mp().getInstance();
-      if (mpInstance && typeof mpInstance.setIntegrationAttribute === 'function') {
+      if (mpInstance && isFunction(mpInstance.setIntegrationAttribute)) {
         mpInstance.setIntegrationAttribute(moduleId, {
           roktSessionId: sessionId,
         });
@@ -1033,20 +994,41 @@ class RoktKit implements KitInterface {
     }
   }
 
+  private readMpSessionId(): string | undefined {
+    // The public mParticle.sessionManager facade exposes only getSession(), which already returns
+    // the session id. getSessionId() lives on the internal _SessionManager and has never been
+    // re-exported, so prefer it if a future core adds it and fall back to getSession() until then.
+    const sessionManager = mp()?.sessionManager;
+    const readSessionId = sessionManager?.getSessionId ?? sessionManager?.getSession;
+    if (!isFunction(readSessionId)) {
+      return undefined;
+    }
+
+    return readSessionId.call(sessionManager) || undefined;
+  }
+
+  private readMpDeviceId(): string | undefined {
+    // The device application stamp (`das`) outlives the session id: core clears the session on
+    // timeout, cross-tab rotation and endSession(), but never the device id, which lives in
+    // localStorage/cookie for cookieExpiration days (365 by default) and survives login/logout.
+    // Read it per call anyway — a partner can reassign it at any time via setDeviceId().
+    return mp()?.getDeviceId?.() || undefined;
+  }
+
   private attachLauncher(
     accountId: string,
-    launcherOptions: Record<string, unknown>,
-    legacyRoktExtensions: string[] = [],
-  ): void {
-    const mpSessionId =
-      mp() && mp().sessionManager && typeof mp().sessionManager!.getSession === 'function'
-        ? mp().sessionManager!.getSession()
-        : undefined;
+    launcherOptions: RoktLauncherOptions,
+    legacyRoktExtensions: readonly string[] = [],
+  ): Promise<void> {
+    rememberAttachContext(this._launcherAttachState, {
+      accountId,
+      launcherOptions: launcherOptions || {},
+      legacyRoktExtensions,
+    });
 
-    const options: Record<string, unknown> = {
+    const options: RoktLauncherOptions = {
       accountId,
       ...(launcherOptions || {}),
-      ...(mpSessionId ? { mpSessionId } : {}),
     };
 
     let launcherPromise: Promise<RoktLauncher>;
@@ -1056,14 +1038,21 @@ class RoktKit implements KitInterface {
       launcherPromise = window.Rokt!.createLauncher(options);
     }
 
-    launcherPromise
+    return launcherPromise
       .then(async (launcher) => {
-        await registerLegacyExtensions(legacyRoktExtensions, launcher);
+        await registerLegacyExtensions([...legacyRoktExtensions], launcher);
         this.initRoktLauncher(launcher);
       })
       .catch((err: unknown) => {
+        markLauncherAttachFailed(this._launcherAttachState);
         console.error('Error creating Rokt launcher:', err);
       });
+  }
+
+  private recreateLauncherIfTerminated(): Promise<void> | undefined {
+    return recreateIfTerminated(this._launcherAttachState, this.isLauncherReadyToAttach(), (context) =>
+      this.attachLauncher(context.accountId, context.launcherOptions, context.legacyRoktExtensions),
+    );
   }
 
   private initRoktLauncher(launcher: RoktLauncher): void {
@@ -1073,6 +1062,7 @@ class RoktKit implements KitInterface {
     }
     // Locally cache the launcher and filters
     this.launcher = launcher;
+    markLauncherAttached(this._launcherAttachState);
 
     const roktFilters = mp().Rokt?.filters;
 
@@ -1217,7 +1207,8 @@ class RoktKit implements KitInterface {
 
     if (this.isTargetingDisabled()) {
       try {
-        clearPageViewsStorage();
+        clearPageViews();
+        clearUtmParams();
       } catch (err) {
         this.errorReportingService?.report({
           message: 'Rokt Kit: Failed to clear page views when targeting is disabled',
@@ -1256,6 +1247,7 @@ class RoktKit implements KitInterface {
         RateLimiter: RateLimiter,
         ErrorCodes: ErrorCodes,
         WSDKErrorSeverity: WSDKErrorSeverity,
+        resetLauncherAttachState: () => resetLauncherAttachState(this._launcherAttachState),
       };
       this.attachLauncher(accountId, launcherOptions);
       return 'Successfully initialized: ' + name;
@@ -1301,20 +1293,13 @@ class RoktKit implements KitInterface {
   public process(event: SDKEvent): string {
     if (!this.isTargetingDisabled()) {
       if (event.EventDataType === MESSAGE_TYPE_PAGE_VIEW) {
+        captureUtmParams(this.loggingService);
         this.capturePageView(event);
       }
 
       if (event.EventDataType === MESSAGE_TYPE_SESSION_END) {
-        try {
-          clearPageViewsStorage();
-        } catch (err) {
-          this.errorReportingService?.report({
-            message: 'Rokt Kit: Failed to clear page views on session end',
-            code: 'PAGE_VIEW_CAPTURE_FAILED',
-            severity: WSDKErrorSeverity.INFO,
-            stackTrace: err instanceof Error ? err.stack : undefined,
-          });
-        }
+        clearPageViews();
+        clearUtmParams();
       }
     }
 
@@ -1324,7 +1309,7 @@ class RoktKit implements KitInterface {
       return 'Kit not ready for forwarder: ' + name;
     }
 
-    if (typeof mp().Rokt?.setLocalSessionAttribute === 'function') {
+    if (isFunction(mp().Rokt?.setLocalSessionAttribute)) {
       if (!isEmpty(this.placementEventAttributeMappingLookup)) {
         this.applyPlacementEventAttributeMapping(event);
       }
@@ -1492,9 +1477,23 @@ class RoktKit implements KitInterface {
    * rejects it as the awaited return of an async function (TS1058) —
    * working around that would require a cast or wrapping every return in
    * `Promise.resolve(...)`. The inner work runs in `_dispatchPlacements`;
-   * this wrapper just gates it on the in-flight search via `Promise.race`.
+   * this wrapper just gates it on the in-flight search via `Promise.race`,
+   * and on a post-terminate createLauncher when the SPA needs a new instance.
    */
   public selectPlacements(options: Record<string, unknown>): RoktSelection | Promise<RoktSelection> | undefined {
+    const recreate = this.recreateLauncherIfTerminated();
+    if (recreate) {
+      const inFlight = this._workspaceSearchInFlightPromise;
+      const waitForSearch = inFlight
+        ? Promise.race([
+            inFlight,
+            new Promise<void>((resolve) => setTimeout(resolve, WORKSPACE_SEARCH_SELECT_TIMEOUT_MS)),
+          ])
+        : Promise.resolve();
+      return Promise.all([recreate, waitForSearch]).then(() =>
+        this._dispatchPlacements(options),
+      ) as Promise<RoktSelection>;
+    }
     if (this._workspaceSearchInFlightPromise) {
       const inFlight = this._workspaceSearchInFlightPromise;
       return Promise.race([
@@ -1533,7 +1532,10 @@ class RoktKit implements KitInterface {
     const filteredUserIdentities = this.returnUserIdentities(filteredUser);
 
     const sessionAttributes = this.returnLocalSessionAttributes();
-    const pageEvents = this.buildPageEvents(readPageViewsStorage());
+    const pageEvents = buildPageEvents(loadPageViews());
+    const utmParams = loadUtmParams();
+    const mpSessionId = this.readMpSessionId();
+    const mpDeviceId = this.readMpDeviceId();
 
     const selectPlacementsAttributes: Record<string, unknown> = {
       ...(filteredUserIdentities as Record<string, unknown>),
@@ -1541,7 +1543,10 @@ class RoktKit implements KitInterface {
       ...optimizelyAttributes,
       ...sessionAttributes,
       ...(pageEvents.length ? { [PAGE_EVENTS_KEY]: JSON.stringify(pageEvents) } : {}),
+      ...(utmParams ? { [PAGE_VIEW_ATTRIBUTES_KEY]: utmParams } : {}),
       ...(this.userIdentifiedInWorkspace ? { [USER_IDENTIFIED_IN_WORKSPACE_KEY]: true } : {}),
+      ...(mpSessionId ? { [MPARTICLE_SESSION_ID_KEY]: mpSessionId } : {}),
+      ...(mpDeviceId ? { [MPARTICLE_DEVICE_ID_KEY]: mpDeviceId } : {}),
       mpid,
     };
 
@@ -1585,6 +1590,24 @@ class RoktKit implements KitInterface {
       return Promise.reject(new Error('Rokt Kit: Invalid extension name'));
     }
     return this.launcher!.use(extensionName);
+  }
+
+  /**
+   * Tears down the Rokt launcher and the placements it rendered.
+   *
+   * The kit's launcher reference is left in place so isKitReady() stays true.
+   * The Web SDK clears its memoized launcher on terminate, so a later
+   * createLauncher (SPA navigation) produces a new instance. The next
+   * selectPlacements call re-attaches that instance. Nulling the reference
+   * here would flip the kit to not-ready with no drain path for queued calls.
+   */
+  public terminate(): Promise<void> {
+    if (!this.isKitReady()) {
+      console.error('Rokt Kit: Not initialized');
+      return Promise.resolve();
+    }
+    markLauncherTerminated(this._launcherAttachState);
+    return this.launcher!.terminate();
   }
 
   /**
@@ -1639,3 +1662,4 @@ if (typeof window !== 'undefined' && window.mParticle && mp().addForwarder) {
 }
 
 export { register };
+export type { LoggingService };

--- a/kits/rokt/src/launcherAttachState.ts
+++ b/kits/rokt/src/launcherAttachState.ts
@@ -1,0 +1,74 @@
+export type RoktLauncherOptions = Record<string, unknown>;
+
+export interface LauncherAttachContext {
+  accountId: string;
+  launcherOptions: RoktLauncherOptions;
+  legacyRoktExtensions: readonly string[];
+}
+
+export type LauncherLifecycle = 'idle' | 'attached' | 'terminated' | 'recreating';
+
+export interface LauncherAttachState {
+  context: LauncherAttachContext | null;
+  lifecycle: LauncherLifecycle;
+  recreateInFlight: Promise<void> | null;
+}
+
+export type AttachLauncher = (context: LauncherAttachContext) => Promise<void>;
+
+export function createLauncherAttachState(): LauncherAttachState {
+  return {
+    context: null,
+    lifecycle: 'idle',
+    recreateInFlight: null,
+  };
+}
+
+export function rememberAttachContext(state: LauncherAttachState, context: LauncherAttachContext): void {
+  state.context = {
+    accountId: context.accountId,
+    launcherOptions: { ...context.launcherOptions },
+    legacyRoktExtensions: [...context.legacyRoktExtensions],
+  };
+}
+
+export function markLauncherAttached(state: LauncherAttachState): void {
+  state.lifecycle = 'attached';
+}
+
+export function markLauncherTerminated(state: LauncherAttachState): void {
+  if (state.lifecycle === 'idle') {
+    return;
+  }
+  state.lifecycle = 'terminated';
+}
+
+export function markLauncherAttachFailed(state: LauncherAttachState): void {
+  state.lifecycle = 'terminated';
+}
+
+export function resetLauncherAttachState(state: LauncherAttachState): void {
+  state.context = null;
+  state.lifecycle = 'idle';
+  state.recreateInFlight = null;
+}
+
+export function recreateIfTerminated(
+  state: LauncherAttachState,
+  canAttach: boolean,
+  attach: AttachLauncher,
+): Promise<void> | undefined {
+  if (state.recreateInFlight) {
+    return state.recreateInFlight;
+  }
+  if (state.lifecycle !== 'terminated' || !state.context || !canAttach) {
+    return undefined;
+  }
+
+  state.lifecycle = 'recreating';
+  const context = state.context;
+  state.recreateInFlight = attach(context).finally(() => {
+    state.recreateInFlight = null;
+  });
+  return state.recreateInFlight;
+}

--- a/kits/rokt/src/pageViewStorage.ts
+++ b/kits/rokt/src/pageViewStorage.ts
@@ -1,0 +1,116 @@
+import type { LoggingService } from './Rokt-Kit';
+import { readNamespacedField, writeNamespacedField, removeNamespacedField, isLocalStorageAvailable } from './storage';
+import { sanitizeUrl, isObject } from './utils';
+
+const LS_NAMESPACE_KEY = 'mp-rokt-kit';
+const LS_PAGE_VIEWS_FIELD = 'pageViews';
+const LS_UTM_PARAMS_FIELD = 'utmParams';
+export const PAGE_VIEWS_MAX_COUNT = 25;
+
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'] as const;
+type UtmKey = (typeof UTM_KEYS)[number];
+export type UtmParams = Partial<Record<UtmKey, string>>;
+
+export interface PageEvent {
+  pageUrl: string;
+  sourceMessageId: string;
+  timestamp: number;
+  pageTitle?: string;
+  canonicalUrl?: string;
+  activeTimeOnSite?: number;
+  activeTimeOnPage?: number;
+}
+
+function capPageViews(views: PageEvent[]): PageEvent[] {
+  return views.slice(-PAGE_VIEWS_MAX_COUNT);
+}
+
+export function loadPageViews(): PageEvent[] {
+  const stored = readNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD);
+  return Array.isArray(stored) ? (stored as PageEvent[]) : [];
+}
+
+export function writePageViews(pageViews: PageEvent[]): number {
+  const views = capPageViews(pageViews);
+  for (let i = 0; i < views.length; i++) {
+    const toWrite = views.slice(i);
+    if (writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, toWrite)) {
+      return toWrite.length;
+    }
+  }
+  return 0;
+}
+
+export function clearPageViews(): void {
+  removeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD);
+}
+
+export function buildPageEvents(pageViews: PageEvent[]): PageEvent[] {
+  const views = capPageViews(pageViews);
+  return views.map((pageView, index) => {
+    const activeTimeOnSite = pageView.activeTimeOnSite;
+    const hasActiveTime = activeTimeOnSite !== undefined && Number.isFinite(activeTimeOnSite);
+
+    const next = views[index + 1];
+    const nextActiveTimeOnSite = next?.activeTimeOnSite;
+    const hasNextActiveTimeOnSite = nextActiveTimeOnSite !== undefined && Number.isFinite(nextActiveTimeOnSite);
+
+    const diff = hasActiveTime && hasNextActiveTimeOnSite ? nextActiveTimeOnSite - activeTimeOnSite : undefined;
+
+    return {
+      pageUrl: pageView.pageUrl,
+      sourceMessageId: pageView.sourceMessageId,
+      timestamp: pageView.timestamp,
+      ...(pageView.pageTitle !== undefined ? { pageTitle: pageView.pageTitle } : {}),
+      ...(pageView.canonicalUrl !== undefined ? { canonicalUrl: pageView.canonicalUrl } : {}),
+      ...(hasActiveTime ? { activeTimeOnSite } : {}),
+      ...(diff !== undefined && diff >= 0 ? { activeTimeOnPage: diff } : {}),
+    };
+  });
+}
+
+export function captureUtmParams(loggingService: LoggingService | null): void {
+  if (readNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD) !== undefined) {
+    return;
+  }
+  const search = new URLSearchParams(window.location.search);
+  const params: UtmParams = {};
+  for (const key of UTM_KEYS) {
+    const value = search.get(key);
+    if (value) params[key] = value;
+  }
+  if (Object.keys(params).length === 0) {
+    return;
+  }
+  const captured = Object.keys(params).join(', ');
+  if (!writeNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD, params)) {
+    const reason = isLocalStorageAvailable() ? 'quota' : 'ls_unavailable';
+    loggingService?.log({
+      message: `Rokt Kit: Failed to persist UTM params [reason: ${reason}]`,
+      code: 'UTM_CAPTURE_FAILED',
+    });
+    return;
+  }
+  loggingService?.log({
+    message: `Rokt Kit: Captured UTM params [${captured}]`,
+    code: 'UTM_CAPTURE_SUCCESS',
+  });
+}
+
+export function loadUtmParams(): UtmParams | null {
+  const stored = readNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD);
+  return isObject(stored) ? (stored as UtmParams) : null;
+}
+
+export function clearUtmParams(): void {
+  removeNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD);
+}
+
+export function readCanonicalUrl(): string | undefined {
+  const link = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  const href = link?.href;
+  if (!href) {
+    return undefined;
+  }
+  return sanitizeUrl(href);
+}

--- a/kits/rokt/src/storage.ts
+++ b/kits/rokt/src/storage.ts
@@ -1,0 +1,65 @@
+import { isObject } from './utils';
+
+const LS_PROBE_KEY = '__rokt_ls_probe__';
+
+export function isLocalStorageAvailable(): boolean {
+  try {
+    window.localStorage.setItem(LS_PROBE_KEY, '1');
+    window.localStorage.removeItem(LS_PROBE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readJSON(key: string): unknown {
+  try {
+    const stored = window.localStorage.getItem(key);
+    return stored === null ? null : JSON.parse(stored);
+  } catch {
+    return null;
+  }
+}
+
+export function writeJSON(key: string, value: unknown): boolean {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removeKey(key: string): void {
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    /* empty */
+  }
+}
+
+export function readNamespacedField(namespaceKey: string, field: string): unknown {
+  const blob = readJSON(namespaceKey);
+  return isObject(blob) ? blob[field] : undefined;
+}
+
+export function writeNamespacedField(namespaceKey: string, field: string, value: unknown): boolean {
+  const blob = readJSON(namespaceKey);
+  const next = isObject(blob) ? { ...blob } : {};
+  next[field] = value;
+  return writeJSON(namespaceKey, next);
+}
+
+export function removeNamespacedField(namespaceKey: string, field: string): void {
+  const blob = readJSON(namespaceKey);
+  if (!isObject(blob) || !(field in blob)) {
+    return;
+  }
+  const next = { ...blob };
+  delete next[field];
+  if (Object.keys(next).length === 0) {
+    removeKey(namespaceKey);
+  } else {
+    writeJSON(namespaceKey, next);
+  }
+}

--- a/kits/rokt/src/utils.ts
+++ b/kits/rokt/src/utils.ts
@@ -1,0 +1,32 @@
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+export function isFunction(value: unknown): value is (...args: Array<unknown>) => unknown {
+  return typeof value === 'function';
+}
+
+export function isEmpty(value: unknown): boolean {
+  if (value == null) return true;
+  if (typeof value === 'object') {
+    return Object.keys(value as object).length === 0;
+  }
+  return false;
+}
+
+// Strips the query string from a URL before it is persisted and sent to Rokt,
+// since query params commonly carry PII (emails, tokens, order refs).
+// Returns the input unchanged if it can't be parsed as a URL.
+export function sanitizeUrl(href: string): string {
+  try {
+    const url = new URL(href);
+    url.search = '';
+    return url.toString();
+  } catch {
+    return href;
+  }
+}

--- a/kits/rokt/test/src/launcherAttachState.spec.ts
+++ b/kits/rokt/test/src/launcherAttachState.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createLauncherAttachState,
+  rememberAttachContext,
+  markLauncherAttached,
+  markLauncherTerminated,
+  markLauncherAttachFailed,
+  resetLauncherAttachState,
+  recreateIfTerminated,
+  type LauncherAttachContext,
+} from '../../src/launcherAttachState';
+
+function context(overrides: Partial<LauncherAttachContext> = {}): LauncherAttachContext {
+  return {
+    accountId: 'acct-1',
+    launcherOptions: { sandbox: true },
+    legacyRoktExtensions: ['ext-a'],
+    ...overrides,
+  };
+}
+
+describe('launcherAttachState', () => {
+  it('starts idle with no context', () => {
+    const state = createLauncherAttachState();
+
+    expect(state.lifecycle).toBe('idle');
+    expect(state.context).toBeNull();
+    expect(state.recreateInFlight).toBeNull();
+  });
+
+  it('copies attach context so later mutations do not leak', () => {
+    const state = createLauncherAttachState();
+    const launcherOptions = { sandbox: true };
+    const legacyRoktExtensions = ['ext-a'];
+
+    rememberAttachContext(state, { accountId: 'acct-1', launcherOptions, legacyRoktExtensions });
+    launcherOptions.sandbox = false;
+    legacyRoktExtensions.push('ext-b');
+
+    expect(state.context).toEqual({
+      accountId: 'acct-1',
+      launcherOptions: { sandbox: true },
+      legacyRoktExtensions: ['ext-a'],
+    });
+  });
+
+  it('does not treat idle as terminated', () => {
+    const state = createLauncherAttachState();
+
+    markLauncherTerminated(state);
+
+    expect(state.lifecycle).toBe('idle');
+    expect(recreateIfTerminated(state, true, vi.fn())).toBeUndefined();
+  });
+
+  it('recreates once after terminate and coalesces concurrent callers', async () => {
+    const state = createLauncherAttachState();
+    rememberAttachContext(state, context());
+    markLauncherAttached(state);
+    markLauncherTerminated(state);
+
+    let resolveAttach: () => void = () => undefined;
+    const attach = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAttach = resolve;
+        }),
+    );
+
+    const first = recreateIfTerminated(state, true, attach);
+    const second = recreateIfTerminated(state, true, attach);
+
+    expect(first).toBeInstanceOf(Promise);
+    expect(second).toBe(first);
+    expect(attach).toHaveBeenCalledTimes(1);
+    expect(attach).toHaveBeenCalledWith({
+      accountId: 'acct-1',
+      launcherOptions: { sandbox: true },
+      legacyRoktExtensions: ['ext-a'],
+    });
+    expect(state.lifecycle).toBe('recreating');
+
+    resolveAttach();
+    await first;
+
+    expect(state.recreateInFlight).toBeNull();
+  });
+
+  it('does not recreate without context or when attach is unavailable', () => {
+    const attach = vi.fn();
+    const noContext = createLauncherAttachState();
+    noContext.lifecycle = 'terminated';
+
+    expect(recreateIfTerminated(noContext, true, attach)).toBeUndefined();
+
+    const blocked = createLauncherAttachState();
+    rememberAttachContext(blocked, context());
+    markLauncherAttached(blocked);
+    markLauncherTerminated(blocked);
+
+    expect(recreateIfTerminated(blocked, false, attach)).toBeUndefined();
+    expect(attach).not.toHaveBeenCalled();
+  });
+
+  it('can retry after a failed attach', async () => {
+    const state = createLauncherAttachState();
+    rememberAttachContext(state, context());
+    markLauncherAttached(state);
+    markLauncherTerminated(state);
+
+    const firstAttach = vi.fn().mockRejectedValue(new Error('createLauncher failed'));
+    const failed = recreateIfTerminated(state, true, firstAttach);
+    await expect(failed).rejects.toThrow('createLauncher failed');
+    markLauncherAttachFailed(state);
+
+    const secondAttach = vi.fn().mockResolvedValue(undefined);
+    const retried = recreateIfTerminated(state, true, secondAttach);
+    await retried;
+
+    expect(secondAttach).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets to idle', () => {
+    const state = createLauncherAttachState();
+    rememberAttachContext(state, context());
+    markLauncherAttached(state);
+    markLauncherTerminated(state);
+
+    resetLauncherAttachState(state);
+
+    expect(state).toEqual(createLauncherAttachState());
+  });
+});

--- a/kits/rokt/test/src/pageViewStorage.spec.ts
+++ b/kits/rokt/test/src/pageViewStorage.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readJSON, writeNamespacedField } from '../../src/storage';
+import {
+  loadPageViews,
+  writePageViews,
+  clearPageViews,
+  buildPageEvents,
+  captureUtmParams,
+  loadUtmParams,
+  clearUtmParams,
+} from '../../src/pageViewStorage';
+
+const NAMESPACE_KEY = 'mp-rokt-kit';
+const PAGE_VIEWS_FIELD = 'pageViews';
+const UTM_PARAMS_FIELD = 'utmParams';
+
+function stubSearch(search: string): void {
+  vi.stubGlobal('location', { ...window.location, search });
+}
+
+const pageView = (id: string) => ({ pageUrl: 'https://example.com/' + id, sourceMessageId: id, timestamp: 1 });
+
+describe('pageViewStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  describe('loadPageViews', () => {
+    it('returns an empty array when nothing is stored', () => {
+      expect(loadPageViews()).toEqual([]);
+    });
+
+    it('returns the stored page views', () => {
+      writeNamespacedField(NAMESPACE_KEY, PAGE_VIEWS_FIELD, [pageView('home'), pageView('about')]);
+      expect(loadPageViews()).toEqual([pageView('home'), pageView('about')]);
+    });
+
+    it('returns an empty array when the stored value is not an array', () => {
+      writeNamespacedField(NAMESPACE_KEY, PAGE_VIEWS_FIELD, { not: 'an array' });
+      expect(loadPageViews()).toEqual([]);
+    });
+  });
+
+  describe('writePageViews', () => {
+    it('persists the page views and returns the stored count', () => {
+      expect(writePageViews([pageView('home')])).toBe(1);
+      expect(loadPageViews()).toEqual([pageView('home')]);
+    });
+
+    it('keeps only the 25 most-recent views when given more than 25', () => {
+      const views = Array.from({ length: 40 }, (_, i) => pageView('page-' + i));
+      expect(writePageViews(views)).toBe(25);
+      const stored = loadPageViews();
+      expect(stored).toHaveLength(25);
+      expect(stored[0].sourceMessageId).toBe('page-15');
+      expect(stored[24].sourceMessageId).toBe('page-39');
+    });
+
+    it('evicts oldest records and retries when the initial write fails due to quota', () => {
+      const views = Array.from({ length: 5 }, (_, i) => pageView('page-' + i));
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls === 1) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(views)).toBe(4);
+      const stored = loadPageViews();
+      expect(stored).toHaveLength(4);
+      expect(stored[0].sourceMessageId).toBe('page-1');
+      expect(stored[3].sourceMessageId).toBe('page-4');
+    });
+
+    it('evicts oldest records across multiple failed writes until one succeeds', () => {
+      const views = Array.from({ length: 5 }, (_, i) => pageView('page-' + i));
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls <= 3) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(views)).toBe(2);
+      const stored = loadPageViews();
+      expect(stored).toHaveLength(2);
+      expect(stored[0].sourceMessageId).toBe('page-3');
+      expect(stored[1].sourceMessageId).toBe('page-4');
+    });
+
+    it('evicts the oldest record from pre-existing storage when quota is tight on the next write', () => {
+      const existing = Array.from({ length: 5 }, (_, i) => pageView('existing-' + i));
+      writePageViews(existing); // seed storage
+
+      const updated = [...existing, pageView('new')];
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls === 1) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(updated)).toBe(5);
+      const stored = loadPageViews();
+      expect(stored).toHaveLength(5);
+      expect(stored[0].sourceMessageId).toBe('existing-1');
+      expect(stored[4].sourceMessageId).toBe('new');
+    });
+
+    it('returns 0 when every write attempt fails', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('quota', 'QuotaExceededError');
+      });
+      expect(writePageViews([pageView('home')])).toBe(0);
+    });
+  });
+
+  describe('buildPageEvents', () => {
+    it('returns all views when count is within the send limit', () => {
+      const views = Array.from({ length: 10 }, (_, i) => pageView('page-' + i));
+      expect(buildPageEvents(views)).toHaveLength(10);
+    });
+
+    it('caps output at 25 most-recent views when storage exceeds the send limit', () => {
+      const views = Array.from({ length: 40 }, (_, i) => ({
+        pageUrl: 'https://example.com/page-' + i,
+        sourceMessageId: 'id-' + i,
+        timestamp: i,
+      }));
+      const result = buildPageEvents(views);
+      expect(result).toHaveLength(25);
+      expect(result[0].sourceMessageId).toBe('id-15');
+      expect(result[24].sourceMessageId).toBe('id-39');
+    });
+
+    it('computes activeTimeOnPage correctly within the capped window', () => {
+      const views = Array.from({ length: 30 }, (_, i) => ({
+        pageUrl: 'https://example.com/page-' + i,
+        sourceMessageId: 'id-' + i,
+        timestamp: i,
+        activeTimeOnSite: i * 1000,
+      }));
+      const result = buildPageEvents(views);
+      expect(result).toHaveLength(25);
+      expect(result[0].activeTimeOnPage).toBe(1000);
+      expect(result[24].activeTimeOnPage).toBeUndefined();
+    });
+  });
+
+  describe('clearPageViews', () => {
+    it('removes the page-view field', () => {
+      writeNamespacedField(NAMESPACE_KEY, PAGE_VIEWS_FIELD, [pageView('home')]);
+      writeNamespacedField(NAMESPACE_KEY, 'unrelatedField', 'keep-me');
+      clearPageViews();
+
+      const blob = readJSON(NAMESPACE_KEY);
+      expect(blob).not.toHaveProperty(PAGE_VIEWS_FIELD);
+      expect(blob).toHaveProperty('unrelatedField', 'keep-me');
+    });
+  });
+
+  describe('captureUtmParams', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('stores present UTM params on first call', () => {
+      stubSearch('?utm_source=google&utm_medium=cpc&utm_campaign=spring');
+      captureUtmParams(null);
+      expect(readJSON(NAMESPACE_KEY)).toHaveProperty(UTM_PARAMS_FIELD, {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'spring',
+      });
+    });
+
+    it('only stores the keys that are present', () => {
+      stubSearch('?utm_source=email');
+      captureUtmParams(null);
+      const stored = readJSON(NAMESPACE_KEY) as Record<string, unknown>;
+      expect(stored[UTM_PARAMS_FIELD]).toEqual({ utm_source: 'email' });
+    });
+
+    it('does nothing when no UTM params are in the URL', () => {
+      stubSearch('?unrelated=value');
+      captureUtmParams(null);
+      expect(readJSON(NAMESPACE_KEY)).toBeNull();
+    });
+
+    it('does nothing when the URL has no query string', () => {
+      stubSearch('');
+      captureUtmParams(null);
+      expect(readJSON(NAMESPACE_KEY)).toBeNull();
+    });
+
+    it('first touch wins — does not overwrite when UTMs are already stored', () => {
+      stubSearch('?utm_source=google');
+      captureUtmParams(null);
+      stubSearch('?utm_source=facebook&utm_medium=paid');
+      captureUtmParams(null);
+      const stored = readJSON(NAMESPACE_KEY) as Record<string, unknown>;
+      expect(stored[UTM_PARAMS_FIELD]).toEqual({ utm_source: 'google' });
+    });
+  });
+
+  describe('loadUtmParams', () => {
+    it('returns null when nothing is stored', () => {
+      expect(loadUtmParams()).toBeNull();
+    });
+
+    it('returns the stored UTM params', () => {
+      writeNamespacedField(NAMESPACE_KEY, UTM_PARAMS_FIELD, { utm_source: 'google', utm_medium: 'cpc' });
+      expect(loadUtmParams()).toEqual({ utm_source: 'google', utm_medium: 'cpc' });
+    });
+
+    it('returns null when the stored value is not an object', () => {
+      writeNamespacedField(NAMESPACE_KEY, UTM_PARAMS_FIELD, 'invalid');
+      expect(loadUtmParams()).toBeNull();
+    });
+  });
+
+  describe('clearUtmParams', () => {
+    it('removes the utmParams field without affecting other fields', () => {
+      writeNamespacedField(NAMESPACE_KEY, UTM_PARAMS_FIELD, { utm_source: 'google' });
+      writeNamespacedField(NAMESPACE_KEY, PAGE_VIEWS_FIELD, [pageView('home')]);
+      clearUtmParams();
+
+      const blob = readJSON(NAMESPACE_KEY);
+      expect(blob).not.toHaveProperty(UTM_PARAMS_FIELD);
+      expect(blob).toHaveProperty(PAGE_VIEWS_FIELD);
+    });
+  });
+});

--- a/kits/rokt/test/src/storage.spec.ts
+++ b/kits/rokt/test/src/storage.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  isLocalStorageAvailable,
+  readJSON,
+  writeJSON,
+  removeKey,
+  readNamespacedField,
+  writeNamespacedField,
+  removeNamespacedField,
+} from '../../src/storage';
+
+describe('storage: key-agnostic localStorage helpers', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  describe('readJSON', () => {
+    it('returns the parsed value for a stored JSON string', () => {
+      window.localStorage.setItem('k', JSON.stringify({ a: 1, b: [2, 3] }));
+      expect(readJSON('k')).toEqual({ a: 1, b: [2, 3] });
+    });
+
+    it('round-trips values written by writeJSON', () => {
+      writeJSON('k', ['x', 'y']);
+      expect(readJSON('k')).toEqual(['x', 'y']);
+    });
+
+    it('returns null when the key is absent', () => {
+      expect(readJSON('missing')).toBeNull();
+    });
+
+    it('returns null for malformed JSON (does not throw)', () => {
+      window.localStorage.setItem('k', '{not valid json');
+      expect(readJSON('k')).toBeNull();
+    });
+
+    it('returns null when getItem throws (access denied)', () => {
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('SecurityError');
+      });
+      expect(readJSON('k')).toBeNull();
+    });
+  });
+
+  describe('writeJSON', () => {
+    it('persists the value as a JSON string and returns true', () => {
+      expect(writeJSON('k', { hello: 'world' })).toBe(true);
+      expect(window.localStorage.getItem('k')).toBe(JSON.stringify({ hello: 'world' }));
+    });
+
+    it('returns false when setItem throws (quota exceeded / private mode)', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      expect(writeJSON('k', { hello: 'world' })).toBe(false);
+    });
+
+    it('overwrites an existing value', () => {
+      writeJSON('k', 1);
+      writeJSON('k', 2);
+      expect(readJSON('k')).toBe(2);
+    });
+  });
+
+  describe('removeKey', () => {
+    it('removes the stored key', () => {
+      window.localStorage.setItem('k', '1');
+      removeKey('k');
+      expect(window.localStorage.getItem('k')).toBeNull();
+    });
+
+    it('does not throw when removeItem throws', () => {
+      vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+        throw new Error('SecurityError');
+      });
+      expect(() => removeKey('k')).not.toThrow();
+    });
+
+    it('is a no-op for an absent key', () => {
+      expect(() => removeKey('missing')).not.toThrow();
+    });
+  });
+
+  describe('namespaced fields', () => {
+    const NAMESPACE_KEY = 'mp-rokt-kit';
+
+    it('writeNamespacedField stores the value under a field of the namespace object', () => {
+      expect(writeNamespacedField(NAMESPACE_KEY, 'pageViews', [1, 2])).toBe(true);
+      expect(readJSON(NAMESPACE_KEY)).toEqual({ pageViews: [1, 2] });
+    });
+
+    it('readNamespacedField returns the stored field value', () => {
+      writeNamespacedField(NAMESPACE_KEY, 'pageViews', ['a']);
+      expect(readNamespacedField(NAMESPACE_KEY, 'pageViews')).toEqual(['a']);
+    });
+
+    it('preserves sibling fields on write (read-modify-write)', () => {
+      writeNamespacedField(NAMESPACE_KEY, 'pageViews', ['a']);
+      writeNamespacedField(NAMESPACE_KEY, 'other', { x: 1 });
+      expect(readJSON(NAMESPACE_KEY)).toEqual({ pageViews: ['a'], other: { x: 1 } });
+    });
+
+    it('overwrites only the targeted field', () => {
+      writeNamespacedField(NAMESPACE_KEY, 'pageViews', ['a']);
+      writeNamespacedField(NAMESPACE_KEY, 'other', 1);
+      writeNamespacedField(NAMESPACE_KEY, 'pageViews', ['b']);
+      expect(readNamespacedField(NAMESPACE_KEY, 'pageViews')).toEqual(['b']);
+      expect(readNamespacedField(NAMESPACE_KEY, 'other')).toBe(1);
+    });
+
+    it('readNamespacedField returns undefined when the key is absent', () => {
+      expect(readNamespacedField(NAMESPACE_KEY, 'pageViews')).toBeUndefined();
+    });
+
+    it('readNamespacedField returns undefined when the field is absent', () => {
+      writeNamespacedField(NAMESPACE_KEY, 'other', 1);
+      expect(readNamespacedField(NAMESPACE_KEY, 'pageViews')).toBeUndefined();
+    });
+
+    it('readNamespacedField returns undefined when the stored value is not a plain object', () => {
+      writeJSON(NAMESPACE_KEY, [1, 2, 3]);
+      expect(readNamespacedField(NAMESPACE_KEY, 'pageViews')).toBeUndefined();
+    });
+
+    it('writeNamespacedField returns false when the write throws', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      expect(writeNamespacedField(NAMESPACE_KEY, 'pageViews', ['a'])).toBe(false);
+    });
+
+    it('removeNamespacedField clears the field but keeps other fields', () => {
+      writeNamespacedField(NAMESPACE_KEY, 'pageViews', ['a']);
+      writeNamespacedField(NAMESPACE_KEY, 'other', 1);
+      removeNamespacedField(NAMESPACE_KEY, 'pageViews');
+      expect(readNamespacedField(NAMESPACE_KEY, 'pageViews')).toBeUndefined();
+      expect(readJSON(NAMESPACE_KEY)).toEqual({ other: 1 });
+    });
+
+    it('removeNamespacedField drops the namespace key once its last field is gone', () => {
+      writeNamespacedField(NAMESPACE_KEY, 'pageViews', ['a']);
+      removeNamespacedField(NAMESPACE_KEY, 'pageViews');
+      expect(window.localStorage.getItem(NAMESPACE_KEY)).toBeNull();
+    });
+
+    it('removeNamespacedField is a no-op for an absent key or field', () => {
+      expect(() => removeNamespacedField(NAMESPACE_KEY, 'pageViews')).not.toThrow();
+      writeNamespacedField(NAMESPACE_KEY, 'other', 1);
+      removeNamespacedField(NAMESPACE_KEY, 'pageViews');
+      expect(readJSON(NAMESPACE_KEY)).toEqual({ other: 1 });
+    });
+  });
+});
+
+describe('isLocalStorageAvailable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when localStorage is accessible', () => {
+    expect(isLocalStorageAvailable()).toBe(true);
+  });
+
+  it('returns false when setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('SecurityError');
+    });
+    expect(isLocalStorageAvailable()).toBe(false);
+  });
+});

--- a/kits/rokt/test/src/tests.spec.ts
+++ b/kits/rokt/test/src/tests.spec.ts
@@ -5,6 +5,7 @@ import {
   isSelectPlacementsAttributePersistenceDenied,
   removeSelectPlacementsAttributePersistenceDeniedAttributes,
 } from '../../src/selectPlacementsAttributePersistence';
+import { readNamespacedField, writeNamespacedField } from '../../src/storage';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -103,6 +104,9 @@ describe('Rokt Forwarder', () => {
       return 'test-mp-session-id';
     },
   };
+  mParticle.getDeviceId = function () {
+    return 'test-mp-device-id';
+  };
   mParticle._getActiveForwarders = function () {
     return [];
   };
@@ -136,6 +140,8 @@ describe('Rokt Forwarder', () => {
       self.noFunctional = options.noFunctional;
       self.noTargeting = options.noTargeting;
       self.mpSessionId = options.mpSessionId;
+      self.sessionId = options.sessionId;
+      self.sessionToken = options.sessionToken;
       self.createLauncherCalled = true;
       self.isInitialized = true;
       self.sandbox = options.sandbox;
@@ -161,6 +167,8 @@ describe('Rokt Forwarder', () => {
       self.noFunctional = options.noFunctional;
       self.noTargeting = options.noTargeting;
       self.mpSessionId = options.mpSessionId;
+      self.sessionId = options.sessionId;
+      self.sessionToken = options.sessionToken;
       self.createLocalLauncherCalled = true;
       self.isInitialized = true;
       self.sandbox = options.sandbox;
@@ -177,7 +185,7 @@ describe('Rokt Forwarder', () => {
     };
 
     this.currentLauncher = function () {};
-  };
+  } as unknown as { new (): Record<string, unknown> };
 
   beforeAll(async () => {
     (window as any).Rokt = new (MockRoktForwarder as any)();
@@ -215,6 +223,7 @@ describe('Rokt Forwarder', () => {
 
   afterEach(() => {
     (window as any).mParticle.forwarder.userAttributes = {};
+    (window as any).mParticle.forwarder.testHelpers?.resetLauncherAttachState();
     delete (window as any).mParticle.forwarder.launcherOptions;
     delete (window as any).mParticle.Rokt.launcherOptions;
   });
@@ -318,6 +327,32 @@ describe('Rokt Forwarder', () => {
       expect((window as any).Rokt.integrationName).toBe(expectedIntegrationName);
       expect((window as any).Rokt.noFunctional).toBe(true);
       expect((window as any).Rokt.noTargeting).toBe(true);
+    });
+
+    it('should forward sessionId and sessionToken from launcherOptions to createLauncher', async () => {
+      const sessionId = '0198c1a2-3b4c-7d5e-8f90-1a2b3c4d5e6f';
+      const sessionToken = 'header.payload.signature';
+      (window as any).mParticle.Rokt.launcherOptions = {
+        sessionId,
+        sessionToken,
+      };
+
+      await mParticle.forwarder.init(
+        {
+          accountId: '123456',
+        },
+        reportService.cb,
+        true,
+        null,
+        {},
+        null,
+        null,
+        null,
+      );
+
+      expect((window as any).Rokt.createLauncherCalled).toBe(true);
+      expect((window as any).Rokt.sessionId).toBe(sessionId);
+      expect((window as any).Rokt.sessionToken).toBe(sessionToken);
     });
 
     it('should set the filters on the forwarder', async () => {
@@ -820,20 +855,12 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.Rokt.createLauncherCalled).toBe(true);
     });
 
-    it('should pass mpSessionId from mParticle sessionManager to createLauncher', async () => {
+    it('should not pass mpSessionId to createLauncher', async () => {
       (window as any).mParticle.sessionManager = {
         getSession: function () {
           return 'my-mp-session-123';
         },
       };
-
-      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
-
-      expect((window as any).mParticle.Rokt.mpSessionId).toBe('my-mp-session-123');
-    });
-
-    it('should not pass mpSessionId when sessionManager is unavailable', async () => {
-      delete (window as any).mParticle.sessionManager;
 
       await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
 
@@ -850,6 +877,14 @@ describe('Rokt Forwarder', () => {
         return Promise.resolve();
       };
       mParticle.loggedEvents = [];
+      (window as any).mParticle.sessionManager = {
+        getSession: function () {
+          return 'test-mp-session-id';
+        },
+      };
+      (window as any).mParticle.getDeviceId = function () {
+        return 'test-mp-device-id';
+      };
       (window as any).mParticle.Rokt.setLocalSessionAttribute = function (key: any, value: any) {
         mParticle._Store.localSessionAttributes[key] = value;
       };
@@ -901,9 +936,153 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             test: 'test',
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
+      });
+
+      it('should send the mParticle session id current at the time of each call', async () => {
+        let currentSessionId = 'first-mp-session';
+        (window as any).mParticle.sessionManager = {
+          getSession: function () {
+            return currentSessionId;
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('first-mp-session');
+
+        currentSessionId = 'second-mp-session';
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('second-mp-session');
+      });
+
+      it('should omit the mParticle session id when sessionManager is unavailable', async () => {
+        delete (window as any).mParticle.sessionManager;
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes).not.toHaveProperty('mparticle_session_id');
+      });
+
+      // Every published core exposes getSession() and nothing else on the public facade, so this
+      // is the shape that has to keep working.
+      it('should read the mParticle session id from a facade exposing only getSession', async () => {
+        (window as any).mParticle.sessionManager = {
+          getSession: function () {
+            return 'public-facade-session';
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe(
+          'public-facade-session',
+        );
+      });
+
+      it('should prefer getSessionId when a future core exposes it on the facade', async () => {
+        (window as any).mParticle.sessionManager = {
+          getSession: function () {
+            return 'legacy-accessor-session';
+          },
+          getSessionId: function () {
+            return 'preferred-accessor-session';
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe(
+          'preferred-accessor-session',
+        );
+      });
+
+      it('should omit the mParticle session id when the facade exposes neither accessor', async () => {
+        (window as any).mParticle.sessionManager = {};
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes).not.toHaveProperty('mparticle_session_id');
+      });
+
+      it('should keep sending the same device id after the session id rotates', async () => {
+        let currentSessionId = 'first-mp-session';
+        (window as any).mParticle.sessionManager = {
+          getSession: function () {
+            return currentSessionId;
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('first-mp-session');
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_device_id).toBe('test-mp-device-id');
+
+        currentSessionId = 'second-mp-session';
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('second-mp-session');
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_device_id).toBe('test-mp-device-id');
+      });
+
+      it('should send the device id current at the time of each call', async () => {
+        let currentDeviceId = 'first-mp-device';
+        (window as any).mParticle.getDeviceId = function () {
+          return currentDeviceId;
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_device_id).toBe('first-mp-device');
+
+        currentDeviceId = 'second-mp-device';
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_device_id).toBe('second-mp-device');
+      });
+
+      it('should omit the device id when getDeviceId is unavailable', async () => {
+        delete (window as any).mParticle.getDeviceId;
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes).not.toHaveProperty('mparticle_device_id');
+      });
+
+      it('should omit the device id when getDeviceId returns nothing', async () => {
+        (window as any).mParticle.getDeviceId = function () {
+          return undefined;
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes).not.toHaveProperty('mparticle_device_id');
       });
 
       it('should collect mpid and send to launcher.selectPlacements', async () => {
@@ -931,6 +1110,8 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             'user-attribute': 'user-attribute-value',
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
@@ -969,6 +1150,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions).toEqual({
           identifier: 'test-placement',
           attributes: {
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
             'test-attribute': 'test-value',
             'custom-local-attribute': true,
@@ -1043,6 +1226,8 @@ describe('Rokt Forwarder', () => {
           attributes: {
             'user-attribute': 'user-attribute-value',
             'unfiltered-attribute': 'unfiltered-value',
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
@@ -1097,6 +1282,8 @@ describe('Rokt Forwarder', () => {
             'user-attribute': 'user-attribute-value',
             'unfiltered-attribute': 'unfiltered-value',
             'changed-attribute': 'new-value',
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
@@ -1134,6 +1321,8 @@ describe('Rokt Forwarder', () => {
           attributes: {
             loyaltyTier: 'gold',
             page: 'checkout',
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
@@ -1181,6 +1370,8 @@ describe('Rokt Forwarder', () => {
             couponCode: 'SAVE10',
             shippingMethod: 'ground',
             page: 'checkout',
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
@@ -1218,6 +1409,8 @@ describe('Rokt Forwarder', () => {
             loyaltyTier: 'gold',
             active_time_on_site_ms: 12345,
             page: 'checkout',
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
@@ -1256,6 +1449,8 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             active_time_on_site_ms: 67890,
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
@@ -1286,6 +1481,8 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             favoriteStore: 'test-store',
+            mparticle_session_id: 'test-mp-session-id',
+            mparticle_device_id: 'test-mp-device-id',
             mpid: '123',
           },
         });
@@ -1367,6 +1564,8 @@ describe('Rokt Forwarder', () => {
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attribute': 'test-value',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: 'abc',
         });
       });
@@ -1421,6 +1620,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           customerid: 'customer123',
           email: 'test@example.com',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '234',
         });
       });
@@ -1480,6 +1681,8 @@ describe('Rokt Forwarder', () => {
           'test-attribute': 'test-value',
           customerid: 'customer123',
           email: 'test@example.com',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '123',
         });
       });
@@ -1525,6 +1728,8 @@ describe('Rokt Forwarder', () => {
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attribute': 'test-value',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: null,
         });
       });
@@ -1574,6 +1779,8 @@ describe('Rokt Forwarder', () => {
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attribute': 'test-value',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '123',
         });
       });
@@ -1629,6 +1836,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           customerid: 'customer123',
           emailsha256: 'sha256-test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '234',
         });
       });
@@ -1685,6 +1894,8 @@ describe('Rokt Forwarder', () => {
         const attrs = (window as any).Rokt.selectPlacementsOptions.attributes;
         expect(attrs).toEqual({
           customerid: 'customer123',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '234',
         });
         expect(attrs).not.toHaveProperty('emailsha256');
@@ -1747,6 +1958,8 @@ describe('Rokt Forwarder', () => {
           'test-attribute': 'test-value',
           customerid: 'customer123',
           other: 'other-attribute',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '123',
         });
       });
@@ -1809,6 +2022,8 @@ describe('Rokt Forwarder', () => {
           customerid: 'customer123',
           other: 'continues-to-exist',
           emailsha256: 'other-id',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '123',
         });
       });
@@ -1869,6 +2084,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attribute': 'test-value',
           emailsha256: 'hashed-customer-id-value', // mapped from customerid in userIdentities
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '789',
         });
       });
@@ -1929,6 +2146,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attr': 'test-value',
           other: 'hashed-custom-identity-value',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '999',
         });
       });
@@ -1987,6 +2206,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@example.com',
           emailsha256: 'hashed-email-value',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '456',
         });
       });
@@ -2046,6 +2267,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'developer-email@example.com',
           emailsha256: 'hashed-email-value',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '789',
         });
       });
@@ -2106,6 +2329,8 @@ describe('Rokt Forwarder', () => {
           email: 'identity-email@example.com',
           customerid: 'customer456',
           someAttribute: 'someValue',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '901',
         });
       });
@@ -2166,6 +2391,8 @@ describe('Rokt Forwarder', () => {
           email: 'identity-email@example.com',
           emailsha256: 'hashed-from-other',
           customerid: 'customer789',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '912',
         });
       });
@@ -2224,6 +2451,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'developer-email@example.com',
           customerid: 'customer202',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '934',
         });
       });
@@ -2279,6 +2508,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           emailsha256: 'developer-hashed-email',
           customerid: 'customer303',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '945',
         });
       });
@@ -2331,6 +2562,8 @@ describe('Rokt Forwarder', () => {
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           customerid: 'customer505',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '967',
         });
       });
@@ -2386,6 +2619,8 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           emailsha256: 'hashed-from-useridentities',
           customerid: 'customer606',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '978',
         });
       });
@@ -2447,6 +2682,8 @@ describe('Rokt Forwarder', () => {
           email: 'developer-email@example.com',
           emailsha256: 'developer-hashed-email',
           customerid: 'customer909',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '992',
         });
       });
@@ -2502,6 +2739,8 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was empty
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '234',
         });
       });
@@ -2557,6 +2796,8 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was null
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '345',
         });
       });
@@ -2612,6 +2853,8 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was undefined
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '456',
         });
       });
@@ -2667,6 +2910,8 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was 0
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '567',
         });
       });
@@ -2722,6 +2967,8 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was false
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
+          mparticle_device_id: 'test-mp-device-id',
           mpid: '678',
         });
       });
@@ -3135,6 +3382,253 @@ describe('Rokt Forwarder', () => {
 
       expect((window as any).Rokt.useCalled).toBe(true);
       expect((window as any).Rokt.useName).toBe('ThankYouPageJourney');
+    });
+  });
+
+  describe('#terminate', () => {
+    interface TerminateTestLauncher {
+      id?: number;
+      terminate: () => Promise<void>;
+      selectPlacements?: (options: Record<string, unknown>) => unknown;
+    }
+
+    interface TerminateTestKit {
+      isInitialized: boolean;
+      launcher: TerminateTestLauncher | null;
+      terminate: () => Promise<void>;
+      init: (
+        settings: Record<string, unknown>,
+        service: unknown,
+        testMode: boolean,
+        trackerId: null,
+        filteredUserAttributes: Record<string, unknown>,
+      ) => string;
+      selectPlacements: (options: Record<string, unknown>) => unknown;
+    }
+
+    interface TerminateTestRokt {
+      currentLauncher?: TerminateTestLauncher;
+      createLauncher: (options?: Record<string, unknown>) => Promise<TerminateTestLauncher>;
+      attachKitCalled: boolean;
+      attachKit: (kit: TerminateTestKit) => Promise<void>;
+      kit?: TerminateTestKit;
+      filters?: {
+        userAttributesFilters: unknown[];
+        filterUserAttributes: (attributes: Record<string, unknown>) => Record<string, unknown>;
+        filteredUser: { getMPID: () => string };
+      };
+      selectPlacementsCalled?: boolean;
+      selectPlacementsLauncherId?: number;
+      selectPlacementsOptions?: Record<string, unknown>;
+    }
+
+    interface TerminateTestWindow {
+      Rokt: TerminateTestRokt;
+      mParticle: {
+        Rokt: TerminateTestRokt;
+        forwarder: TerminateTestKit;
+      };
+    }
+
+    function tw(): TerminateTestWindow {
+      return window as unknown as TerminateTestWindow;
+    }
+
+    beforeEach(() => {
+      const rokt = new MockRoktForwarder() as unknown as TerminateTestRokt;
+      tw().Rokt = rokt;
+      tw().mParticle.Rokt = rokt;
+      tw().mParticle.Rokt.attachKitCalled = false;
+      tw().mParticle.Rokt.attachKit = async (kit: TerminateTestKit) => {
+        tw().mParticle.Rokt.attachKitCalled = true;
+        tw().mParticle.Rokt.kit = kit;
+      };
+    });
+
+    it('should call launcher.terminate when fully initialized', async () => {
+      let terminateCalled = false;
+      tw().mParticle.forwarder.isInitialized = true;
+      tw().mParticle.forwarder.launcher = {
+        terminate: function () {
+          terminateCalled = true;
+          return Promise.resolve();
+        },
+      };
+
+      await tw().mParticle.forwarder.terminate();
+
+      expect(terminateCalled).toBe(true);
+    });
+
+    it('should return the promise from launcher.terminate', async () => {
+      let resolved = false;
+      tw().mParticle.forwarder.isInitialized = true;
+      tw().mParticle.forwarder.launcher = {
+        terminate: () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
+      };
+
+      await tw()
+        .mParticle.forwarder.terminate()
+        .then(() => {
+          resolved = true;
+        });
+
+      expect(resolved).toBe(true);
+    });
+
+    it('should resolve without calling the launcher when called before initialization', async () => {
+      const originalConsoleError = window.console.error;
+      let errorMessage: string | null = null;
+      window.console.error = function (message: string) {
+        errorMessage = message;
+      };
+
+      tw().mParticle.forwarder.isInitialized = false;
+      tw().mParticle.forwarder.launcher = null;
+
+      try {
+        await expect(tw().mParticle.forwarder.terminate()).resolves.toBeUndefined();
+      } finally {
+        window.console.error = originalConsoleError;
+      }
+
+      expect(errorMessage).toBe('Rokt Kit: Not initialized');
+    });
+
+    it('should resolve without calling the launcher when initialized but the launcher is missing', async () => {
+      const originalConsoleError = window.console.error;
+      let errorMessage: string | null = null;
+      window.console.error = function (message: string) {
+        errorMessage = message;
+      };
+
+      tw().mParticle.forwarder.isInitialized = true;
+      tw().mParticle.forwarder.launcher = null;
+
+      try {
+        await expect(tw().mParticle.forwarder.terminate()).resolves.toBeUndefined();
+      } finally {
+        window.console.error = originalConsoleError;
+      }
+
+      expect(errorMessage).toBe('Rokt Kit: Not initialized');
+    });
+
+    // Leave the kit ready after terminate. A later createLauncher (SPA) can
+    // still mint a new instance because the Web SDK drops its memoized launcher.
+    it('should leave the launcher references intact so the kit stays ready', async () => {
+      const launcher: TerminateTestLauncher = {
+        terminate: () => Promise.resolve(),
+      };
+      tw().mParticle.forwarder.isInitialized = true;
+      tw().mParticle.forwarder.launcher = launcher;
+      tw().Rokt.currentLauncher = launcher;
+
+      await tw().mParticle.forwarder.terminate();
+
+      expect(tw().mParticle.forwarder.launcher).toBe(launcher);
+      expect(tw().Rokt.currentLauncher).toBe(launcher);
+    });
+
+    it('should create a new launcher instance and continue after terminate', async () => {
+      let createCount = 0;
+      const launchers: TerminateTestLauncher[] = [];
+
+      tw().mParticle.Rokt.filters = {
+        userAttributesFilters: [],
+        filterUserAttributes: function (attributes: Record<string, unknown>) {
+          return attributes;
+        },
+        filteredUser: {
+          getMPID: function () {
+            return '123';
+          },
+        },
+      };
+
+      tw().Rokt.createLauncher = async function (): Promise<TerminateTestLauncher> {
+        createCount += 1;
+        const id = createCount;
+        const launcher: TerminateTestLauncher = {
+          id,
+          terminate: () => Promise.resolve(),
+          selectPlacements: function (options: Record<string, unknown>) {
+            tw().Rokt.selectPlacementsCalled = true;
+            tw().Rokt.selectPlacementsLauncherId = id;
+            tw().Rokt.selectPlacementsOptions = options;
+          },
+        };
+        launchers.push(launcher);
+        return launcher;
+      };
+
+      await tw().mParticle.forwarder.init(
+        {
+          accountId: '123456',
+        },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      await waitForCondition(() => tw().mParticle.Rokt.attachKitCalled);
+
+      const firstLauncher = tw().mParticle.forwarder.launcher;
+      expect(firstLauncher).toBe(launchers[0]);
+
+      await tw().mParticle.forwarder.terminate();
+
+      expect(tw().mParticle.forwarder.launcher).toBe(firstLauncher);
+
+      tw().mParticle.Rokt.attachKitCalled = false;
+
+      await tw().mParticle.forwarder.selectPlacements({ attributes: {} });
+
+      await waitForCondition(() => tw().mParticle.Rokt.attachKitCalled);
+
+      const secondLauncher = tw().mParticle.forwarder.launcher;
+      expect(createCount).toBe(2);
+      expect(secondLauncher).toBe(launchers[1]);
+      expect(secondLauncher).not.toBe(firstLauncher);
+      expect(tw().Rokt.currentLauncher).toBe(secondLauncher);
+      expect(tw().Rokt.selectPlacementsCalled).toBe(true);
+      expect(tw().Rokt.selectPlacementsLauncherId).toBe(2);
+    });
+
+    it('should call launcher.terminate after init (test mode) and attach', async () => {
+      let terminateCalled = false;
+
+      tw().mParticle.Rokt.attachKitCalled = false;
+      tw().mParticle.Rokt.attachKit = async (kit: TerminateTestKit) => {
+        tw().mParticle.Rokt.attachKitCalled = true;
+        tw().mParticle.Rokt.kit = kit;
+      };
+
+      tw().Rokt.createLauncher = async function () {
+        return Promise.resolve({
+          terminate: function () {
+            terminateCalled = true;
+            return Promise.resolve();
+          },
+        });
+      };
+
+      await tw().mParticle.forwarder.init(
+        {
+          accountId: '123456',
+        },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      await waitForCondition(() => tw().mParticle.Rokt.attachKitCalled);
+
+      await tw().mParticle.forwarder.terminate();
+
+      expect(terminateCalled).toBe(true);
     });
   });
 
@@ -4116,6 +4610,24 @@ describe('Rokt Forwarder', () => {
       );
     });
 
+    it('should use a chrome-extension origin verbatim so the launcher loads from the bundled extension', () => {
+      expect(
+        (window as any).mParticle.forwarder.testHelpers.generateLauncherScript('chrome-extension://abcdef123/rokt'),
+      ).toBe('chrome-extension://abcdef123/rokt/wsdk/integrations/launcher.js');
+    });
+
+    it('should trim a trailing slash from a full origin so the path join stays clean', () => {
+      expect(
+        (window as any).mParticle.forwarder.testHelpers.generateLauncherScript('chrome-extension://abcdef123/rokt/'),
+      ).toBe('chrome-extension://abcdef123/rokt/wsdk/integrations/launcher.js');
+    });
+
+    it('should preserve an http origin for local development', () => {
+      expect((window as any).mParticle.forwarder.testHelpers.generateLauncherScript('http://localhost:8001')).toBe(
+        'http://localhost:8001/wsdk/integrations/launcher.js',
+      );
+    });
+
     it('should return base URL when no extensions are provided', () => {
       const url = (window as any).mParticle.forwarder.testHelpers.generateLauncherScript();
       expect(url).toBe(baseUrl);
@@ -4163,6 +4675,13 @@ describe('Rokt Forwarder', () => {
     it('should return an updated base URL with CNAME when domain is passed', () => {
       const url = (window as any).mParticle.forwarder.testHelpers.generateThankYouElementScript('cname.rokt.com');
       expect(url).toBe('https://cname.rokt.com/rokt-elements/rokt-element-thank-you.js');
+    });
+
+    it('should use a full custom origin verbatim', () => {
+      const url = (window as any).mParticle.forwarder.testHelpers.generateThankYouElementScript(
+        'chrome-extension://abcdef123/rokt',
+      );
+      expect(url).toBe('chrome-extension://abcdef123/rokt/rokt-elements/rokt-element-thank-you.js');
     });
   });
 
@@ -5638,10 +6157,11 @@ describe('Rokt Forwarder', () => {
     });
 
     describe('page view capture', () => {
-      const readStoredPageViews = () => {
-        const raw = window.localStorage.getItem('mpPageViews');
-        return raw === null ? null : JSON.parse(raw);
-      };
+      const NS_KEY = 'mp-rokt-kit';
+      const PAGE_VIEWS_FIELD = 'pageViews';
+
+      const readStoredPageViews = () => readNamespacedField(NS_KEY, PAGE_VIEWS_FIELD) ?? null;
+      const seedStoredPageViews = (views: unknown) => writeNamespacedField(NS_KEY, PAGE_VIEWS_FIELD, views);
 
       beforeEach(() => {
         window.localStorage.clear();
@@ -5682,7 +6202,121 @@ describe('Rokt Forwarder', () => {
             pageUrl: window.location.href,
             sourceMessageId: 'source-message-id-1',
             timestamp: 1712345678000,
+            pageTitle: 'Home',
             activeTimeOnSite: 4200,
+          },
+        ]);
+      });
+
+      it('captures the page title and canonical URL when present', async () => {
+        document.title = 'Home Page Title';
+        const canonical = document.createElement('link');
+        canonical.setAttribute('rel', 'canonical');
+        canonical.setAttribute('href', 'https://example.com/canonical?tracking=abc#section');
+        document.head.appendChild(canonical);
+
+        try {
+          await (window as any).mParticle.forwarder.init(
+            {
+              accountId: '123456',
+            },
+            reportService.cb,
+            true,
+            null,
+            {},
+          );
+
+          await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+          (window as any).mParticle.forwarder.process({
+            EventName: 'Home Page',
+            EventCategory: EventType.Unknown,
+            EventDataType: MessageType.PageView,
+            SourceMessageId: 'source-message-id-title',
+            Timestamp: 1712345678000,
+          });
+
+          expect(readStoredPageViews()).toEqual([
+            {
+              pageUrl: window.location.href,
+              sourceMessageId: 'source-message-id-title',
+              timestamp: 1712345678000,
+              pageTitle: 'Home Page Title',
+              canonicalUrl: 'https://example.com/canonical#section',
+            },
+          ]);
+        } finally {
+          document.title = '';
+          document.head.removeChild(canonical);
+        }
+      });
+
+      it('prefers the event title over document.title when both are present', async () => {
+        document.title = 'Document Title';
+
+        try {
+          await (window as any).mParticle.forwarder.init(
+            {
+              accountId: '123456',
+            },
+            reportService.cb,
+            true,
+            null,
+            {},
+          );
+
+          await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+          (window as any).mParticle.forwarder.process({
+            EventName: 'Home Page',
+            EventCategory: EventType.Unknown,
+            EventDataType: MessageType.PageView,
+            SourceMessageId: 'source-message-id-event-title',
+            Timestamp: 1712345678000,
+            EventAttributes: {
+              title: 'Event Title',
+            },
+          });
+
+          expect(readStoredPageViews()).toEqual([
+            {
+              pageUrl: window.location.href,
+              sourceMessageId: 'source-message-id-event-title',
+              timestamp: 1712345678000,
+              pageTitle: 'Event Title',
+            },
+          ]);
+        } finally {
+          document.title = '';
+        }
+      });
+
+      it('omits pageTitle and canonicalUrl when neither is available', async () => {
+        await (window as any).mParticle.forwarder.init(
+          {
+            accountId: '123456',
+          },
+          reportService.cb,
+          true,
+          null,
+          {},
+        );
+
+        await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+        (window as any).mParticle.forwarder.process({
+          EventName: 'Home Page',
+          EventCategory: EventType.Unknown,
+          EventDataType: MessageType.PageView,
+          SourceMessageId: 'source-message-id-bare',
+          Timestamp: 1712345678000,
+        });
+
+        expect(readStoredPageViews()).toEqual([
+          {
+            pageUrl: window.location.href,
+            sourceMessageId: 'source-message-id-bare',
+            timestamp: 1712345678000,
           },
         ]);
       });
@@ -5748,7 +6382,7 @@ describe('Rokt Forwarder', () => {
         expect(readStoredPageViews()).toBeNull();
       });
 
-      it('caps the stored history at 25 records, evicting oldest first', async () => {
+      it('keeps only the 25 most-recent views when more than 25 are written', async () => {
         await (window as any).mParticle.forwarder.init(
           {
             accountId: '123456',
@@ -5761,22 +6395,64 @@ describe('Rokt Forwarder', () => {
 
         await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
 
+        const seed = [];
         for (let i = 0; i < 30; i++) {
-          (window as any).mParticle.forwarder.process({
-            EventName: 'Page ' + i,
-            EventCategory: EventType.Unknown,
-            EventDataType: MessageType.PageView,
-            SourceMessageId: 'source-message-id-' + i,
-            Timestamp: 1712345678000 + i,
-            ActiveTimeOnSite: i,
+          seed.push({
+            pageUrl: 'https://example.com/page-' + i,
+            sourceMessageId: 'seed-' + i,
+            timestamp: 1712345678000 + i,
           });
         }
+        seedStoredPageViews(seed);
+
+        (window as any).mParticle.forwarder.process({
+          EventName: 'Newest',
+          EventCategory: EventType.Unknown,
+          EventDataType: MessageType.PageView,
+          SourceMessageId: 'newest',
+          Timestamp: 1712345678999,
+          ActiveTimeOnSite: 1,
+        });
 
         const stored = readStoredPageViews();
-        // 30 written, capped at 25 — the 5 oldest evicted, newest always retained.
         expect(stored.length).toBe(25);
-        expect(stored[0].sourceMessageId).toBe('source-message-id-5');
-        expect(stored[stored.length - 1].sourceMessageId).toBe('source-message-id-29');
+        expect(stored[stored.length - 1].sourceMessageId).toBe('newest');
+        expect(stored[0].sourceMessageId).toBe('seed-6');
+      });
+
+      it('stores both old and new record regardless of individual record size', async () => {
+        await (window as any).mParticle.forwarder.init(
+          {
+            accountId: '123456',
+          },
+          reportService.cb,
+          true,
+          null,
+          {},
+        );
+
+        await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+        seedStoredPageViews([
+          {
+            pageUrl: 'https://example.com/' + 'a'.repeat(50000),
+            sourceMessageId: 'seed-huge',
+            timestamp: 1712345678000,
+          },
+        ]);
+
+        (window as any).mParticle.forwarder.process({
+          EventName: 'Newest',
+          EventCategory: EventType.Unknown,
+          EventDataType: MessageType.PageView,
+          SourceMessageId: 'newest',
+          Timestamp: 1712345678999,
+          ActiveTimeOnSite: 1,
+        });
+
+        const stored = readStoredPageViews();
+        expect(stored.length).toBe(2);
+        expect(stored[stored.length - 1].sourceMessageId).toBe('newest');
       });
 
       it('clears the stored page-view history on a SessionEnd event', async () => {
@@ -5870,7 +6546,7 @@ describe('Rokt Forwarder', () => {
         expect(readStoredPageViews()).toBeNull();
       });
 
-      it('does not throw and reports a warning when localStorage writes throw', async () => {
+      it('does not throw and logs a diagnostic when localStorage writes throw', async () => {
         await (window as any).mParticle.forwarder.init(
           {
             accountId: '123456',
@@ -5884,6 +6560,7 @@ describe('Rokt Forwarder', () => {
         await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
 
         const reportSpy = vi.spyOn((window as any).mParticle.forwarder.errorReportingService, 'report');
+        const logSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'log');
         const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
           throw new Error('QuotaExceededError');
         });
@@ -5905,11 +6582,54 @@ describe('Rokt Forwarder', () => {
 
         // Nothing is persisted, but the forwarder keeps running.
         expect(readStoredPageViews()).toBeNull();
-        // The write failure is surfaced as an INFO (rate-limited per severity).
-        expect(reportSpy).toHaveBeenCalledWith(
-          expect.objectContaining({ code: 'PAGE_VIEW_CAPTURE_FAILED', severity: 'INFO' }),
-        );
+        // The failed write is best-effort: surfaced as a diagnostic INFO log
+        // (loggingService.log), never an error report.
+        expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({ code: 'PAGE_VIEW_CAPTURE_FAILED' }));
+        expect(reportSpy).not.toHaveBeenCalledWith(expect.objectContaining({ code: 'PAGE_VIEW_CAPTURE_FAILED' }));
+        logSpy.mockRestore();
         reportSpy.mockRestore();
+      });
+
+      it('fails gracefully and preserves existing data when localStorage quota is exceeded', async () => {
+        await (window as any).mParticle.forwarder.init(
+          {
+            accountId: '123456',
+          },
+          reportService.cb,
+          true,
+          null,
+          {},
+        );
+
+        await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+        const seed = [];
+        for (let i = 0; i < 5; i++) {
+          seed.push({ pageUrl: 'https://example.com/', sourceMessageId: 'seed-' + i, timestamp: 1712345678000 + i });
+        }
+        seedStoredPageViews(seed);
+
+        const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function () {
+          throw new DOMException('quota', 'QuotaExceededError');
+        });
+
+        try {
+          (window as any).mParticle.forwarder.process({
+            EventName: 'Newest',
+            EventCategory: EventType.Unknown,
+            EventDataType: MessageType.PageView,
+            SourceMessageId: 'newest',
+            Timestamp: 1712345678999,
+            ActiveTimeOnSite: 1,
+          });
+        } finally {
+          setItemSpy.mockRestore();
+        }
+
+        // Write failed silently — existing seed data is unchanged.
+        const stored = readStoredPageViews();
+        expect(stored.length).toBe(5);
+        expect(stored[stored.length - 1].sourceMessageId).toBe('seed-4');
       });
 
       it('captures page views independently of setLocalSessionAttribute availability', async () => {
@@ -5985,6 +6705,43 @@ describe('Rokt Forwarder', () => {
             sourceMessageId: 'source-message-id-4',
             timestamp: 1712345678000,
             activeTimeOnSite: 4200,
+          },
+        ]);
+      });
+
+      it('carries pageTitle and canonicalUrl through selectPlacements when stored', async () => {
+        seedStoredPageViews([
+          {
+            pageUrl: 'https://example.com/a',
+            sourceMessageId: 'source-message-id-a',
+            timestamp: 1712345678000,
+            pageTitle: 'Page A',
+            canonicalUrl: 'https://example.com/canonical-a',
+          },
+        ]);
+
+        await (window as any).mParticle.forwarder.init(
+          {
+            accountId: '123456',
+          },
+          reportService.cb,
+          true,
+          null,
+          {},
+        );
+
+        await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        const forwardedAttributes = (window as any).mParticle.Rokt.selectPlacementsOptions.attributes;
+        expect(JSON.parse(forwardedAttributes.page_events)).toEqual([
+          {
+            pageUrl: 'https://example.com/a',
+            sourceMessageId: 'source-message-id-a',
+            timestamp: 1712345678000,
+            pageTitle: 'Page A',
+            canonicalUrl: 'https://example.com/canonical-a',
           },
         ]);
       });
@@ -6157,22 +6914,19 @@ describe('Rokt Forwarder', () => {
         // followed by one that has it. A coerced-to-0 first record would diff
         // against the next (300000 - 0) and invent a 5-minute dwell that never
         // happened; "unknown" must stay distinguishable from a genuine zero.
-        window.localStorage.setItem(
-          'mpPageViews',
-          JSON.stringify([
-            {
-              pageUrl: 'https://example.com/a',
-              sourceMessageId: 'missing-ats',
-              timestamp: 1712345678000,
-            },
-            {
-              pageUrl: 'https://example.com/b',
-              sourceMessageId: 'has-ats',
-              timestamp: 1712345679000,
-              activeTimeOnSite: 300000,
-            },
-          ]),
-        );
+        seedStoredPageViews([
+          {
+            pageUrl: 'https://example.com/a',
+            sourceMessageId: 'missing-ats',
+            timestamp: 1712345678000,
+          },
+          {
+            pageUrl: 'https://example.com/b',
+            sourceMessageId: 'has-ats',
+            timestamp: 1712345679000,
+            activeTimeOnSite: 300000,
+          },
+        ]);
 
         await (window as any).mParticle.forwarder.init(
           {
@@ -6201,17 +6955,14 @@ describe('Rokt Forwarder', () => {
 
       it('clears stored page views on init when targeting is disabled', async () => {
         // Seed a stored page view from a period when targeting was permitted.
-        window.localStorage.setItem(
-          'mpPageViews',
-          JSON.stringify([
-            {
-              pageUrl: 'https://example.com/',
-              sourceMessageId: 'seeded',
-              timestamp: 1712345678000,
-              activeTimeOnSite: 4200,
-            },
-          ]),
-        );
+        seedStoredPageViews([
+          {
+            pageUrl: 'https://example.com/',
+            sourceMessageId: 'seeded',
+            timestamp: 1712345678000,
+            activeTimeOnSite: 4200,
+          },
+        ]);
 
         (window as any).mParticle.Rokt.launcherOptions = {
           noTargeting: true,
@@ -6688,6 +7439,42 @@ describe('Rokt Forwarder', () => {
       expect(defaultDomainIframe).toBeTruthy();
     });
 
+    it('should still create the probe for a full https origin', () => {
+      Math.random = () => 0.05;
+      (window as any).__rokt_li_guid__ = 'test-guid-123';
+
+      (window as any).mParticle.forwarder.testHelpers.sendAdBlockMeasurementSignals(
+        'https://custom.rokt.com',
+        'test-version',
+      );
+
+      const iframes = document.querySelectorAll('iframe');
+      const srcs = Array.prototype.map.call(iframes, (iframe: any) => iframe.src) as string[];
+
+      const httpsDomainIframe = srcs.find(
+        (src) => src.indexOf('https://custom.rokt.com/v1/wsdk-init/index.html') !== -1,
+      );
+
+      expect(httpsDomainIframe).toBeTruthy();
+    });
+
+    it('should not create the probe for a chrome-extension origin', () => {
+      Math.random = () => 0.05;
+      (window as any).__rokt_li_guid__ = 'test-guid-123';
+
+      (window as any).mParticle.forwarder.testHelpers.sendAdBlockMeasurementSignals(
+        'chrome-extension://abcdef123/rokt',
+        'test-version',
+      );
+
+      const iframes = document.querySelectorAll('iframe');
+      const srcs = Array.prototype.map.call(iframes, (iframe: any) => iframe.src) as string[];
+
+      const anyProbe = srcs.find((src) => src.indexOf('/v1/wsdk-init/index.html') !== -1);
+
+      expect(anyProbe).toBeUndefined();
+    });
+
     it('should not create iframes when sampled out', () => {
       Math.random = () => 0.5; // Above 0.1 threshold
       (window as any).__rokt_li_guid__ = 'test-guid-123';
@@ -6973,6 +7760,26 @@ describe('Rokt Forwarder', () => {
 
     it('should use default Rokt error URL when not configured', () => {
       const service = new ErrorReportingServiceClass({ isLoggingEnabled: true }, '1.0.0', 'test-guid');
+      service.report({ message: 'test error', severity: WSDKErrorSeverityConst.ERROR });
+      expect(fetchCalls[0].url).toBe('https://apps.rokt-api.com/v1/errors');
+    });
+
+    it('should use a full https integration domain for the error URL', () => {
+      const service = new ErrorReportingServiceClass(
+        { isLoggingEnabled: true, integrationDomain: 'https://custom.rokt.com' },
+        '1.0.0',
+        'test-guid',
+      );
+      service.report({ message: 'test error', severity: WSDKErrorSeverityConst.ERROR });
+      expect(fetchCalls[0].url).toBe('https://custom.rokt.com/v1/errors');
+    });
+
+    it('should fall back to the default error URL for a chrome-extension integration domain', () => {
+      const service = new ErrorReportingServiceClass(
+        { isLoggingEnabled: true, integrationDomain: 'chrome-extension://abcdef123/rokt' },
+        '1.0.0',
+        'test-guid',
+      );
       service.report({ message: 'test error', severity: WSDKErrorSeverityConst.ERROR });
       expect(fetchCalls[0].url).toBe('https://apps.rokt-api.com/v1/errors');
     });

--- a/kits/rokt/test/src/utils.spec.ts
+++ b/kits/rokt/test/src/utils.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { isObject, isString, isEmpty, isFunction } from '../../src/utils';
+
+describe('utils: type guards', () => {
+  describe('isObject', () => {
+    it('is true for plain objects', () => {
+      expect(isObject({})).toBe(true);
+      expect(isObject({ a: 1 })).toBe(true);
+    });
+
+    it('is false for arrays', () => {
+      expect(isObject([])).toBe(false);
+      expect(isObject([1, 2])).toBe(false);
+    });
+
+    it('is false for null and undefined', () => {
+      expect(isObject(null)).toBe(false);
+      expect(isObject(undefined)).toBe(false);
+    });
+
+    it('is false for primitives', () => {
+      expect(isObject('s')).toBe(false);
+      expect(isObject(1)).toBe(false);
+      expect(isObject(true)).toBe(false);
+    });
+  });
+
+  describe('isString', () => {
+    it('is true for strings', () => {
+      expect(isString('')).toBe(true);
+      expect(isString('abc')).toBe(true);
+    });
+
+    it('is false for non-strings', () => {
+      expect(isString(1)).toBe(false);
+      expect(isString(null)).toBe(false);
+      expect(isString(undefined)).toBe(false);
+      expect(isString({})).toBe(false);
+      expect(isString(['a'])).toBe(false);
+    });
+  });
+
+  describe('isFunction', () => {
+    it('is true for function declarations and expressions', () => {
+      expect(isFunction(function named() {})).toBe(true);
+      expect(isFunction(() => undefined)).toBe(true);
+      expect(isFunction(async () => undefined)).toBe(true);
+    });
+
+    it('is true for methods read off an object', () => {
+      const sessionManager = { getSessionId: () => 'session-id' };
+      expect(isFunction(sessionManager.getSessionId)).toBe(true);
+    });
+
+    it('is false for a missing method', () => {
+      const sessionManager = {} as { getSessionId?: () => string };
+      expect(isFunction(sessionManager.getSessionId)).toBe(false);
+    });
+
+    it('is false for null and undefined', () => {
+      expect(isFunction(null)).toBe(false);
+      expect(isFunction(undefined)).toBe(false);
+    });
+
+    it('is false for non-callable values', () => {
+      expect(isFunction({})).toBe(false);
+      expect(isFunction([])).toBe(false);
+      expect(isFunction('getSessionId')).toBe(false);
+      expect(isFunction(1)).toBe(false);
+      expect(isFunction(true)).toBe(false);
+    });
+  });
+
+  describe('isEmpty', () => {
+    it('is true for null and undefined', () => {
+      expect(isEmpty(null)).toBe(true);
+      expect(isEmpty(undefined)).toBe(true);
+    });
+
+    it('is true for empty objects and arrays', () => {
+      expect(isEmpty({})).toBe(true);
+      expect(isEmpty([])).toBe(true);
+    });
+
+    it('is false for non-empty objects and arrays', () => {
+      expect(isEmpty({ a: 1 })).toBe(false);
+      expect(isEmpty([1])).toBe(false);
+    });
+
+    it('is false for non-empty primitives', () => {
+      expect(isEmpty('abc')).toBe(false);
+      expect(isEmpty(0)).toBe(false);
+      expect(isEmpty(false)).toBe(false);
+    });
+  });
+});

--- a/kits/rokt/test/vitest.setup.ts
+++ b/kits/rokt/test/vitest.setup.ts
@@ -26,6 +26,7 @@
   sessionManager: {
     getSession: () => 'test-mp-session-id',
   },
+  getDeviceId: () => 'test-mp-device-id',
   _getActiveForwarders: () => [],
   generateHash: (input: string) => 'hashed-<' + input + '>-value',
   loggedEvents: [] as unknown[],


### PR DESCRIPTION
## Background
- Bring the monorepo kit to the latest standalone release (terminate + remove legacy page-view migration) while preserving v3 packaging metadata.

## What Has Changed
- {Describe the changes introduced by this PR}

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
