### PR TITLE
fix(braze): point kit homepage URLs at main

### DIFF
--- a/kits/braze/braze-3/package.json
+++ b/kits/braze/braze-3/package.json
@@ -38,7 +38,7 @@
         "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/braze/braze-3#readme",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/braze/braze-3#readme",
     "publishConfig": {
         "access": "public"
     }

--- a/kits/braze/braze-4/package.json
+++ b/kits/braze/braze-4/package.json
@@ -40,7 +40,7 @@
         "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/braze/braze-4#readme",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/braze/braze-4#readme",
     "publishConfig": {
         "access": "public"
     }

--- a/kits/braze/braze-5/package.json
+++ b/kits/braze/braze-5/package.json
@@ -42,7 +42,7 @@
         "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/braze/braze-5#readme",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/braze/braze-5#readme",
     "publishConfig": {
         "access": "public"
     }

--- a/kits/braze/braze-6/package.json
+++ b/kits/braze/braze-6/package.json
@@ -42,7 +42,7 @@
         "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/braze/braze-6#readme",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/braze/braze-6#readme",
     "publishConfig": {
         "access": "public"
     }


### PR DESCRIPTION
## Background
- These kits live on the v3 line; the npm homepage still linked to master, which 404s.
- Braze kit tracks were first-published from `main` as `@mparticle/web-braze-kit-3` … `-6`.
- Each kit `package.json` `homepage` still used `tree/master/…`. Those paths do not exist on `master` (v2), so the GitHub link on the npm package page 404s.
- `@mparticle/web-braze-kit-3@3.0.0` is already on npm; npm will not update that version’s metadata. This PR only fixes git so later publishes (4/5/6, and a future 3.0.1) get a working link.

## What Has Changed
- Updated `homepage` in `kits/braze/braze-3` … `braze-6` `package.json` from `tree/master/` to `tree/main/`.
- No version bump, no runtime/dist changes.

## Screenshots/Video
- N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- Confirm https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/braze/braze-3#readme loads.
- Merge into **`main` only**. Do not merge into `master`.
- Merge before publishing Braze-4/5/6 so those first npm pages get the correct homepage.
- Braze-3@3.0.0 on npm keeps the old `master` link until a later `3.0.1`.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]