### PR TITLE
feat(rokt): add diagnostic logging for setter/selectPlacements timing

### DIFF
--- a/kits/rokt/src/Rokt-Kit.ts
+++ b/kits/rokt/src/Rokt-Kit.ts
@@ -39,6 +39,7 @@ import {
 import { isLocalStorageAvailable } from './storage';
 
 import { isObject, isString, isEmpty, isFunction, sanitizeUrl } from './utils';
+import { buildSetterDiagnosticLogEntry, buildSelectPlacementsDiagnosticLogEntry } from './diagnosticTiming';
 import {
   createLauncherAttachState,
   markLauncherAttached,
@@ -690,6 +691,10 @@ class ErrorReportingService {
 
 class LoggingService {
   private _transport: ReportingTransport;
+  // Own ReportingTransport (and thus own RateLimiter) so a burst of
+  // diagnostic timing entries can't starve the operational INFO budget
+  // that _transport shares with page-view/quota logging via log().
+  private _diagnosticTransport: ReportingTransport;
   private _loggingUrl: string;
   private _errorReportingService: { report: (e: ErrorReport) => void };
 
@@ -702,13 +707,25 @@ class LoggingService {
     rateLimiter?: RateLimiter,
   ) {
     this._transport = new ReportingTransport(config, integrationName, launcherInstanceGuid, accountId, rateLimiter);
+    this._diagnosticTransport = new ReportingTransport(config, integrationName, launcherInstanceGuid, accountId);
     this._loggingUrl = generateReportingUrl(config?.loggingUrl, config?.integrationDomain, LOGGING_ENDPOINT);
     this._errorReportingService = errorReportingService;
   }
 
   log(entry: LogEntry | null | undefined): void {
     if (!entry) return;
-    this._transport.send(
+    this._send(this._transport, entry);
+  }
+
+  // Ships at INFO severity like log(), but through a separate transport
+  // instance so it has its own rate-limit budget.
+  logDiagnostic(entry: LogEntry | null | undefined): void {
+    if (!entry) return;
+    this._send(this._diagnosticTransport, entry);
+  }
+
+  private _send(transport: ReportingTransport, entry: LogEntry): void {
+    transport.send(
       this._loggingUrl,
       WSDKErrorSeverity.INFO,
       entry.message,
@@ -1335,6 +1352,7 @@ class RoktKit implements KitInterface {
   }
 
   public setUserAttribute(key: string, value: unknown): string {
+    this.loggingService?.logDiagnostic(buildSetterDiagnosticLogEntry('setUserAttribute', [key]));
     if (!isSelectPlacementsAttributePersistenceDenied(key)) {
       this.userAttributes[key] = value;
     }
@@ -1342,12 +1360,14 @@ class RoktKit implements KitInterface {
   }
 
   public removeUserAttribute(key: string): string {
+    this.loggingService?.logDiagnostic(buildSetterDiagnosticLogEntry('removeUserAttribute', [key]));
     delete this.userAttributes[key];
     return 'Successfully removed user attribute for forwarder: ' + name;
   }
 
   private handleIdentityComplete(user: IMParticleUser, callbackName: string): string {
     this.userAttributes = removeSelectPlacementsAttributePersistenceDeniedAttributes(user.getAllUserAttributes());
+    this.loggingService?.logDiagnostic(buildSetterDiagnosticLogEntry(callbackName, Object.keys(this.userAttributes)));
     return 'Successfully called ' + callbackName + ' for forwarder: ' + name;
   }
 
@@ -1551,6 +1571,10 @@ class RoktKit implements KitInterface {
     };
 
     const selectPlacementsOptions: Record<string, unknown> = { ...options, attributes: selectPlacementsAttributes };
+
+    this.loggingService?.logDiagnostic(
+      buildSelectPlacementsDiagnosticLogEntry(Object.keys(selectPlacementsAttributes)),
+    );
 
     const selection = this.launcher!.selectPlacements(selectPlacementsOptions);
 

--- a/kits/rokt/src/Rokt-Kit.ts
+++ b/kits/rokt/src/Rokt-Kit.ts
@@ -690,13 +690,18 @@ class ErrorReportingService {
 }
 
 class LoggingService {
-  private _transport: ReportingTransport;
+  private readonly _transport: ReportingTransport;
   // Own ReportingTransport (and thus own RateLimiter) so a burst of
   // diagnostic timing entries can't starve the operational INFO budget
   // that _transport shares with page-view/quota logging via log().
-  private _diagnosticTransport: ReportingTransport;
-  private _loggingUrl: string;
-  private _errorReportingService: { report: (e: ErrorReport) => void };
+  private readonly _diagnosticTransport: ReportingTransport;
+  // Separate again from _diagnosticTransport: a burst of setter/identity
+  // calls (e.g. setUserAttributes looping per key) must not exhaust the
+  // budget a selectPlacements dispatch needs, or placement diagnostics go
+  // silent for the rest of the session.
+  private readonly _placementDiagnosticTransport: ReportingTransport;
+  private readonly _loggingUrl: string;
+  private readonly _errorReportingService: { report: (e: ErrorReport) => void };
 
   constructor(
     config: ReportingConfig,
@@ -708,6 +713,12 @@ class LoggingService {
   ) {
     this._transport = new ReportingTransport(config, integrationName, launcherInstanceGuid, accountId, rateLimiter);
     this._diagnosticTransport = new ReportingTransport(config, integrationName, launcherInstanceGuid, accountId);
+    this._placementDiagnosticTransport = new ReportingTransport(
+      config,
+      integrationName,
+      launcherInstanceGuid,
+      accountId,
+    );
     this._loggingUrl = generateReportingUrl(config?.loggingUrl, config?.integrationDomain, LOGGING_ENDPOINT);
     this._errorReportingService = errorReportingService;
   }
@@ -722,6 +733,13 @@ class LoggingService {
   logDiagnostic(entry: LogEntry | null | undefined): void {
     if (!entry) return;
     this._send(this._diagnosticTransport, entry);
+  }
+
+  // Same as logDiagnostic(), but on its own transport/budget so a burst of
+  // setter diagnostics can't starve selectPlacements dispatch diagnostics.
+  logPlacementDiagnostic(entry: LogEntry | null | undefined): void {
+    if (!entry) return;
+    this._send(this._placementDiagnosticTransport, entry);
   }
 
   private _send(transport: ReportingTransport, entry: LogEntry): void {
@@ -1572,7 +1590,7 @@ class RoktKit implements KitInterface {
 
     const selectPlacementsOptions: Record<string, unknown> = { ...options, attributes: selectPlacementsAttributes };
 
-    this.loggingService?.logDiagnostic(
+    this.loggingService?.logPlacementDiagnostic(
       buildSelectPlacementsDiagnosticLogEntry(Object.keys(selectPlacementsAttributes)),
     );
 

--- a/kits/rokt/src/Rokt-Kit.ts
+++ b/kits/rokt/src/Rokt-Kit.ts
@@ -728,15 +728,11 @@ class LoggingService {
     this._send(this._transport, entry);
   }
 
-  // Ships at INFO severity like log(), but through a separate transport
-  // instance so it has its own rate-limit budget.
   logDiagnostic(entry: LogEntry | null | undefined): void {
     if (!entry) return;
     this._send(this._diagnosticTransport, entry);
   }
 
-  // Same as logDiagnostic(), but on its own transport/budget so a burst of
-  // setter diagnostics can't starve selectPlacements dispatch diagnostics.
   logPlacementDiagnostic(entry: LogEntry | null | undefined): void {
     if (!entry) return;
     this._send(this._placementDiagnosticTransport, entry);

--- a/kits/rokt/src/diagnosticTiming.ts
+++ b/kits/rokt/src/diagnosticTiming.ts
@@ -1,0 +1,26 @@
+// Builds diagnostic log entries for attribute/identity setter calls and
+// selectPlacements dispatches. Each fires independently at the moment it
+// happens; correlating the two (timing delta, which setters preceded a given
+// placement call) is done downstream from the logged timestamps and page URL
+// that ReportingTransport already attaches to every log request. Attribute
+// names only — never values — since this ships over the network logging
+// pipeline and setter payloads can carry customer PII.
+
+export interface DiagnosticLogEntry {
+  message: string;
+  code: string;
+}
+
+export function buildSetterDiagnosticLogEntry(source: string, attributeKeys: string[]): DiagnosticLogEntry {
+  return {
+    message: `Rokt Kit: ${source} called [attributeKeys=${attributeKeys.join(',')}]`,
+    code: 'ATTRIBUTE_SETTER_CALLED',
+  };
+}
+
+export function buildSelectPlacementsDiagnosticLogEntry(placementAttributeKeys: string[]): DiagnosticLogEntry {
+  return {
+    message: `Rokt Kit: selectPlacements dispatched [placementAttributeKeys=${placementAttributeKeys.join(',')}]`,
+    code: 'SELECT_PLACEMENTS_DISPATCHED',
+  };
+}

--- a/kits/rokt/test/src/diagnosticTiming.spec.ts
+++ b/kits/rokt/test/src/diagnosticTiming.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildSetterDiagnosticLogEntry, buildSelectPlacementsDiagnosticLogEntry } from '../../src/diagnosticTiming';
+
+describe('diagnosticTiming', () => {
+  describe('buildSetterDiagnosticLogEntry', () => {
+    it('reports the source and attribute keys', () => {
+      const entry = buildSetterDiagnosticLogEntry('setUserAttribute', ['favoriteColor']);
+
+      expect(entry.code).toBe('ATTRIBUTE_SETTER_CALLED');
+      expect(entry.message).toBe('Rokt Kit: setUserAttribute called [attributeKeys=favoriteColor]');
+    });
+
+    it('joins multiple attribute keys', () => {
+      const entry = buildSetterDiagnosticLogEntry('onUserIdentified', ['email', 'firstName']);
+
+      expect(entry.message).toContain('[attributeKeys=email,firstName]');
+    });
+
+    it('never includes attribute values, only keys', () => {
+      const entry = buildSetterDiagnosticLogEntry('setUserAttribute', ['email']);
+
+      expect(entry.message).not.toContain('test@example.com');
+    });
+  });
+
+  describe('buildSelectPlacementsDiagnosticLogEntry', () => {
+    it('reports the full set of placement attribute keys', () => {
+      const entry = buildSelectPlacementsDiagnosticLogEntry(['favoriteColor', 'mpid']);
+
+      expect(entry.code).toBe('SELECT_PLACEMENTS_DISPATCHED');
+      expect(entry.message).toBe('Rokt Kit: selectPlacements dispatched [placementAttributeKeys=favoriteColor,mpid]');
+    });
+  });
+});

--- a/kits/rokt/test/src/tests.spec.ts
+++ b/kits/rokt/test/src/tests.spec.ts
@@ -943,6 +943,40 @@ describe('Rokt Forwarder', () => {
         });
       });
 
+      it('should log a diagnostic entry with the full set of placement attribute keys, independent of any setter log', async () => {
+        await (window as any).mParticle.forwarder.init(
+          {
+            accountId: '123456',
+          },
+          reportService.cb,
+          true,
+          null,
+          {},
+        );
+
+        const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+
+        (window as any).mParticle.forwarder.setUserAttribute('favoriteColor', 'blue');
+
+        await (window as any).mParticle.forwarder.selectPlacements({
+          identifier: 'test-placement',
+          attributes: { test: 'test' },
+        });
+
+        // One log for the setter call, one for the selectPlacements dispatch — no correlation between them.
+        expect(logDiagnosticSpy).toHaveBeenCalledTimes(2);
+        expect(logDiagnosticSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'Rokt Kit: setUserAttribute called [attributeKeys=favoriteColor]' }),
+        );
+        const dispatchEntry = logDiagnosticSpy.mock.calls.find(
+          (call) => call[0].code === 'SELECT_PLACEMENTS_DISPATCHED',
+        )?.[0];
+        expect(dispatchEntry.message).toContain('placementAttributeKeys=');
+        expect(dispatchEntry.message).toContain('favoriteColor');
+        expect(dispatchEntry.message).not.toContain('blue');
+        logDiagnosticSpy.mockRestore();
+      });
+
       it('should send the mParticle session id current at the time of each call', async () => {
         let currentSessionId = 'first-mp-session';
         (window as any).mParticle.sessionManager = {
@@ -3647,6 +3681,31 @@ describe('Rokt Forwarder', () => {
         'test-attribute': 'test-value',
       });
     });
+
+    it('should log a diagnostic entry with the attribute key but not its value', async () => {
+      const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+
+      (window as any).mParticle.forwarder.setUserAttribute('test-attribute', 'sensitive-value');
+
+      expect(logDiagnosticSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'ATTRIBUTE_SETTER_CALLED',
+          message: 'Rokt Kit: setUserAttribute called [attributeKeys=test-attribute]',
+        }),
+      );
+      logDiagnosticSpy.mockRestore();
+    });
+
+    it('should log a diagnostic entry even for a denylisted attribute key', async () => {
+      const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+
+      (window as any).mParticle.forwarder.setUserAttribute('confirmationRef', 'order-123');
+
+      expect(logDiagnosticSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Rokt Kit: setUserAttribute called [attributeKeys=confirmationRef]' }),
+      );
+      logDiagnosticSpy.mockRestore();
+    });
   });
 
   describe('#removeUserAttribute', () => {
@@ -3656,6 +3715,20 @@ describe('Rokt Forwarder', () => {
       (window as any).mParticle.forwarder.removeUserAttribute('test-attribute');
 
       expect((window as any).mParticle.forwarder.userAttributes).toEqual({});
+    });
+
+    it('should log a diagnostic entry for the removed key', async () => {
+      const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+
+      (window as any).mParticle.forwarder.removeUserAttribute('test-attribute');
+
+      expect(logDiagnosticSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'ATTRIBUTE_SETTER_CALLED',
+          message: 'Rokt Kit: removeUserAttribute called [attributeKeys=test-attribute]',
+        }),
+      );
+      logDiagnosticSpy.mockRestore();
     });
   });
 
@@ -3677,6 +3750,30 @@ describe('Rokt Forwarder', () => {
         'test-attribute': 'test-value',
       });
       expect((window as any).mParticle.forwarder.filters.filteredUser.getMPID()).toBe('123');
+    });
+
+    it('should log a diagnostic entry with the resulting attribute keys but not their values', () => {
+      const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+
+      (window as any).mParticle.forwarder.onUserIdentified({
+        getAllUserAttributes: function () {
+          return { email: 'test@example.com' };
+        },
+        getMPID: function () {
+          return '123';
+        },
+        getUserIdentities: function () {
+          return { userIdentities: {} };
+        },
+      });
+
+      expect(logDiagnosticSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'ATTRIBUTE_SETTER_CALLED',
+          message: 'Rokt Kit: onUserIdentified called [attributeKeys=email]',
+        }),
+      );
+      logDiagnosticSpy.mockRestore();
     });
 
     it('should not cache denylisted commerce attributes from the filtered user', () => {
@@ -4357,6 +4454,24 @@ describe('Rokt Forwarder', () => {
         'user-attr': 'user-value',
       });
     });
+
+    it('should log a diagnostic entry sourced as onLoginComplete', () => {
+      const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+
+      (window as any).mParticle.forwarder.onLoginComplete({
+        getAllUserAttributes: function () {
+          return { 'user-attr': 'user-value' };
+        },
+        getMPID: function () {
+          return '123';
+        },
+      });
+
+      expect(logDiagnosticSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Rokt Kit: onLoginComplete called [attributeKeys=user-attr]' }),
+      );
+      logDiagnosticSpy.mockRestore();
+    });
   });
 
   describe('#onLogoutComplete', () => {
@@ -4373,6 +4488,24 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userAttributes).toEqual({
         'remaining-attr': 'some-value',
       });
+    });
+
+    it('should log a diagnostic entry sourced as onLogoutComplete', () => {
+      const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+
+      (window as any).mParticle.forwarder.onLogoutComplete({
+        getAllUserAttributes: function () {
+          return { 'remaining-attr': 'some-value' };
+        },
+        getMPID: function () {
+          return '123';
+        },
+      });
+
+      expect(logDiagnosticSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Rokt Kit: onLogoutComplete called [attributeKeys=remaining-attr]' }),
+      );
+      logDiagnosticSpy.mockRestore();
     });
   });
 
