### PR TITLE
fix(ci): validate release tag baseline major

### DIFF
--- a/.github/workflows/staging-step-1.yml
+++ b/.github/workflows/staging-step-1.yml
@@ -152,6 +152,41 @@ jobs:
                       exit 1
                   fi
 
+            - name: Validate reachable release tag major
+              env:
+                  TRACK: ${{ inputs.track }}
+              run: |
+                  set -eu
+                  # Stop a wrong-major semantic-release lineage before expensive tests.
+                  STABLE_TAG_PATTERN='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+                  case "$TRACK" in
+                      v2) EXPECTED_MAJOR=2 ;;
+                      v3) EXPECTED_MAJOR=3 ;;
+                      *) exit 1 ;;
+                  esac
+                  BASELINE_TAG="$(
+                      git tag --merged HEAD --list 'v*' --sort=-v:refname |
+                          awk -v pattern="$STABLE_TAG_PATTERN" \
+                              '$0 ~ pattern { print; exit }'
+                  )"
+                  if [ -z "$BASELINE_TAG" ]; then
+                      echo "Track ${TRACK} expects major ${EXPECTED_MAJOR}, but no stable release tag is reachable from staging HEAD"
+                      exit 1
+                  fi
+
+                  FOUND_MAJOR="${BASELINE_TAG#v}"
+                  FOUND_MAJOR="${FOUND_MAJOR%%.*}"
+                  if [ "$FOUND_MAJOR" != "$EXPECTED_MAJOR" ]; then
+                      echo "Track ${TRACK} expects major ${EXPECTED_MAJOR}, but highest reachable stable tag ${BASELINE_TAG} has major ${FOUND_MAJOR}"
+                      exit 1
+                  fi
+
+                  {
+                      printf '## Release tag baseline\n\n'
+                      printf -- '- Track: `%s`\n' "$TRACK"
+                      printf -- '- Highest reachable stable tag: `%s`\n' "$BASELINE_TAG"
+                  } >> "$GITHUB_STEP_SUMMARY"
+
     build-bundle:
         name: Build Distribution Bundle
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Port the final narrow release-tag baseline guard merged in [#1389](https://github.com/mParticle/mparticle-web-sdk/pull/1389) to `master` as the required paired workflow change.
- Reject a staging lineage when its highest reachable stable release tag has the wrong major, before expensive release tests run.
- Keep `.github/workflows/staging-step-1.yml` byte-for-byte identical to the merged `main` workflow.

## Test plan
- [x] Parse the workflow as YAML and execute the exact embedded guard.
- [x] Verify version-aware sorting (`v2.10.0` over `v2.9.0`) and strict stable-tag filtering.
- [x] Verify v2 and v3 matching-major passes and wrong-major failures.
- [x] Verify unreachable tags are ignored and malformed-only or missing tags fail.
- [x] Run `git diff --check`.
- [x] Inspect the complete diff and confirm only `.github/workflows/staging-step-1.yml` changes (35 insertions).
- [x] Confirm byte identity with current `origin/main`.

## Rollout
After this PR merges, staging must receive the updated `.github/workflows/staging-step-1.yml` before the next release.