### PR TITLE
feat(apv): let a customer remove a default query param, not just add

### DIFF
--- a/kits/braze/braze-3/README.md
+++ b/kits/braze/braze-3/README.md
@@ -1,52 +1,116 @@
-![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png) 
+![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png)
 
-⚠️⚠️⚠️
-# Notice! Opt in is now available for Braze Web SDK V4 - Action Required
+# mParticle Braze Kit — Braze Web SDK V3
 
-You can now select what version of the Braze SDK you want to use when setting up a Braze connection in the mParticle UI.  Braze occasionally makes breaking changes to their SDK, so if you call `appboy` directly in your code, you will have to update your code to ensure your website performs as expected when updating versions of Braze.
+This kit bundles **Braze Web SDK V3** (`@braze/web-sdk@^3.5.0`) and exposes it on the page as `window.appboy`.
 
-Please review the [Braze Changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog#400) and [V4 migration guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md) to learn about the differences between V3 and V4 and what changes you will need to make in your code. The most significant breaking changes are the replacement of the `appboy` class name with `braze`, in addition to the removal and renaming of several APIs.
+---
 
-You can opt into the latest major version of the Braze Web SDK whether you implement mParticle's Web SDK using npm or our snippet/CDN.
-* Customers who self-host mParticle via npm - You should add @mparticle/web-braze-kit version 4.0.0 or greater in your package.json now! You must also select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
-* Customers who load mParticle via snippet/CDN - Opting in is available via the mParticle UI in your Braze connection settings.
+## ⚠️ We recommend upgrading to Braze Web SDK V6
 
-Note that the following is only one example.  Everywhere you manually call `appboy` needs to be updated similar to the below. If you are using NPM, you can skip to step 3.  Please be sure to test your site fully in development prior to releasing.
+Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
+See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
 
-* Step 1: Legacy code sample. Find all the places where your code references the `appboy.display` namespace.  Braze has removed all instances of the `display` namespace:
+### How to upgrade
+
+1. **Audit the code you own.** If you call Braze directly, find every `appboy` reference and compare it with the table below and Braze's upgrade documentation.
+2. **Move to the V6 kit.**
+   - Self-hosting via npm with **core Web SDK v3 (latest)**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2 (legacy)**: `npm install @mparticle/web-braze-kit@^6`
+   - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
+3. **Add defensive code** if you load mParticle via the snippet and call Braze directly. Skip this if you self-host via npm. See [Write version-tolerant code](#write-version-tolerant-code).
+4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+
+---
+
+## What changed from V3 to V6
+
+The table below is the V3 API you have today mapped to the V6 API you should use. Several of these were deprecated in V3 and then removed.
+
+Primary sources: the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) and the [Braze upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md).
+
+| V3 | V6 |
+| --- | --- |
+| `appboy` global | `braze` |
+| `appboy.display.*` namespace | Methods moved to the top level: `braze.*` |
+| `appboy.registerAppboyPushMessages()` | `braze.requestPushPermission()` |
+| `appboy.unregisterAppboyPushMessages()` | `braze.unregisterPush()` |
+| `appboy.display.automaticallyShowNewInAppMessages()` | `braze.automaticallyShowInAppMessages()` — must run *before* `openSession()` |
+| `appboy.toggleAppboyLogging()` | `braze.toggleLogging()` |
+| `appboy.isPushGranted()` *(deprecated since 1.6.2)* | `braze.isPushPermissionGranted()` |
+| `appboy.subscribeToNewInAppMessages()` *(deprecated since 2.4.0)* | `braze.subscribeToInAppMessage()` |
+| `appboy.trackLocation()` *(deprecated since 3.3.0)* | Native Geolocation API + `User.setLastKnownLocation()` |
+| `appboy.stopWebTracking()` *(deprecated since 3.5.0)* | `braze.disableSDK()` |
+| `appboy.resumeWebTracking()` *(deprecated since 3.5.0)* | `braze.enableSDK()` |
+| `appboy.logCardClick()` | `braze.logContentCardClick()` |
+| `appboy.logCardImpressions()` | `braze.logContentCardImpressions()` |
+| `appboy.logContentCardsDisplayed()` | Delete it — it was already a no-op |
+| Legacy News Feed: `Feed`, `destroyFeed()`, `getCachedFeed()`, `logFeedDisplayed()`, `requestFeedRefresh()`, `showFeed()`, `subscribeToFeedUpdates()`, `toggleFeed()` | **No drop-in replacement.** Migrate to Content Cards |
+| `devicePropertyWhitelist` init option *(deprecated since 3.1.0)* | `devicePropertyAllowlist` |
+| `enableHtmlInAppMessages` init option *(deprecated since 3.3.0)* | `allowUserSuppliedJavascript` |
+| `language` init option | `localization` |
+| `safariWebsitePushId` param on `registerAppboyPushMessages()` | `safariWebsitePushId` initialization option |
+| `cardId` / `campaignId` on in-app messages | Update your `InAppMessage` subclass constructors |
+| `User.setAvatarImageUrl()` | No replacement; no longer used |
+| `appboy.Banner` card class | `braze.ImageOnly` |
+| `ab-banner` CSS class | `ab-image-only` |
+
+If you call Braze directly, search your codebase for **every** `appboy` reference and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, the `appboy.display` namespace was removed and its methods moved to `braze`:
+
 ```javascript
-window.appboy.display.destroyFeed();
+// V3
+window.appboy.display.showContentCards();
+
+// V6
+window.braze.showContentCards();
 ```
 
-Step 2: Roll out code changes prior to opting in to V4
+---
+
+## Write version-tolerant code
+
+Do this if you load mParticle via the snippet. After you select `Version 6`, cache busting can leave some visitors on the old kit for a while, so if you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+If you self-host via npm, you control when the kit version ships with your own deploy, so you do not need version-tolerant fallbacks — update your Braze calls and deploy them together with the V6 kit.
+
+The V3 → V6 change that matters most is the global rename, so guard on which global is present:
+
 ```javascript
-if (window.appboy) {
-	window.appboy.display.destroyFeed();
-} else if (window.braze) {
-	window.braze.destroyFeed();
+if (window.braze) {
+    window.braze.showContentCards();
+} else if (window.appboy) {
+    window.appboy.display.showContentCards();
 }
 ```
-Step 3: Opt into Version 4.  Simply navigate to your connection settings and selection `Version 4` from the new Braze Web SDK Version drop down.  
 
-Step 4: After you opt in, you can simplify your code. We recommend testing and waiting at least 24 hours between opting in and removing previous instances of `appboy` and doing thorough testing of your application in a development environment to ensure everything is working:
+Search your codebase for every remaining direct `appboy` call and apply the same pattern, using the mapping table above and Braze's changelog to find the V6 equivalent of each one.
+
+Once V6 is live and verified, you can delete the `window.appboy` fallbacks and call `window.braze` directly.
+
+---
+
+## Push notifications
+
+If you use push notifications, update your `service-worker.js` to import the V6 service worker that mParticle hosts:
+
 ```javascript
-window.braze.destroyFeed();
+self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-Step 5: Push Notifications via service-worker.js
-If you use Push Notifications, we have updated the `service-worker.js` file.  In our testing, Braze’s push notifications work as expected regardless of what version of the service-worker is used, but we recommend updating this file to ensure future compatibility.  In your `service-worker.js` file, update the code to reference `https://static.mparticle.com/sdk/js/braze/service-worker-4.2.1.js` instead of `https://static.mparticle.com/sdk/js/braze/service-worker-3.5.0.js`.  Your `service-worker.js` file should now contain:
+mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
-```javascript
-self.imports('https://static.mparticle.com/sdk/js/braze/service-worker-4.2.1.js')
-```
+---
 
-### Transition from @mparticle/web-appboy-kit to @mparticle/web-braze-kit
+## Reference
 
-The legacy @mparticle/web-appboy-kit from npm includes version 2 of the Braze Web SDK.  As part of this update, we've created a new [Braze web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze) to replace our deprecated [Appboy web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy).  If you are still using `@mparticle/web-appboy-kit`, you will need to consider the breaking changes Braze made between V2 and V3 of the Braze SDK (found [here](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog/#300)) as well as the instructions above to get from V2 to V4 of the Braze SDK.
-
-
-
+- [mParticle Braze integration docs](https://docs.mparticle.com/integrations/braze/event/)
+- [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md)
+- [Braze Web SDK upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md)
+- [Braze Web SDK API reference](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html)
 
 # License
 

--- a/kits/braze/braze-3/package-lock.json
+++ b/kits/braze/braze-3/package-lock.json
@@ -23,6 +23,7 @@
                 "rollup": "^1.13.1",
                 "rollup-plugin-commonjs": "^10.0.0",
                 "rollup-plugin-node-resolve": "^5.0.1",
+                "rollup-plugin-replace": "^2.2.0",
                 "shelljs": "^0.8.4",
                 "should": "^7.1.0",
                 "watchify": "^3.11.1"
@@ -3740,6 +3741,18 @@
             },
             "peerDependencies": {
                 "rollup": ">=1.11.0"
+            }
+        },
+        "node_modules/rollup-plugin-replace": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
+            "integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
+            "deprecated": "This module has moved and is now available at @rollup/plugin-replace. Please update your dependencies. This version is no longer maintained.",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "magic-string": "^0.25.2",
+                "rollup-pluginutils": "^2.6.0"
             }
         },
         "node_modules/rollup-pluginutils": {

--- a/kits/braze/braze-3/package.json
+++ b/kits/braze/braze-3/package.json
@@ -29,6 +29,7 @@
         "rollup": "^1.13.1",
         "rollup-plugin-commonjs": "^10.0.0",
         "rollup-plugin-node-resolve": "^5.0.1",
+        "rollup-plugin-replace": "^2.2.0",
         "shelljs": "^0.8.4",
         "should": "^7.1.0",
         "watchify": "^3.11.1"

--- a/kits/braze/braze-3/rollup.config.js
+++ b/kits/braze/braze-3/rollup.config.js
@@ -1,5 +1,17 @@
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import replace from 'rollup-plugin-replace';
+
+const packageVersion = process.env.npm_package_version;
+if (!packageVersion) {
+    throw new Error('npm_package_version is required to build the Braze kit');
+}
+
+function replacePackageVersion() {
+    return replace({
+        'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+    });
+}
 
 export default [
     {
@@ -12,6 +24,7 @@ export default [
             strict: false,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -28,6 +41,7 @@ export default [
             strict: false,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),

--- a/kits/braze/braze-3/src/BrazeKit-dev.js
+++ b/kits/braze/braze-3/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.appboy = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v3',
     moduleId = 28,
-    version = '3.0.9',
+    version = process.env.PACKAGE_VERSION,
     MessageType = {
         PageView: 3,
         PageEvent: 4,

--- a/kits/braze/braze-3/test/tests.js
+++ b/kits/braze/braze-3/test/tests.js
@@ -1,11 +1,13 @@
 /* eslint-disable no-undef */
 // If we are testing this in a node environemnt, we load the common.js Braze kit
 
-var brazeInstance;
+var brazeInstance, packageVersion;
 if (typeof require !== 'undefined') {
+    packageVersion = require('../package.json').version;
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
     brazeInstance = mpBrazeKitV3.default;
+    packageVersion = brazeInstance.getVersion();
 }
 
 describe('Appboy Forwarder', function () {
@@ -286,6 +288,10 @@ describe('Appboy Forwarder', function () {
 
     it('should have a property of suffix', function() {
         window.mParticle.forwarder.should.have.property('suffix', 'v3');
+    });
+
+    it('should expose its package version', function() {
+        brazeInstance.getVersion().should.equal(packageVersion);
     });
 
     it('should register a forwarder with version number onto a config', function() {

--- a/kits/braze/braze-4/README.md
+++ b/kits/braze/braze-4/README.md
@@ -1,52 +1,103 @@
-![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png) 
+![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png)
 
-⚠️⚠️⚠️
-# Notice! Opt in is now available for Braze Web SDK V4 - Action Required
+# mParticle Braze Kit — Braze Web SDK V4
 
-You can now select what version of the Braze SDK you want to use when setting up a Braze connection in the mParticle UI.  Braze occasionally makes breaking changes to their SDK, so if you call `appboy` directly in your code, you will have to update your code to ensure your website performs as expected when updating versions of Braze.
+This kit bundles **Braze Web SDK V4** (`@braze/web-sdk@^4.2.1`) and exposes it on the page as `window.braze`.
 
-Please review the [Braze Changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog#400) and [V4 migration guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md) to learn about the differences between V3 and V4 and what changes you will need to make in your code. The most significant breaking changes are the replacement of the `appboy` class name with `braze`, in addition to the removal and renaming of several APIs.
+---
 
-You can opt into the latest major version of the Braze Web SDK whether you implement mParticle's Web SDK using npm or our snippet/CDN.
-* Customers who self-host mParticle via npm - You should add @mparticle/web-braze-kit version 4.0.0 or greater in your package.json.  You must also select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
-* Customers who load mParticle via snippet/CDN - You must  select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
+## ⚠️ We recommend upgrading to Braze Web SDK V6
 
-Note that the following is only one example.  Everywhere you manually call `appboy` needs to be updated similar to the below. If you are using NPM, you can skip to step 3.  Please be sure to test your site fully in development prior to releasing.
+Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
+See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
 
-* Step 1: Legacy code sample. Find all the places where your code references the `appboy.display` namespace.  Braze has removed all instances of the `display` namespace:
+### How to upgrade
+
+1. **Audit the code you own.** If you call Braze directly, find every `braze` reference and compare it with the table below and Braze's upgrade documentation.
+2. **Move to the V6 kit.**
+   - Self-hosting via npm with **core Web SDK v3 (latest)**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2 (legacy)**: `npm install @mparticle/web-braze-kit@^6`
+   - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
+3. **Add defensive code** if you load mParticle via the snippet and call Braze directly. Skip this if you self-host via npm. See [Write version-tolerant code](#write-version-tolerant-code).
+4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+
+---
+
+## What changed from V4 to V6
+
+The table below is the V4 API you have today mapped to the V6 API you should use.
+
+Primary sources: the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) and the [Braze upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md).
+
+| V4 | V6 |
+| --- | --- |
+| `braze.logCardClick()` | `braze.logContentCardClick()` — already exists in V4, so you can rename before you upgrade |
+| `braze.logCardImpressions()` | `braze.logContentCardImpressions()` — already exists in V4 |
+| `braze.logContentCardsDisplayed()` *(already a no-op)* | Delete it |
+| Legacy News Feed: `Feed`, `destroyFeed()`, `getCachedFeed()`, `logFeedDisplayed()`, `requestFeedRefresh()`, `showFeed()`, `subscribeToFeedUpdates()`, `toggleFeed()` | **No drop-in replacement.** Migrate to Content Cards |
+| `braze.Banner` card class *(deprecated since 4.9.0)* | `braze.ImageOnly` |
+| `ab-banner` CSS class | `ab-image-only` |
+| `enableHtmlInAppMessages` init option *(deprecated since 3.3.0)* | `allowUserSuppliedJavascript` |
+| `getDeviceId(callback)` / `User.getUserId(callback)` *(callback params deprecated since 4.10.0)* | Return values directly: `getDeviceId()`, `getUserId()` |
+| `Card.created`, `Card.categories` | No replacement; these were News Feed fields |
+| `ImageOnly.linkText` | No replacement; unused |
+
+If you call Braze directly, search your codebase for **every** `braze` reference and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, use the Content Card-specific analytics methods:
+
 ```javascript
-window.appboy.display.destroyFeed();
+// V4
+window.braze.logCardImpressions([card], true);
+
+// V6
+window.braze.logContentCardImpressions([card]);
 ```
 
-Step 2: Roll out code changes prior to opting in to V4
+---
+
+## Write version-tolerant code
+
+Do this if you load mParticle via the snippet. After you select `Version 6`, cache busting can leave some visitors on the old kit for a while, so if you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+If you self-host via npm, you control when the kit version ships with your own deploy, so you do not need version-tolerant fallbacks — update your Braze calls and deploy them together with the V6 kit.
+
+The `braze` global is the same in V4 and V6, so guard on the method instead. For the card-analytics renames:
+
 ```javascript
-if (window.appboy) {
-	window.appboy.display.destroyFeed();
-} else if (window.braze) {
-	window.braze.destroyFeed();
+if (window.braze.logContentCardImpressions) {
+    window.braze.logContentCardImpressions([card]);
+} else {
+    window.braze.logCardImpressions([card], true);
 }
 ```
-Step 3: Whether you are using the snippet or self hosting, you need to navigate to your Braze connection settings and select `Version 4` from the `Braze Web SDK Version` drop down.
 
-Step 4: After you opt in, you can simplify your code. We recommend testing and waiting at least 24 hours between opting in and removing previous instances of `appboy` and doing thorough testing of your application in a development environment to ensure everything is working:
+Search your codebase for every remaining direct `braze` call and apply the same pattern, using the mapping table above and Braze's changelog to find the V6 equivalent of each one.
+
+Once V6 is live and verified, you can delete the fallbacks and call the V6 methods directly.
+
+---
+
+## Push notifications
+
+If you use push notifications, update your `service-worker.js` to import the V6 service worker that mParticle hosts:
+
 ```javascript
-window.braze.destroyFeed();
+self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-Step 5: Push Notifications via service-worker.js
-If you use Push Notifications, we have updated the `service-worker.js` file.  In our testing, Braze’s push notifications work as expected regardless of what version of the service-worker is used, but we recommend updating this file to ensure future compatibility.  In your `service-worker.js` file, update the code to reference `https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js` instead of `https://static.mparticle.com/sdk/js/braze/service-worker-3.5.0.js`.  Your `service-worker.js` file should now contain:
+mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
-```javascript
-self.imports('https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js')
-```
+---
 
-### Transition from @mparticle/web-appboy-kit to @mparticle/web-braze-kit
+## Reference
 
-The legacy @mparticle/web-appboy-kit from npm includes version 2 of the Braze Web SDK.  As part of this update, we've created a new [Braze web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze) to replace our deprecated [Appboy web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy).  If you are still using `@mparticle/web-appboy-kit`, you will need to consider the breaking changes Braze made between V2 and V3 of the Braze SDK (found [here](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog/#300)) as well as the instructions above to get from V2 to V4 of the Braze SDK.
-
-
-
+- [mParticle Braze integration docs](https://docs.mparticle.com/integrations/braze/event/)
+- [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md)
+- [Braze Web SDK upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md)
+- [Braze Web SDK API reference](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html)
 
 # License
 

--- a/kits/braze/braze-4/package-lock.json
+++ b/kits/braze/braze-4/package-lock.json
@@ -15,6 +15,7 @@
             "devDependencies": {
                 "@rollup/plugin-commonjs": "22.0.1",
                 "@rollup/plugin-node-resolve": "13.3.0",
+                "@rollup/plugin-replace": "^6.0.3",
                 "chai": "^4.2.0",
                 "karma": "^5.1.0",
                 "karma-chai": "^0.1.0",
@@ -41,6 +42,13 @@
             "version": "4.8.0",
             "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-4.8.0.tgz",
             "integrity": "sha512-yWiZzg87GrbN9EvE7wQvVXQGE5/z6hm0murahxJTMD3KjtYXmwBunKAHNR2ILdRjpmaEqCdcg73+Flrt/yoYag=="
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@mparticle/event-models": {
             "version": "1.3.1",
@@ -81,12 +89,6 @@
             "peerDependencies": {
                 "rollup": "^2.68.0"
             }
-        },
-        "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true
         },
         "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
             "version": "7.2.3",
@@ -218,6 +220,71 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rollup/pluginutils": {
@@ -1630,6 +1697,13 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/eventemitter3": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
@@ -2861,6 +2935,16 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
             "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
             "dev": true
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
         },
         "node_modules/map-cache": {
             "version": "0.2.2",

--- a/kits/braze/braze-4/package.json
+++ b/kits/braze/braze-4/package.json
@@ -23,6 +23,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
         "@rollup/plugin-node-resolve": "13.3.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "chai": "^4.2.0",
         "karma": "^5.1.0",
         "karma-chai": "^0.1.0",

--- a/kits/braze/braze-4/rollup.config.js
+++ b/kits/braze/braze-4/rollup.config.js
@@ -1,5 +1,18 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+
+const packageVersion = process.env.npm_package_version;
+if (!packageVersion) {
+    throw new Error('npm_package_version is required to build the Braze kit');
+}
+
+function replacePackageVersion() {
+    return replace({
+        preventAssignment: true,
+        'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+    });
+}
 
 export default [
     {
@@ -13,6 +26,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -30,6 +44,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),

--- a/kits/braze/braze-4/src/BrazeKit-dev.js
+++ b/kits/braze/braze-4/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.braze = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v4',
     moduleId = 28,
-    version = '4.2.2',
+    version = process.env.PACKAGE_VERSION,
     MessageType = {
         PageView: 3,
         PageEvent: 4,

--- a/kits/braze/braze-4/test/tests.js
+++ b/kits/braze/braze-4/test/tests.js
@@ -1,10 +1,12 @@
 // If we are testing this in a node environemnt, we load the common.js Braze kit
 
-var brazeInstance;
+var brazeInstance, packageVersion;
 if (typeof require !== 'undefined') {
+    packageVersion = require('../package.json').version;
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
     brazeInstance = mpBrazeKitV4.default;
+    packageVersion = brazeInstance.getVersion();
 }
 
 describe('Braze Forwarder', function() {
@@ -317,6 +319,10 @@ describe('Braze Forwarder', function() {
 
     it('should have a property of suffix', function() {
         window.mParticle.forwarder.should.have.property('suffix', 'v4');
+    });
+
+    it('should expose its package version', function() {
+        brazeInstance.getVersion().should.equal(packageVersion);
     });
 
     it('should register a forwarder with version number onto a config', function() {

--- a/kits/braze/braze-5/README.md
+++ b/kits/braze/braze-5/README.md
@@ -1,46 +1,101 @@
-![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png) 
+![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png)
 
-⚠️⚠️⚠️
-# Notice! Opt in is now available for Braze Web SDK V5 - Action Required
+# mParticle Braze Kit — Braze Web SDK V5
 
-You can now select what version of the Braze SDK you want to use when setting up a Braze connection in the mParticle UI.  Braze occasionally makes breaking changes to their SDK, so if you call `appboy` directly in your code, you will have to update your code to ensure your website performs as expected when updating versions of Braze.
+This kit bundles **Braze Web SDK V5** (`@braze/web-sdk@^5.5.0`) and exposes it on the page as `window.braze`.
 
-Please review the [Braze Changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog#500) and [V5 migration guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md) to learn about the differences between V4 and V5 and what changes you will need to make in your code. The most significant breaking changes are the removal of the deprecated `enableHtmlInAppMessages` initialization option (replaced by `allowUserSuppliedJavascript`), in addition to the removal and renaming of several APIs.
+---
 
-You can opt into the latest major version of the Braze Web SDK whether you implement mParticle's Web SDK using npm or our snippet/CDN.
-* Customers who self-host mParticle via npm - You should add @mparticle/web-braze-kit version 5.0.0 or greater in your package.json.  You must also select `Version 5` under `Braze Web SDK Version`  in the Braze connection settings.
-* Customers who load mParticle via snippet/CDN - You must  select `Version 5` under `Braze Web SDK Version`  in the Braze connection settings.
+## ⚠️ We recommend upgrading to Braze Web SDK V6
 
-Note that the following is only one example of migrating from V3 to V5.  Everywhere you manually call `appboy` needs to be updated similar to the below. If you are using NPM, you can skip to step 3.  Please be sure to test your site fully in development prior to releasing.
+Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
+The `braze` global, initialization options, and the vast majority of the API are unchanged. Two areas break — the **legacy News Feed**, which V6 removes entirely, and **manual card-analytics method names**.
 
-* Step 1: Legacy code sample. Find all the places where your code references the `appboy.display` namespace. Braze has removed all instances of the `display` namespace:
+See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
+
+### How to upgrade
+
+1. **Audit the code you own.** If you call Braze directly, find every `braze` reference and compare it with the table below and Braze's upgrade documentation.
+2. **Move to the V6 kit.**
+   - Self-hosting via npm with **core Web SDK v3 (latest)**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2 (legacy)**: `npm install @mparticle/web-braze-kit@^6`
+   - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
+3. **Add defensive code** if you load mParticle via the snippet and call Braze directly. Skip this if you self-host via npm. See [Write version-tolerant code](#write-version-tolerant-code).
+4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+
+---
+
+## What changed from V5 to V6
+
+The table below is the V5 API you have today mapped to the V6 API you should use.
+
+Primary sources: the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) and the [Braze upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md).
+
+| V5 | V6 |
+| --- | --- |
+| `braze.logCardClick()` | `braze.logContentCardClick()` — already exists in V5, so you can rename before you upgrade |
+| `braze.logCardImpressions()` | `braze.logContentCardImpressions()` — already exists in V5 |
+| Legacy News Feed: `Feed`, `destroyFeed()`, `getCachedFeed()`, `logFeedDisplayed()`, `requestFeedRefresh()`, `showFeed()`, `subscribeToFeedUpdates()`, `toggleFeed()` | **No drop-in replacement.** Migrate to Content Cards |
+| `Card.created`, `Card.categories` | No replacement; these were News Feed fields |
+| `ImageOnly.linkText` | No replacement; unused |
+| Custom banner HTML + `logBannerClick()` / `logBannerImpressions()` | `braze.insertBanner()`, which handles rendering, impressions, and clicks |
+
+If you call Braze directly, search your codebase for **every** `braze` reference and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, use the Content Card-specific analytics methods:
+
 ```javascript
-window.appboy.display.destroyFeed();
+// V5
+window.braze.logCardImpressions([card], true);
+
+// V6
+window.braze.logContentCardImpressions([card]);
 ```
 
-Step 2: Roll out code changes prior to opting in to V5
+---
+
+## Write version-tolerant code
+
+Do this if you load mParticle via the snippet. After you select `Version 6`, cache busting can leave some visitors on the old kit for a while, so if you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+If you self-host via npm, you control when the kit version ships with your own deploy, so you do not need version-tolerant fallbacks — update your Braze calls and deploy them together with the V6 kit.
+
+The `braze` global is the same in V5 and V6, so guard on the method instead. For the card-analytics renames:
+
 ```javascript
-if (window.appboy) {
-	window.appboy.display.destroyFeed();
-} else if (window.braze) {
-	window.braze.destroyFeed();
+if (window.braze.logContentCardImpressions) {
+    window.braze.logContentCardImpressions([card]);
+} else {
+    window.braze.logCardImpressions([card], true);
 }
 ```
-Step 3: Whether you are using the snippet or self hosting, you need to navigate to your Braze connection settings and select `Version 5` from the `Braze Web SDK Version` drop down.
 
-Step 4: After you opt in, you can simplify your code. We recommend testing and waiting at least 24 hours between opting in and removing previous instances of `appboy` and doing thorough testing of your application in a development environment to ensure everything is working:
+Search your codebase for every remaining direct `braze` call and apply the same pattern, using the mapping table above and Braze's changelog to find the V6 equivalent of each one.
+
+Once V6 is live and verified, you can delete the fallbacks and call the V6 methods directly.
+
+---
+
+## Push notifications
+
+If you use push notifications, update your `service-worker.js` to import the V6 service worker that mParticle hosts:
+
 ```javascript
-window.braze.destroyFeed();
+self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-Step 5: Push Notifications via service-worker.js
-If you use Push Notifications, we have updated the `service-worker.js` file.  In our testing, Braze’s push notifications work as expected regardless of what version of the service-worker is used, but we recommend updating this file to ensure future compatibility.  In your `service-worker.js` file, update the code to reference `https://static.mparticle.com/sdk/js/braze/service-worker-5.5.0.js` instead of `https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js`.  Your `service-worker.js` file should now contain:
+mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
-```javascript
-self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-5.5.0.js')
-```
+---
 
+## Reference
+
+- [mParticle Braze integration docs](https://docs.mparticle.com/integrations/braze/event/)
+- [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md)
+- [Braze Web SDK upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md)
+- [Braze Web SDK API reference](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html)
 
 # License
 

--- a/kits/braze/braze-5/package-lock.json
+++ b/kits/braze/braze-5/package-lock.json
@@ -15,6 +15,7 @@
             "devDependencies": {
                 "@rollup/plugin-commonjs": "22.0.1",
                 "@rollup/plugin-node-resolve": "13.3.0",
+                "@rollup/plugin-replace": "^6.0.3",
                 "chai": "^4.2.0",
                 "karma": "^5.1.0",
                 "karma-chai": "^0.1.0",
@@ -43,6 +44,13 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-5.5.0.tgz",
             "integrity": "sha512-1pSxzPbug6420DXieGruURbY5KORshIu9qwCF/Kabf5CAaJTNpW+hzjC+VUaendDPW0fgfDEHrkwt/g/yfafPQ=="
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@mparticle/event-models": {
             "version": "1.3.1",
@@ -102,6 +110,81 @@
             },
             "peerDependencies": {
                 "rollup": "^2.42.0"
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rollup/pluginutils": {

--- a/kits/braze/braze-5/package.json
+++ b/kits/braze/braze-5/package.json
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
         "@rollup/plugin-node-resolve": "13.3.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "chai": "^4.2.0",
         "karma": "^5.1.0",
         "karma-chai": "^0.1.0",

--- a/kits/braze/braze-5/rollup.config.js
+++ b/kits/braze/braze-5/rollup.config.js
@@ -1,5 +1,18 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+
+const packageVersion = process.env.npm_package_version;
+if (!packageVersion) {
+    throw new Error('npm_package_version is required to build the Braze kit');
+}
+
+function replacePackageVersion() {
+    return replace({
+        preventAssignment: true,
+        'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+    });
+}
 
 export default [
     {
@@ -13,6 +26,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -30,6 +44,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -46,6 +61,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),

--- a/kits/braze/braze-5/src/BrazeKit-dev.js
+++ b/kits/braze/braze-5/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.braze = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v5',
     moduleId = 28,
-    version = '5.0.3',
+    version = process.env.PACKAGE_VERSION,
     MessageType = {
         PageView: 3,
         PageEvent: 4,

--- a/kits/braze/braze-5/test/tests.js
+++ b/kits/braze/braze-5/test/tests.js
@@ -1,10 +1,12 @@
 // If we are testing this in a node environemnt, we load the common.js Braze kit
 
-var brazeInstance;
+var brazeInstance, packageVersion;
 if (typeof require !== 'undefined') {
+    packageVersion = require('../package.json').version;
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
     brazeInstance = mpBrazeKitV5.default;
+    packageVersion = brazeInstance.getVersion();
 }
 
 describe('Braze Forwarder', function() {
@@ -327,6 +329,10 @@ describe('Braze Forwarder', function() {
 
     it('should have a property of suffix', function() {
         window.mParticle.forwarder.should.have.property('suffix', 'v5');
+    });
+
+    it('should expose its package version', function() {
+        brazeInstance.getVersion().should.equal(packageVersion);
     });
 
     it('should register a forwarder with version number onto a config', function() {

--- a/kits/braze/braze-6/README.md
+++ b/kits/braze/braze-6/README.md
@@ -1,52 +1,217 @@
-![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png) 
+![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png)
 
-⚠️⚠️⚠️
-# Notice! Opt in is now available for Braze Web SDK V4 - Action Required
+# mParticle Braze Kit — Braze Web SDK V6
 
-You can now select what version of the Braze SDK you want to use when setting up a Braze connection in the mParticle UI.  Braze occasionally makes breaking changes to their SDK, so if you call `appboy` directly in your code, you will have to update your code to ensure your website performs as expected when updating versions of Braze.
+This kit bundles **Braze Web SDK V6** (`@braze/web-sdk@^6.0.0`) and exposes it on the page as `window.braze`.
 
-Please review the [Braze Changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog#400) and [V4 migration guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md) to learn about the differences between V3 and V4 and what changes you will need to make in your code. The most significant breaking changes are the replacement of the `appboy` class name with `braze`, in addition to the removal and renaming of several APIs.
+---
 
-You can opt into the latest major version of the Braze Web SDK whether you implement mParticle's Web SDK using npm or our snippet/CDN.
-* Customers who self-host mParticle via npm - You should add @mparticle/web-braze-kit version 4.0.0 or greater in your package.json.  You must also select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
-* Customers who load mParticle via snippet/CDN - You must  select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
+## ✅ This is the version we recommend
 
-Note that the following is only one example.  Everywhere you manually call `appboy` needs to be updated similar to the below. If you are using NPM, you can skip to step 3.  Please be sure to test your site fully in development prior to releasing.
+**V6 is the current major version of the Braze Web SDK and the version mParticle recommends for all customers.** Braze ships fixes and new features only on the V6 line, so if you are already here, you are on the right kit and there is nothing to upgrade.
 
+If you are still on the V3, V4, or V5 kit, we recommend updating straight to V6 for latest support of all Braze features. Jump to the section for your current version:
 
-* Step 1: Legacy code sample. Find all the places where your code references the `appboy.display` namespace.  Braze has removed all instances of the `display` namespace:
+- [Upgrading from V3 to V6](#upgrading-from-v3-to-v6) — the `appboy` global goes away
+- [Upgrading from V4 to V6](#upgrading-from-v4-to-v6) — deprecated API cleanup plus News Feed removal
+- [Upgrading from V5 to V6](#upgrading-from-v5-to-v6) — News Feed removal and card-analytics renames
+- [Write version-tolerant code](#write-version-tolerant-code) — snippet/CDN only; ship code that works before and after you select Version 6
+
+See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
+
+---
+
+## Installing and enabling V6
+
+Regardless of which version you are coming from, the mechanics are the same:
+
+1. **Install the kit** (only if you self-host mParticle via npm — snippet/CDN users have it delivered automatically):
+   - Self-hosting via npm with **core Web SDK v3 (latest)**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2 (legacy)**: `npm install @mparticle/web-braze-kit@^6`
+2. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. **This is required for both npm and snippet/CDN integrations** — installing the package alone does not switch you over.
+3. **Add defensive code** if you load mParticle via the snippet and call Braze directly. Skip this if you self-host via npm. See [Write version-tolerant code](#write-version-tolerant-code) and use the example for the version you are coming from.
+4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+
+If you never call Braze directly from your own code, or you self-host via npm, skip step 3. The code samples below only matter if you reference `window.appboy` or `window.braze` yourself.
+
+We recommend shipping your code changes **before** flipping the version setting wherever possible, so that the code change and the version change remain two separately revertible steps.
+
+---
+
+## Upgrading from V3 to V6
+
+We recommend updating straight to V6 for latest support of all Braze features.
+
+Primary sources: the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) and the [Braze upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md).
+
+| V3 | V6 |
+| --- | --- |
+| `appboy` global | `braze` |
+| `appboy.display.*` namespace | Methods moved to the top level: `braze.*` |
+| `appboy.registerAppboyPushMessages()` | `braze.requestPushPermission()` |
+| `appboy.unregisterAppboyPushMessages()` | `braze.unregisterPush()` |
+| `appboy.display.automaticallyShowNewInAppMessages()` | `braze.automaticallyShowInAppMessages()` — must run *before* `openSession()` |
+| `appboy.toggleAppboyLogging()` | `braze.toggleLogging()` |
+| `appboy.isPushGranted()` *(deprecated since 1.6.2)* | `braze.isPushPermissionGranted()` |
+| `appboy.subscribeToNewInAppMessages()` *(deprecated since 2.4.0)* | `braze.subscribeToInAppMessage()` |
+| `appboy.trackLocation()` *(deprecated since 3.3.0)* | Native Geolocation API + `User.setLastKnownLocation()` |
+| `appboy.stopWebTracking()` *(deprecated since 3.5.0)* | `braze.disableSDK()` |
+| `appboy.resumeWebTracking()` *(deprecated since 3.5.0)* | `braze.enableSDK()` |
+| `appboy.logCardClick()` | `braze.logContentCardClick()` |
+| `appboy.logCardImpressions()` | `braze.logContentCardImpressions()` |
+| `appboy.logContentCardsDisplayed()` | Delete it — it was already a no-op |
+| Legacy News Feed APIs | **No drop-in replacement.** Migrate to Content Cards |
+| `devicePropertyWhitelist` init option | `devicePropertyAllowlist` |
+| `enableHtmlInAppMessages` init option | `allowUserSuppliedJavascript` |
+| `language` init option | `localization` |
+| `safariWebsitePushId` param on `registerAppboyPushMessages()` | `safariWebsitePushId` initialization option |
+| `User.setAvatarImageUrl()` | No replacement |
+| `appboy.Banner` card class | `braze.ImageOnly` |
+| `ab-banner` CSS class | `ab-image-only` |
+
+Search your codebase for **every** `appboy` reference and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, the `appboy.display` namespace was removed and its methods moved to `braze`:
+
 ```javascript
-window.appboy.display.destroyFeed();
+// V3
+window.appboy.display.showContentCards();
+
+// V6
+window.braze.showContentCards();
 ```
 
-Step 2: Roll out code changes prior to opting in to V4
+---
+
+## Upgrading from V4 to V6
+
+We recommend updating straight to V6 for latest support of all Braze features.
+
+| V4 | V6 |
+| --- | --- |
+| `braze.logCardClick()` | `braze.logContentCardClick()` — already exists in V4 |
+| `braze.logCardImpressions()` | `braze.logContentCardImpressions()` — already exists in V4 |
+| `braze.logContentCardsDisplayed()` *(already a no-op)* | Delete it |
+| Legacy News Feed APIs | **No drop-in replacement.** Migrate to Content Cards |
+| `braze.Banner` card class *(deprecated since 4.9.0)* | `braze.ImageOnly` |
+| `ab-banner` CSS class | `ab-image-only` |
+| `enableHtmlInAppMessages` init option | `allowUserSuppliedJavascript` |
+| `getDeviceId(callback)` / `User.getUserId(callback)` | Return values directly |
+| `Card.created`, `Card.categories` | No replacement; these were News Feed fields |
+
+Search your codebase for **every** direct `braze` call and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, use the Content Card-specific analytics methods:
+
 ```javascript
-if (window.appboy) {
-	window.appboy.display.destroyFeed();
-} else if (window.braze) {
-	window.braze.destroyFeed();
+// V4
+window.braze.logCardImpressions([card], true);
+
+// V6
+window.braze.logContentCardImpressions([card]);
+```
+
+---
+
+## Upgrading from V5 to V6
+
+We recommend updating straight to V6 for latest support of all Braze features. The `braze` global, initialization options, and nearly the whole API are unchanged.
+
+| V5 | V6 |
+| --- | --- |
+| `braze.logCardClick()` | `braze.logContentCardClick()` — already exists in V5 |
+| `braze.logCardImpressions()` | `braze.logContentCardImpressions()` — already exists in V5 |
+| Legacy News Feed APIs | **No drop-in replacement.** Migrate to Content Cards |
+| `Card.created`, `Card.categories` | No replacement; these were News Feed fields |
+| `ImageOnly.linkText` | No replacement |
+| Custom banner HTML + `logBannerClick()` / `logBannerImpressions()` | `braze.insertBanner()` |
+
+Search your codebase for **every** direct `braze` call and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, use the Content Card-specific analytics methods:
+
+```javascript
+// V5
+window.braze.logCardImpressions([card], true);
+
+// V6
+window.braze.logContentCardImpressions([card]);
+```
+
+---
+
+## Write version-tolerant code
+
+Do this if you load mParticle via the snippet. After you select `Version 6`, cache busting can leave some visitors on the old kit for a while, so if you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+If you self-host via npm, you control when the kit version ships with your own deploy, so you do not need version-tolerant fallbacks — update your Braze calls and deploy them together with the V6 kit.
+
+Use the example that matches the version you are coming from. Search your codebase for every remaining direct `appboy` or `braze` call and apply the same pattern, using the mapping table for your starting version and Braze's changelog to find the V6 equivalent of each one.
+
+Once V6 is live and verified, you can delete the fallbacks and call the V6 methods directly.
+
+### From V3
+
+The V3 → V6 change that matters most is the global rename, so guard on which global is present:
+
+```javascript
+if (window.braze) {
+    window.braze.showContentCards();
+} else if (window.appboy) {
+    window.appboy.display.showContentCards();
 }
 ```
-Step 3: Whether you are using the snippet or self hosting, you need to navigate to your Braze connection settings and select `Version 4` from the `Braze Web SDK Version` drop down.
 
-Step 4: After you opt in, you can simplify your code. We recommend testing and waiting at least 24 hours between opting in and removing previous instances of `appboy` and doing thorough testing of your application in a development environment to ensure everything is working:
-```javascript
-window.braze.destroyFeed();
-```
+### From V4
 
-Step 5: Push Notifications via service-worker.js
-If you use Push Notifications, we have updated the `service-worker.js` file.  In our testing, Braze’s push notifications work as expected regardless of what version of the service-worker is used, but we recommend updating this file to ensure future compatibility.  In your `service-worker.js` file, update the code to reference `https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js` instead of `https://static.mparticle.com/sdk/js/braze/service-worker-3.5.0.js`.  Your `service-worker.js` file should now contain:
+The `braze` global is the same in V4 and V6, so guard on the method instead. For the card-analytics renames:
 
 ```javascript
-self.imports('https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js')
+if (window.braze.logContentCardImpressions) {
+    window.braze.logContentCardImpressions([card]);
+} else {
+    window.braze.logCardImpressions([card], true);
+}
 ```
 
-### Transition from @mparticle/web-appboy-kit to @mparticle/web-braze-kit
+### From V5
 
-The legacy @mparticle/web-appboy-kit from npm includes version 2 of the Braze Web SDK.  As part of this update, we've created a new [Braze web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze) to replace our deprecated [Appboy web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy).  If you are still using `@mparticle/web-appboy-kit`, you will need to consider the breaking changes Braze made between V2 and V3 of the Braze SDK (found [here](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog/#300)) as well as the instructions above to get from V2 to V4 of the Braze SDK.
+The `braze` global is the same in V5 and V6, so guard on the method instead. For the card-analytics renames:
 
+```javascript
+if (window.braze.logContentCardImpressions) {
+    window.braze.logContentCardImpressions([card]);
+} else {
+    window.braze.logCardImpressions([card], true);
+}
+```
 
+---
 
+## Push notifications
+
+If you use push notifications, your `service-worker.js` should import the V6 service worker that mParticle hosts:
+
+```javascript
+self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
+```
+
+mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
+
+---
+
+## eCommerce Recommended Events
+
+If you enable the `Enable eCommerce Recommended Events` connection setting, mParticle maps commerce events to Braze's eCommerce Recommended Events schema. Client-side forwarding of these events requires **web Braze kit version 6.1.0 or later**. On earlier versions, mParticle falls back to forwarding commerce events as legacy custom and purchase events. See the [connection settings reference](https://docs.mparticle.com/integrations/braze/event/) for the full event and attribute mapping.
+
+---
+
+## Reference
+
+- [mParticle Braze integration docs](https://docs.mparticle.com/integrations/braze/event/)
+- [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md)
+- [Braze Web SDK upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md)
+- [Braze Web SDK API reference](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html)
 
 # License
 

--- a/kits/braze/braze-6/package-lock.json
+++ b/kits/braze/braze-6/package-lock.json
@@ -9,12 +9,13 @@
             "version": "3.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@braze/web-sdk": "^6.0.0",
+                "@braze/web-sdk": "^6.9.0",
                 "@mparticle/web-sdk": "^3.0.0"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "22.0.1",
                 "@rollup/plugin-node-resolve": "13.3.0",
+                "@rollup/plugin-replace": "^6.0.3",
                 "chai": "^4.2.0",
                 "karma": "^5.1.0",
                 "karma-chai": "^0.1.0",
@@ -40,10 +41,17 @@
             }
         },
         "node_modules/@braze/web-sdk": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-6.5.0.tgz",
-            "integrity": "sha512-MdfwZn+tfe7+tR8Ir5468/njQDGhgVB9tBthq7gwSETsjv6Q+Hw2bXiQy3scDcACI2RLqiq+dNXKh6fD+pN4/Q==",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-6.12.0.tgz",
+            "integrity": "sha512-VreAi6tnPheqwChFUm2EXzsWnCLpNYZT4CowFmx0BsUKWsCgVts7kP1BsoLLOP2IDuDvhgUPlp9M0wSr6PlHEA==",
             "license": "SEE LICENSE IN https://github.com/braze-inc/braze-web-sdk/blob/master/LICENSE"
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@mparticle/event-models": {
             "version": "1.3.1",
@@ -103,6 +111,81 @@
             },
             "peerDependencies": {
                 "rollup": "^2.42.0"
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rollup/pluginutils": {

--- a/kits/braze/braze-6/package.json
+++ b/kits/braze/braze-6/package.json
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
         "@rollup/plugin-node-resolve": "13.3.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "chai": "^4.2.0",
         "karma": "^5.1.0",
         "karma-chai": "^0.1.0",
@@ -38,7 +39,7 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@braze/web-sdk": "^6.0.0",
+        "@braze/web-sdk": "^6.9.0",
         "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",

--- a/kits/braze/braze-6/rollup.config.js
+++ b/kits/braze/braze-6/rollup.config.js
@@ -1,5 +1,18 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+
+const packageVersion = process.env.npm_package_version;
+if (!packageVersion) {
+    throw new Error('npm_package_version is required to build the Braze kit');
+}
+
+function replacePackageVersion() {
+    return replace({
+        preventAssignment: true,
+        'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+    });
+}
 
 export default [
     {
@@ -13,6 +26,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -30,6 +44,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -46,6 +61,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),

--- a/kits/braze/braze-6/src/BrazeKit-dev.js
+++ b/kits/braze/braze-6/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.braze = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v6',
     moduleId = 28,
-    version = '6.0.0',
+    version = process.env.PACKAGE_VERSION,
     MessageType = {
         PageView: 3,
         PageEvent: 4,
@@ -75,6 +75,27 @@ var constructor = function() {
 
     var bundleCommerceEventData = false;
     var forwardSkuAsProductName = false;
+    var useEcommerceRecommendedEvents = false;
+
+    var RECOMMENDED_ECOMMERCE_SOURCE = 'web';
+    var RECOMMENDED_CART_UPDATED_EVENT_NAME = 'ecommerce.cart_updated';
+    var RECOMMENDED_CHECKOUT_STARTED_EVENT_NAME = 'ecommerce.checkout_started';
+    var RECOMMENDED_PRODUCT_VIEWED_EVENT_NAME = 'ecommerce.product_viewed';
+    var RECOMMENDED_ORDER_PLACED_EVENT_NAME = 'ecommerce.order_placed';
+    var RECOMMENDED_ORDER_REFUNDED_EVENT_NAME = 'ecommerce.order_refunded';
+    var RECOMMENDED_IMAGE_URL_ATTRIBUTES = ['image_url', 'Image URL'];
+    var RECOMMENDED_PRODUCT_URL_ATTRIBUTES = ['product_url', 'Product URL'];
+    var RECOMMENDED_CART_ID_ATTRIBUTE = 'cart_id';
+    var RECOMMENDED_CHECKOUT_ID_ATTRIBUTE = 'checkout_id';
+    var RECOMMENDED_SUBTOTAL_VALUE_ATTRIBUTE = 'subtotal_value';
+    // Attribute-name overrides from the connection settings. Each is the
+    // customer-configured attribute that holds the value, or null when
+    // unconfigured, in which case the defaults above are used.
+    var mappedCartIdAttribute = null;
+    var mappedCheckoutIdAttribute = null;
+    var mappedImageUrlAttribute = null;
+    var mappedProductUrlAttribute = null;
+    var mappedSubtotalValueAttribute = null;
 
     var brazeConsentKeys = [
         '$google_ad_user_data',
@@ -253,6 +274,577 @@ var constructor = function() {
         return [eventNamePrefix, eventName].join(' - ');
     }
 
+    // The Braze Web SDK only exposes logEcommerceEvent in v6.8.0+. Guard against
+    // older host SDKs so we can fall back to legacy forwarding when unsupported.
+    function recommendedEcommerceEventsSupported() {
+        return typeof braze.logEcommerceEvent === 'function';
+    }
+
+    // The forwarder event carries the session id, so prefer it over reaching for a
+    // global: it needs no feature detection and works on every core SDK version.
+    //
+    // The previous implementation relied on mParticle.getSession(), which is not
+    // exposed on the global object by any core version (verified on 2.23.0 and
+    // 2.75.0), so the lookup silently returned null and every cart/checkout fell
+    // back to a freshly generated id, leaving Braze unable to correlate a cart
+    // across add/remove/checkout/order. mParticle.sessionManager.getSession() is
+    // the supported public accessor, kept here only as a secondary fallback.
+    function getSessionIdForBraze(event) {
+        if (event && event.SessionId) {
+            return String(event.SessionId);
+        }
+        try {
+            if (
+                mParticle &&
+                mParticle.sessionManager &&
+                typeof mParticle.sessionManager.getSession === 'function'
+            ) {
+                return mParticle.sessionManager.getSession();
+            }
+        } catch (e) {
+            // no-op: session id is a best-effort fallback
+        }
+        return null;
+    }
+
+    function generateEcommerceId() {
+        if (
+            typeof window !== 'undefined' &&
+            window.crypto &&
+            typeof window.crypto.randomUUID === 'function'
+        ) {
+            return window.crypto.randomUUID();
+        }
+        return (
+            'mp-' +
+            new Date().getTime() +
+            '-' +
+            Math.floor(Math.random() * 1000000000)
+        );
+    }
+
+    // Attribute-mapping settings are "custom JSON" (setting data type 7). The config
+    // API delivers them with the quotes HTML-escaped, so they must be decoded before
+    // parsing (same as decodeSubscriptionGroupMappings, decodeClusterSetting and the
+    // consent mapping):
+    //   [{&quot;jsmap&quot;:null,&quot;map&quot;:null,
+    //     &quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,
+    //     &quot;value&quot;:&quot;attr_name&quot;}]
+    //
+    // maptype varies by what the setting selects (EventAttributeClass.Name for the
+    // cart/checkout/subtotal settings, ProductAttributeSelector.Name for the URL
+    // ones) and is deliberately ignored: the settings are single-select, so the
+    // first entry with a value is the mapping. This matches the iOS kit and avoids
+    // maptype strings drifting out of sync with the platform.
+    //
+    // Never throws: a malformed setting must not break event forwarding.
+    function getMappedAttributeName(settingValue) {
+        if (!settingValue) {
+            return null;
+        }
+        // No-op when the value is already unescaped, so both shapes work.
+        var decodedSetting = settingValue.replace(/&quot;/g, '"');
+        try {
+            var mappings = JSON.parse(decodedSetting);
+            if (!Array.isArray(mappings)) {
+                return null;
+            }
+            for (var i = 0; i < mappings.length; i++) {
+                var mapping = mappings[i];
+                if (
+                    mapping &&
+                    typeof mapping.value === 'string' &&
+                    mapping.value !== ''
+                ) {
+                    return mapping.value;
+                }
+            }
+            return null;
+        } catch (e) {
+            // Deliberately stricter than the iOS kit, which treats an unparseable
+            // setting as a plain attribute name. The config API always sends the
+            // JSON array form, so a string that does not parse is malformed rather
+            // than a bare name, and returning null keeps the documented default
+            // attribute in play instead of looking up a garbage key.
+            kitLogger(
+                'Braze kit could not parse attribute mapping setting',
+                settingValue
+            );
+            return null;
+        }
+    }
+
+    function getEcommerceCustomAttribute(event, key) {
+        var attributes = event.EventAttributes || {};
+        if (attributes[key] != null && attributes[key] !== '') {
+            return String(attributes[key]);
+        }
+        return null;
+    }
+
+    function getRecommendedCartId(event) {
+        // Fall back to the mParticle session id, then a generated id, matching the
+        // Android and iOS kits (a missing session id is unlikely but possible).
+        return (
+            getEcommerceCustomAttribute(
+                event,
+                mappedCartIdAttribute || RECOMMENDED_CART_ID_ATTRIBUTE
+            ) ||
+            getSessionIdForBraze(event) ||
+            generateEcommerceId()
+        );
+    }
+
+    function getRecommendedCheckoutId(event) {
+        return (
+            getEcommerceCustomAttribute(
+                event,
+                mappedCheckoutIdAttribute || RECOMMENDED_CHECKOUT_ID_ATTRIBUTE
+            ) ||
+            getSessionIdForBraze(event) ||
+            generateEcommerceId()
+        );
+    }
+
+    function getRecommendedOrderId(event) {
+        if (event.ProductAction && event.ProductAction.TransactionId) {
+            return String(event.ProductAction.TransactionId);
+        }
+        return getSessionIdForBraze(event) || generateEcommerceId();
+    }
+
+    function getRecommendedProductList(event) {
+        if (event.ProductAction && event.ProductAction.ProductList) {
+            return event.ProductAction.ProductList;
+        }
+        return [];
+    }
+
+    // Product quantity is a count, so coerce to an integer >= 1 (mirrors the
+    // Android kit's toLong().coerceAtLeast(1)).
+    function getRecommendedQuantity(product) {
+        var quantity = parseInt(product.Quantity, 10);
+        if (isNaN(quantity) || quantity < 1) {
+            quantity = 1;
+        }
+        return quantity;
+    }
+
+    function getRecommendedTotalValue(event) {
+        if (
+            event.ProductAction &&
+            event.ProductAction.TotalAmount != null &&
+            event.ProductAction.TotalAmount !== ''
+        ) {
+            return parseFloat(event.ProductAction.TotalAmount) || 0;
+        }
+        var total = 0;
+        getRecommendedProductList(event).forEach(function(product) {
+            total +=
+                (parseFloat(product.Price) || 0) *
+                getRecommendedQuantity(product);
+        });
+        return total;
+    }
+
+    function getRecommendedTotalDiscounts(event) {
+        var value = getEcommerceCustomAttribute(event, 'total_discounts');
+        if (value == null) {
+            return null;
+        }
+        var parsed = parseFloat(value);
+        return isNaN(parsed) ? null : parsed;
+    }
+
+    function parseRecommendedFloat(value) {
+        if (value == null || value === '') {
+            return null;
+        }
+        var parsed = parseFloat(value);
+        return isNaN(parsed) ? null : parsed;
+    }
+
+    function getRecommendedTax(event) {
+        return parseRecommendedFloat(
+            event.ProductAction && event.ProductAction.TaxAmount
+        );
+    }
+
+    function getRecommendedShipping(event) {
+        return parseRecommendedFloat(
+            event.ProductAction && event.ProductAction.ShippingAmount
+        );
+    }
+
+    // mParticle has no native subtotal field, so subtotal_value is sourced from a
+    // `subtotal_value` commerce custom attribute (like cart_id/total_discounts).
+    function getRecommendedSubtotalValue(event) {
+        return parseRecommendedFloat(
+            getEcommerceCustomAttribute(
+                event,
+                mappedSubtotalValueAttribute ||
+                    RECOMMENDED_SUBTOTAL_VALUE_ATTRIBUTE
+            )
+        );
+    }
+
+    // tax, shipping, and subtotal_value are optional recognized top-level attributes
+    // on cart_updated/checkout_started/order_placed. Set only when present.
+    function applyRecommendedMonetaryAttributes(properties, event) {
+        var tax = getRecommendedTax(event);
+        if (tax != null) {
+            properties.tax = tax;
+        }
+        var shipping = getRecommendedShipping(event);
+        if (shipping != null) {
+            properties.shipping = shipping;
+        }
+        var subtotalValue = getRecommendedSubtotalValue(event);
+        if (subtotalValue != null) {
+            properties.subtotal_value = subtotalValue;
+        }
+    }
+
+    // product_viewed and order_refunded have no recognized top-level tax/shipping/
+    // subtotal_value fields, so when present these are preserved in metadata rather
+    // than dropped.
+    function buildRecommendedMonetaryMetadata(event) {
+        var metadata = {};
+        var tax = getRecommendedTax(event);
+        if (tax != null) {
+            metadata.tax = tax;
+        }
+        var shipping = getRecommendedShipping(event);
+        if (shipping != null) {
+            metadata.shipping = shipping;
+        }
+        var subtotalValue = getRecommendedSubtotalValue(event);
+        if (subtotalValue != null) {
+            metadata.subtotal_value = subtotalValue;
+        }
+        return metadata;
+    }
+
+    function getRecommendedVariantId(product) {
+        return String(product.Variant || product.Sku);
+    }
+
+    // A configured attribute name takes precedence over the built-in defaults, and
+    // is also excluded from metadata so a promoted value is not emitted twice.
+    function getRecommendedImageUrlAttributes() {
+        return mappedImageUrlAttribute
+            ? [mappedImageUrlAttribute].concat(RECOMMENDED_IMAGE_URL_ATTRIBUTES)
+            : RECOMMENDED_IMAGE_URL_ATTRIBUTES;
+    }
+
+    function getRecommendedProductUrlAttributes() {
+        return mappedProductUrlAttribute
+            ? [mappedProductUrlAttribute].concat(
+                  RECOMMENDED_PRODUCT_URL_ATTRIBUTES
+              )
+            : RECOMMENDED_PRODUCT_URL_ATTRIBUTES;
+    }
+
+    function getRecommendedPromotedEventAttributes(eventCategory) {
+        var cartIdAttribute =
+            mappedCartIdAttribute || RECOMMENDED_CART_ID_ATTRIBUTE;
+        var checkoutIdAttribute =
+            mappedCheckoutIdAttribute || RECOMMENDED_CHECKOUT_ID_ATTRIBUTE;
+        var subtotalValueAttribute =
+            mappedSubtotalValueAttribute ||
+            RECOMMENDED_SUBTOTAL_VALUE_ATTRIBUTE;
+
+        switch (eventCategory) {
+            case CommerceEventType.ProductAddToCart:
+            case CommerceEventType.ProductRemoveFromCart:
+                return [cartIdAttribute, subtotalValueAttribute];
+            case CommerceEventType.ProductCheckout:
+                return [
+                    checkoutIdAttribute,
+                    cartIdAttribute,
+                    subtotalValueAttribute,
+                ];
+            case CommerceEventType.ProductViewDetail:
+                return [subtotalValueAttribute];
+            case CommerceEventType.ProductPurchase:
+                return [
+                    cartIdAttribute,
+                    'total_discounts',
+                    subtotalValueAttribute,
+                ];
+            case CommerceEventType.ProductRefund:
+                return ['total_discounts', subtotalValueAttribute];
+            default:
+                return [];
+        }
+    }
+
+    function getRecommendedProductAttribute(product, keys) {
+        var attributes = product.Attributes || {};
+        for (var i = 0; i < keys.length; i++) {
+            var value = attributes[keys[i]];
+            if (value != null && value !== '') {
+                return String(value);
+            }
+        }
+        return null;
+    }
+
+    function emptyObjectToUndefined(obj) {
+        return obj && Object.keys(obj).length ? obj : undefined;
+    }
+
+    function buildRecommendedProductMetadata(product) {
+        var metadata = {};
+        if (product.Brand) {
+            metadata.brand = product.Brand;
+        }
+        if (product.Category) {
+            metadata.category = product.Category;
+        }
+        if (product.CouponCode) {
+            metadata.coupon_code = product.CouponCode;
+        }
+        if (product.Position != null) {
+            metadata.position = product.Position;
+        }
+        metadata.sku = product.Sku;
+        var attributes = product.Attributes || {};
+        Object.keys(attributes).forEach(function(key) {
+            if (
+                getRecommendedImageUrlAttributes().indexOf(key) === -1 &&
+                getRecommendedProductUrlAttributes().indexOf(key) === -1 &&
+                attributes[key] != null &&
+                attributes[key] !== ''
+            ) {
+                metadata[key] = attributes[key];
+            }
+        });
+        return metadata;
+    }
+
+    function buildRecommendedEventMetadata(event) {
+        var metadata = {};
+        var attributes = event.EventAttributes || {};
+        var promotedAttributes = getRecommendedPromotedEventAttributes(
+            event.EventCategory
+        );
+        Object.keys(attributes).forEach(function(key) {
+            // Skip only attributes promoted by this event type so unrelated values
+            // remain available to Braze as metadata.
+            if (
+                promotedAttributes.indexOf(key) === -1 &&
+                attributes[key] != null &&
+                attributes[key] !== ''
+            ) {
+                metadata[key] = attributes[key];
+            }
+        });
+        var productAction = event.ProductAction || {};
+        if (productAction.Affiliation) {
+            metadata.affiliation = productAction.Affiliation;
+        }
+        if (productAction.CouponCode) {
+            metadata.coupon_code = productAction.CouponCode;
+        }
+        // tax/shipping are recognized top-level recommended-event attributes
+        // (see applyRecommendedMonetaryAttributes), so they are not duplicated here.
+        return metadata;
+    }
+
+    function buildRecommendedLineItem(product) {
+        var lineItem = {
+            product_id: String(product.Sku),
+            product_name: String(product.Name),
+            variant_id: getRecommendedVariantId(product),
+            quantity: getRecommendedQuantity(product),
+            price: parseFloat(product.Price) || 0,
+        };
+        var imageUrl = getRecommendedProductAttribute(
+            product,
+            getRecommendedImageUrlAttributes()
+        );
+        if (imageUrl) {
+            lineItem.image_url = imageUrl;
+        }
+        var productUrl = getRecommendedProductAttribute(
+            product,
+            getRecommendedProductUrlAttributes()
+        );
+        if (productUrl) {
+            lineItem.product_url = productUrl;
+        }
+        var metadata = emptyObjectToUndefined(
+            buildRecommendedProductMetadata(product)
+        );
+        if (metadata) {
+            lineItem.metadata = metadata;
+        }
+        return lineItem;
+    }
+
+    function buildRecommendedLineItems(productList) {
+        return (productList || []).map(buildRecommendedLineItem);
+    }
+
+    // Forwards a commerce event using Braze's recommended eCommerce schema.
+    // Returns true/false when the event was handled, or null to signal the caller
+    // to fall back to legacy forwarding (no products, or an unsupported action).
+    function logRecommendedCommerceEvent(event) {
+        var productList = getRecommendedProductList(event);
+        if (!productList.length) {
+            return null;
+        }
+        var currency = event.CurrencyCode || 'USD';
+        var source = RECOMMENDED_ECOMMERCE_SOURCE;
+        var eventMetadata = emptyObjectToUndefined(
+            buildRecommendedEventMetadata(event)
+        );
+        var reportEvent = false;
+        var properties;
+
+        switch (event.EventCategory) {
+            case CommerceEventType.ProductAddToCart:
+            case CommerceEventType.ProductRemoveFromCart:
+                properties = {
+                    cart_id: getRecommendedCartId(event),
+                    currency: currency,
+                    source: source,
+                    total_value: getRecommendedTotalValue(event),
+                    products: buildRecommendedLineItems(productList),
+                    action:
+                        event.EventCategory ===
+                        CommerceEventType.ProductAddToCart
+                            ? 'add'
+                            : 'remove',
+                };
+                applyRecommendedMonetaryAttributes(properties, event);
+                if (eventMetadata) {
+                    properties.metadata = eventMetadata;
+                }
+                reportEvent = braze.logEcommerceEvent({
+                    name: RECOMMENDED_CART_UPDATED_EVENT_NAME,
+                    properties: properties,
+                });
+                break;
+            case CommerceEventType.ProductCheckout:
+                properties = {
+                    checkout_id: getRecommendedCheckoutId(event),
+                    currency: currency,
+                    source: source,
+                    total_value: getRecommendedTotalValue(event),
+                    products: buildRecommendedLineItems(productList),
+                    cart_id: getRecommendedCartId(event),
+                };
+                applyRecommendedMonetaryAttributes(properties, event);
+                if (eventMetadata) {
+                    properties.metadata = eventMetadata;
+                }
+                reportEvent = braze.logEcommerceEvent({
+                    name: RECOMMENDED_CHECKOUT_STARTED_EVENT_NAME,
+                    properties: properties,
+                });
+                break;
+            case CommerceEventType.ProductViewDetail:
+                reportEvent = false;
+                productList.forEach(function(product) {
+                    var viewedProperties = {
+                        product_id: String(product.Sku),
+                        product_name: String(product.Name),
+                        variant_id: getRecommendedVariantId(product),
+                        price: parseFloat(product.Price) || 0,
+                        currency: currency,
+                        source: source,
+                    };
+                    var imageUrl = getRecommendedProductAttribute(
+                        product,
+                        getRecommendedImageUrlAttributes()
+                    );
+                    if (imageUrl) {
+                        viewedProperties.image_url = imageUrl;
+                    }
+                    var productUrl = getRecommendedProductAttribute(
+                        product,
+                        getRecommendedProductUrlAttributes()
+                    );
+                    if (productUrl) {
+                        viewedProperties.product_url = productUrl;
+                    }
+                    var viewedMetadata = emptyObjectToUndefined(
+                        mergeObjects(
+                            mergeObjects(
+                                buildRecommendedProductMetadata(product),
+                                eventMetadata || {}
+                            ),
+                            buildRecommendedMonetaryMetadata(event)
+                        )
+                    );
+                    if (viewedMetadata) {
+                        viewedProperties.metadata = viewedMetadata;
+                    }
+                    reportEvent =
+                        braze.logEcommerceEvent({
+                            name: RECOMMENDED_PRODUCT_VIEWED_EVENT_NAME,
+                            properties: viewedProperties,
+                        }) === true || reportEvent;
+                });
+                break;
+            case CommerceEventType.ProductPurchase:
+                properties = {
+                    order_id: getRecommendedOrderId(event),
+                    currency: currency,
+                    source: source,
+                    total_value: getRecommendedTotalValue(event),
+                    products: buildRecommendedLineItems(productList),
+                    cart_id: getRecommendedCartId(event),
+                };
+                var totalDiscounts = getRecommendedTotalDiscounts(event);
+                if (totalDiscounts != null) {
+                    properties.total_discounts = totalDiscounts;
+                }
+                applyRecommendedMonetaryAttributes(properties, event);
+                if (eventMetadata) {
+                    properties.metadata = eventMetadata;
+                }
+                reportEvent = braze.logEcommerceEvent({
+                    name: RECOMMENDED_ORDER_PLACED_EVENT_NAME,
+                    properties: properties,
+                });
+                break;
+            case CommerceEventType.ProductRefund:
+                // Braze has no typed order_refunded event; forward it as a custom
+                // event that mirrors the recommended ecommerce.order_refunded schema.
+                var refundProperties = {
+                    order_id: getRecommendedOrderId(event),
+                    total_value: getRecommendedTotalValue(event),
+                    currency: currency,
+                    source: source,
+                    products: buildRecommendedLineItems(productList),
+                };
+                var refundDiscounts = getRecommendedTotalDiscounts(event);
+                if (refundDiscounts != null) {
+                    refundProperties.total_discounts = refundDiscounts;
+                }
+                var refundMetadata = emptyObjectToUndefined(
+                    mergeObjects(
+                        eventMetadata || {},
+                        buildRecommendedMonetaryMetadata(event)
+                    )
+                );
+                if (refundMetadata) {
+                    refundProperties.metadata = refundMetadata;
+                }
+                reportEvent = braze.logCustomEvent(
+                    RECOMMENDED_ORDER_REFUNDED_EVENT_NAME,
+                    refundProperties
+                );
+                break;
+            default:
+                return null;
+        }
+        return reportEvent === true;
+    }
+
     function logBrazePageViewEvent(event) {
         var sanitizedEventName,
             sanitizedAttrs,
@@ -403,6 +995,18 @@ var constructor = function() {
     // a purchase event or a non-purchase commerce event
     function logCommerceEvent(event) {
         var reportEvent = false;
+        // When opted in (and the host Braze SDK supports it), forward supported
+        // commerce actions using Braze's recommended eCommerce schema. Unsupported
+        // actions (or a host SDK without the API) fall back to legacy forwarding.
+        if (
+            useEcommerceRecommendedEvents &&
+            recommendedEcommerceEventsSupported()
+        ) {
+            var recommendedResult = logRecommendedCommerceEvent(event);
+            if (recommendedResult !== null) {
+                return recommendedResult === true;
+            }
+        }
         if (event.EventCategory === CommerceEventType.ProductPurchase) {
             reportEvent = logPurchaseEvent(event);
             return reportEvent === true;
@@ -882,6 +1486,25 @@ var constructor = function() {
                 forwarderSettings.bundleCommerceEventData === 'True';
             forwardSkuAsProductName =
                 forwarderSettings.forwardSkuAsProductName === 'True';
+            useEcommerceRecommendedEvents =
+                forwarderSettings.useEcommerceRecommendedEvents === 'True';
+            // Customer-configured attribute names for the recommended eCommerce
+            // fields. Unset settings leave these null and the defaults apply.
+            mappedCartIdAttribute = getMappedAttributeName(
+                forwarderSettings.cartIdAttribute
+            );
+            mappedCheckoutIdAttribute = getMappedAttributeName(
+                forwarderSettings.checkoutIdAttribute
+            );
+            mappedImageUrlAttribute = getMappedAttributeName(
+                forwarderSettings.imageUrlAttribute
+            );
+            mappedProductUrlAttribute = getMappedAttributeName(
+                forwarderSettings.productUrlAttribute
+            );
+            mappedSubtotalValueAttribute = getMappedAttributeName(
+                forwarderSettings.subtotalValueAttribute
+            );
             reportingService = service;
             // 30 min is Braze default
             options.sessionTimeoutInSeconds =

--- a/kits/braze/braze-6/test/tests.js
+++ b/kits/braze/braze-6/test/tests.js
@@ -1,10 +1,12 @@
 // If we are testing this in a node environemnt, we load the common.js Braze kit
 
-var brazeInstance;
+var brazeInstance, packageVersion;
 if (typeof require !== 'undefined') {
+    packageVersion = require('../package.json').version;
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
     brazeInstance = mpBrazeKitV5.default;
+    packageVersion = brazeInstance.getVersion();
 }
 
 describe('Braze Forwarder', function() {
@@ -167,6 +169,8 @@ describe('Braze Forwarder', function() {
             this.subscribeToInAppMessageCalled = false;
             this.eventProperties = [];
             this.purchaseEventProperties = [];
+            this.logEcommerceEventCalled = false;
+            this.loggedEcommerceEvents = [];
 
             this.user = new MockBrazeUser();
             this.display = new MockDisplay();
@@ -230,6 +234,14 @@ describe('Braze Forwarder', function() {
                     quantity,
                     attributes,
                 ]);
+
+                // Return true to indicate event should be reported
+                return true;
+            };
+
+            this.logEcommerceEvent = function(event) {
+                self.logEcommerceEventCalled = true;
+                self.loggedEcommerceEvents.push(event);
 
                 // Return true to indicate event should be reported
                 return true;
@@ -327,6 +339,10 @@ describe('Braze Forwarder', function() {
 
     it('should have a property of suffix', function() {
         window.mParticle.forwarder.should.have.property('suffix', 'v6');
+    });
+
+    it('should expose its package version', function() {
+        brazeInstance.getVersion().should.equal(packageVersion);
     });
 
     it('should register a forwarder with version number onto a config', function() {
@@ -2591,6 +2607,651 @@ user.getUserIdentities is not a function,\n`;
             };
 
             impressionEvent.should.eql(expectedImpressionEvent);
+        });
+    });
+    describe('Recommended eCommerce Events (useEcommerceRecommendedEvents)', function() {
+        function initRecommended(extraSettings) {
+            var settings = {
+                apiKey: '123456',
+                useEcommerceRecommendedEvents: 'True',
+            };
+            if (extraSettings) {
+                for (var key in extraSettings) {
+                    settings[key] = extraSettings[key];
+                }
+            }
+            mParticle.forwarder.init(
+                settings,
+                reportService.cb,
+                true,
+                null,
+                { gender: 'm' },
+                [{ Identity: 'testUser', Type: IdentityType.CustomerId }],
+                '1.1',
+                'My App'
+            );
+        }
+
+        function recommendedProduct() {
+            return {
+                Sku: 'sku1',
+                Name: 'Product Name',
+                Price: '10',
+                Quantity: 2,
+                Brand: 'brandX',
+                Category: 'catY',
+                Variant: 'variantZ',
+                Position: 3,
+                Attributes: {
+                    image_url: 'https://example.com/img.jpg',
+                    product_url: 'https://example.com/product',
+                    customKey: 'customVal',
+                },
+            };
+        }
+
+        beforeEach(function() {
+            initRecommended();
+        });
+
+        it('should forward add_to_cart as ecommerce.cart_updated with action add', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                EventAttributes: {
+                    cart_id: 'cart-123',
+                    checkout_id: 'checkout-9',
+                    total_discounts: '3.5',
+                    subtotal_value: '18',
+                },
+                ProductAction: {
+                    TotalAmount: 20,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.should.have.property('logEcommerceEventCalled', true);
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(1);
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.cart_updated');
+            event.properties.action.should.equal('add');
+            event.properties.cart_id.should.equal('cart-123');
+            event.properties.currency.should.equal('USD');
+            event.properties.source.should.equal('web');
+            event.properties.total_value.should.equal(20);
+            event.properties.products.should.have.lengthOf(1);
+            var lineItem = event.properties.products[0];
+            lineItem.product_id.should.equal('sku1');
+            lineItem.product_name.should.equal('Product Name');
+            lineItem.variant_id.should.equal('variantZ');
+            lineItem.quantity.should.equal(2);
+            lineItem.price.should.equal(10);
+            lineItem.image_url.should.equal('https://example.com/img.jpg');
+            lineItem.product_url.should.equal('https://example.com/product');
+            // custom/extra props live in metadata, never at the top level
+            lineItem.metadata.brand.should.equal('brandX');
+            lineItem.metadata.category.should.equal('catY');
+            lineItem.metadata.customKey.should.equal('customVal');
+            // cart_id is promoted to the typed cart_id field, so it must not be duplicated in metadata
+            (event.properties.metadata || {}).should.not.have.property(
+                'cart_id'
+            );
+            event.properties.subtotal_value.should.equal(18);
+            event.properties.metadata.should.not.have.property(
+                'subtotal_value'
+            );
+            event.properties.metadata.checkout_id.should.equal('checkout-9');
+            event.properties.metadata.total_discounts.should.equal('3.5');
+        });
+
+        // Mirrors what the config API actually delivers: "custom JSON" with the
+        // quotes HTML-escaped, e.g.
+        //   [{&quot;jsmap&quot;:null,&quot;map&quot;:null,
+        //     &quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,
+        //     &quot;value&quot;:&quot;my_attr&quot;}]
+        // maptype varies (EventAttributeClass.Name for event attributes,
+        // ProductAttributeSelector.Name for product ones) and is not used.
+        function attributeMapping(attributeName, mapType) {
+            return JSON.stringify([
+                {
+                    jsmap: null,
+                    map: null,
+                    maptype: mapType || 'EventAttributeClass.Name',
+                    value: attributeName,
+                },
+            ]).replace(/"/g, '&quot;');
+        }
+
+        // Verbatim setting values from the /config endpoint of the QA1 workspace
+        // used to validate this feature. Every mapping test below is built on
+        // attributeMapping, so if that helper drifts from what the server really
+        // sends, those tests keep passing while the kit is broken in production -
+        // which is how the HTML escaping was missed the first time. Pinning the
+        // helper against real payloads is what makes the rest trustworthy.
+        var LIVE_EVENT_ATTRIBUTE_SETTING =
+            '[{&quot;jsmap&quot;:null,&quot;map&quot;:null,&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;test_cart_id&quot;}]';
+        var LIVE_PRODUCT_ATTRIBUTE_SETTING =
+            '[{&quot;jsmap&quot;:null,&quot;map&quot;:null,&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Variant&quot;}]';
+
+        it('should build fixtures byte for byte identical to the live config', function() {
+            attributeMapping('test_cart_id').should.equal(
+                LIVE_EVENT_ATTRIBUTE_SETTING
+            );
+            attributeMapping(
+                'Variant',
+                'ProductAttributeSelector.Name'
+            ).should.equal(LIVE_PRODUCT_ATTRIBUTE_SETTING);
+        });
+
+        // Belt and braces: drive the kit with the live strings directly, so the
+        // mapping is proven even if the helper is wrong.
+        it('should honor the live config setting strings verbatim', function() {
+            initRecommended({
+                checkoutIdAttribute: LIVE_EVENT_ATTRIBUTE_SETTING,
+                imageUrlAttribute: LIVE_PRODUCT_ATTRIBUTE_SETTING,
+            });
+            var product = recommendedProduct();
+            product.Attributes = { Variant: 'https://example.com/hero.jpg' };
+
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - checkout',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductCheckout,
+                CurrencyCode: 'USD',
+                SessionId: 'session-abc',
+                EventAttributes: { test_cart_id: 'live-checkout-1' },
+                ProductAction: { TotalAmount: 20, ProductList: [product] },
+            });
+
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.properties.checkout_id.should.equal('live-checkout-1');
+            event.properties.products[0].image_url.should.equal(
+                'https://example.com/hero.jpg'
+            );
+            (event.properties.metadata || {}).should.not.have.property(
+                'test_cart_id'
+            );
+        });
+
+        function processAddToCart(eventAttributes, product) {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                SessionId: 'session-abc',
+                EventAttributes: eventAttributes || {},
+                ProductAction: {
+                    TotalAmount: 20,
+                    ProductList: [product || recommendedProduct()],
+                },
+            });
+            return window.braze.loggedEcommerceEvents[0];
+        }
+
+        it('should read cart_id from the configured cartIdAttribute', function() {
+            initRecommended({
+                cartIdAttribute: attributeMapping('my_basket_ref'),
+            });
+            var event = processAddToCart({ my_basket_ref: 'basket-999' });
+            event.properties.cart_id.should.equal('basket-999');
+            // the mapped attribute is promoted, so it must not also sit in metadata
+            (event.properties.metadata || {}).should.not.have.property(
+                'my_basket_ref'
+            );
+        });
+
+        it('should preserve configured identifier aliases on event types that do not promote them', function() {
+            initRecommended({
+                cartIdAttribute: attributeMapping('my_basket_ref'),
+                checkoutIdAttribute: attributeMapping('my_checkout_ref'),
+            });
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                CurrencyCode: 'USD',
+                EventAttributes: {
+                    my_basket_ref: 'basket-999',
+                    my_checkout_ref: 'checkout-9',
+                },
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 20,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            var purchase = window.braze.loggedEcommerceEvents[0];
+            purchase.properties.cart_id.should.equal('basket-999');
+            purchase.properties.metadata.my_checkout_ref.should.equal(
+                'checkout-9'
+            );
+            purchase.properties.metadata.should.not.have.property(
+                'my_basket_ref'
+            );
+
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - refund',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductRefund,
+                CurrencyCode: 'USD',
+                EventAttributes: { my_basket_ref: 'basket-999' },
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 20,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.loggedEvents[0].eventProperties.metadata.my_basket_ref.should.equal(
+                'basket-999'
+            );
+        });
+
+        it('should read image_url and product_url from configured attributes', function() {
+            initRecommended({
+                imageUrlAttribute: attributeMapping('hero_shot'),
+                productUrlAttribute: attributeMapping('pdp_link'),
+            });
+            var product = recommendedProduct();
+            product.Attributes = {
+                hero_shot: 'https://example.com/hero.jpg',
+                pdp_link: 'https://example.com/pdp',
+            };
+            var lineItem = processAddToCart({}, product).properties.products[0];
+            lineItem.image_url.should.equal('https://example.com/hero.jpg');
+            lineItem.product_url.should.equal('https://example.com/pdp');
+            // promoted to typed fields, so not duplicated in product metadata
+            lineItem.metadata.should.not.have.property('hero_shot');
+            lineItem.metadata.should.not.have.property('pdp_link');
+        });
+
+        // The image/product URL settings select a product attribute, so the live
+        // config carries ProductAttributeSelector.Name rather than the event
+        // maptype. maptype is ignored, so both must behave identically.
+        it('should honor product-scoped maptype for URL attributes', function() {
+            initRecommended({
+                imageUrlAttribute: attributeMapping(
+                    'hero_shot',
+                    'ProductAttributeSelector.Name'
+                ),
+                productUrlAttribute: attributeMapping(
+                    'pdp_link',
+                    'ProductAttributeSelector.Name'
+                ),
+            });
+            var product = recommendedProduct();
+            product.Attributes = {
+                hero_shot: 'https://example.com/hero.jpg',
+                pdp_link: 'https://example.com/pdp',
+            };
+            var lineItem = processAddToCart({}, product).properties.products[0];
+            lineItem.image_url.should.equal('https://example.com/hero.jpg');
+            lineItem.product_url.should.equal('https://example.com/pdp');
+        });
+
+        // The configured name is prepended to the defaults rather than replacing
+        // them, so a product that uses the conventional key still resolves when the
+        // mapped attribute is absent.
+        it('should fall back to default URL keys when the mapped attribute is absent', function() {
+            initRecommended({
+                imageUrlAttribute: attributeMapping(
+                    'hero_shot',
+                    'ProductAttributeSelector.Name'
+                ),
+            });
+            var product = recommendedProduct();
+            product.Attributes = {
+                image_url: 'https://example.com/default.jpg',
+            };
+            var lineItem = processAddToCart({}, product).properties.products[0];
+            lineItem.image_url.should.equal(
+                'https://example.com/default.jpg'
+            );
+        });
+
+        // The same setting delivered without HTML escaping must still work.
+        it('should parse an attribute mapping that is not HTML escaped', function() {
+            initRecommended({
+                cartIdAttribute: JSON.stringify([
+                    {
+                        jsmap: null,
+                        map: null,
+                        maptype: 'EventAttributeClass.Name',
+                        value: 'my_basket_ref',
+                    },
+                ]),
+            });
+            processAddToCart({
+                my_basket_ref: 'basket-777',
+            }).properties.cart_id.should.equal('basket-777');
+        });
+
+        // maptype is not inspected, so a new selector type added by the platform
+        // cannot silently disable an otherwise valid mapping.
+        it('should honor a mapping regardless of maptype', function() {
+            initRecommended({
+                cartIdAttribute: attributeMapping(
+                    'my_basket_ref',
+                    'SomeFutureClass.Name'
+                ),
+            });
+            processAddToCart({
+                my_basket_ref: 'basket-999',
+            }).properties.cart_id.should.equal('basket-999');
+        });
+
+        it('should read subtotal_value from the configured subtotalValueAttribute', function() {
+            initRecommended({
+                subtotalValueAttribute: attributeMapping('order_subtotal'),
+            });
+            var event = processAddToCart({ order_subtotal: 42.5 });
+            event.properties.subtotal_value.should.equal(42.5);
+            // promoted to a typed field, so not duplicated in metadata
+            (event.properties.metadata || {}).should.not.have.property(
+                'order_subtotal'
+            );
+        });
+
+        it('should fall back to default attribute names when settings are unset', function() {
+            initRecommended({ cartIdAttribute: '[]', imageUrlAttribute: '[]' });
+            var event = processAddToCart({ cart_id: 'cart-123' });
+            event.properties.cart_id.should.equal('cart-123');
+            event.properties.products[0].image_url.should.equal(
+                'https://example.com/img.jpg'
+            );
+        });
+
+        it('should ignore a malformed attribute mapping setting', function() {
+            initRecommended({ cartIdAttribute: 'not-json' });
+            var event = processAddToCart({ cart_id: 'cart-123' });
+            event.properties.cart_id.should.equal('cart-123');
+        });
+
+        // Without this the kit generates a fresh id per event and Braze cannot
+        // correlate a cart across add/remove/checkout/order.
+        it('should fall back to the session id when no cart_id attribute exists', function() {
+            initRecommended();
+            var event = processAddToCart({});
+            event.properties.cart_id.should.equal('session-abc');
+        });
+
+        it('should forward remove_from_cart as ecommerce.cart_updated with action remove', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - remove_from_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductRemoveFromCart,
+                CurrencyCode: 'USD',
+                EventAttributes: { cart_id: 'cart-123' },
+                ProductAction: { ProductList: [recommendedProduct()] },
+            });
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(1);
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.cart_updated');
+            event.properties.action.should.equal('remove');
+        });
+
+        it('should forward checkout as ecommerce.checkout_started', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - checkout',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductCheckout,
+                CurrencyCode: 'USD',
+                EventAttributes: {
+                    checkout_id: 'checkout-9',
+                    cart_id: 'cart-123',
+                    total_discounts: '3.5',
+                    subtotal_value: '18',
+                },
+                ProductAction: {
+                    TotalAmount: 20,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(1);
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.checkout_started');
+            event.properties.checkout_id.should.equal('checkout-9');
+            event.properties.cart_id.should.equal('cart-123');
+            event.properties.total_value.should.equal(20);
+            event.properties.subtotal_value.should.equal(18);
+            event.properties.metadata.total_discounts.should.equal('3.5');
+            event.properties.metadata.should.not.have.property('checkout_id');
+            event.properties.metadata.should.not.have.property('cart_id');
+            event.properties.metadata.should.not.have.property(
+                'subtotal_value'
+            );
+        });
+
+        it('should forward view_detail as one ecommerce.product_viewed per product', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - view_detail',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductViewDetail,
+                CurrencyCode: 'USD',
+                EventAttributes: {
+                    cart_id: 'cart-123',
+                    checkout_id: 'checkout-9',
+                    total_discounts: '3.5',
+                    subtotal_value: '18',
+                },
+                ProductAction: {
+                    ProductList: [
+                        recommendedProduct(),
+                        {
+                            Sku: 'sku2',
+                            Name: 'Second',
+                            Price: '5',
+                            Quantity: 1,
+                        },
+                    ],
+                },
+            });
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(2);
+            var first = window.braze.loggedEcommerceEvents[0];
+            first.name.should.equal('ecommerce.product_viewed');
+            first.properties.product_id.should.equal('sku1');
+            first.properties.image_url.should.equal(
+                'https://example.com/img.jpg'
+            );
+            first.properties.metadata.cart_id.should.equal('cart-123');
+            first.properties.metadata.checkout_id.should.equal('checkout-9');
+            first.properties.metadata.total_discounts.should.equal('3.5');
+            first.properties.metadata.subtotal_value.should.equal(18);
+            var second = window.braze.loggedEcommerceEvents[1];
+            second.properties.product_id.should.equal('sku2');
+            // variant_id falls back to sku when the product has no variant
+            second.properties.variant_id.should.equal('sku2');
+        });
+
+        it('should forward purchase as ecommerce.order_placed', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                CurrencyCode: 'USD',
+                EventAttributes: {
+                    cart_id: 'cart-123',
+                    checkout_id: 'checkout-9',
+                    total_discounts: '3.5',
+                    subtotal_value: '40',
+                },
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 50,
+                    TaxAmount: 5,
+                    ShippingAmount: 7,
+                    Affiliation: 'the affiliation',
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(1);
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.order_placed');
+            event.properties.order_id.should.equal('order-42');
+            event.properties.cart_id.should.equal('cart-123');
+            event.properties.total_value.should.equal(50);
+            event.properties.total_discounts.should.equal(3.5);
+            // tax/shipping/subtotal_value are recognized top-level attributes (Braze 6.9+)
+            event.properties.tax.should.equal(5);
+            event.properties.shipping.should.equal(7);
+            event.properties.subtotal_value.should.equal(40);
+            // affiliation has no typed field; preserved in metadata
+            event.properties.metadata.affiliation.should.equal(
+                'the affiliation'
+            );
+            // promoted top-level attrs must not be duplicated in metadata
+            event.properties.metadata.should.not.have.property(
+                'total_discounts'
+            );
+            event.properties.metadata.should.not.have.property(
+                'subtotal_value'
+            );
+            event.properties.metadata.should.not.have.property('cart_id');
+            event.properties.metadata.checkout_id.should.equal('checkout-9');
+        });
+
+        it('should send tax/shipping/subtotal_value as top-level attributes on cart_updated', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                EventAttributes: { cart_id: 'cart-123', subtotal_value: '40' },
+                ProductAction: {
+                    TotalAmount: 50,
+                    TaxAmount: 5,
+                    ShippingAmount: 7,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.cart_updated');
+            event.properties.tax.should.equal(5);
+            event.properties.shipping.should.equal(7);
+            event.properties.subtotal_value.should.equal(40);
+        });
+
+        it('should forward refund as an ecommerce.order_refunded custom event', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - refund',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductRefund,
+                CurrencyCode: 'USD',
+                EventAttributes: {
+                    cart_id: 'cart-123',
+                    checkout_id: 'checkout-9',
+                    total_discounts: '3.5',
+                    subtotal_value: '40',
+                },
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 50,
+                    TaxAmount: 5,
+                    ShippingAmount: 7,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            // Refund has no typed Braze event; it is forwarded as a custom event.
+            window.braze.should.have.property('logEcommerceEventCalled', false);
+            window.braze.should.have.property('logCustomEventCalled', true);
+            var loggedEvent = window.braze.loggedEvents[0];
+            loggedEvent.name.should.equal('ecommerce.order_refunded');
+            loggedEvent.eventProperties.order_id.should.equal('order-42');
+            loggedEvent.eventProperties.source.should.equal('web');
+            loggedEvent.eventProperties.products.should.have.lengthOf(1);
+            loggedEvent.eventProperties.total_discounts.should.equal(3.5);
+            loggedEvent.eventProperties.metadata.cart_id.should.equal(
+                'cart-123'
+            );
+            loggedEvent.eventProperties.metadata.checkout_id.should.equal(
+                'checkout-9'
+            );
+            loggedEvent.eventProperties.metadata.should.not.have.property(
+                'total_discounts'
+            );
+            // order_refunded has no recognized top-level tax/shipping/subtotal_value,
+            // so they are preserved in metadata rather than dropped.
+            loggedEvent.eventProperties.metadata.tax.should.equal(5);
+            loggedEvent.eventProperties.metadata.shipping.should.equal(7);
+            loggedEvent.eventProperties.metadata.subtotal_value.should.equal(40);
+        });
+
+        it('should fall back to legacy forwarding when the toggle is off', function() {
+            initRecommended({ useEcommerceRecommendedEvents: 'False' });
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 50,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.should.have.property('logEcommerceEventCalled', false);
+            window.braze.should.have.property('logPurchaseEventCalled', true);
+        });
+
+        it('should fall back to legacy forwarding for unsupported actions', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_wishlist',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToWishlist,
+                CurrencyCode: 'USD',
+                ProductAction: { ProductList: [recommendedProduct()] },
+            });
+            // add_to_wishlist is not a recommended eCommerce event
+            window.braze.should.have.property('logEcommerceEventCalled', false);
+            window.braze.should.have.property('logCustomEventCalled', true);
+        });
+
+        it('should fall back to legacy forwarding when the host Braze SDK lacks logEcommerceEvent', function() {
+            delete window.braze.logEcommerceEvent;
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 50,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.should.have.property('logPurchaseEventCalled', true);
+        });
+
+        it('should fall back to a session/generated cart_id when none is provided', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                ProductAction: { ProductList: [recommendedProduct()] },
+            });
+            var event = window.braze.loggedEcommerceEvents[0];
+            // Matches Android/iOS: cart_id always resolves (custom attr ->
+            // session id -> generated id), never empty/undefined.
+            event.properties.cart_id.should.be.a.String();
+            event.properties.cart_id.should.not.be.empty();
+        });
+
+        it('should send an integer quantity even when the product quantity is fractional', function() {
+            var product = recommendedProduct();
+            product.Quantity = 2.9;
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                ProductAction: { ProductList: [product] },
+            });
+            var lineItem =
+                window.braze.loggedEcommerceEvents[0].properties.products[0];
+            lineItem.quantity.should.equal(2);
+            Number.isInteger(lineItem.quantity).should.equal(true);
         });
     });
 });

--- a/kits/onetrust/test/boilerplate/test-karma.js
+++ b/kits/onetrust/test/boilerplate/test-karma.js
@@ -9,4 +9,5 @@ var testCommand = util.format(
 );
 
 console.log('Running command: \n' + testCommand);
-shell.exec(testCommand);
+var result = shell.exec(testCommand);
+process.exitCode = result.code;

--- a/kits/onetrust/test/tests.js
+++ b/kits/onetrust/test/tests.js
@@ -58,12 +58,14 @@ function configureOneTrustForwarderAndInit(
     consentGroups,
     vendorIABConsentGroups,
     vendorGoogleConsentGroups,
-    vendorGeneralConsentGroups
+    vendorGeneralConsentGroups,
+    identityCallback
 ) {
     mParticle.config = {
         requestConfig: false,
         logLevel: 'none',
         workspaceToken: 'workspaceToken1',
+        identityCallback: identityCallback,
         kitConfigs: [
             {
                 name: 'OneTrust',
@@ -92,32 +94,50 @@ function configureOneTrustForwarderAndInit(
     mParticle.init('apikey', mParticle.config);
 }
 
+function initializeOneTrustForwarder(
+    consentGroups,
+    vendorIABConsentGroups,
+    vendorGoogleConsentGroups,
+    vendorGeneralConsentGroups
+) {
+    return new Promise(function(resolve) {
+        configureOneTrustForwarderAndInit(
+            consentGroups,
+            vendorIABConsentGroups,
+            vendorGoogleConsentGroups,
+            vendorGeneralConsentGroups,
+            resolve
+        );
+    });
+}
+
+before(function() {
+    server.start();
+    server.requests = [];
+});
+
+beforeEach(function() {
+    localStorage.clear();
+    window.Optanon = new MockForwarder();
+    server.requests = [];
+    window.mParticleAndroid = null;
+    window.mParticle.isIOS = null;
+    window.mParticle.useCookieStorage = false;
+    window.fetch = null;
+    mParticle.isDevelopmentMode = false;
+    server.handle = function(request) {
+        request.setResponseHeader('Content-Type', 'application/json');
+        request.receive(
+            200,
+            JSON.stringify({
+                Store: {},
+                mpid: 'testMPID',
+            })
+        );
+    };
+});
+
 describe('OneTrust Forwarder', function() {
-    before(function() {
-        server.start();
-        server.requests = [];
-    });
-
-    beforeEach(function() {
-        localStorage.clear();
-        window.Optanon = new MockForwarder();
-        server.requests = [];
-        window.mParticleAndroid = null;
-        window.mParticle.isIOS = null;
-        window.mParticle.useCookieStorage = false;
-        mParticle.isDevelopmentMode = false;
-        server.handle = function(request) {
-            request.setResponseHeader('Content-Type', 'application/json');
-            request.receive(
-                200,
-                JSON.stringify({
-                    Store: {},
-                    mpid: 'testMPID',
-                })
-            );
-        };
-    });
-
     it('should test consent group parsing', function() {
         var consentGroups = [
             {
@@ -152,7 +172,7 @@ describe('OneTrust Forwarder', function() {
         generatedString.should.equal(expectedString);
     });
 
-    it('should use CCPA regulation if consent purpose is "data_sale_opt_out", otherwise should use GDPR', function(done) {
+    it('should use CCPA regulation if consent purpose is "data_sale_opt_out", otherwise should use GDPR', function() {
         var consentGroups = [
             {
                 jsmap: null,
@@ -169,16 +189,17 @@ describe('OneTrust Forwarder', function() {
         ];
 
         window.OnetrustActiveGroups = ',euro_biscuit,cali_cookie';
-        configureOneTrustForwarderAndInit(consentGroups);
-
-        var consent = mParticle.getInstance()._Persistence.getLocalStorage();
-        consent.testMPID.con.ccpa.should.have.property('data_sale_opt_out');
-        consent.testMPID.con.gdpr['european_privacy'].should.have.property(
-            'd',
-            'european_privacy'
-        );
-
-        done();
+        return initializeOneTrustForwarder(consentGroups).then(function() {
+                var consent = mParticle
+                    .getInstance()
+                    ._Persistence.getLocalStorage();
+                consent.testMPID.con.ccpa.should.have.property(
+                    'data_sale_opt_out'
+                );
+                consent.testMPID.con.gdpr[
+                    'european_privacy'
+                ].should.have.property('d', 'european_privacy');
+            });
     });
 
     describe('vendor consent', function() {
@@ -241,7 +262,7 @@ describe('OneTrust Forwarder', function() {
             },
         ];
 
-        it('should initialize using stored GDPR regulation API for Vendor Consents', function(done) {
+        it('should initialize using stored GDPR regulation API for Vendor Consents', function() {
             window.OnetrustActiveGroups = 'V1';
             window.OneTrust = {
                 getVendorConsentsRequestV2: function(fn) {
@@ -254,53 +275,28 @@ describe('OneTrust Forwarder', function() {
                     fn(vendorConsent);
                 },
             };
-            configureOneTrustForwarderAndInit(
+            return initializeOneTrustForwarder(
                 consentGroups,
                 vendorIABConsentGroups,
                 vendorGoogleConsentGroups,
                 vendorGeneralConsentGroups
-            );
-
-            var consent = mParticle.Identity.getCurrentUser()
-                .getConsentState()
-                .getGDPRConsentState();
-            consent.marketing.Consented.should.equal(true);
-            consent.testconsent.Consented.should.equal(true);
-            consent['vendor consent example'].Consented.should.equal(false);
-            consent.performance.Consented.should.equal(false);
-            consent['some_consent'].Consented.should.equal(true);
-
-            done();
+            ).then(function() {
+                    var consent = mParticle.Identity.getCurrentUser()
+                        .getConsentState()
+                        .getGDPRConsentState();
+                    consent.marketing.Consented.should.equal(true);
+                    consent.testconsent.Consented.should.equal(true);
+                    consent[
+                        'vendor consent example'
+                    ].Consented.should.equal(false);
+                    consent.performance.Consented.should.equal(false);
+                    consent['some_consent'].Consented.should.equal(true);
+                });
         });
     });
 });
 
 describe('OneTrust re-initialization tests', function() {
-    before(function() {
-        server.start();
-        server.requests = [];
-    });
-
-    beforeEach(function() {
-        localStorage.clear();
-        window.Optanon = new MockForwarder();
-        server.requests = [];
-        window.mParticleAndroid = null;
-        window.mParticle.isIOS = null;
-        window.mParticle.useCookieStorage = false;
-        mParticle.isDevelopmentMode = false;
-        server.handle = function(request) {
-            request.setResponseHeader('Content-Type', 'application/json');
-            request.receive(
-                200,
-                JSON.stringify({
-                    Store: {},
-                    mpid: 'testMPID',
-                })
-            );
-        };
-    });
-
     it('should update consent during initialization if consent has changed', function() {
         var consentGroups = [
             {
@@ -317,29 +313,33 @@ describe('OneTrust re-initialization tests', function() {
 
         // After initializing the kit once, the user will have the strictly necessary consent associated with it
         // as true
-        configureOneTrustForwarderAndInit(consentGroups);
+        return initializeOneTrustForwarder(consentGroups).then(function() {
+                var consentBefore = mParticle.Identity.getCurrentUser()
+                    .getConsentState()
+                    .getGDPRConsentState()['strictly necessary'];
+                consentBefore.Timestamp.should.be.ok();
+                consentBefore.Consented.should.equal(true);
+                // Update to remove userEditable1, thus having OneTrust set this consent to false
+                window.OnetrustActiveGroups = ',1,2,4,userEditable2';
 
-        var consentBefore = mParticle.Identity.getCurrentUser()
-            .getConsentState()
-            .getGDPRConsentState()['strictly necessary'];
-        var consentTimestampBefore = consentBefore.Timestamp;
-        consentTimestampBefore.should.be.ok();
-        // Update to remove userEditable1, thus having OneTrust set this consent to false
-        window.OnetrustActiveGroups = ',1,2,4,userEditable2';
+                // With an existing user, kit initialization updates consent
+                // synchronously and does not make another identity request.
+                configureOneTrustForwarderAndInit(
+                    consentGroups,
+                    null,
+                    null,
+                    null
+                );
 
-        // When we re-initialize consent, the strictly necessary consent has not been updated
-        // because there is no change in consent
-        configureOneTrustForwarderAndInit(consentGroups);
+                var consentAfter = mParticle.Identity.getCurrentUser()
+                    .getConsentState()
+                    .getGDPRConsentState()['strictly necessary'];
 
-        var consentAfter = mParticle.Identity.getCurrentUser()
-            .getConsentState()
-            .getGDPRConsentState()['strictly necessary'];
+                var consentTimestampAfter = consentAfter.Timestamp;
+                consentTimestampAfter.should.be.ok();
 
-        var consentTimestampAfter = consentAfter.Timestamp;
-        consentTimestampAfter.should.be.ok();
-
-        // the timestamps should not equal each other because the timestamp has been updated due to the consent change
-        consentTimestampBefore.should.not.equal(consentTimestampAfter);
+                consentAfter.Consented.should.equal(false);
+            });
     });
 
     it('should not update consent during initialization if consent does not change', function() {
@@ -358,26 +358,31 @@ describe('OneTrust re-initialization tests', function() {
 
         // After initializing the kit once, the user will have the strictly necessary consent associated with it
         // as true
-        configureOneTrustForwarderAndInit(consentGroups);
+        return initializeOneTrustForwarder(consentGroups).then(function() {
+                var consentBefore = mParticle.Identity.getCurrentUser()
+                    .getConsentState()
+                    .getGDPRConsentState()['strictly necessary'];
+                var consentTimestampBefore = consentBefore.Timestamp;
+                consentTimestampBefore.should.be.ok();
 
-        var consentBefore = mParticle.Identity.getCurrentUser()
-            .getConsentState()
-            .getGDPRConsentState()['strictly necessary'];
-        var consentTimestampBefore = consentBefore.Timestamp;
-        consentTimestampBefore.should.be.ok();
+                // With an existing user, kit initialization updates consent
+                // synchronously and does not make another identity request.
+                configureOneTrustForwarderAndInit(
+                    consentGroups,
+                    null,
+                    null,
+                    null
+                );
 
-        // When we re-initialize consent, the strictly necessary consent has not been updated
-        // because there is no change in consent
-        configureOneTrustForwarderAndInit(consentGroups);
+                var consentAfter = mParticle.Identity.getCurrentUser()
+                    .getConsentState()
+                    .getGDPRConsentState()['strictly necessary'];
 
-        var consentAfter = mParticle.Identity.getCurrentUser()
-            .getConsentState()
-            .getGDPRConsentState()['strictly necessary'];
+                var consentTimestampAfter = consentAfter.Timestamp;
+                consentTimestampAfter.should.be.ok();
 
-        var consentTimestampAfter = consentAfter.Timestamp;
-        consentTimestampAfter.should.be.ok();
-
-        // The timestamps should be the same because consent was not updated.
-        consentTimestampBefore.should.equal(consentTimestampAfter);
+                // The timestamps should be the same because consent was not updated.
+                consentTimestampBefore.should.equal(consentTimestampAfter);
+            });
     });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -190,6 +190,10 @@ const Constants = {
         CaptureIntegrationSpecificIdsV2: 'captureIntegrationSpecificIds.V2',
         AstBackgroundEvents: 'astBackgroundEvents',
         AutoLogPageView: 'autoLogPageView',
+        // Comma-separated query param names the customer adds to the APV
+        // allowlist, from the Web input's Advanced Settings. Unioned with
+        // ALLOWED_QUERY_PARAMS; absent or empty means built-ins only.
+        AutoLogPageViewQueryParams: 'autoLogPageViewQueryParams',
     },
     DefaultInstance: 'default_instance',
     CCPAPurpose: 'data_sale_opt_out',

--- a/src/events.ts
+++ b/src/events.ts
@@ -151,8 +151,7 @@ export default function Events(
 
     // The auto page view for the landing page. The SPA navigations that follow it
     // come from PageViewTracker instead, so both emitters attach the same
-    // allowlisted query params — and this is the one that matters for campaign
-    // attribution, since utm_*/gclid live on the entry URL.
+    // allowlisted query params.
     this.logPageView = function(): void {
         self.logEvent({
             messageType: Types.MessageType.PageView,

--- a/src/events.ts
+++ b/src/events.ts
@@ -23,7 +23,7 @@ import {
 import { getHref, valueof } from './utils';
 import {
     allowedQueryParams,
-    IQueryParamAllowlist,
+    IQueryParamConfig,
     paramsToAttributes,
 } from './pageViewTracker';
 
@@ -162,12 +162,12 @@ export default function Events(
                 ...paramsToAttributes(
                     allowedQueryParams(
                         getHref(),
-                        // processFlags validated these at the config boundary, so
-                        // only the accepted names are needed here. `?.` because
-                        // getFeatureFlag returns null when the flag is absent.
-                        (mpInstance._Helpers.getFeatureFlag(
+                        // Passed whole: processFlags validated it at the config
+                        // boundary, and allowedQueryParams needs both the additions
+                        // and the exclusions.
+                        mpInstance._Helpers.getFeatureFlag(
                             Constants.FeatureFlags.AutoLogPageViewQueryParams
-                        ) as IQueryParamAllowlist)?.allowed
+                        ) as IQueryParamConfig
                     )
                 ),
                 hostname: window.location.hostname,

--- a/src/events.ts
+++ b/src/events.ts
@@ -21,7 +21,7 @@ import {
     TransactionAttributes,
 } from '@mparticle/web-sdk';
 import { getHref, valueof } from './utils';
-import { allowedQueryParams } from './pageViewTracker';
+import { allowedQueryParams, paramsToAttributes } from './pageViewTracker';
 
 interface DOMHandlerElement extends HTMLElement {
     href?: string;
@@ -156,7 +156,16 @@ export default function Events(
             data: {
                 // Params first so the core fields always win. See
                 // buildPageViewEvent, which does the same for SPA views.
-                ...allowedQueryParams(getHref()),
+                ...paramsToAttributes(
+                    allowedQueryParams(
+                        getHref(),
+                        // getFeatureFlag is declared boolean | string; processFlags
+                        // stores this one as a validated string[].
+                        (mpInstance._Helpers.getFeatureFlag(
+                            Constants.FeatureFlags.AutoLogPageViewQueryParams
+                        ) as unknown) as string[]
+                    )
+                ),
                 hostname: window.location.hostname,
                 title: window.document.title,
             },

--- a/src/events.ts
+++ b/src/events.ts
@@ -21,7 +21,11 @@ import {
     TransactionAttributes,
 } from '@mparticle/web-sdk';
 import { getHref, valueof } from './utils';
-import { allowedQueryParams, paramsToAttributes } from './pageViewTracker';
+import {
+    allowedQueryParams,
+    IQueryParamAllowlist,
+    paramsToAttributes,
+} from './pageViewTracker';
 
 interface DOMHandlerElement extends HTMLElement {
     href?: string;
@@ -159,11 +163,12 @@ export default function Events(
                 ...paramsToAttributes(
                     allowedQueryParams(
                         getHref(),
-                        // getFeatureFlag is declared boolean | string; processFlags
-                        // stores this one as a validated string[].
+                        // processFlags validated these at the config boundary, so
+                        // only the accepted names are needed here. `?.` because
+                        // getFeatureFlag returns null when the flag is absent.
                         (mpInstance._Helpers.getFeatureFlag(
                             Constants.FeatureFlags.AutoLogPageViewQueryParams
-                        ) as unknown) as string[]
+                        ) as IQueryParamAllowlist)?.allowed
                     )
                 ),
                 hostname: window.location.hostname,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,6 +6,7 @@ import Validators from './validators';
 import KitFilterHelper from './kitFilterHelper';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { SDKHelpersApi } from './sdkRuntimeModels';
+import { IQueryParamAllowlist } from './pageViewTracker';
 import { IMParticleUser, IdentityCallback, IdentityResult, ISDKUserIdentity } from './identity-user-interfaces';
 import { IAliasResult } from './identity.interfaces';
 import { AliasUsersCallback, MPID, UserIdentities } from '@mparticle/web-sdk';
@@ -82,7 +83,12 @@ export default function Helpers(
         return false;
     };
 
-    this.getFeatureFlag = function(feature: string): boolean | string {
+    // The union is every shape processFlags can put in SDKConfig.flags. It has to
+    // include IQueryParamAllowlist or the APV callers need an `as unknown as` cast
+    // to read a value this function genuinely returns.
+    this.getFeatureFlag = function(
+        feature: string
+    ): boolean | string | IQueryParamAllowlist {
         if (mpInstance._Store.SDKConfig.flags.hasOwnProperty(feature)) {
             return mpInstance._Store.SDKConfig.flags[feature];
         }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,7 +6,7 @@ import Validators from './validators';
 import KitFilterHelper from './kitFilterHelper';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { SDKHelpersApi } from './sdkRuntimeModels';
-import { IQueryParamAllowlist } from './pageViewTracker';
+import { IQueryParamConfig } from './pageViewTracker';
 import { IMParticleUser, IdentityCallback, IdentityResult, ISDKUserIdentity } from './identity-user-interfaces';
 import { IAliasResult } from './identity.interfaces';
 import { AliasUsersCallback, MPID, UserIdentities } from '@mparticle/web-sdk';
@@ -84,11 +84,11 @@ export default function Helpers(
     };
 
     // The union is every shape processFlags can put in SDKConfig.flags. It has to
-    // include IQueryParamAllowlist or the APV callers need an `as unknown as` cast
+    // include IQueryParamConfig or the APV callers need an `as unknown as` cast
     // to read a value this function genuinely returns.
     this.getFeatureFlag = function(
         feature: string
-    ): boolean | string | IQueryParamAllowlist {
+    ): boolean | string | IQueryParamConfig {
         if (mpInstance._Store.SDKConfig.flags.hasOwnProperty(feature)) {
             return mpInstance._Store.SDKConfig.flags[feature];
         }

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -106,6 +106,11 @@ export const ALLOWED_QUERY_PARAMS: string[] = [
 // constructor/__proto__/prototype resolve to something truthy through the
 // prototype chain. hasOwnProp neutralises them at capture, and rejecting them at
 // the config boundary means they never travel far enough to depend on that.
+//
+// true/false are here because every other flag in this SDK is a string compared
+// against 'True'. An operator who sets this one the same way sends the literal
+// `True`, which is a legal param name — so it would silently pass validation and
+// the SDK would start capturing `?true=`. Rejecting it surfaces the mistake.
 const RESERVED_QUERY_PARAMS: string[] = [
     'hostname',
     'title',
@@ -113,6 +118,8 @@ const RESERVED_QUERY_PARAMS: string[] = [
     'constructor',
     '__proto__',
     'prototype',
+    'true',
+    'false',
 ];
 
 // Must start with a letter, digit or underscore, then up to 63 more of the same
@@ -123,26 +130,32 @@ const QUERY_PARAM_NAME = /^[a-z0-9_][a-z0-9_.-]{0,63}$/;
 // mParticle caps attributes per event; 31 built-ins plus this leaves headroom.
 export const MAX_CUSTOM_QUERY_PARAMS = 25;
 
-// How much of a rejected entry is safe to name in a log.
-const REJECTED_LABEL_LIMIT = 32;
+// The outcome of validating the customer's additions: one value with three parts,
+// produced by a single parse. processFlags stores it whole and the tracker reports
+// from it, so there is no second validator that can drift from the first.
+export interface IQueryParamAllowlist {
+    // The names to union with ALLOWED_QUERY_PARAMS.
+    allowed: string[];
 
-// A log-safe label for a rejected entry.
-//
-// An entry is rejected BECAUSE of a character, and everything from that character
-// onwards is untrusted: a customer who types `password=hunter2` into the field must
-// not have the value echoed into the console, where session-replay tooling would
-// ship it off-domain. So cut at the first character that is not name-legal, and cap
-// the length. The surviving prefix is still enough to identify which entry was
-// dropped, which is the whole point of reporting it.
-const rejectedLabel = (entry: string): string => {
-    const legalPrefix = /^[a-z0-9_.-]*/.exec(entry);
-    const kept = (legalPrefix ? legalPrefix[0] : '').slice(
-        0,
-        REJECTED_LABEL_LIMIT
-    );
+    // 1-based positions, in the order the customer wrote them, of the entries whose
+    // name was illegal or reserved.
+    //
+    // Positions rather than the text, because none of the text is safe to log. An
+    // entry is rejected BECAUSE of a character, so the entry may be something the
+    // customer pasted into the wrong field: `password=hunter2` must not reach
+    // Logger.warning, where session-replay tooling ships the console off-domain.
+    // Truncating at the first illegal character does not achieve that — `.`, `-`
+    // and `_` are all legal, so `token.hunter2` and `-secret-value` survive whole.
+    // A position cannot leak anything, and it still identifies the entry, which is
+    // the entire point of reporting it. It also works for a non-ASCII name, where
+    // every character is illegal and a legal prefix would be empty.
+    rejectedPositions: number[];
 
-    return kept.length < entry.length ? `${kept}...` : kept;
-};
+    // How many otherwise-valid entries were dropped for exceeding
+    // MAX_CUSTOM_QUERY_PARAMS. A count, not positions: past the cap the remedy is
+    // "ask for fewer", not "fix entry 31".
+    overLimit: number;
+}
 
 // Applies to CUSTOM params only — see allowedQueryParams.
 export const MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH = 512;
@@ -184,26 +197,27 @@ interface IPendingNavigation {
 // array as well as a comma-separated string so a self-hosted config can pass one
 // directly.
 //
-// Returns the accepted names alongside log-safe labels for what it dropped. The raw
-// rejected entry never escapes this function — see rejectedLabel.
+// Returns the accepted names alongside positions for what it dropped. No part of a
+// rejected entry escapes this function — see IQueryParamAllowlist.
 export const parseQueryParamAllowlist = (
     configured: string | string[]
-): { allowed: string[]; rejected: string[] } => {
+): IQueryParamAllowlist => {
     const allowed: string[] = [];
-    const rejected: string[] = [];
+    const rejectedPositions: number[] = [];
+    let overLimit = 0;
 
     if (!configured) {
-        return { allowed, rejected };
+        return { allowed, rejectedPositions, overLimit };
     }
 
     const entries: string[] = Array.isArray(configured)
         ? configured
         : String(configured).split(',');
 
-    entries.forEach(entry => {
-        if (allowed.length >= MAX_CUSTOM_QUERY_PARAMS) {
-            return;
-        }
+    entries.forEach((entry, index) => {
+        // 1-based, and counted over every comma-separated slot including the blank
+        // ones, so a reported position matches what the customer typed.
+        const position = index + 1;
 
         // Lowercased because queryStringParser matches case-insensitively and keys
         // its result by the allowlist's casing — so this is what makes the emitted
@@ -220,7 +234,7 @@ export const parseQueryParamAllowlist = (
             !QUERY_PARAM_NAME.test(name) ||
             RESERVED_QUERY_PARAMS.indexOf(name) !== -1
         ) {
-            rejected.push(rejectedLabel(name));
+            rejectedPositions.push(position);
             return;
         }
 
@@ -233,40 +247,50 @@ export const parseQueryParamAllowlist = (
             return;
         }
 
+        // The cap is checked here rather than at the top of the loop so that a
+        // blank or a duplicate does not consume headroom, and — the reason it
+        // moved — so the entries that lose out are counted instead of vanishing
+        // with no report at all.
+        if (allowed.length >= MAX_CUSTOM_QUERY_PARAMS) {
+            overLimit++;
+            return;
+        }
+
         allowed.push(name);
     });
 
-    return { allowed, rejected };
+    return { allowed, rejectedPositions, overLimit };
 };
 
-// Built-ins first, in their existing order, then the customer's additions in the
-// order given.
+// Built-ins first, in their existing order, then the customer's additions sorted.
 //
 // The order is load-bearing, not cosmetic. pageKey walks this list, so keeping the
 // built-in prefix intact means a customer who adds params gets byte-identical keys
 // for pages that use none of them. Without it, adding a single param would change
 // every key at once and fire one spurious page view per page on the first
 // navigation after rollout.
-export const effectiveAllowlist = (
-    extras: string | string[] = []
-): string[] => {
-    // Tolerates a raw comma-separated string as well as the validated list
-    // processFlags stores. Not decoration: a mis-shaped config value reaching this
-    // unguarded would throw inside logPageView and take every page view with it,
-    // which is a much worse failure than ignoring a bad setting.
-    //
-    // An array is trusted as already validated. That is deliberate — it is what
-    // lets the tests inject hostile names directly and prove the own-property check
-    // in allowedQueryParams is a real backstop rather than dead code behind
-    // validation.
-    const list = Array.isArray(extras)
-        ? extras
-        : parseQueryParamAllowlist(extras).allowed;
-
-    return ALLOWED_QUERY_PARAMS.concat(
-        list.filter(name => ALLOWED_QUERY_PARAMS.indexOf(name) === -1)
+//
+// The additions are sorted for the same reason one step further in. They arrive in
+// the order the customer typed them into a config string, so appending them in that
+// order makes the key of every page carrying two of them depend on which order they
+// were listed — swap `promo_code, affiliate_id` around and each such page fires one
+// spurious view. Sorting makes the suffix depend on the SET rather than the
+// sequence. Built-ins keep their positions, and custom params do not exist in
+// 2.80.x, so no key that exists today moves.
+//
+// The list is trusted as already validated: processFlags parses and validates at the
+// config boundary, once. Passing an array directly is also what lets the tests
+// inject hostile names and prove the own-property check in allowedQueryParams is a
+// real backstop rather than dead code behind validation.
+export const effectiveAllowlist = (extras: string[] = []): string[] =>
+    // `|| []` as well as the default parameter, because they cover different
+    // things: the default only fires for `undefined`, and getFeatureFlag returns
+    // null when the flag is absent.
+    ALLOWED_QUERY_PARAMS.concat(
+        (extras || [])
+            .filter(name => ALLOWED_QUERY_PARAMS.indexOf(name) === -1)
+            .sort()
     );
-};
 
 // Pulls the allowlisted query params off a URL, in allowlist order.
 //
@@ -280,7 +304,7 @@ export const effectiveAllowlist = (
 // every page.
 export const allowedQueryParams = (
     href: string,
-    extras: string | string[] = []
+    extras: string[] = []
 ): ICapturedParam[] => {
     const allowlist = effectiveAllowlist(extras);
     const found = queryStringParser(href, allowlist);
@@ -647,19 +671,36 @@ export class PageViewTracker {
         clearActiveTracker(this);
     }
 
-    // Reads and validates the configured additions. Logs the names it rejected —
-    // names only, never values, for the same reason describePage omits them.
+    // Reports what processFlags rejected, and returns what it accepted.
+    //
+    // It does NOT re-validate. processFlags already parsed the customer's string at
+    // the config boundary and stored the whole result; parsing that clean list a
+    // second time here would have nothing left to reject, which is precisely how
+    // this warning was dead in production while its test passed — the test handed
+    // the tracker a raw string that production never sends.
+    //
+    // The warning names positions, never text. See IQueryParamAllowlist.
     private readCustomQueryParams(): string[] {
-        const configured = this.mpInstance._Helpers.getFeatureFlag(
+        const {
+            allowed = [],
+            rejectedPositions = [],
+            overLimit = 0,
+        } = (this.mpInstance._Helpers.getFeatureFlag(
             Constants.FeatureFlags.AutoLogPageViewQueryParams
-        ) as string | string[];
+        ) || {}) as IQueryParamAllowlist;
 
-        const { allowed, rejected } = parseQueryParamAllowlist(configured);
-
-        if (rejected.length) {
+        if (rejectedPositions.length) {
             this.mpInstance.Logger.warning(
                 'mParticle APV: ignoring invalid additional page view query ' +
-                    `parameters: ${rejected.join()}`
+                    `parameters at positions ${rejectedPositions.join(', ')}`
+            );
+        }
+
+        if (overLimit) {
+            this.mpInstance.Logger.warning(
+                `mParticle APV: ignoring ${overLimit} additional page view ` +
+                    `query parameters beyond the limit of ` +
+                    `${MAX_CUSTOM_QUERY_PARAMS}`
             );
         }
 

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -43,16 +43,15 @@ type WindowWithApv = Window & {
     [WIN_APV_KEY]?: IApvState;
 };
 
-// The query params an auto page view may carry. An allowlist, not a denylist:
-// partner URLs routinely hold order ids, email addresses and session tokens, and
-// none of those should reach the event stream because someone forgot to exclude
-// them. Anything absent from this list is dropped.
+// The default allowlist. A floor, not a ceiling: customers add their own names in the
+// Web input's Advanced Settings and they are unioned with this list, which is what
+// makes keeping the default narrow safe.
 //
-// SECURITY: `code`, `state` and `nonce` are the OAuth 2.0 / OIDC authorization
-// code and the CSRF/replay tokens. They are credentials until redeemed, and
-// attaching them here persists them in the event store and forwards them to
-// every configured kit. They are on the list by explicit product decision —
-// deleting that line is the whole of the fix if that decision is revisited.
+// Do NOT re-add the OAuth/OIDC params (code, state, nonce, client_id, redirect_uri,
+// response_type, scope). They were removed deliberately — code is an authorization
+// code and state/nonce are CSRF and replay tokens, so capturing them by default put
+// credentials in the event store and every connected kit. A customer who needs one
+// configures it per input.
 export const ALLOWED_QUERY_PARAMS: string[] = [
     // Campaign attribution
     'utm_source',
@@ -72,15 +71,6 @@ export const ALLOWED_QUERY_PARAMS: string[] = [
     'twclid',
     'li_fat_id',
     'dclid',
-
-    // OAuth / OIDC — see the SECURITY note above
-    'client_id',
-    'redirect_uri',
-    'response_type',
-    'scope',
-    'state',
-    'code',
-    'nonce',
 
     // Pagination and search
     'page',
@@ -117,7 +107,7 @@ const RESERVED_QUERY_PARAMS: string[] = [
 // Excludes `&`, `=`, `%` and whitespace: they would distort the dedup key.
 const QUERY_PARAM_NAME = /^[a-z0-9_][a-z0-9_.-]{0,63}$/;
 
-// mParticle caps attributes per event; 31 built-ins plus this leaves headroom.
+// mParticle caps attributes per event; 24 built-ins plus this leaves headroom.
 export const MAX_CUSTOM_QUERY_PARAMS = 25;
 
 // One parse, stored whole by processFlags, so no second validator can drift from it.

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -1,3 +1,4 @@
+import Constants from './constants';
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { BaseEvent } from './sdkRuntimeModels';
 import { EventType, MessageType } from './types';
@@ -95,9 +96,69 @@ export const ALLOWED_QUERY_PARAMS: string[] = [
     'referrer',
 ];
 
+// Names a customer may not add, on top of the format rule below.
+//
+// hostname/title/path are the three core event fields. buildPageViewEvent's spread
+// order already stops a param overwriting them, but rejecting the names here keeps
+// them out of the dedup key as well, rather than leaving one guard doing all the
+// work.
+//
+// constructor/__proto__/prototype resolve to something truthy through the
+// prototype chain. hasOwnProp neutralises them at capture, and rejecting them at
+// the config boundary means they never travel far enough to depend on that.
+const RESERVED_QUERY_PARAMS: string[] = [
+    'hostname',
+    'title',
+    'path',
+    'constructor',
+    '__proto__',
+    'prototype',
+];
+
+// Must start with a letter, digit or underscore, then up to 63 more of the same
+// plus dot and hyphen. Excludes `&`, `=`, `%` and whitespace — the characters that
+// would let a name distort the dedup key or an event attribute name.
+const QUERY_PARAM_NAME = /^[a-z0-9_][a-z0-9_.-]{0,63}$/;
+
+// mParticle caps attributes per event; 31 built-ins plus this leaves headroom.
+export const MAX_CUSTOM_QUERY_PARAMS = 25;
+
+// How much of a rejected entry is safe to name in a log.
+const REJECTED_LABEL_LIMIT = 32;
+
+// A log-safe label for a rejected entry.
+//
+// An entry is rejected BECAUSE of a character, and everything from that character
+// onwards is untrusted: a customer who types `password=hunter2` into the field must
+// not have the value echoed into the console, where session-replay tooling would
+// ship it off-domain. So cut at the first character that is not name-legal, and cap
+// the length. The surviving prefix is still enough to identify which entry was
+// dropped, which is the whole point of reporting it.
+const rejectedLabel = (entry: string): string => {
+    const legalPrefix = /^[a-z0-9_.-]*/.exec(entry);
+    const kept = (legalPrefix ? legalPrefix[0] : '').slice(
+        0,
+        REJECTED_LABEL_LIMIT
+    );
+
+    return kept.length < entry.length ? `${kept}...` : kept;
+};
+
+// Applies to CUSTOM params only — see allowedQueryParams.
+export const MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH = 512;
+
+// One captured param. An ordered list rather than a dictionary because the dedup
+// key depends on a stable order, and once the allowlist is configurable that order
+// can no longer come from a module constant. Capturing it here means pageKey and
+// describePage need no knowledge of the allowlist at all.
+export interface ICapturedParam {
+    name: string;
+    value: string;
+}
+
 interface IPageSnapshot {
     path: string;
-    params: Dictionary<string>;
+    params: ICapturedParam[];
 }
 
 interface IPageViewData extends IPageSnapshot {
@@ -115,40 +176,160 @@ interface IPendingNavigation {
 // on their own, which is where the interesting rules live.
 // ---------------------------------------------------------------------------
 
-// Pulls the allowlisted query params off a URL. Delegates to the SDK's own
-// parser, which lowercases keys (so `?UTM_Source=` and `?utm_source=` land on one
-// attribute), drops empty values, and carries the fallback for browsers without
-// URLSearchParams. Tolerates an empty href, so SSR yields no params rather than
-// throwing.
-export const allowedQueryParams = (href: string): Dictionary<string> =>
-    queryStringParser(href, ALLOWED_QUERY_PARAMS);
-
-// The captured params, in allowlist order. Ordering comes from the constant
-// rather than a sort: it is deterministic without needing a comparator, and it
-// does not depend on the object's insertion order, so reordering the query string
-// cannot produce a different key.
+// Normalises the customer's additions, as delivered by remote config.
 //
-// Membership is an own-property check, not `in`. `in` walks the prototype
-// chain, so a name matching an Object.prototype member reports as present on
-// any plain object. ALLOWED_QUERY_PARAMS contains no such name, which was the
-// only thing making `in` safe here — and it stops being a safe assumption the
-// moment this list can be extended from configuration.
-const capturedNames = (params: Dictionary<string>): string[] =>
-    ALLOWED_QUERY_PARAMS.filter(name => hasOwnProp(params, name));
-
-// The dedup key: pathname plus the allowlisted params in a fixed order, so that
-// reordering the query string is not a new page. Params outside the allowlist
-// never make it into `page.params` and so cannot key a view — nor can the hash.
+// Runs in the SDK even though the dashboard validates too, because remote config is
+// untrusted input: it arrives over the network into a third-party embed on the
+// customer's page, and the SDK cannot assume anything validated it. Accepts an
+// array as well as a comma-separated string so a self-hosted config can pass one
+// directly.
 //
-// Values are re-encoded because queryStringParser hands them back DECODED. A
-// value holding the pair delimiters would otherwise serialize exactly like two
-// separate params — `{q: 'a&search=b'}` and `{q: 'a', search: 'b'}` both becoming
-// `q=a&search=b` — and dedup would treat a real navigation between them as the
-// same page and drop the view. `q`, `search` and `redirect_uri` carry `&` and `=`
+// Returns the accepted names alongside log-safe labels for what it dropped. The raw
+// rejected entry never escapes this function — see rejectedLabel.
+export const parseQueryParamAllowlist = (
+    configured: string | string[]
+): { allowed: string[]; rejected: string[] } => {
+    const allowed: string[] = [];
+    const rejected: string[] = [];
+
+    if (!configured) {
+        return { allowed, rejected };
+    }
+
+    const entries: string[] = Array.isArray(configured)
+        ? configured
+        : String(configured).split(',');
+
+    entries.forEach(entry => {
+        if (allowed.length >= MAX_CUSTOM_QUERY_PARAMS) {
+            return;
+        }
+
+        // Lowercased because queryStringParser matches case-insensitively and keys
+        // its result by the allowlist's casing — so this is what makes the emitted
+        // attribute name stable however the customer typed it.
+        const name = String(entry)
+            .trim()
+            .toLowerCase();
+
+        if (!name) {
+            return;
+        }
+
+        if (
+            !QUERY_PARAM_NAME.test(name) ||
+            RESERVED_QUERY_PARAMS.indexOf(name) !== -1
+        ) {
+            rejected.push(rejectedLabel(name));
+            return;
+        }
+
+        // Already built in, or already accepted. Not a rejection — there is nothing
+        // wrong with asking for something you already have.
+        if (
+            ALLOWED_QUERY_PARAMS.indexOf(name) !== -1 ||
+            allowed.indexOf(name) !== -1
+        ) {
+            return;
+        }
+
+        allowed.push(name);
+    });
+
+    return { allowed, rejected };
+};
+
+// Built-ins first, in their existing order, then the customer's additions in the
+// order given.
+//
+// The order is load-bearing, not cosmetic. pageKey walks this list, so keeping the
+// built-in prefix intact means a customer who adds params gets byte-identical keys
+// for pages that use none of them. Without it, adding a single param would change
+// every key at once and fire one spurious page view per page on the first
+// navigation after rollout.
+export const effectiveAllowlist = (
+    extras: string | string[] = []
+): string[] => {
+    // Tolerates a raw comma-separated string as well as the validated list
+    // processFlags stores. Not decoration: a mis-shaped config value reaching this
+    // unguarded would throw inside logPageView and take every page view with it,
+    // which is a much worse failure than ignoring a bad setting.
+    //
+    // An array is trusted as already validated. That is deliberate — it is what
+    // lets the tests inject hostile names directly and prove the own-property check
+    // in allowedQueryParams is a real backstop rather than dead code behind
+    // validation.
+    const list = Array.isArray(extras)
+        ? extras
+        : parseQueryParamAllowlist(extras).allowed;
+
+    return ALLOWED_QUERY_PARAMS.concat(
+        list.filter(name => ALLOWED_QUERY_PARAMS.indexOf(name) === -1)
+    );
+};
+
+// Pulls the allowlisted query params off a URL, in allowlist order.
+//
+// Delegates to the SDK's own parser, which lowercases keys (so `?UTM_Source=` and
+// `?utm_source=` land on one attribute), drops empty values, and carries the
+// fallback for browsers without URLSearchParams. Tolerates an empty href, so SSR
+// yields no params rather than throwing.
+//
+// Membership is an own-property check, not `in`: `in` walks the prototype chain, so
+// a configured name matching an Object.prototype member would report as present on
+// every page.
+export const allowedQueryParams = (
+    href: string,
+    extras: string | string[] = []
+): ICapturedParam[] => {
+    const allowlist = effectiveAllowlist(extras);
+    const found = queryStringParser(href, allowlist);
+
+    return allowlist
+        .filter(name => hasOwnProp(found, name))
+        .filter(name => {
+            // The length cap applies to CUSTOM params only. Built-in behaviour is
+            // deliberately untouched, so no existing customer can lose a long
+            // utm_content on upgrade. Custom params are where unbounded choice
+            // enters: a param holding a base64 blob would bloat every APV event
+            // and every dedup key.
+            //
+            // Dropped, not truncated — truncating makes two different long values
+            // produce the same key, which silently swallows a real page view.
+            if (ALLOWED_QUERY_PARAMS.indexOf(name) !== -1) {
+                return true;
+            }
+
+            return found[name].length <= MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH;
+        })
+        .map(name => ({ name, value: found[name] }));
+};
+
+// Folds the ordered pairs into the flat attribute map an event carries.
+export const paramsToAttributes = (
+    params: ICapturedParam[]
+): Dictionary<string> => {
+    const attributes: Dictionary<string> = {};
+    params.forEach(({ name, value }) => {
+        attributes[name] = value;
+    });
+    return attributes;
+};
+
+// The dedup key: pathname plus the captured params in allowlist order, so that
+// reordering the query string is not a new page. Params outside the effective
+// allowlist never make it into `page.params` and so cannot key a view — nor can the
+// hash.
+//
+// Values are re-encoded because queryStringParser hands them back DECODED. A value
+// holding the pair delimiters would otherwise serialize exactly like two separate
+// params — `{q: 'a&search=b'}` and `{q: 'a', search: 'b'}` both becoming
+// `q=a&search=b` — and dedup would treat a real navigation between them as the same
+// page and drop the view. `q`, `search` and `redirect_uri` carry `&` and `=`
 // routinely, so this is reachable rather than theoretical.
 export const pageKey = (page: IPageSnapshot): string => {
-    const query = capturedNames(page.params)
-        .map(name => `${name}=${encodeURIComponent(page.params[name])}`)
+    const query = page.params
+        .map(({ name, value }) => `${name}=${encodeURIComponent(value)}`)
         .join('&');
 
     return query ? `${page.path}?${query}` : page.path;
@@ -183,7 +364,7 @@ export const buildPageViewEvent = ({
     // wins. No allowlist entry collides with hostname/title/path today; naming
     // them here is what keeps a later addition from silently overwriting one.
     data: {
-        ...params,
+        ...paramsToAttributes(params),
         hostname,
         title,
         path,
@@ -272,9 +453,9 @@ const clearActiveTracker = (tracker: PageViewTracker): void => {
     }
 };
 
-const currentPage = (): IPageSnapshot => ({
+const currentPage = (extras: string[]): IPageSnapshot => ({
     path: window.location.pathname,
-    params: allowedQueryParams(getHref()),
+    params: allowedQueryParams(getHref(), extras),
 });
 
 // Log-safe description of a page: the path, plus the NAMES of the captured
@@ -288,7 +469,7 @@ const describePage = (page: IPageSnapshot | null): string => {
         return '';
     }
 
-    const names = capturedNames(page.params);
+    const names = page.params.map(({ name }) => name);
     return names.length ? `${page.path} (params: ${names.join()})` : page.path;
 };
 
@@ -382,6 +563,11 @@ export class PageViewTracker {
 
     private lastPage: IPageSnapshot | null = null;
     private active = false;
+
+    // The customer's additions to the allowlist, read once per init() rather than
+    // per navigation: config cannot change without a re-init, and re-reading it on
+    // every pushState would re-validate the same list thousands of times.
+    private customQueryParams: string[] = [];
     private pendingNavigations: IPendingNavigation[] = [];
 
     private undoHistoryPatch: (() => void) | null = null;
@@ -421,7 +607,8 @@ export class PageViewTracker {
         }
 
         this.active = true;
-        this.lastPage = currentPage();
+        this.customQueryParams = this.readCustomQueryParams();
+        this.lastPage = currentPage(this.customQueryParams);
         this.log(`[init] seeded lastPage: ${describePage(this.lastPage)}`);
 
         this.undoHistoryPatch = patchHistory(
@@ -458,6 +645,29 @@ export class PageViewTracker {
 
         this.active = false;
         clearActiveTracker(this);
+    }
+
+    // Reads and validates the configured additions. Logs the names it rejected —
+    // names only, never values, for the same reason describePage omits them.
+    private readCustomQueryParams(): string[] {
+        const configured = this.mpInstance._Helpers.getFeatureFlag(
+            Constants.FeatureFlags.AutoLogPageViewQueryParams
+        ) as string | string[];
+
+        const { allowed, rejected } = parseQueryParamAllowlist(configured);
+
+        if (rejected.length) {
+            this.mpInstance.Logger.warning(
+                'mParticle APV: ignoring invalid additional page view query ' +
+                    `parameters: ${rejected.join()}`
+            );
+        }
+
+        if (allowed.length) {
+            this.log(`[init] additional query params: ${allowed.join()}`);
+        }
+
+        return allowed;
     }
 
     // Stops the outgoing tracker and returns the pages it had queued so this
@@ -507,7 +717,7 @@ export class PageViewTracker {
     }
 
     private handleNavigation(source: NavigationSource): void {
-        const candidate = currentPage();
+        const candidate = currentPage(this.customQueryParams);
         const lastKey = this.lastPage ? pageKey(this.lastPage) : null;
 
         this.log(

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -282,6 +282,10 @@ export const parseQueryParamAllowlist = (
 // config boundary, once. Passing an array directly is also what lets the tests
 // inject hostile names and prove the own-property check in allowedQueryParams is a
 // real backstop rather than dead code behind validation.
+// Total, locale-independent ordering for the dedup key. See the comment in
+// effectiveAllowlist for why localeCompare is the wrong tool here.
+const byName = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
 export const effectiveAllowlist = (extras: string[] = []): string[] =>
     // `|| []` as well as the default parameter, because they cover different
     // things: the default only fires for `undefined`, and getFeatureFlag returns
@@ -289,7 +293,13 @@ export const effectiveAllowlist = (extras: string[] = []): string[] =>
     ALLOWED_QUERY_PARAMS.concat(
         (extras || [])
             .filter(name => ALLOWED_QUERY_PARAMS.indexOf(name) === -1)
-            .sort()
+            // Explicit comparator, and deliberately NOT localeCompare, which is what
+            // Sonar's S2871 message suggests. This ordering feeds the dedup key, so it
+            // has to be identical everywhere: localeCompare varies by locale, which
+            // would make two browsers disagree about whether a page had changed. Names
+            // are validated to /^[a-z0-9_][a-z0-9_.-]{0,63}$/, so a plain code-unit
+            // comparison is total and stable over the whole input domain.
+            .sort(byName)
     );
 
 // Pulls the allowlisted query params off a URL, in allowlist order.

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -44,8 +44,8 @@ type WindowWithApv = Window & {
 };
 
 // The default allowlist: params that identify WHICH page you are on, which is also
-// what the dedup key needs. A floor, not a ceiling — customers add their own names in
-// the Web input's Advanced Settings.
+// what the dedup key needs. A default, not a floor — in the Web input's Advanced
+// Settings a customer adds their own names and removes any of these with a `-` prefix.
 //
 // Two groups were removed deliberately and should not come back:
 //
@@ -104,8 +104,13 @@ const QUERY_PARAM_NAME = /^[a-z0-9_][a-z0-9_.-]{0,63}$/;
 export const MAX_CUSTOM_QUERY_PARAMS = 25;
 
 // One parse, stored whole by processFlags, so no second validator can drift from it.
-export interface IQueryParamAllowlist {
-    allowed: string[];
+export interface IQueryParamConfig {
+    // Names to add to ALLOWED_QUERY_PARAMS.
+    added: string[];
+
+    // Names to take out of it, written with a leading `-`. Applied after `added`, so
+    // `-ref, ref` removes rather than adds however the two are ordered.
+    excluded: string[];
 
     // 1-based, in the order the customer wrote them. Positions and not names because
     // a rejected entry may be something pasted into the wrong field, and
@@ -117,7 +122,6 @@ export interface IQueryParamAllowlist {
     overLimit: number;
 }
 
-// Applies to CUSTOM params only — see allowedQueryParams.
 export const MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH = 512;
 
 // Ordered rather than a dictionary: the dedup key needs a stable order, and once the
@@ -147,7 +151,7 @@ interface IPendingNavigation {
 // on their own, which is where the interesting rules live.
 // ---------------------------------------------------------------------------
 
-// Normalises the customer's additions, as delivered by remote config.
+// Normalises the customer's additions and exclusions, as delivered by remote config.
 //
 // Runs in the SDK even though the dashboard validates too, because remote config is
 // untrusted input: it arrives over the network into a third-party embed on the
@@ -155,17 +159,17 @@ interface IPendingNavigation {
 // array as well as a comma-separated string so a self-hosted config can pass one
 // directly.
 //
-// Returns the accepted names alongside positions for what it dropped. No part of a
-// rejected entry escapes this function — see IQueryParamAllowlist.
-export const parseQueryParamAllowlist = (
+// No part of a rejected entry escapes this function — see IQueryParamConfig.
+export const parseQueryParamConfig = (
     configured: string | string[]
-): IQueryParamAllowlist => {
-    const allowed: string[] = [];
+): IQueryParamConfig => {
+    const added: string[] = [];
+    const excluded: string[] = [];
     const rejectedPositions: number[] = [];
     let overLimit = 0;
 
     if (!configured) {
-        return { allowed, rejectedPositions, overLimit };
+        return { added, excluded, rejectedPositions, overLimit };
     }
 
     const entries: string[] = Array.isArray(configured)
@@ -180,13 +184,19 @@ export const parseQueryParamAllowlist = (
         // Lowercased because queryStringParser matches case-insensitively and keys
         // its result by the allowlist's casing — so this is what makes the emitted
         // attribute name stable however the customer typed it.
-        const name = String(entry)
+        const raw = String(entry)
             .trim()
             .toLowerCase();
 
-        if (!name) {
+        if (!raw) {
             return;
         }
+
+        // A `-` prefix removes rather than adds. QUERY_PARAM_NAME forbids a leading
+        // hyphen, so before this every `-name` was a rejected entry — no stored config
+        // can already mean something else by it.
+        const isExclusion = raw.charAt(0) === '-';
+        const name = isExclusion ? raw.slice(1) : raw;
 
         if (
             !QUERY_PARAM_NAME.test(name) ||
@@ -196,11 +206,21 @@ export const parseQueryParamAllowlist = (
             return;
         }
 
+        // Not capped, and a name that is not built in is not an error: exclusions only
+        // ever shrink the list, and rejecting `-gclid` would make a config break the
+        // next time the default list changes underneath it.
+        if (isExclusion) {
+            if (excluded.indexOf(name) === -1) {
+                excluded.push(name);
+            }
+            return;
+        }
+
         // Already built in, or already accepted. Not a rejection — there is nothing
         // wrong with asking for something you already have.
         if (
             ALLOWED_QUERY_PARAMS.indexOf(name) !== -1 ||
-            allowed.indexOf(name) !== -1
+            added.indexOf(name) !== -1
         ) {
             return;
         }
@@ -209,15 +229,15 @@ export const parseQueryParamAllowlist = (
         // blank or a duplicate does not consume headroom, and — the reason it
         // moved — so the entries that lose out are counted instead of vanishing
         // with no report at all.
-        if (allowed.length >= MAX_CUSTOM_QUERY_PARAMS) {
+        if (added.length >= MAX_CUSTOM_QUERY_PARAMS) {
             overLimit++;
             return;
         }
 
-        allowed.push(name);
+        added.push(name);
     });
 
-    return { allowed, rejectedPositions, overLimit };
+    return { added, excluded, rejectedPositions, overLimit };
 };
 
 // Not localeCompare: this ordering feeds the dedup key, so it has to be identical in
@@ -229,30 +249,37 @@ const byName = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
 // (asserted by the pageKey tests), and additions are sorted so a key depends on the SET
 // a customer configured rather than the order they typed it in.
 //
-// `extras` is trusted as already validated; processFlags does that once, at the config
-// boundary. `|| []` covers the null getFeatureFlag returns for an absent flag, which the
-// default parameter does not.
-export const effectiveAllowlist = (extras: string[] = []): string[] =>
-    ALLOWED_QUERY_PARAMS.concat(
-        (extras || [])
+// Excluding a param is a deliberate merge of pages that used to be distinct: drop
+// `page` and `?page=2` keys the same as `?page=3`, so the second view dedups away. That
+// is the customer's call to make, but it is why exclusion is not a cosmetic setting.
+//
+// `config` is trusted as already validated; processFlags does that once, at the config
+// boundary. Both `|| {}` and the field defaults are needed: getFeatureFlag returns null
+// for an absent flag, and a partial object reaches here from hand-written config.
+export const effectiveAllowlist = (config?: Partial<IQueryParamConfig>): string[] => {
+    const { added = [], excluded = [] } = config || {};
+
+    return ALLOWED_QUERY_PARAMS.concat(
+        added
             .filter(name => ALLOWED_QUERY_PARAMS.indexOf(name) === -1)
             .sort(byName)
-    );
+    ).filter(name => excluded.indexOf(name) === -1);
+};
 
 // queryStringParser lowercases keys, drops empty values, carries the
 // pre-URLSearchParams fallback, and tolerates an empty href — so SSR yields no params
 // rather than throwing.
 export const allowedQueryParams = (
     href: string,
-    extras: string[] = []
+    config?: Partial<IQueryParamConfig>
 ): ICapturedParam[] => {
-    const allowlist = effectiveAllowlist(extras);
+    const allowlist = effectiveAllowlist(config);
     const found = queryStringParser(href, allowlist);
 
     return allowlist
         .filter(name => hasOwnProp(found, name))
         .filter(name => {
-            // Custom params only, so nobody loses a long utm_content on upgrade.
+            // Custom params only, so nobody loses a long search term on upgrade.
             // Dropped rather than truncated: two long values sharing a truncated
             // prefix would share a dedup key and swallow a real view.
             if (ALLOWED_QUERY_PARAMS.indexOf(name) !== -1) {
@@ -404,9 +431,9 @@ const clearActiveTracker = (tracker: PageViewTracker): void => {
     }
 };
 
-const currentPage = (extras: string[]): IPageSnapshot => ({
+const currentPage = (config?: Partial<IQueryParamConfig>): IPageSnapshot => ({
     path: window.location.pathname,
-    params: allowedQueryParams(getHref(), extras),
+    params: allowedQueryParams(getHref(), config),
 });
 
 // Log-safe description of a page: the path, plus the NAMES of the captured
@@ -515,10 +542,10 @@ export class PageViewTracker {
     private lastPage: IPageSnapshot | null = null;
     private active = false;
 
-    // The customer's additions to the allowlist, read once per init() rather than
-    // per navigation: config cannot change without a re-init, and re-reading it on
-    // every pushState would re-validate the same list thousands of times.
-    private customQueryParams: string[] = [];
+    // The customer's additions and exclusions, read once per init() rather than per
+    // navigation: config cannot change without a re-init, and re-reading it on every
+    // pushState would re-validate the same list thousands of times.
+    private queryParamConfig: IQueryParamConfig | undefined;
     private pendingNavigations: IPendingNavigation[] = [];
 
     private undoHistoryPatch: (() => void) | null = null;
@@ -558,8 +585,8 @@ export class PageViewTracker {
         }
 
         this.active = true;
-        this.customQueryParams = this.readCustomQueryParams();
-        this.lastPage = currentPage(this.customQueryParams);
+        this.queryParamConfig = this.readQueryParamConfig();
+        this.lastPage = currentPage(this.queryParamConfig);
         this.log(`[init] seeded lastPage: ${describePage(this.lastPage)}`);
 
         this.undoHistoryPatch = patchHistory(
@@ -601,14 +628,17 @@ export class PageViewTracker {
     // Reports what processFlags rejected; deliberately does NOT re-validate. Parsing
     // the already-clean list again would have nothing left to reject, which is how
     // this warning was once dead in production while its test passed.
-    private readCustomQueryParams(): string[] {
+    private readQueryParamConfig(): IQueryParamConfig {
+        const config = (this.mpInstance._Helpers.getFeatureFlag(
+            Constants.FeatureFlags.AutoLogPageViewQueryParams
+        ) || {}) as IQueryParamConfig;
+
         const {
-            allowed = [],
+            added = [],
+            excluded = [],
             rejectedPositions = [],
             overLimit = 0,
-        } = (this.mpInstance._Helpers.getFeatureFlag(
-            Constants.FeatureFlags.AutoLogPageViewQueryParams
-        ) || {}) as IQueryParamAllowlist;
+        } = config;
 
         if (rejectedPositions.length) {
             this.mpInstance.Logger.warning(
@@ -625,11 +655,29 @@ export class PageViewTracker {
             );
         }
 
-        if (allowed.length) {
-            this.log(`[init] additional query params: ${allowed.join()}`);
+        if (added.length) {
+            this.log(`[init] additional query params: ${added.join()}`);
         }
 
-        return allowed;
+        // Only the exclusions that hit the default list are named, and those names are
+        // our own constants — an exclusion matching nothing is a no-op whose name is
+        // customer-typed text, which must not reach a log. `-` makes that reachable:
+        // `-secret-abc` fails no validation, so it arrives here as an exclusion.
+        //
+        // Warning rather than verbose because an exclusion merges pages that used to be
+        // distinct, so it is the setting most likely to be blamed for missing page
+        // views by someone who does not know it is set.
+        const applied = excluded.filter(
+            name => ALLOWED_QUERY_PARAMS.indexOf(name) !== -1
+        );
+        if (applied.length) {
+            this.mpInstance.Logger.warning(
+                'mParticle APV: not capturing the excluded query parameters ' +
+                    `${applied.join(', ')}`
+            );
+        }
+
+        return config;
     }
 
     // Stops the outgoing tracker and returns the pages it had queued so this
@@ -679,7 +727,7 @@ export class PageViewTracker {
     }
 
     private handleNavigation(source: NavigationSource): void {
-        const candidate = currentPage(this.customQueryParams);
+        const candidate = currentPage(this.queryParamConfig);
         const lastKey = this.lastPage ? pageKey(this.lastPage) : null;
 
         this.log(

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -96,74 +96,49 @@ export const ALLOWED_QUERY_PARAMS: string[] = [
     'referrer',
 ];
 
-// Names a customer may not add, on top of the format rule below.
-//
-// hostname/title/path are the three core event fields. buildPageViewEvent's spread
-// order already stops a param overwriting them, but rejecting the names here keeps
-// them out of the dedup key as well, rather than leaving one guard doing all the
-// work.
-//
-// constructor/__proto__/prototype resolve to something truthy through the
-// prototype chain. hasOwnProp neutralises them at capture, and rejecting them at
-// the config boundary means they never travel far enough to depend on that.
-//
-// true/false are here because every other flag in this SDK is a string compared
-// against 'True'. An operator who sets this one the same way sends the literal
-// `True`, which is a legal param name — so it would silently pass validation and
-// the SDK would start capturing `?true=`. Rejecting it surfaces the mistake.
+// Rejected whatever their format, grouped by why.
 const RESERVED_QUERY_PARAMS: string[] = [
+    // Core event fields: must not reach the dedup key or an attribute name.
     'hostname',
     'title',
     'path',
+
+    // Truthy through the prototype chain.
     'constructor',
     '__proto__',
     'prototype',
+
+    // Every other flag here is compared against 'True'; an operator copying that
+    // convention would silently start capturing `?true=`.
     'true',
     'false',
 ];
 
-// Must start with a letter, digit or underscore, then up to 63 more of the same
-// plus dot and hyphen. Excludes `&`, `=`, `%` and whitespace — the characters that
-// would let a name distort the dedup key or an event attribute name.
+// Excludes `&`, `=`, `%` and whitespace: they would distort the dedup key.
 const QUERY_PARAM_NAME = /^[a-z0-9_][a-z0-9_.-]{0,63}$/;
 
 // mParticle caps attributes per event; 31 built-ins plus this leaves headroom.
 export const MAX_CUSTOM_QUERY_PARAMS = 25;
 
-// The outcome of validating the customer's additions: one value with three parts,
-// produced by a single parse. processFlags stores it whole and the tracker reports
-// from it, so there is no second validator that can drift from the first.
+// One parse, stored whole by processFlags, so no second validator can drift from it.
 export interface IQueryParamAllowlist {
-    // The names to union with ALLOWED_QUERY_PARAMS.
     allowed: string[];
 
-    // 1-based positions, in the order the customer wrote them, of the entries whose
-    // name was illegal or reserved.
-    //
-    // Positions rather than the text, because none of the text is safe to log. An
-    // entry is rejected BECAUSE of a character, so the entry may be something the
-    // customer pasted into the wrong field: `password=hunter2` must not reach
-    // Logger.warning, where session-replay tooling ships the console off-domain.
-    // Truncating at the first illegal character does not achieve that — `.`, `-`
-    // and `_` are all legal, so `token.hunter2` and `-secret-value` survive whole.
-    // A position cannot leak anything, and it still identifies the entry, which is
-    // the entire point of reporting it. It also works for a non-ASCII name, where
-    // every character is illegal and a legal prefix would be empty.
+    // 1-based, in the order the customer wrote them. Positions and not names because
+    // a rejected entry may be something pasted into the wrong field, and
+    // `password=hunter2` must not reach Logger.warning. Truncating at the first
+    // illegal character does not work: `.`, `-` and `_` are all legal.
     rejectedPositions: number[];
 
-    // How many otherwise-valid entries were dropped for exceeding
-    // MAX_CUSTOM_QUERY_PARAMS. A count, not positions: past the cap the remedy is
-    // "ask for fewer", not "fix entry 31".
+    // Count, not positions: past the cap the remedy is "ask for fewer".
     overLimit: number;
 }
 
 // Applies to CUSTOM params only — see allowedQueryParams.
 export const MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH = 512;
 
-// One captured param. An ordered list rather than a dictionary because the dedup
-// key depends on a stable order, and once the allowlist is configurable that order
-// can no longer come from a module constant. Capturing it here means pageKey and
-// describePage need no knowledge of the allowlist at all.
+// Ordered rather than a dictionary: the dedup key needs a stable order, and once the
+// allowlist is configurable that order cannot come from a module constant.
 export interface ICapturedParam {
     name: string;
     value: string;
@@ -262,56 +237,28 @@ export const parseQueryParamAllowlist = (
     return { allowed, rejectedPositions, overLimit };
 };
 
-// Built-ins first, in their existing order, then the customer's additions sorted.
-//
-// The order is load-bearing, not cosmetic. pageKey walks this list, so keeping the
-// built-in prefix intact means a customer who adds params gets byte-identical keys
-// for pages that use none of them. Without it, adding a single param would change
-// every key at once and fire one spurious page view per page on the first
-// navigation after rollout.
-//
-// The additions are sorted for the same reason one step further in. They arrive in
-// the order the customer typed them into a config string, so appending them in that
-// order makes the key of every page carrying two of them depend on which order they
-// were listed — swap `promo_code, affiliate_id` around and each such page fires one
-// spurious view. Sorting makes the suffix depend on the SET rather than the
-// sequence. Built-ins keep their positions, and custom params do not exist in
-// 2.80.x, so no key that exists today moves.
-//
-// The list is trusted as already validated: processFlags parses and validates at the
-// config boundary, once. Passing an array directly is also what lets the tests
-// inject hostile names and prove the own-property check in allowedQueryParams is a
-// real backstop rather than dead code behind validation.
-// Total, locale-independent ordering for the dedup key. See the comment in
-// effectiveAllowlist for why localeCompare is the wrong tool here.
+// Not localeCompare: this ordering feeds the dedup key, so it has to be identical in
+// every browser, and localeCompare is locale-dependent.
 const byName = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
 
+// Ordering is load-bearing — pageKey walks this list, so it decides which navigations
+// count as a new page. Built-ins keep their positions so no key that exists today moves
+// (asserted by the pageKey tests), and additions are sorted so a key depends on the SET
+// a customer configured rather than the order they typed it in.
+//
+// `extras` is trusted as already validated; processFlags does that once, at the config
+// boundary. `|| []` covers the null getFeatureFlag returns for an absent flag, which the
+// default parameter does not.
 export const effectiveAllowlist = (extras: string[] = []): string[] =>
-    // `|| []` as well as the default parameter, because they cover different
-    // things: the default only fires for `undefined`, and getFeatureFlag returns
-    // null when the flag is absent.
     ALLOWED_QUERY_PARAMS.concat(
         (extras || [])
             .filter(name => ALLOWED_QUERY_PARAMS.indexOf(name) === -1)
-            // Explicit comparator, and deliberately NOT localeCompare, which is what
-            // Sonar's S2871 message suggests. This ordering feeds the dedup key, so it
-            // has to be identical everywhere: localeCompare varies by locale, which
-            // would make two browsers disagree about whether a page had changed. Names
-            // are validated to /^[a-z0-9_][a-z0-9_.-]{0,63}$/, so a plain code-unit
-            // comparison is total and stable over the whole input domain.
             .sort(byName)
     );
 
-// Pulls the allowlisted query params off a URL, in allowlist order.
-//
-// Delegates to the SDK's own parser, which lowercases keys (so `?UTM_Source=` and
-// `?utm_source=` land on one attribute), drops empty values, and carries the
-// fallback for browsers without URLSearchParams. Tolerates an empty href, so SSR
-// yields no params rather than throwing.
-//
-// Membership is an own-property check, not `in`: `in` walks the prototype chain, so
-// a configured name matching an Object.prototype member would report as present on
-// every page.
+// queryStringParser lowercases keys, drops empty values, carries the
+// pre-URLSearchParams fallback, and tolerates an empty href — so SSR yields no params
+// rather than throwing.
 export const allowedQueryParams = (
     href: string,
     extras: string[] = []
@@ -322,14 +269,9 @@ export const allowedQueryParams = (
     return allowlist
         .filter(name => hasOwnProp(found, name))
         .filter(name => {
-            // The length cap applies to CUSTOM params only. Built-in behaviour is
-            // deliberately untouched, so no existing customer can lose a long
-            // utm_content on upgrade. Custom params are where unbounded choice
-            // enters: a param holding a base64 blob would bloat every APV event
-            // and every dedup key.
-            //
-            // Dropped, not truncated — truncating makes two different long values
-            // produce the same key, which silently swallows a real page view.
+            // Custom params only, so nobody loses a long utm_content on upgrade.
+            // Dropped rather than truncated: two long values sharing a truncated
+            // prefix would share a dedup key and swallow a real view.
             if (ALLOWED_QUERY_PARAMS.indexOf(name) !== -1) {
                 return true;
             }
@@ -350,17 +292,9 @@ export const paramsToAttributes = (
     return attributes;
 };
 
-// The dedup key: pathname plus the captured params in allowlist order, so that
-// reordering the query string is not a new page. Params outside the effective
-// allowlist never make it into `page.params` and so cannot key a view — nor can the
-// hash.
-//
-// Values are re-encoded because queryStringParser hands them back DECODED. A value
-// holding the pair delimiters would otherwise serialize exactly like two separate
-// params — `{q: 'a&search=b'}` and `{q: 'a', search: 'b'}` both becoming
-// `q=a&search=b` — and dedup would treat a real navigation between them as the same
-// page and drop the view. `q`, `search` and `redirect_uri` carry `&` and `=`
-// routinely, so this is reachable rather than theoretical.
+// Values are re-encoded because queryStringParser returns them DECODED: otherwise
+// `{q: 'a&search=b'}` and `{q: 'a', search: 'b'}` both serialize to `q=a&search=b`, so
+// a real navigation between the two would dedup away.
 export const pageKey = (page: IPageSnapshot): string => {
     const query = page.params
         .map(({ name, value }) => `${name}=${encodeURIComponent(value)}`)
@@ -681,15 +615,9 @@ export class PageViewTracker {
         clearActiveTracker(this);
     }
 
-    // Reports what processFlags rejected, and returns what it accepted.
-    //
-    // It does NOT re-validate. processFlags already parsed the customer's string at
-    // the config boundary and stored the whole result; parsing that clean list a
-    // second time here would have nothing left to reject, which is precisely how
-    // this warning was dead in production while its test passed — the test handed
-    // the tracker a raw string that production never sends.
-    //
-    // The warning names positions, never text. See IQueryParamAllowlist.
+    // Reports what processFlags rejected; deliberately does NOT re-validate. Parsing
+    // the already-clean list again would have nothing left to reject, which is how
+    // this warning was once dead in production while its test passed.
     private readCustomQueryParams(): string[] {
         const {
             allowed = [],

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -43,41 +43,32 @@ type WindowWithApv = Window & {
     [WIN_APV_KEY]?: IApvState;
 };
 
-// The default allowlist. A floor, not a ceiling: customers add their own names in the
-// Web input's Advanced Settings and they are unioned with this list, which is what
-// makes keeping the default narrow safe.
+// The default allowlist: params that identify WHICH page you are on, which is also
+// what the dedup key needs. A floor, not a ceiling — customers add their own names in
+// the Web input's Advanced Settings.
 //
-// Do NOT re-add the OAuth/OIDC params (code, state, nonce, client_id, redirect_uri,
-// response_type, scope). They were removed deliberately — code is an authorization
-// code and state/nonce are CSRF and replay tokens, so capturing them by default put
-// credentials in the event store and every connected kit. A customer who needs one
-// configures it per input.
+// Two groups were removed deliberately and should not come back:
+//
+// OAuth/OIDC (code, state, nonce, client_id, redirect_uri, response_type, scope) —
+// `code` is an authorization code and state/nonce are CSRF and replay tokens, so
+// capturing them by default put credentials in the event store and every connected
+// kit.
+//
+// Attribution (utm_*, gclid, gbraid, wbraid, fbclid, msclkid, ttclid, twclid,
+// li_fat_id, dclid) — carried on better-suited planes already: click ids by
+// IntegrationCapture as per-network custom flags, campaign data by the reserved
+// `$utm_*` user attributes that forwarders actually read. As page view attributes they
+// were a copy nothing consumed, and 15 of them on every view displace the customer's
+// own wherever a forwarder caps the count (Flurry keeps 10).
 export const ALLOWED_QUERY_PARAMS: string[] = [
-    // Campaign attribution
-    'utm_source',
-    'utm_medium',
-    'utm_campaign',
-    'utm_term',
-    'utm_content',
-    'utm_id',
-
-    // Ad-network click ids
-    'gclid',
-    'gbraid',
-    'wbraid',
-    'fbclid',
-    'msclkid',
-    'ttclid',
-    'twclid',
-    'li_fat_id',
-    'dclid',
-
-    // Pagination and search
+    // Pagination
     'page',
     'limit',
     'offset',
     'cursor',
     'per_page',
+
+    // Search
     'q',
     'search',
 
@@ -107,7 +98,9 @@ const RESERVED_QUERY_PARAMS: string[] = [
 // Excludes `&`, `=`, `%` and whitespace: they would distort the dedup key.
 const QUERY_PARAM_NAME = /^[a-z0-9_][a-z0-9_.-]{0,63}$/;
 
-// mParticle caps attributes per event; 24 built-ins plus this leaves headroom.
+// A ceiling on what one input's config can add. The SDK imposes no per-event attribute
+// cap of its own, but forwarders do (Flurry keeps 10), so an unbounded list would
+// quietly displace the customer's own attributes.
 export const MAX_CUSTOM_QUERY_PARAMS = 25;
 
 // One parse, stored whole by processFlags, so no second validator can drift from it.

--- a/src/pageViewTracker.ts
+++ b/src/pageViewTracker.ts
@@ -1,7 +1,7 @@
 import { IMParticleWebSDKInstance } from './mp-instance';
 import { BaseEvent } from './sdkRuntimeModels';
 import { EventType, MessageType } from './types';
-import { Dictionary, getHref, queryStringParser } from './utils';
+import { Dictionary, getHref, hasOwnProp, queryStringParser } from './utils';
 
 type HistoryStateMethod = History['pushState'];
 type HistoryMethodName = 'pushState' | 'replaceState';
@@ -127,8 +127,14 @@ export const allowedQueryParams = (href: string): Dictionary<string> =>
 // rather than a sort: it is deterministic without needing a comparator, and it
 // does not depend on the object's insertion order, so reordering the query string
 // cannot produce a different key.
+//
+// Membership is an own-property check, not `in`. `in` walks the prototype
+// chain, so a name matching an Object.prototype member reports as present on
+// any plain object. ALLOWED_QUERY_PARAMS contains no such name, which was the
+// only thing making `in` safe here — and it stops being a safe assumption the
+// moment this list can be extended from configuration.
 const capturedNames = (params: Dictionary<string>): string[] =>
-    ALLOWED_QUERY_PARAMS.filter(name => name in params);
+    ALLOWED_QUERY_PARAMS.filter(name => hasOwnProp(params, name));
 
 // The dedup key: pathname plus the allowlisted params in a fixed order, so that
 // reordering the query string is not a new page. Params outside the allowlist

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -17,6 +17,7 @@ import {
 import Validators from './validators';
 import { Dictionary, valueof } from './utils';
 import { IKitConfigs } from './configAPIClient';
+import { IQueryParamAllowlist } from './pageViewTracker';
 import { SDKConsentApi, SDKConsentState } from './consent';
 import MPSideloadedKit from './sideloadedKit';
 import { ISessionManager } from './sessionManager';
@@ -374,7 +375,10 @@ export interface SDKHelpersApi {
     generateUniqueId();
     generateHash?(value: string): number;
     // https://go.mparticle.com/work/SQDSDKS-6317
-    getFeatureFlag?(feature: string): boolean | string; // TODO: Feature Constants should be converted to enum
+    // TODO: Feature Constants should be converted to enum
+    getFeatureFlag?(
+        feature: string
+    ): boolean | string | IQueryParamAllowlist;
     decoded?(s: string): string;
     parseStringOrNumber?(value: string | number): string | number | null;
     inArray?(items: any[], value: any): boolean;

--- a/src/sdkRuntimeModels.ts
+++ b/src/sdkRuntimeModels.ts
@@ -17,7 +17,7 @@ import {
 import Validators from './validators';
 import { Dictionary, valueof } from './utils';
 import { IKitConfigs } from './configAPIClient';
-import { IQueryParamAllowlist } from './pageViewTracker';
+import { IQueryParamConfig } from './pageViewTracker';
 import { SDKConsentApi, SDKConsentState } from './consent';
 import MPSideloadedKit from './sideloadedKit';
 import { ISessionManager } from './sessionManager';
@@ -378,7 +378,7 @@ export interface SDKHelpersApi {
     // TODO: Feature Constants should be converted to enum
     getFeatureFlag?(
         feature: string
-    ): boolean | string | IQueryParamAllowlist;
+    ): boolean | string | IQueryParamConfig;
     decoded?(s: string): string;
     parseStringOrNumber?(value: string | number): string | number | null;
     inArray?(items: any[], value: any): boolean;

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,7 +9,10 @@ import {
 } from '@mparticle/web-sdk';
 import { IKitConfigs } from './configAPIClient';
 import Constants from './constants';
-import { parseQueryParamAllowlist } from './pageViewTracker';
+import {
+    IQueryParamAllowlist,
+    parseQueryParamAllowlist,
+} from './pageViewTracker';
 import {
     DataPlanResult,
     KitBlockerOptions,
@@ -154,8 +157,10 @@ export interface IFeatureFlags {
     'captureIntegrationSpecificIds.V2'?: string;
     astBackgroundEvents?: boolean;
     autoLogPageView?: boolean;
-    // Processed into a validated list; the server sends a comma-separated string.
-    autoLogPageViewQueryParams?: string[];
+    // The server sends a comma-separated string; processFlags validates it into
+    // accepted names plus a report of what it dropped. Both halves are kept so that
+    // the tracker can log the rejections without validating a second time.
+    autoLogPageViewQueryParams?: IQueryParamAllowlist;
 }
 
 // Temporary Interface until Store can be refactored as a class
@@ -802,12 +807,16 @@ export function processFlags(config: SDKInitConfig): IFeatureFlags {
     flags[CaptureIntegrationSpecificIdsV2] = (config.flags[CaptureIntegrationSpecificIdsV2] || 'none');
     flags[AstBackgroundEvents] = config.flags[AstBackgroundEvents] === 'True';
     flags[AutoLogPageView] = config.flags[AutoLogPageView] === 'True';
-    // The server sends a comma-separated string; parse and validate it here so the
-    // rest of the SDK only ever sees a clean list. Rejected names are logged by the
-    // tracker, which has a Logger to hand.
+    // The server sends a comma-separated string. It is parsed and validated HERE,
+    // once, at the config boundary — and the whole result is stored, including what
+    // was rejected. The tracker warns about the rejections when it starts, because
+    // that is where the Logger is; it does not re-derive them.
+    //
+    // Storing only `.allowed` is what made that warning dead code: re-parsing an
+    // already-clean list downstream has nothing left to reject.
     flags[AutoLogPageViewQueryParams] = parseQueryParamAllowlist(
         (config.flags[AutoLogPageViewQueryParams] as unknown) as string
-    ).allowed;
+    );
     return flags;
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,6 +9,7 @@ import {
 } from '@mparticle/web-sdk';
 import { IKitConfigs } from './configAPIClient';
 import Constants from './constants';
+import { parseQueryParamAllowlist } from './pageViewTracker';
 import {
     DataPlanResult,
     KitBlockerOptions,
@@ -153,6 +154,8 @@ export interface IFeatureFlags {
     'captureIntegrationSpecificIds.V2'?: string;
     astBackgroundEvents?: boolean;
     autoLogPageView?: boolean;
+    // Processed into a validated list; the server sends a comma-separated string.
+    autoLogPageViewQueryParams?: string[];
 }
 
 // Temporary Interface until Store can be refactored as a class
@@ -776,7 +779,8 @@ export function processFlags(config: SDKInitConfig): IFeatureFlags {
         CaptureIntegrationSpecificIds,
         CaptureIntegrationSpecificIdsV2,
         AstBackgroundEvents,
-        AutoLogPageView
+        AutoLogPageView,
+        AutoLogPageViewQueryParams
     } = Constants.FeatureFlags;
 
     if (!config.flags) {
@@ -798,6 +802,12 @@ export function processFlags(config: SDKInitConfig): IFeatureFlags {
     flags[CaptureIntegrationSpecificIdsV2] = (config.flags[CaptureIntegrationSpecificIdsV2] || 'none');
     flags[AstBackgroundEvents] = config.flags[AstBackgroundEvents] === 'True';
     flags[AutoLogPageView] = config.flags[AutoLogPageView] === 'True';
+    // The server sends a comma-separated string; parse and validate it here so the
+    // rest of the SDK only ever sees a clean list. Rejected names are logged by the
+    // tracker, which has a Logger to hand.
+    flags[AutoLogPageViewQueryParams] = parseQueryParamAllowlist(
+        (config.flags[AutoLogPageViewQueryParams] as unknown) as string
+    ).allowed;
     return flags;
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -807,13 +807,8 @@ export function processFlags(config: SDKInitConfig): IFeatureFlags {
     flags[CaptureIntegrationSpecificIdsV2] = (config.flags[CaptureIntegrationSpecificIdsV2] || 'none');
     flags[AstBackgroundEvents] = config.flags[AstBackgroundEvents] === 'True';
     flags[AutoLogPageView] = config.flags[AutoLogPageView] === 'True';
-    // The server sends a comma-separated string. It is parsed and validated HERE,
-    // once, at the config boundary — and the whole result is stored, including what
-    // was rejected. The tracker warns about the rejections when it starts, because
-    // that is where the Logger is; it does not re-derive them.
-    //
-    // Storing only `.allowed` is what made that warning dead code: re-parsing an
-    // already-clean list downstream has nothing left to reject.
+    // Parsed once here, at the config boundary, and stored whole — including the
+    // rejections, which the tracker warns about because that is where the Logger is.
     flags[AutoLogPageViewQueryParams] = parseQueryParamAllowlist(
         (config.flags[AutoLogPageViewQueryParams] as unknown) as string
     );

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,8 +10,8 @@ import {
 import { IKitConfigs } from './configAPIClient';
 import Constants from './constants';
 import {
-    IQueryParamAllowlist,
-    parseQueryParamAllowlist,
+    IQueryParamConfig,
+    parseQueryParamConfig,
 } from './pageViewTracker';
 import {
     DataPlanResult,
@@ -160,7 +160,7 @@ export interface IFeatureFlags {
     // The server sends a comma-separated string; processFlags validates it into
     // accepted names plus a report of what it dropped. Both halves are kept so that
     // the tracker can log the rejections without validating a second time.
-    autoLogPageViewQueryParams?: IQueryParamAllowlist;
+    autoLogPageViewQueryParams?: IQueryParamConfig;
 }
 
 // Temporary Interface until Store can be refactored as a class
@@ -809,7 +809,7 @@ export function processFlags(config: SDKInitConfig): IFeatureFlags {
     flags[AutoLogPageView] = config.flags[AutoLogPageView] === 'True';
     // Parsed once here, at the config boundary, and stored whole — including the
     // rejections, which the tracker warns about because that is where the Logger is.
-    flags[AutoLogPageViewQueryParams] = parseQueryParamAllowlist(
+    flags[AutoLogPageViewQueryParams] = parseQueryParamConfig(
         (config.flags[AutoLogPageViewQueryParams] as unknown) as string
     );
     return flags;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -309,6 +309,16 @@ const mergeObjects = <T extends object>(...objects: T[]): T => {
 const moveElementToEnd = <T>(array: T[], index: number): T[] =>
     array.slice(0, index).concat(array.slice(index + 1), array[index]);
 
+// For keys that did not come from the object itself: `obj[name]` and `name in obj`
+// both walk the prototype chain, so `constructor` is truthy on any plain object.
+//
+// Not `Object.hasOwn`, which Sonar recommends here (typescript:S6653). It is ES2022 and
+// does not compile under this project's `lib: ["es5", "es6", "dom"]`; widening that
+// would emit a call absent from every browser before 2021, and this same file still
+// carries a fallback for browsers with no URLSearchParams.
+const hasOwnProp = (obj: object, key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(obj, key);
+
 const queryStringParser = (
     url: string,
     keys: string[] = []
@@ -334,9 +344,11 @@ const queryStringParser = (
         return lowerCaseUrlParams;
     } else {
         keys.forEach(key => {
-            const value = lowerCaseUrlParams[key.toLowerCase()];
-            if (value) {
-                results[key] = value;
+            const name = key.toLowerCase();
+
+            // Callers pass their own key list, so `name` may not be from this URL.
+            if (hasOwnProp(lowerCaseUrlParams, name) && lowerCaseUrlParams[name]) {
+                results[key] = lowerCaseUrlParams[name];
             }
         });
     }
@@ -372,7 +384,9 @@ const queryStringParserFallback = (url: string): URLSearchParamsFallback => {
         },
         forEach: function(callback: (value: string, key: string) => void) {
             for (var key in params) {
-                if (params.hasOwnProperty(key)) {
+                // Keys come straight off the URL, so `?hasOwnProperty=1` would
+                // shadow the method and `params.hasOwnProperty(key)` would throw.
+                if (hasOwnProp(params, key)) {
                     callback(params[key], key);
                 }
             }
@@ -706,6 +720,7 @@ export {
     mergeObjects,
     moveElementToEnd,
     queryStringParser,
+    hasOwnProp,
     getCookies,
     getHref,
     replaceMPID,

--- a/test/jest/events-page-view.spec.ts
+++ b/test/jest/events-page-view.spec.ts
@@ -2,8 +2,8 @@ import Events from '../../src/events';
 import { IEvents } from '../../src/events.interfaces';
 import { IMParticleWebSDKInstance } from '../../src/mp-instance';
 import {
-    IQueryParamAllowlist,
-    parseQueryParamAllowlist,
+    IQueryParamConfig,
+    parseQueryParamConfig,
 } from '../../src/pageViewTracker';
 import { MessageType } from '../../src/types';
 
@@ -15,7 +15,7 @@ describe('Events#logPageView', () => {
     let events: IEvents;
     let createEventObject: jest.Mock;
     let originalUrl: string;
-    let configuredQueryParams: IQueryParamAllowlist | undefined;
+    let configuredQueryParams: IQueryParamConfig | undefined;
 
     const loggedPageView = (): any => createEventObject.mock.calls[0][0];
 
@@ -79,7 +79,7 @@ describe('Events#logPageView', () => {
     it('should attach a configured additional query param', () => {
         // processFlags parses the customer's string once, at the config boundary,
         // and the flag holds the whole result — so that is what logPageView reads.
-        configuredQueryParams = parseQueryParamAllowlist('promo_code');
+        configuredQueryParams = parseQueryParamConfig('promo_code');
         window.history.replaceState({}, '', '/?promo_code=SAVE20&ref=g');
 
         events.logPageView();

--- a/test/jest/events-page-view.spec.ts
+++ b/test/jest/events-page-view.spec.ts
@@ -1,6 +1,10 @@
 import Events from '../../src/events';
 import { IEvents } from '../../src/events.interfaces';
 import { IMParticleWebSDKInstance } from '../../src/mp-instance';
+import {
+    IQueryParamAllowlist,
+    parseQueryParamAllowlist,
+} from '../../src/pageViewTracker';
 import { MessageType } from '../../src/types';
 
 // _Events.logPageView is the auto page view for the LANDING page — the SPA
@@ -11,7 +15,7 @@ describe('Events#logPageView', () => {
     let events: IEvents;
     let createEventObject: jest.Mock;
     let originalUrl: string;
-    let configuredQueryParams: string[] | string | undefined;
+    let configuredQueryParams: IQueryParamAllowlist | undefined;
 
     const loggedPageView = (): any => createEventObject.mock.calls[0][0];
 
@@ -75,8 +79,9 @@ describe('Events#logPageView', () => {
     // The landing view is where campaign params live, so it is also where a
     // customer's own campaign params have to work.
     it('should attach a configured additional query param', () => {
-        // processFlags stores the validated list, so that is what the flag holds.
-        configuredQueryParams = ['promo_code'];
+        // processFlags parses the customer's string once, at the config boundary,
+        // and the flag holds the whole result — so that is what logPageView reads.
+        configuredQueryParams = parseQueryParamAllowlist('promo_code');
         window.history.replaceState({}, '', '/?promo_code=SAVE20&utm_source=g');
 
         events.logPageView();
@@ -93,6 +98,17 @@ describe('Events#logPageView', () => {
         events.logPageView();
 
         expect(loggedPageView().data.promo_code).toBeUndefined();
+    });
+
+    // getFeatureFlag returns null for an absent flag, which is the common case, and
+    // a default parameter would not catch it. A throw here lands inside logPageView
+    // and takes the landing page view with it.
+    it('should not throw when the flag is absent', () => {
+        configuredQueryParams = null;
+        window.history.replaceState({}, '', '/?utm_source=google');
+
+        expect(() => events.logPageView()).not.toThrow();
+        expect(loggedPageView().data.utm_source).toBe('google');
     });
 
     // The allowlist is the point: a partner URL carrying an email or an order id

--- a/test/jest/events-page-view.spec.ts
+++ b/test/jest/events-page-view.spec.ts
@@ -8,9 +8,9 @@ import {
 import { MessageType } from '../../src/types';
 
 // _Events.logPageView is the auto page view for the LANDING page — the SPA
-// navigations that follow it come from PageViewTracker instead. It is therefore
-// the emitter that carries campaign attribution, since utm_*/gclid live on the
-// entry URL, and it needs its own coverage for the query-param allowlist.
+// navigations that follow it come from PageViewTracker instead. The two emitters
+// share only the pure helpers, so the allowlist needs pinning on both or one of
+// them can silently stop attaching params.
 describe('Events#logPageView', () => {
     let events: IEvents;
     let createEventObject: jest.Mock;
@@ -62,7 +62,7 @@ describe('Events#logPageView', () => {
         window.history.replaceState(
             {},
             '',
-            '/?utm_source=google&utm_medium=cpc&gclid=Cj0KC'
+            '/?page=2&q=boots&ref=google'
         );
 
         events.logPageView();
@@ -70,24 +70,22 @@ describe('Events#logPageView', () => {
         expect(loggedPageView().data).toEqual({
             hostname: 'localhost',
             title: 'Landing',
-            utm_source: 'google',
-            utm_medium: 'cpc',
-            gclid: 'Cj0KC',
+            page: '2',
+            q: 'boots',
+            ref: 'google',
         });
     });
 
-    // The landing view is where campaign params live, so it is also where a
-    // customer's own campaign params have to work.
     it('should attach a configured additional query param', () => {
         // processFlags parses the customer's string once, at the config boundary,
         // and the flag holds the whole result — so that is what logPageView reads.
         configuredQueryParams = parseQueryParamAllowlist('promo_code');
-        window.history.replaceState({}, '', '/?promo_code=SAVE20&utm_source=g');
+        window.history.replaceState({}, '', '/?promo_code=SAVE20&ref=g');
 
         events.logPageView();
 
         expect(loggedPageView().data).toMatchObject({
-            utm_source: 'g',
+            ref: 'g',
             promo_code: 'SAVE20',
         });
     });
@@ -105,10 +103,10 @@ describe('Events#logPageView', () => {
     // and takes the landing page view with it.
     it('should not throw when the flag is absent', () => {
         configuredQueryParams = null;
-        window.history.replaceState({}, '', '/?utm_source=google');
+        window.history.replaceState({}, '', '/?ref=google');
 
         expect(() => events.logPageView()).not.toThrow();
-        expect(loggedPageView().data.utm_source).toBe('google');
+        expect(loggedPageView().data.ref).toBe('google');
     });
 
     // The allowlist is the point: a partner URL carrying an email or an order id
@@ -117,13 +115,13 @@ describe('Events#logPageView', () => {
         window.history.replaceState(
             {},
             '',
-            '/?utm_source=google&email=someone@example.com&order_id=42'
+            '/?ref=google&email=someone@example.com&order_id=42'
         );
 
         events.logPageView();
 
         const { data } = loggedPageView();
-        expect(data.utm_source).toBe('google');
+        expect(data.ref).toBe('google');
         expect(data).not.toHaveProperty('email');
         expect(data).not.toHaveProperty('order_id');
     });

--- a/test/jest/events-page-view.spec.ts
+++ b/test/jest/events-page-view.spec.ts
@@ -11,17 +11,23 @@ describe('Events#logPageView', () => {
     let events: IEvents;
     let createEventObject: jest.Mock;
     let originalUrl: string;
+    let configuredQueryParams: string[] | string | undefined;
 
     const loggedPageView = (): any => createEventObject.mock.calls[0][0];
 
     beforeEach(() => {
         originalUrl = window.location.pathname + window.location.search;
 
+        configuredQueryParams = undefined;
         createEventObject = jest.fn(event => event);
 
         const mpInstance = ({
             Logger: { verbose: jest.fn() },
-            _Helpers: { canLog: () => true },
+            _Helpers: {
+                canLog: () => true,
+                // No configured additions; individual tests override this.
+                getFeatureFlag: () => configuredQueryParams,
+            },
             _ServerModel: { createEventObject },
             _APIClient: { sendEventToServer: jest.fn() },
         } as unknown) as IMParticleWebSDKInstance;
@@ -64,6 +70,29 @@ describe('Events#logPageView', () => {
             utm_medium: 'cpc',
             gclid: 'Cj0KC',
         });
+    });
+
+    // The landing view is where campaign params live, so it is also where a
+    // customer's own campaign params have to work.
+    it('should attach a configured additional query param', () => {
+        // processFlags stores the validated list, so that is what the flag holds.
+        configuredQueryParams = ['promo_code'];
+        window.history.replaceState({}, '', '/?promo_code=SAVE20&utm_source=g');
+
+        events.logPageView();
+
+        expect(loggedPageView().data).toMatchObject({
+            utm_source: 'g',
+            promo_code: 'SAVE20',
+        });
+    });
+
+    it('should ignore the param when nothing is configured', () => {
+        window.history.replaceState({}, '', '/?promo_code=SAVE20');
+
+        events.logPageView();
+
+        expect(loggedPageView().data.promo_code).toBeUndefined();
     });
 
     // The allowlist is the point: a partner URL carrying an email or an order id

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -17,6 +17,7 @@ import {
     supportsHistoryTracking,
     WIN_APV_KEY,
 } from '../../src/pageViewTracker';
+import Constants from '../../src/constants';
 import { IMParticleWebSDKInstance } from '../../src/mp-instance';
 import { EventType, MessageType } from '../../src/types';
 
@@ -188,8 +189,10 @@ describe('pageViewTracker pure helpers', () => {
     describe('#parseQueryParamAllowlist', () => {
         const allowed = (input: string | string[]): string[] =>
             parseQueryParamAllowlist(input).allowed;
-        const rejected = (input: string | string[]): string[] =>
-            parseQueryParamAllowlist(input).rejected;
+        const rejectedPositions = (input: string | string[]): number[] =>
+            parseQueryParamAllowlist(input).rejectedPositions;
+        const overLimit = (input: string | string[]): number =>
+            parseQueryParamAllowlist(input).overLimit;
 
         it('should split, trim and lowercase a comma-separated string', () => {
             expect(allowed(' Promo_Code , AFFILIATE_ID ')).toEqual([
@@ -212,42 +215,63 @@ describe('pageViewTracker pure helpers', () => {
         it('should drop a duplicate of a built-in without rejecting it', () => {
             // Asking for something you already have is not an error.
             expect(allowed('utm_source, promo_code')).toEqual(['promo_code']);
-            expect(rejected('utm_source')).toEqual([]);
+            expect(rejectedPositions('utm_source')).toEqual([]);
         });
 
         it('should drop a repeat of itself', () => {
             expect(allowed('promo_code, promo_code')).toEqual(['promo_code']);
         });
 
-        // The reported label is cut at the first illegal character, so it can
-        // identify the entry without echoing anything that followed. See
-        // 'should not echo a value back in the rejected label' below.
         it.each([
-            ['a name with spaces', 'bad name', 'bad...'],
-            ['an equals sign', 'a=b', 'a...'],
-            ['an ampersand', 'a&b', 'a...'],
-            ['a percent', 'a%20b', 'a...'],
-            ['a leading hyphen', '-lead', '-lead'],
-            ['a leading dot', '.lead', '.lead'],
-        ])('should reject %s', (_label, name, expectedLabel) => {
+            ['a name with spaces', 'bad name'],
+            ['an equals sign', 'a=b'],
+            ['an ampersand', 'a&b'],
+            ['a percent', 'a%20b'],
+            ['a leading hyphen', '-lead'],
+            ['a leading dot', '.lead'],
+            ['a non-ASCII name', 'émail'],
+        ])('should reject %s', (_label, name) => {
             expect(allowed(name)).toEqual([]);
-            expect(rejected(name)).toEqual([expectedLabel]);
+            expect(rejectedPositions(name)).toEqual([1]);
         });
 
-        // A malformed entry can carry a value inside it. The rule is names only, so
-        // nothing after the offending character may reach a log.
-        it('should not echo a value back in the rejected label', () => {
-            const [label] = rejected('password=hunter2');
+        // Positions are 1-based and count every comma-separated slot, so a reported
+        // position lines up with what the customer typed into the field.
+        it('should report the position of each rejected entry', () => {
+            expect(
+                rejectedPositions('promo_code, bad name, affiliate_id, a=b')
+            ).toEqual([2, 4]);
+        });
 
-            expect(label).toBe('password...');
-            expect(label).not.toContain('hunter2');
+        it('should count a blank slot as a position without rejecting it', () => {
+            expect(rejectedPositions('promo_code, , bad name')).toEqual([3]);
+        });
+
+        // No part of a rejected entry may reach a log. An earlier version reported a
+        // prefix cut at the first illegal character, which does not achieve that:
+        // `.`, `-` and `_` are all legal, so these leaked whole or nearly whole.
+        it.each([
+            'password=hunter2',
+            'token.hunter2 x',
+            'user.email.hunter2@x',
+            '-secret-value-abcdef',
+            '.hunter2',
+        ])('should report only a position for %p', entry => {
+            const { allowed: names, rejectedPositions: positions } =
+                parseQueryParamAllowlist(entry);
+
+            expect(names).toEqual([]);
+            expect(positions).toEqual([1]);
+            // A number cannot carry the customer's text at all, which is the point.
+            expect(JSON.stringify(positions)).not.toContain('hunter2');
+            expect(JSON.stringify(positions)).not.toContain('secret');
+            expect(JSON.stringify(positions)).not.toContain('abc');
         });
 
         it('should reject a name longer than 64 characters', () => {
             const long = 'a'.repeat(65);
             expect(allowed(long)).toEqual([]);
-            // Legal characters throughout, so the label is a length-capped prefix.
-            expect(rejected(long)).toEqual([`${'a'.repeat(32)}...`]);
+            expect(rejectedPositions(long)).toEqual([1]);
         });
 
         it('should accept a name of exactly 64 characters', () => {
@@ -259,7 +283,7 @@ describe('pageViewTracker pure helpers', () => {
             'should reject the core event field %s',
             name => {
                 expect(allowed(name)).toEqual([]);
-                expect(rejected(name)).toEqual([name]);
+                expect(rejectedPositions(name)).toEqual([1]);
             }
         );
 
@@ -267,7 +291,18 @@ describe('pageViewTracker pure helpers', () => {
             'should reject the prototype member name %s',
             name => {
                 expect(allowed(name)).toEqual([]);
-                expect(rejected(name)).toEqual([name]);
+                expect(rejectedPositions(name)).toEqual([1]);
+            }
+        );
+
+        // Every other flag in this SDK is a string compared against 'True', so
+        // setting this one to `True` is a plausible operator slip — and `true` is a
+        // legal param name, so nothing else would catch it.
+        it.each(['True', 'true', 'False', 'false'])(
+            'should reject the boolean-looking value %p',
+            name => {
+                expect(allowed(name)).toEqual([]);
+                expect(rejectedPositions(name)).toEqual([1]);
             }
         );
 
@@ -278,6 +313,36 @@ describe('pageViewTracker pure helpers', () => {
             ).join(',');
 
             expect(allowed(many)).toHaveLength(MAX_CUSTOM_QUERY_PARAMS);
+        });
+
+        // Entries past the cap used to be dropped with no report of any kind: the
+        // cap was checked at the top of the loop, so they were neither accepted nor
+        // rejected. They are counted so the warning can say how many were lost.
+        it('should count the entries dropped past the cap', () => {
+            const many = Array.from(
+                { length: MAX_CUSTOM_QUERY_PARAMS + 15 },
+                (_unused, i) => `p${i}`
+            ).join(',');
+
+            expect(overLimit(many)).toBe(15);
+            expect(rejectedPositions(many)).toEqual([]);
+        });
+
+        // The cap is checked after the duplicate and blank filters, so neither
+        // consumes headroom that a real addition could have used.
+        it('should not let duplicates consume cap headroom', () => {
+            const names = Array.from(
+                { length: MAX_CUSTOM_QUERY_PARAMS },
+                (_unused, i) => `p${i}`
+            );
+            const withDuplicates = names
+                .concat(names)
+                .concat(['utm_source', '', 'last_one'])
+                .join(',');
+
+            expect(allowed(withDuplicates)).toEqual(names);
+            // Only `last_one` was a genuine addition with nowhere to go.
+            expect(overLimit(withDuplicates)).toBe(1);
         });
     });
 
@@ -299,19 +364,24 @@ describe('pageViewTracker pure helpers', () => {
             expect(list[list.length - 1]).toBe('promo_code');
         });
 
-        it('should append extras in the order given', () => {
-            expect(
-                effectiveAllowlist(['zeta', 'alpha']).slice(
-                    ALLOWED_QUERY_PARAMS.length
-                )
-            ).toEqual(['zeta', 'alpha']);
+        // Sorted, not in config order. The suffix has to depend on the SET of
+        // custom params, because pageKey walks this list: appended in config order,
+        // a customer who merely swaps two co-occurring params in the Advanced
+        // Settings field changes the key of every page carrying both, and each of
+        // those fires one spurious page view.
+        it('should append extras sorted, whatever order they were given in', () => {
+            const suffix = (extras: string[]): string[] =>
+                effectiveAllowlist(extras).slice(ALLOWED_QUERY_PARAMS.length);
+
+            expect(suffix(['zeta', 'alpha'])).toEqual(['alpha', 'zeta']);
+            expect(suffix(['alpha', 'zeta'])).toEqual(['alpha', 'zeta']);
         });
 
-        // A mis-shaped config value must not throw: the crash would land inside
-        // logPageView and take every page view with it.
-        it('should tolerate a raw comma-separated string', () => {
-            expect(effectiveAllowlist('promo_code, bad name')).toEqual(
-                ALLOWED_QUERY_PARAMS.concat(['promo_code'])
+        // getFeatureFlag returns null when the flag is absent, and a default
+        // parameter only fires for undefined.
+        it.each([undefined, null])('should tolerate %p', extras => {
+            expect(effectiveAllowlist(extras as string[])).toEqual(
+                ALLOWED_QUERY_PARAMS
             );
         });
 
@@ -385,17 +455,27 @@ describe('pageViewTracker pure helpers', () => {
         // custom params must key identically before and after a customer adds them.
         // If this breaks, every such page fires one spurious view on the first
         // navigation after rollout.
-        it('should be unchanged for a page that uses no custom params', () => {
+        //
+        // Asserted against a literal, which is what "byte-identical" means. Comparing
+        // two calls to the current allowedQueryParams would compare new against new
+        // and pass even if the whole union were reordered, since both sides move
+        // together.
+        const keyFor = (extras?: string[]): string => {
             const href = 'https://x.com/p?utm_source=google&gclid=abc';
 
-            expect(pageKey(pageFromHref(href))).toBe(
-                pageKey({
-                    path: new URL(href).pathname,
-                    params: allowedQueryParams(href, [
-                        'promo_code',
-                        'affiliate_id',
-                    ]),
-                })
+            return pageKey({
+                path: new URL(href).pathname,
+                params: allowedQueryParams(href, extras),
+            });
+        };
+
+        it('should be this exact key with no custom params configured', () => {
+            expect(keyFor()).toBe('/p?utm_source=google&gclid=abc');
+        });
+
+        it('should be the same key once custom params are configured', () => {
+            expect(keyFor(['promo_code', 'affiliate_id'])).toBe(
+                '/p?utm_source=google&gclid=abc'
             );
         });
 
@@ -908,8 +988,23 @@ describe('PageViewTracker', () => {
     });
 
     describe('configured additional query params', () => {
+        // Mirrors production: the raw comma-separated string is parsed ONCE, by
+        // processFlags, and the flag holds the whole IQueryParamAllowlist. The
+        // tracker never sees the raw string, so neither does this test.
+        //
+        // That distinction is load-bearing rather than pedantic. These tests used to
+        // mock getFeatureFlag with the raw string, which let the tracker re-parse it
+        // and made the rejection warning look alive when in production it received
+        // an already-clean list and could never fire.
         const initWith = (configured: string | undefined): PageViewTracker => {
-            getFeatureFlag.mockReturnValue(configured);
+            const parsed = parseQueryParamAllowlist(configured);
+
+            getFeatureFlag.mockImplementation((flag: string) =>
+                flag === Constants.FeatureFlags.AutoLogPageViewQueryParams
+                    ? parsed
+                    : undefined
+            );
+
             const tracker = createTracker();
             tracker.init();
             return tracker;
@@ -952,20 +1047,37 @@ describe('PageViewTracker', () => {
             expect(logEvent.mock.calls[0][0].data.promo_code).toBe('B');
         });
 
-        it('should warn with log-safe labels for what it rejected, never values', () => {
+        it('should warn with positions for what it rejected, never text', () => {
             navigateNatively('/');
-            initWith('promo_code, bad name, password=hunter2');
+            initWith('promo_code, bad name, affiliate_id, password=hunter2');
 
             expect(warning).toHaveBeenCalledTimes(1);
             const [message] = warning.mock.calls[0];
 
             // Enough to identify which entries were dropped...
-            expect(message).toContain('bad...');
-            expect(message).toContain('password...');
-            // ...and nothing that followed the offending character.
+            expect(message).toContain('positions 2, 4');
+            // ...and none of the customer's text, valid or otherwise.
             expect(message).not.toContain('hunter2');
-            // The valid entry is not reported as a problem.
+            expect(message).not.toContain('password');
+            expect(message).not.toContain('bad');
             expect(message).not.toContain('promo_code');
+        });
+
+        // The whole point of F5's fix: processFlags validates, the tracker reports.
+        // If the tracker re-parsed the clean list it was handed, this could not fire.
+        it('should warn about entries dropped past the cap', () => {
+            navigateNatively('/');
+            initWith(
+                Array.from(
+                    { length: MAX_CUSTOM_QUERY_PARAMS + 3 },
+                    (_unused, i) => `p${i}`
+                ).join(',')
+            );
+
+            expect(warning).toHaveBeenCalledTimes(1);
+            expect(warning.mock.calls[0][0]).toContain(
+                `ignoring 3 additional page view query parameters beyond the limit of ${MAX_CUSTOM_QUERY_PARAMS}`
+            );
         });
 
         it('should not warn when every configured name is valid', () => {
@@ -974,6 +1086,18 @@ describe('PageViewTracker', () => {
 
             expect(warning).not.toHaveBeenCalled();
         });
+
+        // A hand-mutated or absent flag must not throw on the init path.
+        it.each([undefined, null, 'promo_code', []])(
+            'should tolerate a flag value of %p',
+            value => {
+                navigateNatively('/');
+                getFeatureFlag.mockReturnValue(value);
+
+                expect(() => createTracker().init()).not.toThrow();
+                expect(warning).not.toHaveBeenCalled();
+            }
+        );
     });
 
     describe('navigation detection', () => {

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -97,6 +97,58 @@ describe('pageViewTracker pure helpers', () => {
             ).toEqual([{ name: 'utm_source', value: 'google' }]);
         });
 
+        // Removed from the default list deliberately: `code` is an OAuth
+        // authorization code and `state`/`nonce` are CSRF/replay tokens, and
+        // capturing them by default put credentials in the event store and every
+        // connected kit for customers who had no use for them. A customer who needs
+        // them configures them per input — see the next test.
+        it.each([
+            'code',
+            'state',
+            'nonce',
+            'client_id',
+            'redirect_uri',
+            'response_type',
+            'scope',
+        ])('should not capture the OAuth/OIDC param %s by default', name => {
+            expect(
+                allowedQueryParams(
+                    `https://example.com/callback?${name}=sensitive&utm_source=g`
+                )
+            ).toEqual([{ name: 'utm_source', value: 'g' }]);
+        });
+
+        // The removal is a change of DEFAULT, not of capability. This is what makes
+        // it a safe change rather than a regression.
+        it('should still capture an OAuth param when a customer configures it', () => {
+            expect(
+                allowedQueryParams('https://example.com/callback?code=abc123', [
+                    'code',
+                ])
+            ).toEqual([{ name: 'code', value: 'abc123' }]);
+        });
+
+        // The same escape hatch through the path a real customer takes: the value
+        // arrives as a comma-separated string and processFlags validates it before
+        // anything downstream sees it.
+        //
+        // This assertion is the one that matters for this PR. While `code` was a
+        // built-in, parseQueryParamAllowlist dropped it as a duplicate — so a
+        // customer typing `code` into Advanced Settings would have got an empty list
+        // and the escape hatch would have silently done nothing. Removing it from the
+        // defaults is precisely what makes that work, and nothing else pins it.
+        it('should accept a configured OAuth param through the string config path', () => {
+            const { allowed } = parseQueryParamAllowlist('code');
+
+            expect(allowed).toEqual(['code']);
+            expect(
+                allowedQueryParams(
+                    'https://example.com/callback?code=abc123',
+                    allowed
+                )
+            ).toEqual([{ name: 'code', value: 'abc123' }]);
+        });
+
         it('should capture a configured custom param', () => {
             expect(
                 allowedQueryParams(
@@ -1306,13 +1358,13 @@ describe('PageViewTracker', () => {
             const tracker = createTracker();
             tracker.init();
 
-            window.history.pushState({}, '', '/callback?code=SECRET-AUTH-CODE');
+            window.history.pushState({}, '', '/search?q=SECRET-SEARCH-TERM');
             jest.runAllTimers();
 
             const logged = verbose.mock.calls.map(([message]) => message).join('\n');
 
-            expect(logged).toContain('code');
-            expect(logged).not.toContain('SECRET-AUTH-CODE');
+            expect(logged).toContain('q');
+            expect(logged).not.toContain('SECRET-SEARCH-TERM');
         });
 
         // The title is read at flush time, not when the navigation is accepted,

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -6,7 +6,11 @@ import {
     hasInitialPageViewFired,
     isNewPage,
     markInitialPageViewFired,
+    effectiveAllowlist,
+    MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH,
+    MAX_CUSTOM_QUERY_PARAMS,
     pageKey,
+    parseQueryParamAllowlist,
     PageViewTracker,
     patchHistory,
     resetPageViewTracking,
@@ -52,7 +56,7 @@ describe('pageViewTracker pure helpers', () => {
         it('should keep an allowlisted param', () => {
             expect(
                 allowedQueryParams('https://example.com/?utm_source=google')
-            ).toEqual({ utm_source: 'google' });
+            ).toEqual([{ name: 'utm_source', value: 'google' }]);
         });
 
         // The allowlist is the whole point: anything not named is dropped, so a
@@ -62,22 +66,22 @@ describe('pageViewTracker pure helpers', () => {
                 allowedQueryParams(
                     'https://example.com/?utm_source=google&email=someone@example.com&order_id=42'
                 )
-            ).toEqual({ utm_source: 'google' });
+            ).toEqual([{ name: 'utm_source', value: 'google' }]);
         });
 
         it('should fold key casing onto the allowlisted name', () => {
             expect(
                 allowedQueryParams('https://example.com/?UTM_Source=google')
-            ).toEqual({ utm_source: 'google' });
+            ).toEqual([{ name: 'utm_source', value: 'google' }]);
         });
 
         it('should return nothing for a URL with no query string', () => {
-            expect(allowedQueryParams('https://example.com/cart')).toEqual({});
+            expect(allowedQueryParams('https://example.com/cart')).toEqual([]);
         });
 
         // getHref() yields '' under SSR, so this is the path that must not throw.
         it('should return nothing for an empty href', () => {
-            expect(allowedQueryParams('')).toEqual({});
+            expect(allowedQueryParams('')).toEqual([]);
         });
 
         // A URL is free to carry a param named after an Object.prototype member.
@@ -89,7 +93,85 @@ describe('pageViewTracker pure helpers', () => {
                 allowedQueryParams(
                     'https://example.com/?constructor=x&__proto__=y&toString=z&utm_source=google'
                 )
-            ).toEqual({ utm_source: 'google' });
+            ).toEqual([{ name: 'utm_source', value: 'google' }]);
+        });
+
+        it('should capture a configured custom param', () => {
+            expect(
+                allowedQueryParams(
+                    'https://example.com/?promo_code=SAVE20&utm_source=google',
+                    ['promo_code']
+                )
+            ).toEqual([
+                { name: 'utm_source', value: 'google' },
+                { name: 'promo_code', value: 'SAVE20' },
+            ]);
+        });
+
+        it('should still drop an unlisted param when extras are configured', () => {
+            expect(
+                allowedQueryParams(
+                    'https://example.com/?promo_code=x&email=a@b.com',
+                    ['promo_code']
+                )
+            ).toEqual([{ name: 'promo_code', value: 'x' }]);
+        });
+
+        // This is the regression the hardening PR could not test: with a hardcoded
+        // allowlist, `in` and hasOwnProperty are indistinguishable because no
+        // built-in names a prototype member. A configured list makes it reachable.
+        // parseQueryParamAllowlist rejects these names, so reaching allowedQueryParams
+        // with them means someone bypassed that — and it must still be inert.
+        it.each(['constructor', '__proto__', 'toString', 'valueOf'])(
+            'should capture nothing for a configured extra named %s',
+            name => {
+                expect(
+                    allowedQueryParams(
+                        'https://example.com/?utm_source=google',
+                        [name]
+                    )
+                ).toEqual([{ name: 'utm_source', value: 'google' }]);
+            }
+        );
+
+        it('should not pollute Object.prototype via a configured extra', () => {
+            allowedQueryParams('https://example.com/?__proto__=polluted', [
+                '__proto__',
+            ]);
+
+            expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+        });
+
+        // Custom params are where unbounded customer choice enters, so their values
+        // are bounded. Dropped rather than truncated: truncating would make two
+        // different long values produce the same dedup key and swallow a real view.
+        it('should drop a custom param whose value exceeds the cap', () => {
+            const tooLong = 'x'.repeat(MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH + 1);
+
+            expect(
+                allowedQueryParams(
+                    `https://example.com/?blob=${tooLong}&utm_source=g`,
+                    ['blob']
+                )
+            ).toEqual([{ name: 'utm_source', value: 'g' }]);
+        });
+
+        it('should keep a custom param whose value is exactly at the cap', () => {
+            const exact = 'x'.repeat(MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH);
+
+            expect(
+                allowedQueryParams(`https://example.com/?blob=${exact}`, ['blob'])
+            ).toEqual([{ name: 'blob', value: exact }]);
+        });
+
+        // Built-in behaviour is deliberately untouched by the cap, so nobody can
+        // lose a long utm_content on upgrade.
+        it('should keep a built-in param whose value exceeds the custom cap', () => {
+            const tooLong = 'x'.repeat(MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH + 1);
+
+            expect(
+                allowedQueryParams(`https://example.com/?utm_content=${tooLong}`)
+            ).toEqual([{ name: 'utm_content', value: tooLong }]);
         });
 
         it('should keep every param on the allowlist', () => {
@@ -98,8 +180,145 @@ describe('pageViewTracker pure helpers', () => {
             ).join('&');
 
             expect(
-                Object.keys(allowedQueryParams(`https://example.com/?${query}`))
+                allowedQueryParams(`https://example.com/?${query}`)
             ).toHaveLength(ALLOWED_QUERY_PARAMS.length);
+        });
+    });
+
+    describe('#parseQueryParamAllowlist', () => {
+        const allowed = (input: string | string[]): string[] =>
+            parseQueryParamAllowlist(input).allowed;
+        const rejected = (input: string | string[]): string[] =>
+            parseQueryParamAllowlist(input).rejected;
+
+        it('should split, trim and lowercase a comma-separated string', () => {
+            expect(allowed(' Promo_Code , AFFILIATE_ID ')).toEqual([
+                'promo_code',
+                'affiliate_id',
+            ]);
+        });
+
+        it('should accept an array as well as a string', () => {
+            expect(allowed(['promo_code'])).toEqual(['promo_code']);
+        });
+
+        it.each([undefined, null, '', ' , , '])(
+            'should return nothing for %p',
+            input => {
+                expect(allowed(input as string)).toEqual([]);
+            }
+        );
+
+        it('should drop a duplicate of a built-in without rejecting it', () => {
+            // Asking for something you already have is not an error.
+            expect(allowed('utm_source, promo_code')).toEqual(['promo_code']);
+            expect(rejected('utm_source')).toEqual([]);
+        });
+
+        it('should drop a repeat of itself', () => {
+            expect(allowed('promo_code, promo_code')).toEqual(['promo_code']);
+        });
+
+        // The reported label is cut at the first illegal character, so it can
+        // identify the entry without echoing anything that followed. See
+        // 'should not echo a value back in the rejected label' below.
+        it.each([
+            ['a name with spaces', 'bad name', 'bad...'],
+            ['an equals sign', 'a=b', 'a...'],
+            ['an ampersand', 'a&b', 'a...'],
+            ['a percent', 'a%20b', 'a...'],
+            ['a leading hyphen', '-lead', '-lead'],
+            ['a leading dot', '.lead', '.lead'],
+        ])('should reject %s', (_label, name, expectedLabel) => {
+            expect(allowed(name)).toEqual([]);
+            expect(rejected(name)).toEqual([expectedLabel]);
+        });
+
+        // A malformed entry can carry a value inside it. The rule is names only, so
+        // nothing after the offending character may reach a log.
+        it('should not echo a value back in the rejected label', () => {
+            const [label] = rejected('password=hunter2');
+
+            expect(label).toBe('password...');
+            expect(label).not.toContain('hunter2');
+        });
+
+        it('should reject a name longer than 64 characters', () => {
+            const long = 'a'.repeat(65);
+            expect(allowed(long)).toEqual([]);
+            // Legal characters throughout, so the label is a length-capped prefix.
+            expect(rejected(long)).toEqual([`${'a'.repeat(32)}...`]);
+        });
+
+        it('should accept a name of exactly 64 characters', () => {
+            const exact = 'a'.repeat(64);
+            expect(allowed(exact)).toEqual([exact]);
+        });
+
+        it.each(['hostname', 'title', 'path'])(
+            'should reject the core event field %s',
+            name => {
+                expect(allowed(name)).toEqual([]);
+                expect(rejected(name)).toEqual([name]);
+            }
+        );
+
+        it.each(['constructor', '__proto__', 'prototype'])(
+            'should reject the prototype member name %s',
+            name => {
+                expect(allowed(name)).toEqual([]);
+                expect(rejected(name)).toEqual([name]);
+            }
+        );
+
+        it('should cap the accepted list', () => {
+            const many = Array.from(
+                { length: MAX_CUSTOM_QUERY_PARAMS + 15 },
+                (_unused, i) => `p${i}`
+            ).join(',');
+
+            expect(allowed(many)).toHaveLength(MAX_CUSTOM_QUERY_PARAMS);
+        });
+    });
+
+    describe('#effectiveAllowlist', () => {
+        it('should be the built-ins alone when nothing is configured', () => {
+            expect(effectiveAllowlist()).toEqual(ALLOWED_QUERY_PARAMS);
+            expect(effectiveAllowlist([])).toEqual(ALLOWED_QUERY_PARAMS);
+        });
+
+        // The built-in prefix is what keeps existing dedup keys byte-identical for
+        // pages that use no custom params. Reordering here would fire one spurious
+        // page view per page on the first navigation after a customer opts in.
+        it('should keep the built-ins first, in their existing order', () => {
+            const list = effectiveAllowlist(['promo_code']);
+
+            expect(list.slice(0, ALLOWED_QUERY_PARAMS.length)).toEqual(
+                ALLOWED_QUERY_PARAMS
+            );
+            expect(list[list.length - 1]).toBe('promo_code');
+        });
+
+        it('should append extras in the order given', () => {
+            expect(
+                effectiveAllowlist(['zeta', 'alpha']).slice(
+                    ALLOWED_QUERY_PARAMS.length
+                )
+            ).toEqual(['zeta', 'alpha']);
+        });
+
+        // A mis-shaped config value must not throw: the crash would land inside
+        // logPageView and take every page view with it.
+        it('should tolerate a raw comma-separated string', () => {
+            expect(effectiveAllowlist('promo_code, bad name')).toEqual(
+                ALLOWED_QUERY_PARAMS.concat(['promo_code'])
+            );
+        });
+
+        it('should not duplicate an extra that is already built in', () => {
+            expect(effectiveAllowlist(['utm_source'])).toEqual(
+                ALLOWED_QUERY_PARAMS
+            );
         });
     });
 
@@ -113,27 +332,32 @@ describe('pageViewTracker pure helpers', () => {
         });
 
         it('should be the pathname alone when no params are captured', () => {
-            expect(pageKey({ path: '/cart', params: {} })).toBe('/cart');
+            expect(pageKey({ path: '/cart', params: [] })).toBe('/cart');
         });
 
         it('should include the captured params', () => {
-            expect(pageKey({ path: '/search', params: { q: 'shoes' } })).toBe(
-                '/search?q=shoes'
-            );
+            expect(
+                pageKey({ path: '/search', params: [{ name: 'q', value: 'shoes' }] })
+            ).toBe('/search?q=shoes');
         });
 
         // Sorted, so a router that reorders the query string on an otherwise
         // identical navigation does not produce a spurious second page view.
         it('should be stable against param reordering', () => {
-            const a = pageKey({ path: '/s', params: { q: 'x', page: '2' } });
-            const b = pageKey({ path: '/s', params: { page: '2', q: 'x' } });
+            // The capture order is fixed by the allowlist, so two URLs whose
+            // query strings differ only in order produce the same pair list and
+            // therefore the same key.
+            const a = pageKey(pageFromHref('https://x.com/s?q=x&page=2'));
+            const b = pageKey(pageFromHref('https://x.com/s?page=2&q=x'));
 
             expect(a).toBe(b);
         });
 
         it('should distinguish two values of the same param', () => {
-            expect(pageKey({ path: '/s', params: { page: '1' } })).not.toBe(
-                pageKey({ path: '/s', params: { page: '2' } })
+            expect(
+                pageKey({ path: '/s', params: [{ name: 'page', value: '1' }] })
+            ).not.toBe(
+                pageKey({ path: '/s', params: [{ name: 'page', value: '2' }] })
             );
         });
 
@@ -144,14 +368,35 @@ describe('pageViewTracker pure helpers', () => {
         it('should not collide when a value contains the pair delimiters', () => {
             const injected = pageKey({
                 path: '/s',
-                params: { q: 'a&search=b' },
+                params: [{ name: 'q', value: 'a&search=b' }],
             });
             const genuine = pageKey({
                 path: '/s',
-                params: { q: 'a', search: 'b' },
+                params: [
+                    { name: 'q', value: 'a' },
+                    { name: 'search', value: 'b' },
+                ],
             });
 
             expect(injected).not.toBe(genuine);
+        });
+
+        // The property that makes opting in safe: a page whose URL uses none of the
+        // custom params must key identically before and after a customer adds them.
+        // If this breaks, every such page fires one spurious view on the first
+        // navigation after rollout.
+        it('should be unchanged for a page that uses no custom params', () => {
+            const href = 'https://x.com/p?utm_source=google&gclid=abc';
+
+            expect(pageKey(pageFromHref(href))).toBe(
+                pageKey({
+                    path: new URL(href).pathname,
+                    params: allowedQueryParams(href, [
+                        'promo_code',
+                        'affiliate_id',
+                    ]),
+                })
+            );
         });
 
         // The same collision reached through the tracker rather than by hand:
@@ -218,7 +463,7 @@ describe('pageViewTracker pure helpers', () => {
                 hostname: 'example.com',
                 title: 'Cart',
                 path: '/cart',
-                params: {},
+                params: [],
             });
 
             expect(event).toEqual({
@@ -238,7 +483,10 @@ describe('pageViewTracker pure helpers', () => {
                 hostname: 'example.com',
                 title: 'Cart',
                 path: '/cart',
-                params: { utm_source: 'google', gclid: 'Cj0KC' },
+                params: [
+                    { name: 'utm_source', value: 'google' },
+                    { name: 'gclid', value: 'Cj0KC' },
+                ],
             });
 
             expect(event.data).toEqual({
@@ -257,7 +505,10 @@ describe('pageViewTracker pure helpers', () => {
                 hostname: 'example.com',
                 title: 'Cart',
                 path: '/cart',
-                params: { path: '/spoofed', hostname: 'evil.com' },
+                params: [
+                    { name: 'path', value: '/spoofed' },
+                    { name: 'hostname', value: 'evil.com' },
+                ],
             });
 
             expect(event.data.path).toBe('/cart');
@@ -269,12 +520,12 @@ describe('pageViewTracker pure helpers', () => {
                 hostname: 'example.com',
                 title: 'Cart',
                 path: '/cart',
-                params: { q: 'shoes' },
+                params: [{ name: 'q', value: 'shoes' }],
             };
             const event = buildPageViewEvent(data);
 
             data.path = '/mutated-after-the-fact';
-            data.params.q = 'mutated-after-the-fact';
+            data.params[0].value = 'mutated-after-the-fact';
 
             expect(event.data.path).toBe('/cart');
             expect(event.data.q).toBe('shoes');
@@ -408,6 +659,8 @@ describe('PageViewTracker', () => {
     let logEvent: jest.Mock;
     let resetSessionTimer: jest.Mock;
     let verbose: jest.Mock;
+    let warning: jest.Mock;
+    let getFeatureFlag: jest.Mock;
 
     const createTracker = (): PageViewTracker => new PageViewTracker(mpInstance);
 
@@ -425,11 +678,15 @@ describe('PageViewTracker', () => {
         logEvent = jest.fn();
         resetSessionTimer = jest.fn();
         verbose = jest.fn();
+        warning = jest.fn();
+        // No configured additions unless a test says otherwise.
+        getFeatureFlag = jest.fn().mockReturnValue(undefined);
 
         mpInstance = ({
-            Logger: { verbose },
+            Logger: { verbose, warning },
             _SessionManager: { resetSessionTimer },
             _Events: { logEvent },
+            _Helpers: { getFeatureFlag },
         } as unknown) as IMParticleWebSDKInstance;
     });
 
@@ -647,6 +904,75 @@ describe('PageViewTracker', () => {
                     configurable: true,
                 });
             }
+        });
+    });
+
+    describe('configured additional query params', () => {
+        const initWith = (configured: string | undefined): PageViewTracker => {
+            getFeatureFlag.mockReturnValue(configured);
+            const tracker = createTracker();
+            tracker.init();
+            return tracker;
+        };
+
+        it('should capture a configured param on a page view', () => {
+            navigateNatively('/');
+            initWith('promo_code');
+
+            window.history.pushState({}, '', '/promo?promo_code=SAVE20');
+            jest.runAllTimers();
+
+            expect(logEvent.mock.calls[0][0].data).toMatchObject({
+                path: '/promo',
+                promo_code: 'SAVE20',
+            });
+        });
+
+        // Without the flag the param is not on the allowlist, so it is neither
+        // captured nor part of the dedup key.
+        it('should ignore the param when nothing is configured', () => {
+            navigateNatively('/');
+            initWith(undefined);
+
+            window.history.pushState({}, '', '/promo?promo_code=SAVE20');
+            jest.runAllTimers();
+
+            expect(logEvent.mock.calls[0][0].data.promo_code).toBeUndefined();
+        });
+
+        // A configured param joins the dedup key, so changing it is a new page.
+        it('should fire a view when a configured param changes', () => {
+            navigateNatively('/list?promo_code=A');
+            initWith('promo_code');
+
+            window.history.pushState({}, '', '/list?promo_code=B');
+            jest.runAllTimers();
+
+            expect(logEvent).toHaveBeenCalledTimes(1);
+            expect(logEvent.mock.calls[0][0].data.promo_code).toBe('B');
+        });
+
+        it('should warn with log-safe labels for what it rejected, never values', () => {
+            navigateNatively('/');
+            initWith('promo_code, bad name, password=hunter2');
+
+            expect(warning).toHaveBeenCalledTimes(1);
+            const [message] = warning.mock.calls[0];
+
+            // Enough to identify which entries were dropped...
+            expect(message).toContain('bad...');
+            expect(message).toContain('password...');
+            // ...and nothing that followed the offending character.
+            expect(message).not.toContain('hunter2');
+            // The valid entry is not reported as a problem.
+            expect(message).not.toContain('promo_code');
+        });
+
+        it('should not warn when every configured name is valid', () => {
+            navigateNatively('/');
+            initWith('promo_code, affiliate_id');
+
+            expect(warning).not.toHaveBeenCalled();
         });
     });
 

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -56,8 +56,8 @@ describe('pageViewTracker pure helpers', () => {
     describe('#allowedQueryParams', () => {
         it('should keep an allowlisted param', () => {
             expect(
-                allowedQueryParams('https://example.com/?utm_source=google')
-            ).toEqual([{ name: 'utm_source', value: 'google' }]);
+                allowedQueryParams('https://example.com/?ref=google')
+            ).toEqual([{ name: 'ref', value: 'google' }]);
         });
 
         // The allowlist is the whole point: anything not named is dropped, so a
@@ -65,15 +65,15 @@ describe('pageViewTracker pure helpers', () => {
         it('should drop a param that is not allowlisted', () => {
             expect(
                 allowedQueryParams(
-                    'https://example.com/?utm_source=google&email=someone@example.com&order_id=42'
+                    'https://example.com/?ref=google&email=someone@example.com&order_id=42'
                 )
-            ).toEqual([{ name: 'utm_source', value: 'google' }]);
+            ).toEqual([{ name: 'ref', value: 'google' }]);
         });
 
         it('should fold key casing onto the allowlisted name', () => {
             expect(
-                allowedQueryParams('https://example.com/?UTM_Source=google')
-            ).toEqual([{ name: 'utm_source', value: 'google' }]);
+                allowedQueryParams('https://example.com/?Ref=google')
+            ).toEqual([{ name: 'ref', value: 'google' }]);
         });
 
         it('should return nothing for a URL with no query string', () => {
@@ -92,9 +92,9 @@ describe('pageViewTracker pure helpers', () => {
         it('should drop params named after Object.prototype members', () => {
             expect(
                 allowedQueryParams(
-                    'https://example.com/?constructor=x&__proto__=y&toString=z&utm_source=google'
+                    'https://example.com/?constructor=x&__proto__=y&toString=z&ref=google'
                 )
-            ).toEqual([{ name: 'utm_source', value: 'google' }]);
+            ).toEqual([{ name: 'ref', value: 'google' }]);
         });
 
         // Removed from the default list deliberately: `code` is an OAuth
@@ -113,10 +113,56 @@ describe('pageViewTracker pure helpers', () => {
         ])('should not capture the OAuth/OIDC param %s by default', name => {
             expect(
                 allowedQueryParams(
-                    `https://example.com/callback?${name}=sensitive&utm_source=g`
+                    `https://example.com/callback?${name}=sensitive&ref=g`
                 )
-            ).toEqual([{ name: 'utm_source', value: 'g' }]);
+            ).toEqual([{ name: 'ref', value: 'g' }]);
         });
+
+        // Also removed from the default, for a different reason: these are already
+        // carried on planes built for them — click ids by IntegrationCapture as
+        // per-network custom flags, campaign data by the reserved `$utm_*` user
+        // attributes. As page view attributes they were a copy nothing read.
+        it.each([
+            'utm_source',
+            'utm_medium',
+            'utm_campaign',
+            'utm_term',
+            'utm_content',
+            'utm_id',
+            'gclid',
+            'gbraid',
+            'wbraid',
+            'fbclid',
+            'msclkid',
+            'ttclid',
+            'twclid',
+            'li_fat_id',
+            'dclid',
+        ])('should not capture the attribution param %s by default', name => {
+            expect(
+                allowedQueryParams(
+                    `https://example.com/landing?${name}=abc&ref=g`
+                )
+            ).toEqual([{ name: 'ref', value: 'g' }]);
+        });
+
+        // A customer who does want one as a page view attribute configures it, through
+        // the same path a real config takes. Nothing else pins this: while these were
+        // built-ins, parseQueryParamAllowlist dropped a configured copy as a duplicate.
+        it.each(['utm_source', 'gclid'])(
+            'should capture the attribution param %s once configured',
+            name => {
+                const { allowed } = parseQueryParamAllowlist(name);
+
+                expect(allowed).toEqual([name]);
+                expect(
+                    allowedQueryParams(
+                        `https://example.com/landing?${name}=abc`,
+                        allowed
+                    )
+                ).toEqual([{ name, value: 'abc' }]);
+            }
+        );
 
         // The removal is a change of DEFAULT, not of capability. This is what makes
         // it a safe change rather than a regression.
@@ -152,11 +198,11 @@ describe('pageViewTracker pure helpers', () => {
         it('should capture a configured custom param', () => {
             expect(
                 allowedQueryParams(
-                    'https://example.com/?promo_code=SAVE20&utm_source=google',
+                    'https://example.com/?promo_code=SAVE20&ref=google',
                     ['promo_code']
                 )
             ).toEqual([
-                { name: 'utm_source', value: 'google' },
+                { name: 'ref', value: 'google' },
                 { name: 'promo_code', value: 'SAVE20' },
             ]);
         });
@@ -179,11 +225,10 @@ describe('pageViewTracker pure helpers', () => {
             'should capture nothing for a configured extra named %s',
             name => {
                 expect(
-                    allowedQueryParams(
-                        'https://example.com/?utm_source=google',
-                        [name]
-                    )
-                ).toEqual([{ name: 'utm_source', value: 'google' }]);
+                    allowedQueryParams('https://example.com/?ref=google', [
+                        name,
+                    ])
+                ).toEqual([{ name: 'ref', value: 'google' }]);
             }
         );
 
@@ -203,10 +248,10 @@ describe('pageViewTracker pure helpers', () => {
 
             expect(
                 allowedQueryParams(
-                    `https://example.com/?blob=${tooLong}&utm_source=g`,
+                    `https://example.com/?blob=${tooLong}&ref=g`,
                     ['blob']
                 )
-            ).toEqual([{ name: 'utm_source', value: 'g' }]);
+            ).toEqual([{ name: 'ref', value: 'g' }]);
         });
 
         it('should keep a custom param whose value is exactly at the cap', () => {
@@ -218,13 +263,13 @@ describe('pageViewTracker pure helpers', () => {
         });
 
         // Built-in behaviour is deliberately untouched by the cap, so nobody can
-        // lose a long utm_content on upgrade.
+        // lose a long search term on upgrade.
         it('should keep a built-in param whose value exceeds the custom cap', () => {
             const tooLong = 'x'.repeat(MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH + 1);
 
             expect(
-                allowedQueryParams(`https://example.com/?utm_content=${tooLong}`)
-            ).toEqual([{ name: 'utm_content', value: tooLong }]);
+                allowedQueryParams(`https://example.com/?search=${tooLong}`)
+            ).toEqual([{ name: 'search', value: tooLong }]);
         });
 
         it('should keep every param on the allowlist', () => {
@@ -266,8 +311,8 @@ describe('pageViewTracker pure helpers', () => {
 
         it('should drop a duplicate of a built-in without rejecting it', () => {
             // Asking for something you already have is not an error.
-            expect(allowed('utm_source, promo_code')).toEqual(['promo_code']);
-            expect(rejectedPositions('utm_source')).toEqual([]);
+            expect(allowed('ref, promo_code')).toEqual(['promo_code']);
+            expect(rejectedPositions('ref')).toEqual([]);
         });
 
         it('should drop a repeat of itself', () => {
@@ -389,7 +434,7 @@ describe('pageViewTracker pure helpers', () => {
             );
             const withDuplicates = names
                 .concat(names)
-                .concat(['utm_source', '', 'last_one'])
+                .concat(['ref', '', 'last_one'])
                 .join(',');
 
             expect(allowed(withDuplicates)).toEqual(names);
@@ -438,9 +483,7 @@ describe('pageViewTracker pure helpers', () => {
         });
 
         it('should not duplicate an extra that is already built in', () => {
-            expect(effectiveAllowlist(['utm_source'])).toEqual(
-                ALLOWED_QUERY_PARAMS
-            );
+            expect(effectiveAllowlist(['ref'])).toEqual(ALLOWED_QUERY_PARAMS);
         });
     });
 
@@ -513,7 +556,7 @@ describe('pageViewTracker pure helpers', () => {
         // and pass even if the whole union were reordered, since both sides move
         // together.
         const keyFor = (extras?: string[]): string => {
-            const href = 'https://x.com/p?utm_source=google&gclid=abc';
+            const href = 'https://x.com/p?page=2&ref=google';
 
             return pageKey({
                 path: new URL(href).pathname,
@@ -522,12 +565,12 @@ describe('pageViewTracker pure helpers', () => {
         };
 
         it('should be this exact key with no custom params configured', () => {
-            expect(keyFor()).toBe('/p?utm_source=google&gclid=abc');
+            expect(keyFor()).toBe('/p?page=2&ref=google');
         });
 
         it('should be the same key once custom params are configured', () => {
             expect(keyFor(['promo_code', 'affiliate_id'])).toBe(
-                '/p?utm_source=google&gclid=abc'
+                '/p?page=2&ref=google'
             );
         });
 
@@ -616,8 +659,8 @@ describe('pageViewTracker pure helpers', () => {
                 title: 'Cart',
                 path: '/cart',
                 params: [
-                    { name: 'utm_source', value: 'google' },
-                    { name: 'gclid', value: 'Cj0KC' },
+                    { name: 'page', value: '2' },
+                    { name: 'ref', value: 'google' },
                 ],
             });
 
@@ -625,8 +668,8 @@ describe('pageViewTracker pure helpers', () => {
                 hostname: 'example.com',
                 title: 'Cart',
                 path: '/cart',
-                utm_source: 'google',
-                gclid: 'Cj0KC',
+                page: '2',
+                ref: 'google',
             });
         });
 
@@ -1318,7 +1361,7 @@ describe('PageViewTracker', () => {
             window.history.pushState(
                 {},
                 '',
-                '/promo?utm_source=google&utm_medium=cpc&gclid=Cj0KC&session_token=secret#top'
+                '/promo?page=2&q=boots&ref=google&session_token=secret#top'
             );
             jest.runAllTimers();
 
@@ -1326,9 +1369,9 @@ describe('PageViewTracker', () => {
                 hostname: 'localhost',
                 title: 'Landing',
                 path: '/promo',
-                utm_source: 'google',
-                utm_medium: 'cpc',
-                gclid: 'Cj0KC',
+                page: '2',
+                q: 'boots',
+                ref: 'google',
             });
         });
 
@@ -1340,13 +1383,13 @@ describe('PageViewTracker', () => {
             const tracker = createTracker();
             tracker.init();
 
-            window.history.pushState({}, '', '/b?utm_source=first');
-            window.history.pushState({}, '', '/c?utm_source=second');
+            window.history.pushState({}, '', '/b?ref=first');
+            window.history.pushState({}, '', '/c?ref=second');
 
             jest.runAllTimers();
 
             expect(
-                logEvent.mock.calls.map(([event]) => event.data.utm_source)
+                logEvent.mock.calls.map(([event]) => event.data.ref)
             ).toEqual(['first', 'second']);
         });
 

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -80,6 +80,18 @@ describe('pageViewTracker pure helpers', () => {
             expect(allowedQueryParams('')).toEqual({});
         });
 
+        // A URL is free to carry a param named after an Object.prototype member.
+        // It is not on the allowlist, so it is dropped like any other unlisted
+        // param — this asserts the drop, not the own-property guard in
+        // queryStringParser, which only bites when the KEY LIST names such a member.
+        it('should drop params named after Object.prototype members', () => {
+            expect(
+                allowedQueryParams(
+                    'https://example.com/?constructor=x&__proto__=y&toString=z&utm_source=google'
+                )
+            ).toEqual({ utm_source: 'google' });
+        });
+
         it('should keep every param on the allowlist', () => {
             const query = ALLOWED_QUERY_PARAMS.map(
                 name => `${name}=v-${name}`

--- a/test/jest/pageViewTracker.spec.ts
+++ b/test/jest/pageViewTracker.spec.ts
@@ -10,7 +10,7 @@ import {
     MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH,
     MAX_CUSTOM_QUERY_PARAMS,
     pageKey,
-    parseQueryParamAllowlist,
+    parseQueryParamConfig,
     PageViewTracker,
     patchHistory,
     resetPageViewTracking,
@@ -148,17 +148,17 @@ describe('pageViewTracker pure helpers', () => {
 
         // A customer who does want one as a page view attribute configures it, through
         // the same path a real config takes. Nothing else pins this: while these were
-        // built-ins, parseQueryParamAllowlist dropped a configured copy as a duplicate.
+        // built-ins, parseQueryParamConfig dropped a configured copy as a duplicate.
         it.each(['utm_source', 'gclid'])(
             'should capture the attribution param %s once configured',
             name => {
-                const { allowed } = parseQueryParamAllowlist(name);
+                const config = parseQueryParamConfig(name);
 
-                expect(allowed).toEqual([name]);
+                expect(config.added).toEqual([name]);
                 expect(
                     allowedQueryParams(
                         `https://example.com/landing?${name}=abc`,
-                        allowed
+                        config
                     )
                 ).toEqual([{ name, value: 'abc' }]);
             }
@@ -168,9 +168,9 @@ describe('pageViewTracker pure helpers', () => {
         // it a safe change rather than a regression.
         it('should still capture an OAuth param when a customer configures it', () => {
             expect(
-                allowedQueryParams('https://example.com/callback?code=abc123', [
-                    'code',
-                ])
+                allowedQueryParams('https://example.com/callback?code=abc123', {
+                    added: ['code'],
+                })
             ).toEqual([{ name: 'code', value: 'abc123' }]);
         });
 
@@ -179,18 +179,18 @@ describe('pageViewTracker pure helpers', () => {
         // anything downstream sees it.
         //
         // This assertion is the one that matters for this PR. While `code` was a
-        // built-in, parseQueryParamAllowlist dropped it as a duplicate — so a
+        // built-in, parseQueryParamConfig dropped it as a duplicate — so a
         // customer typing `code` into Advanced Settings would have got an empty list
         // and the escape hatch would have silently done nothing. Removing it from the
         // defaults is precisely what makes that work, and nothing else pins it.
         it('should accept a configured OAuth param through the string config path', () => {
-            const { allowed } = parseQueryParamAllowlist('code');
+            const config = parseQueryParamConfig('code');
 
-            expect(allowed).toEqual(['code']);
+            expect(config.added).toEqual(['code']);
             expect(
                 allowedQueryParams(
                     'https://example.com/callback?code=abc123',
-                    allowed
+                    config
                 )
             ).toEqual([{ name: 'code', value: 'abc123' }]);
         });
@@ -199,7 +199,7 @@ describe('pageViewTracker pure helpers', () => {
             expect(
                 allowedQueryParams(
                     'https://example.com/?promo_code=SAVE20&ref=google',
-                    ['promo_code']
+                    { added: ['promo_code'] }
                 )
             ).toEqual([
                 { name: 'ref', value: 'google' },
@@ -211,7 +211,7 @@ describe('pageViewTracker pure helpers', () => {
             expect(
                 allowedQueryParams(
                     'https://example.com/?promo_code=x&email=a@b.com',
-                    ['promo_code']
+                    { added: ['promo_code'] }
                 )
             ).toEqual([{ name: 'promo_code', value: 'x' }]);
         });
@@ -219,23 +219,23 @@ describe('pageViewTracker pure helpers', () => {
         // This is the regression the hardening PR could not test: with a hardcoded
         // allowlist, `in` and hasOwnProperty are indistinguishable because no
         // built-in names a prototype member. A configured list makes it reachable.
-        // parseQueryParamAllowlist rejects these names, so reaching allowedQueryParams
+        // parseQueryParamConfig rejects these names, so reaching allowedQueryParams
         // with them means someone bypassed that — and it must still be inert.
         it.each(['constructor', '__proto__', 'toString', 'valueOf'])(
             'should capture nothing for a configured extra named %s',
             name => {
                 expect(
-                    allowedQueryParams('https://example.com/?ref=google', [
-                        name,
-                    ])
+                    allowedQueryParams('https://example.com/?ref=google', {
+                        added: [name],
+                    })
                 ).toEqual([{ name: 'ref', value: 'google' }]);
             }
         );
 
         it('should not pollute Object.prototype via a configured extra', () => {
-            allowedQueryParams('https://example.com/?__proto__=polluted', [
-                '__proto__',
-            ]);
+            allowedQueryParams('https://example.com/?__proto__=polluted', {
+                added: ['__proto__'],
+            });
 
             expect(({} as Record<string, unknown>).polluted).toBeUndefined();
         });
@@ -249,7 +249,7 @@ describe('pageViewTracker pure helpers', () => {
             expect(
                 allowedQueryParams(
                     `https://example.com/?blob=${tooLong}&ref=g`,
-                    ['blob']
+                    { added: ['blob'] }
                 )
             ).toEqual([{ name: 'ref', value: 'g' }]);
         });
@@ -258,7 +258,9 @@ describe('pageViewTracker pure helpers', () => {
             const exact = 'x'.repeat(MAX_CUSTOM_QUERY_PARAM_VALUE_LENGTH);
 
             expect(
-                allowedQueryParams(`https://example.com/?blob=${exact}`, ['blob'])
+                allowedQueryParams(`https://example.com/?blob=${exact}`, {
+                    added: ['blob'],
+                })
             ).toEqual([{ name: 'blob', value: exact }]);
         });
 
@@ -283,13 +285,15 @@ describe('pageViewTracker pure helpers', () => {
         });
     });
 
-    describe('#parseQueryParamAllowlist', () => {
+    describe('#parseQueryParamConfig', () => {
         const allowed = (input: string | string[]): string[] =>
-            parseQueryParamAllowlist(input).allowed;
+            parseQueryParamConfig(input).added;
+        const excluded = (input: string | string[]): string[] =>
+            parseQueryParamConfig(input).excluded;
         const rejectedPositions = (input: string | string[]): number[] =>
-            parseQueryParamAllowlist(input).rejectedPositions;
+            parseQueryParamConfig(input).rejectedPositions;
         const overLimit = (input: string | string[]): number =>
-            parseQueryParamAllowlist(input).overLimit;
+            parseQueryParamConfig(input).overLimit;
 
         it('should split, trim and lowercase a comma-separated string', () => {
             expect(allowed(' Promo_Code , AFFILIATE_ID ')).toEqual([
@@ -324,12 +328,54 @@ describe('pageViewTracker pure helpers', () => {
             ['an equals sign', 'a=b'],
             ['an ampersand', 'a&b'],
             ['a percent', 'a%20b'],
-            ['a leading hyphen', '-lead'],
             ['a leading dot', '.lead'],
             ['a non-ASCII name', 'émail'],
+            // `-` prefixes an exclusion, so what follows it still has to be a legal
+            // name: a bare or doubled hyphen leaves '' and '-x', which are not.
+            ['a bare hyphen', '-'],
+            ['a doubled hyphen', '--lead'],
         ])('should reject %s', (_label, name) => {
             expect(allowed(name)).toEqual([]);
+            expect(excluded(name)).toEqual([]);
             expect(rejectedPositions(name)).toEqual([1]);
+        });
+
+        it('should read a `-` prefix as an exclusion rather than an addition', () => {
+            expect(excluded('-ref')).toEqual(['ref']);
+            expect(allowed('-ref')).toEqual([]);
+            expect(rejectedPositions('-ref')).toEqual([]);
+        });
+
+        it('should split additions and exclusions out of one field', () => {
+            expect(allowed('promo_code, -ref, -page')).toEqual(['promo_code']);
+            expect(excluded('promo_code, -ref, -page')).toEqual(['ref', 'page']);
+        });
+
+        it('should drop a repeated exclusion', () => {
+            expect(excluded('-ref, -REF')).toEqual(['ref']);
+        });
+
+        // An exclusion naming something that is not a default is a no-op, not an
+        // error: rejecting it would turn every stored `-thatparam` into a warning the
+        // next time ALLOWED_QUERY_PARAMS changes underneath a config. The dashboard is
+        // where a customer gets told their exclusion matches nothing.
+        it('should accept an exclusion that matches no default', () => {
+            expect(excluded('-not_a_default')).toEqual(['not_a_default']);
+            expect(rejectedPositions('-not_a_default')).toEqual([]);
+        });
+
+        // Exclusions are not capped: they only ever shrink the list, so they cannot
+        // be the reason an event runs out of attribute headroom.
+        it('should not count exclusions against the addition cap', () => {
+            const exclusions = Array.from(
+                { length: MAX_CUSTOM_QUERY_PARAMS + 5 },
+                (_unused, i) => `-p${i}`
+            ).join(',');
+
+            expect(excluded(exclusions)).toHaveLength(
+                MAX_CUSTOM_QUERY_PARAMS + 5
+            );
+            expect(overLimit(exclusions)).toBe(0);
         });
 
         // Positions are 1-based and count every comma-separated slot, so a reported
@@ -351,11 +397,10 @@ describe('pageViewTracker pure helpers', () => {
             'password=hunter2',
             'token.hunter2 x',
             'user.email.hunter2@x',
-            '-secret-value-abcdef',
             '.hunter2',
         ])('should report only a position for %p', entry => {
-            const { allowed: names, rejectedPositions: positions } =
-                parseQueryParamAllowlist(entry);
+            const { added: names, rejectedPositions: positions } =
+                parseQueryParamConfig(entry);
 
             expect(names).toEqual([]);
             expect(positions).toEqual([1]);
@@ -446,14 +491,14 @@ describe('pageViewTracker pure helpers', () => {
     describe('#effectiveAllowlist', () => {
         it('should be the built-ins alone when nothing is configured', () => {
             expect(effectiveAllowlist()).toEqual(ALLOWED_QUERY_PARAMS);
-            expect(effectiveAllowlist([])).toEqual(ALLOWED_QUERY_PARAMS);
+            expect(effectiveAllowlist({})).toEqual(ALLOWED_QUERY_PARAMS);
         });
 
         // The built-in prefix is what keeps existing dedup keys byte-identical for
         // pages that use no custom params. Reordering here would fire one spurious
         // page view per page on the first navigation after a customer opts in.
         it('should keep the built-ins first, in their existing order', () => {
-            const list = effectiveAllowlist(['promo_code']);
+            const list = effectiveAllowlist({ added: ['promo_code'] });
 
             expect(list.slice(0, ALLOWED_QUERY_PARAMS.length)).toEqual(
                 ALLOWED_QUERY_PARAMS
@@ -467,8 +512,10 @@ describe('pageViewTracker pure helpers', () => {
         // Settings field changes the key of every page carrying both, and each of
         // those fires one spurious page view.
         it('should append extras sorted, whatever order they were given in', () => {
-            const suffix = (extras: string[]): string[] =>
-                effectiveAllowlist(extras).slice(ALLOWED_QUERY_PARAMS.length);
+            const suffix = (added: string[]): string[] =>
+                effectiveAllowlist({ added }).slice(
+                    ALLOWED_QUERY_PARAMS.length
+                );
 
             expect(suffix(['zeta', 'alpha'])).toEqual(['alpha', 'zeta']);
             expect(suffix(['alpha', 'zeta'])).toEqual(['alpha', 'zeta']);
@@ -476,14 +523,62 @@ describe('pageViewTracker pure helpers', () => {
 
         // getFeatureFlag returns null when the flag is absent, and a default
         // parameter only fires for undefined.
-        it.each([undefined, null])('should tolerate %p', extras => {
-            expect(effectiveAllowlist(extras as string[])).toEqual(
+        it.each([undefined, null])('should tolerate %p', config => {
+            expect(effectiveAllowlist(config)).toEqual(ALLOWED_QUERY_PARAMS);
+        });
+
+        it('should not duplicate an extra that is already built in', () => {
+            expect(effectiveAllowlist({ added: ['ref'] })).toEqual(
                 ALLOWED_QUERY_PARAMS
             );
         });
 
-        it('should not duplicate an extra that is already built in', () => {
-            expect(effectiveAllowlist(['ref'])).toEqual(ALLOWED_QUERY_PARAMS);
+        it('should take an excluded built-in out of the list', () => {
+            expect(effectiveAllowlist({ excluded: ['ref'] })).toEqual(
+                ALLOWED_QUERY_PARAMS.filter(name => name !== 'ref')
+            );
+        });
+
+        // Removal leaves the survivors in their existing relative order, so a page
+        // that never carried the excluded param keys exactly as it did before.
+        it('should keep the remaining built-ins in order after an exclusion', () => {
+            expect(effectiveAllowlist({ excluded: ['q', 'offset'] })).toEqual(
+                ALLOWED_QUERY_PARAMS.filter(
+                    name => name !== 'q' && name !== 'offset'
+                )
+            );
+        });
+
+        it('should let every built-in be excluded', () => {
+            expect(
+                effectiveAllowlist({ excluded: ALLOWED_QUERY_PARAMS })
+            ).toEqual([]);
+        });
+
+        it('should exclude a customer addition too', () => {
+            expect(
+                effectiveAllowlist({
+                    added: ['promo_code', 'variant'],
+                    excluded: ['promo_code'],
+                })
+            ).toEqual(ALLOWED_QUERY_PARAMS.concat(['variant']));
+        });
+
+        // Exclusion wins whatever the order in the field, so the outcome cannot
+        // depend on which side of the comma a customer wrote first.
+        it('should let an exclusion beat an addition of the same name', () => {
+            expect(
+                effectiveAllowlist(parseQueryParamConfig('-ref, ref'))
+            ).toEqual(effectiveAllowlist(parseQueryParamConfig('ref, -ref')));
+            expect(
+                effectiveAllowlist(parseQueryParamConfig('ref, -ref'))
+            ).not.toContain('ref');
+        });
+
+        it('should ignore an exclusion that names nothing on the list', () => {
+            expect(effectiveAllowlist({ excluded: ['nope'] })).toEqual(
+                ALLOWED_QUERY_PARAMS
+            );
         });
     });
 
@@ -555,12 +650,12 @@ describe('pageViewTracker pure helpers', () => {
         // two calls to the current allowedQueryParams would compare new against new
         // and pass even if the whole union were reordered, since both sides move
         // together.
-        const keyFor = (extras?: string[]): string => {
+        const keyFor = (added?: string[]): string => {
             const href = 'https://x.com/p?page=2&ref=google';
 
             return pageKey({
                 path: new URL(href).pathname,
-                params: allowedQueryParams(href, extras),
+                params: allowedQueryParams(href, added && { added }),
             });
         };
 
@@ -572,6 +667,18 @@ describe('pageViewTracker pure helpers', () => {
             expect(keyFor(['promo_code', 'affiliate_id'])).toBe(
                 '/p?page=2&ref=google'
             );
+        });
+
+        // An exclusion is the one config change that DOES move an existing key, which
+        // is the point of the warning the tracker logs for it: drop `page` and the
+        // pagination views of a list all collapse onto one key.
+        it('should drop an excluded param out of the key', () => {
+            const params = allowedQueryParams(
+                'https://x.com/p?page=2&ref=google',
+                { excluded: ['page'] }
+            );
+
+            expect(pageKey({ path: '/p', params })).toBe('/p?ref=google');
         });
 
         // The same collision reached through the tracker rather than by hand:
@@ -1084,7 +1191,7 @@ describe('PageViewTracker', () => {
 
     describe('configured additional query params', () => {
         // Mirrors production: the raw comma-separated string is parsed ONCE, by
-        // processFlags, and the flag holds the whole IQueryParamAllowlist. The
+        // processFlags, and the flag holds the whole IQueryParamConfig. The
         // tracker never sees the raw string, so neither does this test.
         //
         // That distinction is load-bearing rather than pedantic. These tests used to
@@ -1092,7 +1199,7 @@ describe('PageViewTracker', () => {
         // and made the rejection warning look alive when in production it received
         // an already-clean list and could never fire.
         const initWith = (configured: string | undefined): PageViewTracker => {
-            const parsed = parseQueryParamAllowlist(configured);
+            const parsed = parseQueryParamConfig(configured);
 
             getFeatureFlag.mockImplementation((flag: string) =>
                 flag === Constants.FeatureFlags.AutoLogPageViewQueryParams
@@ -1178,6 +1285,55 @@ describe('PageViewTracker', () => {
         it('should not warn when every configured name is valid', () => {
             navigateNatively('/');
             initWith('promo_code, affiliate_id');
+
+            expect(warning).not.toHaveBeenCalled();
+        });
+
+        it('should stop capturing an excluded built-in', () => {
+            navigateNatively('/');
+            initWith('-ref');
+
+            window.history.pushState({}, '', '/promo?ref=google&page=2');
+            jest.runAllTimers();
+
+            const { data } = logEvent.mock.calls[0][0];
+            expect(data.page).toBe('2');
+            expect(data).not.toHaveProperty('ref');
+        });
+
+        // An exclusion merges pages that used to be distinct, so it is warned about:
+        // it is the setting most likely to be blamed for missing page views by
+        // someone who does not know it is set.
+        it('should warn about the exclusions it applied', () => {
+            navigateNatively('/');
+            initWith('-ref, -page');
+
+            expect(warning).toHaveBeenCalledTimes(1);
+            expect(warning.mock.calls[0][0]).toContain(
+                'not capturing the excluded query parameters ref, page'
+            );
+        });
+
+        // `-` reaches past the validator: `-secret-abc` is a legal name behind the
+        // prefix, so it arrives as an exclusion rather than a rejection. It matches no
+        // built-in, so it must be silently inert — naming it would put the customer's
+        // own text in a log, which is exactly what the positions-not-names rule for
+        // rejections exists to prevent.
+        it('should never name an exclusion that matched no built-in', () => {
+            navigateNatively('/');
+            initWith('-ref, -secret-value-abcdef');
+
+            expect(warning).toHaveBeenCalledTimes(1);
+            const [message] = warning.mock.calls[0];
+
+            expect(message).toContain('ref');
+            expect(message).not.toContain('secret');
+            expect(message).not.toContain('abcdef');
+        });
+
+        it('should not warn about an exclusion that matched no built-in at all', () => {
+            navigateNatively('/');
+            initWith('-not_a_default');
 
             expect(warning).not.toHaveBeenCalled();
         });

--- a/test/jest/release-scripts.spec.ts
+++ b/test/jest/release-scripts.spec.ts
@@ -76,6 +76,76 @@ describe('kit release scripts', () => {
         ]);
     });
 
+    it('derives every runtime kit version from its package manifest', () => {
+        const sourceFiles: string[] = [];
+        const excludedDirectories = new Set(['dist', 'node_modules', 'test']);
+        const visitSourceDirectory = (directory: string): void => {
+            for (const entry of fs.readdirSync(directory, {
+                withFileTypes: true,
+            })) {
+                if (excludedDirectories.has(entry.name)) {
+                    continue;
+                }
+
+                const entryPath = path.join(directory, entry.name);
+                if (entry.isDirectory()) {
+                    visitSourceDirectory(entryPath);
+                } else if (/\.(?:js|ts)$/.test(entry.name)) {
+                    sourceFiles.push(entryPath);
+                }
+            }
+        };
+
+        visitSourceDirectory(path.join(__dirname, '../../kits'));
+
+        const versionSurfacePattern =
+            /(?:getVersion\s*:\s*function|const kitVersion\s*=)/;
+        const runtimeVersionFiles = sourceFiles
+            .filter((filePath) =>
+                versionSurfacePattern.test(fs.readFileSync(filePath, 'utf8'))
+            )
+            .map((filePath) =>
+                path.relative(path.join(__dirname, '../..'), filePath)
+            )
+            .sort();
+        const expectedRuntimeVersionFiles = [
+            'kits/braze/braze-3/src/BrazeKit-dev.js',
+            'kits/braze/braze-4/src/BrazeKit-dev.js',
+            'kits/braze/braze-5/src/BrazeKit-dev.js',
+            'kits/braze/braze-6/src/BrazeKit-dev.js',
+            'kits/rokt/src/Rokt-Kit.ts',
+        ];
+
+        expect(runtimeVersionFiles).toEqual(expectedRuntimeVersionFiles);
+
+        for (const filePath of runtimeVersionFiles) {
+            const source = fs.readFileSync(
+                path.join(__dirname, '../..', filePath),
+                'utf8'
+            );
+            expect(source).toContain('process.env.PACKAGE_VERSION');
+        }
+
+        const versionBuildConfigs = [
+            'kits/braze/braze-3/rollup.config.js',
+            'kits/braze/braze-4/rollup.config.js',
+            'kits/braze/braze-5/rollup.config.js',
+            'kits/braze/braze-6/rollup.config.js',
+            'kits/rokt/vite.config.ts',
+        ];
+        for (const configPath of versionBuildConfigs) {
+            const config = fs.readFileSync(
+                path.join(__dirname, '../..', configPath),
+                'utf8'
+            );
+            expect(config).toContain('process.env.npm_package_version');
+            expect(config).toContain('process.env.PACKAGE_VERSION');
+            if (configPath.includes('/braze/')) {
+                expect(config).toContain('if (!packageVersion)');
+            }
+        }
+    });
+
     it('terminates every serialized kit build path with a newline', () => {
         const buildPaths = loadReleaseInventory().buildPaths;
         const serializedBuildPaths = serializeBuildPaths(buildPaths);

--- a/test/jest/utils.spec.ts
+++ b/test/jest/utils.spec.ts
@@ -112,6 +112,39 @@ describe('Utils', () => {
 
                 expect(queryStringParser(url)).toEqual(expectedResult);
             });
+
+            it('does not resolve a key naming an inherited prototype member', () => {
+                expect(
+                    queryStringParser(url, ['foo', 'constructor', '__proto__'])
+                ).toEqual({ foo: 'bar' });
+            });
+
+            // Held inert by the lookup being lowercased (`toString` -> `tostring`),
+            // not by the own-property guard. Pinned so that making the lookup
+            // case-sensitive fails here rather than silently.
+            it('does not resolve mixed-case prototype member names either', () => {
+                expect(
+                    queryStringParser(url, ['foo', 'toString', 'valueOf', 'hasOwnProperty'])
+                ).toEqual({ foo: 'bar' });
+            });
+
+            it('still resolves a real query param sharing a prototype member name', () => {
+                expect(
+                    queryStringParser(
+                        'https://www.example.com?constructor=legitimate',
+                        ['constructor']
+                    )
+                ).toEqual({ constructor: 'legitimate' });
+            });
+
+            it('returns a plain object so callers can call hasOwnProperty on it', () => {
+                // integrationCapture#applyProcessors calls .hasOwnProperty() on this
+                // return value, so it must keep its prototype.
+                const result = queryStringParser(url, ['foo']);
+
+                expect(() => result.hasOwnProperty('foo')).not.toThrow();
+                expect(result.hasOwnProperty('foo')).toBe(true);
+            });
         });
 
         describe('without URLSearchParams', () => {
@@ -193,6 +226,29 @@ describe('Utils', () => {
                 };
 
                 expect(queryStringParser(url, keys)).toEqual(expectedResult);
+            });
+
+            // The fallback builds its param map from the URL, so a param NAMED
+            // after a prototype method gives that map an own property shadowing
+            // the method with a string. Calling it on the next iteration threw
+            // `TypeError: params.hasOwnProperty is not a function` out of
+            // queryStringParser — and this needs no configuration, just a URL.
+            it('survives a query param named after a prototype method', () => {
+                expect(
+                    queryStringParser(
+                        'https://www.example.com?hasOwnProperty=1&foo=bar',
+                        ['foo']
+                    )
+                ).toEqual({ foo: 'bar' });
+            });
+
+            it('still returns a param named after a prototype method when asked for it', () => {
+                expect(
+                    queryStringParser(
+                        'https://www.example.com?hasOwnProperty=1&foo=bar',
+                        ['hasOwnProperty']
+                    )
+                ).toEqual({ hasOwnProperty: '1' });
             });
         });
     });

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1402,7 +1402,11 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'none',
                 astBackgroundEvents: true,
                 autoLogPageView: false,
-                autoLogPageViewQueryParams: [],
+                autoLogPageViewQueryParams: {
+                    allowed: [],
+                    rejectedPositions: [],
+                    overLimit: 0,
+                },
             };
 
             expect(store.SDKConfig.flags).to.deep.equal(expectedResult);
@@ -1625,7 +1629,11 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'none',
                 astBackgroundEvents: false,
                 autoLogPageView: false,
-                autoLogPageViewQueryParams: [],
+                autoLogPageViewQueryParams: {
+                    allowed: [],
+                    rejectedPositions: [],
+                    overLimit: 0,
+                },
             };
 
             expect(flags).to.deep.equal(expectedResult);
@@ -1665,7 +1673,15 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'all',
                 astBackgroundEvents: true,
                 autoLogPageView: true,
-                autoLogPageViewQueryParams: ['promo_code'],
+                // Both halves are kept. Storing only `allowed` here is what left
+                // the tracker's rejection warning unable to ever fire: it re-parsed
+                // a list that had already had its rejects removed. `bad name` is
+                // the 4th comma-separated entry, and positions are 1-based.
+                autoLogPageViewQueryParams: {
+                    allowed: ['promo_code'],
+                    rejectedPositions: [4],
+                    overLimit: 0,
+                },
             };
 
             expect(flags).to.deep.equal(expectedResult);

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1402,6 +1402,7 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'none',
                 astBackgroundEvents: true,
                 autoLogPageView: false,
+                autoLogPageViewQueryParams: [],
             };
 
             expect(store.SDKConfig.flags).to.deep.equal(expectedResult);
@@ -1624,6 +1625,7 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'none',
                 astBackgroundEvents: false,
                 autoLogPageView: false,
+                autoLogPageViewQueryParams: [],
             };
 
             expect(flags).to.deep.equal(expectedResult);
@@ -1641,6 +1643,11 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'all',
                 astBackgroundEvents: 'True',
                 autoLogPageView: 'True',
+                // The server sends a comma-separated string; processFlags parses,
+                // validates and dedupes it into a list. `utm_source` is already
+                // built in and `bad name` is not a legal param name, so both drop.
+                autoLogPageViewQueryParams:
+                    'promo_code, PROMO_CODE, utm_source, bad name',
             };
 
             const flags = processFlags(
@@ -1658,6 +1665,7 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'all',
                 astBackgroundEvents: true,
                 autoLogPageView: true,
+                autoLogPageViewQueryParams: ['promo_code'],
             };
 
             expect(flags).to.deep.equal(expectedResult);

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1403,7 +1403,8 @@ describe('Store', () => {
                 astBackgroundEvents: true,
                 autoLogPageView: false,
                 autoLogPageViewQueryParams: {
-                    allowed: [],
+                    added: [],
+                    excluded: [],
                     rejectedPositions: [],
                     overLimit: 0,
                 },
@@ -1630,7 +1631,8 @@ describe('Store', () => {
                 astBackgroundEvents: false,
                 autoLogPageView: false,
                 autoLogPageViewQueryParams: {
-                    allowed: [],
+                    added: [],
+                    excluded: [],
                     rejectedPositions: [],
                     overLimit: 0,
                 },
@@ -1651,11 +1653,12 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'all',
                 astBackgroundEvents: 'True',
                 autoLogPageView: 'True',
-                // The server sends a comma-separated string; processFlags parses,
-                // validates and dedupes it into a list. `ref` is already built in
-                // and `bad name` is not a legal param name, so both drop.
+                // The server sends one comma-separated string carrying both additions
+                // and `-` exclusions; processFlags splits, validates and dedupes it.
+                // `ref` is already built in and `bad name` is not a legal param name,
+                // so both drop.
                 autoLogPageViewQueryParams:
-                    'promo_code, PROMO_CODE, ref, bad name',
+                    'promo_code, PROMO_CODE, ref, bad name, -page',
             };
 
             const flags = processFlags(
@@ -1673,12 +1676,13 @@ describe('Store', () => {
                 'captureIntegrationSpecificIds.V2': 'all',
                 astBackgroundEvents: true,
                 autoLogPageView: true,
-                // Both halves are kept. Storing only `allowed` here is what left
-                // the tracker's rejection warning unable to ever fire: it re-parsed
-                // a list that had already had its rejects removed. `bad name` is
-                // the 4th comma-separated entry, and positions are 1-based.
+                // Every part is kept. Storing only `added` here is what left the
+                // tracker's rejection warning unable to ever fire: it re-parsed a list
+                // that had already had its rejects removed. `bad name` is the 4th
+                // comma-separated entry, and positions are 1-based.
                 autoLogPageViewQueryParams: {
-                    allowed: ['promo_code'],
+                    added: ['promo_code'],
+                    excluded: ['page'],
                     rejectedPositions: [4],
                     overLimit: 0,
                 },

--- a/test/src/tests-store.ts
+++ b/test/src/tests-store.ts
@@ -1652,10 +1652,10 @@ describe('Store', () => {
                 astBackgroundEvents: 'True',
                 autoLogPageView: 'True',
                 // The server sends a comma-separated string; processFlags parses,
-                // validates and dedupes it into a list. `utm_source` is already
-                // built in and `bad name` is not a legal param name, so both drop.
+                // validates and dedupes it into a list. `ref` is already built in
+                // and `bad name` is not a legal param name, so both drop.
                 autoLogPageViewQueryParams:
-                    'promo_code, PROMO_CODE, utm_source, bad name',
+                    'promo_code, PROMO_CODE, ref, bad name',
             };
 
             const flags = processFlags(


### PR DESCRIPTION
> **Merge last of five.** Stacked on #1375 → #1373 → #1374, so the diff shown here includes all three until they land. Nothing in it is safe before #1374, which is what makes the default list small enough for removal to be the missing half rather than a nicety.

## Summary

Advanced Settings took **additions only**, so after #1374 the nine built-in params were a floor no customer could get under. A `-` prefix in the same field now removes one:

```
-ref, promo_code        →  drops `ref`, adds `promo_code`
```

## Why one field and not two

`QUERY_PARAM_NAME` is `/^[a-z0-9_][a-z0-9_.-]{0,63}$/` — it **forbids a leading hyphen**. So before this change every `-name` entry was rejected outright, which means:

- no stored config can already mean something else by it,
- no second `SettingTemplate` id, feature flag, validator or migration is needed,
- the existing "a leading hyphen is invalid" test is the thing that proves it, and it is deliberately flipped here.

## Semantics, and why each choice is the safe one

**Exclusions apply after additions.** `-ref, ref` and `ref, -ref` both remove. The outcome cannot depend on which side of the comma a customer wrote first — pinned by a test that asserts the two orderings are equal.

**Exclusions are not capped.** `MAX_CUSTOM_QUERY_PARAMS` exists to stop the attribute count growing; exclusions only ever shrink the list, so they cannot be the reason an event runs out of headroom.

**An exclusion naming something that is not a default is a no-op, not an error.** Rejecting it would turn every stored `-thatparam` into a warning the next time `ALLOWED_QUERY_PARAMS` changes underneath a config, and SDK versions in the wild lag the dashboard's list by months.

> The dashboard is permissive here too, for the mirror-image reason: its error channel **disables Save for the whole app-config dialog**, so a stored `-name` going stale would block a customer from saving unrelated settings. The cost of both sides being permissive is real and worth a reviewer's opinion — a typo'd `-referer` does nothing, quietly, in both places.

## Two consequences worth reviewing carefully

### 1. An exclusion merges pages that used to be distinct

`pageKey` walks the effective allowlist, so removing an entry changes the key of every page that carried it. Exclude `page` and `?page=2` keys the same as `?page=3` — the second view **dedups away and never fires**.

That is the customer's call to make, but it is not a cosmetic setting, so the tracker logs it at **`warning`** rather than verbose. It is the setting most likely to be blamed for missing page views by whoever did not know it was set.

### 2. `-` reaches past the validator, and that opened a log-echo hole

This is the one thing in the PR I would most want a second pair of eyes on.

The established rule for rejected entries is **positions, never names** — a rejected entry may be something pasted into the wrong field, so `password=hunter2` must not reach `Logger.warning`. `-` weakens the validator's reach: `-secret-value-abcdef` has a perfectly legal name behind the prefix, so it no longer fails validation. It arrives as an **exclusion**, and exclusions are named in a log.

Fixed by naming only the exclusions that actually hit the default list:

```ts
const applied = excluded.filter(
    name => ALLOWED_QUERY_PARAMS.indexOf(name) !== -1
);
```

Those names are **our own constants**, so that log echoes our words, not the customer's. An exclusion matching nothing is inert and stays silent. Pinned by `should never name an exclusion that matched no built-in`, which asserts the warning contains `ref` but not `secret` or `abcdef`.

The old rejection test that used `-secret-value-abcdef` as a leaked-prefix case is **moved rather than deleted** — it now covers this path instead, because under the new syntax it is no longer a rejection at all.

## Rename: `IQueryParamAllowlist` → `IQueryParamConfig`

A type that holds exclusions is not an allowlist. Alongside it, `allowed` → `added`, so `added`/`excluded` read as the pair they are, and `parseQueryParamAllowlist` → `parseQueryParamConfig`.

Callers now pass the **whole config object** rather than reaching in for one field:

```diff
-allowedQueryParams(getHref(), (getFeatureFlag(FLAG) as IQueryParamAllowlist)?.allowed)
+allowedQueryParams(getHref(), getFeatureFlag(FLAG) as IQueryParamConfig)
```

That is smaller at both call sites, and it removes the `extras: string[]` parameter that a reviewer flagged as under-named. The helper signatures take `Partial<IQueryParamConfig>`, which is honest: `getFeatureFlag` returns `null` for an absent flag and a self-hosted `config.flags` can pass an incomplete object.

## Verification

Measured on this branch's tip:

- `jest` — **811 pass / 0 fail**, up from **795** on #1374 (+16)
- `karma` ChromeHeadless — **1089 pass / 0 fail**, 10 skipped, after a fresh `npm run build && npm run build:test-bundle`
- `tsc -p . --noEmit` clean, `eslint src/ test/src/` exit 0

New coverage, by the rule it holds:

| rule | test |
| :-- | :-- |
| `-` means exclude, not add | `should read a '-' prefix as an exclusion rather than an addition` |
| one field carries both | `should split additions and exclusions out of one field` |
| exclusion beats addition, either order | `should let an exclusion beat an addition of the same name` |
| removal preserves survivor order | `should keep the remaining built-ins in order after an exclusion` |
| exclusions are uncapped | `should not count exclusions against the addition cap` |
| unknown exclusion is inert | `should accept an exclusion that matches no default` |
| `-` / `--x` are still rejected | `should reject a bare hyphen` / `a doubled hyphen` |
| the dedup-key consequence is real | `should drop an excluded param out of the key` |
| no customer text in the log | `should never name an exclusion that matched no built-in` |
| end to end through the tracker | `should stop capturing an excluded built-in` |

## The mPServer half

mparticle-by-rokt/mPServer#44037 carries it: `validateAutoLogPageViewQueryParams` accepts a `-` prefix, `normalize()` keeps exclusions verbatim, the help text and placeholder document the syntax, and the hand-copied `BUILT_IN_QUERY_PARAMS` shrinks to the same nine names #1374 leaves.

**The two must ship together.** This PR alone is inert — the UI would refuse to save a `-name`. That PR alone is worse than inert: the SDK re-validates remote config, so a stored `-ref` would be rejected as an illegal name and reported as a position warning, and the exclusion would silently do nothing.

That PR also fixes a silent failure this one exposes: the stale 24-name `BUILT_IN_QUERY_PARAMS` *drops* names it thinks are redundant, so after #1374 a customer typing `gclid` would have had it discarded as "you already have this" when the SDK no longer captures it — no error, no attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