@@ -4393,6 +4526,27 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userAttributes).toEqual({
         'modified-attr': 'modified-value',
       });
+    });
+
+    it('should log a diagnostic entry sourced as onModifyComplete', () => {
+      const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+
+      (window as any).mParticle.forwarder.onModifyComplete({
+        getAllUserAttributes: function () {
+          return { 'modified-attr': 'modified-value' };
+        },
+        getMPID: function () {
+          return '123';
+        },
+        getUserIdentities: function () {
+          return { userIdentities: {} };
+        },
+      });
+
+      expect(logDiagnosticSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Rokt Kit: onModifyComplete called [attributeKeys=modified-attr]' }),
+      );
+      logDiagnosticSpy.mockRestore();
     });
   });
 
@@ -7934,6 +8088,43 @@ describe('Rokt Forwarder', () => {
       const service = new LoggingServiceClass({ isLoggingEnabled: true }, errorService, '1.0.0', 'test-guid');
       service.log(null);
       expect(fetchCalls.length).toBe(0);
+    });
+
+    it('logDiagnostic should send to the logging endpoint with severity INFO', () => {
+      const errorService = new ErrorReportingServiceClass({ isLoggingEnabled: true }, '1.0.0', 'test-guid');
+      const service = new LoggingServiceClass(
+        { loggingUrl: 'test.com/v1/log', isLoggingEnabled: true },
+        errorService,
+        '1.0.0',
+        'test-guid',
+      );
+      service.logDiagnostic({ message: 'diagnostic entry', code: 'SELECT_PLACEMENTS_SETTER_TIMING' });
+      expect(fetchCalls.length).toBe(1);
+      const body = JSON.parse(fetchCalls[0].options.body);
+      expect(body.severity).toBe('INFO');
+      expect(body.additionalInformation.message).toBe('diagnostic entry');
+    });
+
+    it('logDiagnostic should not share its rate-limit budget with log()', () => {
+      const errorService = new ErrorReportingServiceClass({ isLoggingEnabled: true }, '1.0.0', 'test-guid');
+      const service = new LoggingServiceClass(
+        { loggingUrl: 'test.com/v1/log', isLoggingEnabled: true },
+        errorService,
+        '1.0.0',
+        'test-guid',
+      );
+
+      // Exhaust log()'s INFO budget.
+      for (let i = 0; i < 10; i++) {
+        service.log({ message: 'operational log ' + i });
+      }
+      expect(fetchCalls.length).toBe(10);
+      service.log({ message: 'rate limited operational log' });
+      expect(fetchCalls.length).toBe(10);
+
+      // logDiagnostic still gets through on its own budget.
+      service.logDiagnostic({ message: 'diagnostic entry', code: 'SELECT_PLACEMENTS_SETTER_TIMING' });
+      expect(fetchCalls.length).toBe(11);
     });
   });
 

