### PR TITLE
fix(kits): point remaining kit homepage URLs at main

### DIFF
--- a/kits/amplitude/amplitude-8/package.json
+++ b/kits/amplitude/amplitude-8/package.json
@@ -10,7 +10,7 @@
         "dist/Amplitude.esm.js",
         "dist/Amplitude.iife.js"
     ],
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/amplitude/amplitude-8#readme",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/amplitude/amplitude-8#readme",
     "repository": {
         "type": "git",
         "url": "https://github.com/mParticle/mparticle-web-sdk.git",

--- a/kits/id5/id5-1/package.json
+++ b/kits/id5/id5-1/package.json
@@ -46,7 +46,7 @@
         "access": "public"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/id5/id5-1#readme",
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/id5/id5-1#readme",
     "repository": {
         "type": "git",
         "url": "https://github.com/mParticle/mparticle-web-sdk.git",

--- a/kits/leanplum/leanplum-1/package.json
+++ b/kits/leanplum/leanplum-1/package.json
@@ -43,5 +43,5 @@
         "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/leanplum/leanplum-1#readme"
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/leanplum/leanplum-1#readme"
 }

--- a/kits/localytics/localytics-4/package.json
+++ b/kits/localytics/localytics-4/package.json
@@ -38,5 +38,5 @@
         "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/localytics/localytics-4#readme"
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/localytics/localytics-4#readme"
 }

--- a/kits/mixpanel/mixpanel-2/package.json
+++ b/kits/mixpanel/mixpanel-2/package.json
@@ -50,5 +50,5 @@
         "watchify": "^3.11.1"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/master/kits/mixpanel/mixpanel-2#readme"
+    "homepage": "https://github.com/mParticle/mparticle-web-sdk/tree/main/kits/mixpanel/mixpanel-2#readme"
 }


### PR DESCRIPTION


## Background
- Match the Braze homepage change so npm package pages link to v3 source on main, not master.

## What Has Changed
- {Describe the changes introduced by this PR}

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