--- a/kits/rokt/test/src/tests.spec.ts
+++ b/kits/rokt/test/src/tests.spec.ts
@@ -955,6 +955,10 @@ describe('Rokt Forwarder', () => {
         );
 
         const logDiagnosticSpy = vi.spyOn((window as any).mParticle.forwarder.loggingService, 'logDiagnostic');
+        const logPlacementDiagnosticSpy = vi.spyOn(
+          (window as any).mParticle.forwarder.loggingService,
+          'logPlacementDiagnostic',
+        );
 
         (window as any).mParticle.forwarder.setUserAttribute('favoriteColor', 'blue');
 
@@ -963,18 +967,19 @@ describe('Rokt Forwarder', () => {
           attributes: { test: 'test' },
         });
 
-        // One log for the setter call, one for the selectPlacements dispatch — no correlation between them.
-        expect(logDiagnosticSpy).toHaveBeenCalledTimes(2);
+        // One log for the setter call, one for the selectPlacements dispatch — no correlation between them,
+        // and each on its own logging method/budget so a setter burst can't starve a placement dispatch.
+        expect(logDiagnosticSpy).toHaveBeenCalledTimes(1);
         expect(logDiagnosticSpy).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Rokt Kit: setUserAttribute called [attributeKeys=favoriteColor]' }),
         );
-        const dispatchEntry = logDiagnosticSpy.mock.calls.find(
-          (call) => call[0].code === 'SELECT_PLACEMENTS_DISPATCHED',
-        )?.[0];
+        expect(logPlacementDiagnosticSpy).toHaveBeenCalledTimes(1);
+        const dispatchEntry = logPlacementDiagnosticSpy.mock.calls[0][0];
         expect(dispatchEntry.message).toContain('placementAttributeKeys=');
         expect(dispatchEntry.message).toContain('favoriteColor');
         expect(dispatchEntry.message).not.toContain('blue');
         logDiagnosticSpy.mockRestore();
+        logPlacementDiagnosticSpy.mockRestore();
       });
 
       it('should send the mParticle session id current at the time of each call', async () => {
@@ -8099,7 +8104,7 @@ describe('Rokt Forwarder', () => {
         'test-guid',
       );
       service.logDiagnostic({ message: 'diagnostic entry', code: 'SELECT_PLACEMENTS_SETTER_TIMING' });
-      expect(fetchCalls.length).toBe(1);
+      expect(fetchCalls).toHaveLength(1);
       const body = JSON.parse(fetchCalls[0].options.body);
       expect(body.severity).toBe('INFO');
       expect(body.additionalInformation.message).toBe('diagnostic entry');
@@ -8118,13 +8123,35 @@ describe('Rokt Forwarder', () => {
       for (let i = 0; i < 10; i++) {
         service.log({ message: 'operational log ' + i });
       }
-      expect(fetchCalls.length).toBe(10);
+      expect(fetchCalls).toHaveLength(10);
       service.log({ message: 'rate limited operational log' });
-      expect(fetchCalls.length).toBe(10);
+      expect(fetchCalls).toHaveLength(10);
 
       // logDiagnostic still gets through on its own budget.
       service.logDiagnostic({ message: 'diagnostic entry', code: 'SELECT_PLACEMENTS_SETTER_TIMING' });
-      expect(fetchCalls.length).toBe(11);
+      expect(fetchCalls).toHaveLength(11);
+    });
+
+    it('logPlacementDiagnostic should not share its rate-limit budget with logDiagnostic', () => {
+      const errorService = new ErrorReportingServiceClass({ isLoggingEnabled: true }, '1.0.0', 'test-guid');
+      const service = new LoggingServiceClass(
+        { loggingUrl: 'test.com/v1/log', isLoggingEnabled: true },
+        errorService,
+        '1.0.0',
+        'test-guid',
+      );
+
+      // Exhaust logDiagnostic's budget with a burst of setter-call diagnostics.
+      for (let i = 0; i < 10; i++) {
+        service.logDiagnostic({ message: 'setter diagnostic ' + i, code: 'ATTRIBUTE_SETTER_CALLED' });
+      }
+      expect(fetchCalls).toHaveLength(10);
+      service.logDiagnostic({ message: 'rate limited setter diagnostic', code: 'ATTRIBUTE_SETTER_CALLED' });
+      expect(fetchCalls).toHaveLength(10);
+
+      // logPlacementDiagnostic still gets through on its own budget.
+      service.logPlacementDiagnostic({ message: 'placement diagnostic', code: 'SELECT_PLACEMENTS_DISPATCHED' });
+      expect(fetchCalls).toHaveLength(11);
     });
   });
 

--- a/kits/rokt/test/src/tests.spec.ts
+++ b/kits/rokt/test/src/tests.spec.ts
@@ -967,8 +967,6 @@ describe('Rokt Forwarder', () => {
           attributes: { test: 'test' },
         });
 
-        // One log for the setter call, one for the selectPlacements dispatch — no correlation between them,
-        // and each on its own logging method/budget so a setter burst can't starve a placement dispatch.
         expect(logDiagnosticSpy).toHaveBeenCalledTimes(1);
         expect(logDiagnosticSpy).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Rokt Kit: setUserAttribute called [attributeKeys=favoriteColor]' }),
@@ -8119,7 +8117,6 @@ describe('Rokt Forwarder', () => {
         'test-guid',
       );
 
-      // Exhaust log()'s INFO budget.
       for (let i = 0; i < 10; i++) {
         service.log({ message: 'operational log ' + i });
       }
@@ -8127,7 +8124,6 @@ describe('Rokt Forwarder', () => {
       service.log({ message: 'rate limited operational log' });
       expect(fetchCalls).toHaveLength(10);
 
-      // logDiagnostic still gets through on its own budget.
       service.logDiagnostic({ message: 'diagnostic entry', code: 'SELECT_PLACEMENTS_SETTER_TIMING' });
       expect(fetchCalls).toHaveLength(11);
     });
@@ -8141,7 +8137,6 @@ describe('Rokt Forwarder', () => {
         'test-guid',
       );
 
-      // Exhaust logDiagnostic's budget with a burst of setter-call diagnostics.
       for (let i = 0; i < 10; i++) {
         service.logDiagnostic({ message: 'setter diagnostic ' + i, code: 'ATTRIBUTE_SETTER_CALLED' });
       }
@@ -8149,7 +8144,6 @@ describe('Rokt Forwarder', () => {
       service.logDiagnostic({ message: 'rate limited setter diagnostic', code: 'ATTRIBUTE_SETTER_CALLED' });
       expect(fetchCalls).toHaveLength(10);
 
-      // logPlacementDiagnostic still gets through on its own budget.
       service.logPlacementDiagnostic({ message: 'placement diagnostic', code: 'SELECT_PLACEMENTS_DISPATCHED' });
       expect(fetchCalls).toHaveLength(11);
     });


### PR DESCRIPTION
## Summary
- Logs each attribute/identity setter call (`setUserAttribute`, `removeUserAttribute`, `onUserIdentified`, `onLoginComplete`, `onLogoutComplete`, `onModifyComplete`) via `LoggingService.logDiagnostic()` with the affected attribute *keys* (never values).
- Logs each `selectPlacements` dispatch with the full set of placement attribute keys.
- The two log calls are independent — no in-kit correlation or timing math. The delta between "attributes set" and "placement requested" is computed downstream using the logged timestamp-of-receipt and page URL that `ReportingTransport` already attaches to every log request.
- `logDiagnostic()` ships at `severity: "INFO"` on the wire (same as `log()`) but through its own `ReportingTransport`/`RateLimiter` instance, so a burst of setter/placement diagnostics can't starve the operational INFO budget shared with page-view/quota logging.
- Only attribute *keys* are ever logged — never values — since setter payloads can carry customer PII and this ships over the network logging pipeline.

## Context
Relands mparticle-integrations/mparticle-javascript-integration-rokt#130 against this monorepo now that the rokt kit lives here under `kits/rokt`. That PR targeted `development` on the old standalone repo; this one targets `main` here since `development` doesn't carry `kits/rokt` and the kit source of truth has moved.

The two commits from #130 didn't cherry-pick cleanly since `kits/rokt/src/Rokt-Kit.ts` and `test/src/tests.spec.ts` have diverged since the kit moved (new `launcherAttachState.ts`, reworked `pageViewStorage.ts`, etc.), so the logic was manually reapplied onto the current file versions instead.

## Example log messages
```
Rokt Kit: setUserAttribute called [attributeKeys=favoriteColor]
Rokt Kit: onUserIdentified called [attributeKeys=email,firstName,loyaltyTier]
Rokt Kit: selectPlacements dispatched [placementAttributeKeys=email,firstName,loyaltyTier,mpid]
```

## Test plan
- [x] `npm run test` (kits/rokt) — 340/340 passing, including new unit tests for `diagnosticTiming.ts` and integration coverage for every setter/identity call site and the `selectPlacements` dispatch
- [x] `npm run build` (kits/rokt) — pre-existing `vault.ts` generic-constraint type errors reproduce identically on `main` — unrelated to this change