### PR TITLE
docs: rewrite Braze kit READMEs to recommend V6

### DIFF
--- a/kits/braze/braze-3/README.md
+++ b/kits/braze/braze-3/README.md
@@ -19,8 +19,9 @@ Braze is now on **V6**, and V6 is the version mParticle recommends for all custo
    - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
    - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
    - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
-3. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
-4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+3. **Add defensive code**, if you call Braze directly, so your site works before and after the switch. See [Write version-tolerant code](#write-version-tolerant-code).
+4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
 
 ---
 
@@ -70,6 +71,26 @@ window.braze.showContentCards();
 
 ---
 
+## Write version-tolerant code
+
+Selecting `Version 6` in your connection settings swaps the kit that loads on your site, and that happens outside of your own deploy. If you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+The V3 → V6 change that matters most is the global rename, so guard on which global is present:
+
+```javascript
+if (window.braze) {
+    window.braze.showContentCards();
+} else if (window.appboy) {
+    window.appboy.display.showContentCards();
+}
+```
+
+Search your codebase for every remaining direct `appboy` call and apply the same pattern, using the mapping table above and Braze's changelog to find the V6 equivalent of each one.
+
+Once V6 is live and verified, you can delete the `window.appboy` fallbacks and call `window.braze` directly.
+
+---
+
 ## Push notifications
 
 If you use push notifications, update your `service-worker.js` to import the V6 service worker that mParticle hosts:
@@ -79,14 +100,6 @@ self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5
 ```
 
 The V3 kit references `service-worker-3.5.0.js`. mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
-
----
-
-## Transition from `@mparticle/web-appboy-kit` to `@mparticle/web-braze-kit`
-
-The legacy `@mparticle/web-appboy-kit` package on npm bundles **V2** of the Braze Web SDK and is deprecated. Its replacement is the Braze kit you are reading about now, which lives in this repository (the standalone [Braze web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze) superseded the deprecated [Appboy web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy)).
-
-If you are still on `@mparticle/web-appboy-kit`, you are on Braze V2. Account for the [V2 → V3 breaking changes](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md#v2-to-v3) — removal of the `appboy.ab` namespace, the `InAppMessage.Button` → `InAppMessageButton` rename, removal of the `openSession()` / `changeUser()` callback parameters, and `baseUrl` becoming required — then follow the V3 → V6 instructions above. We recommend updating straight to V6 for latest support of all Braze features.
 
 ---
 

--- a/kits/braze/braze-3/README.md
+++ b/kits/braze/braze-3/README.md
@@ -10,16 +10,16 @@ This kit bundles **Braze Web SDK V3** (`@braze/web-sdk@^3.5.0`) and exposes it o
 
 Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
-**Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
+See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
 
 ### How to upgrade
 
 1. **Audit the code you own.** If you call Braze directly, find every `appboy` reference and compare it with the table below and Braze's upgrade documentation.
 2. **Move to the V6 kit.**
-   - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
-   - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
+   - Self-hosting via npm with **core Web SDK v3 (latest)**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2 (legacy)**: `npm install @mparticle/web-braze-kit@^6`
    - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
-3. **Add defensive code**, if you call Braze directly, so your site works before and after the switch. See [Write version-tolerant code](#write-version-tolerant-code).
+3. **Add defensive code** if you load mParticle via the snippet and call Braze directly. Skip this if you self-host via npm. See [Write version-tolerant code](#write-version-tolerant-code).
 4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
 5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
 
@@ -73,7 +73,9 @@ window.braze.showContentCards();
 
 ## Write version-tolerant code
 
-Selecting `Version 6` in your connection settings swaps the kit that loads on your site, and that happens outside of your own deploy. If you call Braze directly, ship code that works against both versions first, then flip the setting.
+Do this if you load mParticle via the snippet. After you select `Version 6`, cache busting can leave some visitors on the old kit for a while, so if you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+If you self-host via npm, you control when the kit version ships with your own deploy, so you do not need version-tolerant fallbacks — update your Braze calls and deploy them together with the V6 kit.
 
 The V3 → V6 change that matters most is the global rename, so guard on which global is present:
 

--- a/kits/braze/braze-3/README.md
+++ b/kits/braze/braze-3/README.md
@@ -1,52 +1,101 @@
-![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png) 
+![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png)
 
-⚠️⚠️⚠️
-# Notice! Opt in is now available for Braze Web SDK V4 - Action Required
+# mParticle Braze Kit — Braze Web SDK V3
 
-You can now select what version of the Braze SDK you want to use when setting up a Braze connection in the mParticle UI.  Braze occasionally makes breaking changes to their SDK, so if you call `appboy` directly in your code, you will have to update your code to ensure your website performs as expected when updating versions of Braze.
+This kit bundles **Braze Web SDK V3** (`@braze/web-sdk@^3.5.0`) and exposes it on the page as `window.appboy`.
 
-Please review the [Braze Changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog#400) and [V4 migration guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md) to learn about the differences between V3 and V4 and what changes you will need to make in your code. The most significant breaking changes are the replacement of the `appboy` class name with `braze`, in addition to the removal and renaming of several APIs.
+---
 
-You can opt into the latest major version of the Braze Web SDK whether you implement mParticle's Web SDK using npm or our snippet/CDN.
-* Customers who self-host mParticle via npm - You should add @mparticle/web-braze-kit version 4.0.0 or greater in your package.json now! You must also select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
-* Customers who load mParticle via snippet/CDN - Opting in is available via the mParticle UI in your Braze connection settings.
+## ⚠️ We recommend upgrading to Braze Web SDK V6
 
-Note that the following is only one example.  Everywhere you manually call `appboy` needs to be updated similar to the below. If you are using NPM, you can skip to step 3.  Please be sure to test your site fully in development prior to releasing.
+Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
+**Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
 
-* Step 1: Legacy code sample. Find all the places where your code references the `appboy.display` namespace.  Braze has removed all instances of the `display` namespace:
+### How to upgrade
+
+1. **Audit the code you own.** If you call Braze directly, find every `appboy` reference and compare it with the table below and Braze's upgrade documentation.
+2. **Move to the V6 kit.**
+   - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
+   - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
+3. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+
+---
+
+## What changed from V3 to V6
+
+The table below is the V3 API you have today mapped to the V6 API you should use. Several of these were deprecated in V3 and then removed.
+
+Primary sources: the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) and the [Braze upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md).
+
+| V3 | V6 |
+| --- | --- |
+| `appboy` global | `braze` |
+| `appboy.display.*` namespace | Methods moved to the top level: `braze.*` |
+| `appboy.registerAppboyPushMessages()` | `braze.requestPushPermission()` |
+| `appboy.unregisterAppboyPushMessages()` | `braze.unregisterPush()` |
+| `appboy.display.automaticallyShowNewInAppMessages()` | `braze.automaticallyShowInAppMessages()` — must run *before* `openSession()` |
+| `appboy.toggleAppboyLogging()` | `braze.toggleLogging()` |
+| `appboy.isPushGranted()` *(deprecated since 1.6.2)* | `braze.isPushPermissionGranted()` |
+| `appboy.subscribeToNewInAppMessages()` *(deprecated since 2.4.0)* | `braze.subscribeToInAppMessage()` |
+| `appboy.trackLocation()` *(deprecated since 3.3.0)* | Native Geolocation API + `User.setLastKnownLocation()` |
+| `appboy.stopWebTracking()` *(deprecated since 3.5.0)* | `braze.disableSDK()` |
+| `appboy.resumeWebTracking()` *(deprecated since 3.5.0)* | `braze.enableSDK()` |
+| `appboy.logCardClick()` | `braze.logContentCardClick()` |
+| `appboy.logCardImpressions()` | `braze.logContentCardImpressions()` |
+| `appboy.logContentCardsDisplayed()` | Delete it — it was already a no-op |
+| Legacy News Feed: `Feed`, `destroyFeed()`, `getCachedFeed()`, `logFeedDisplayed()`, `requestFeedRefresh()`, `showFeed()`, `subscribeToFeedUpdates()`, `toggleFeed()` | **No drop-in replacement.** Migrate to Content Cards |
+| `devicePropertyWhitelist` init option *(deprecated since 3.1.0)* | `devicePropertyAllowlist` |
+| `enableHtmlInAppMessages` init option *(deprecated since 3.3.0)* | `allowUserSuppliedJavascript` |
+| `language` init option | `localization` |
+| `safariWebsitePushId` param on `registerAppboyPushMessages()` | `safariWebsitePushId` initialization option |
+| `cardId` / `campaignId` on in-app messages | Update your `InAppMessage` subclass constructors |
+| `User.setAvatarImageUrl()` | No replacement; no longer used |
+| `appboy.Banner` card class | `braze.ImageOnly` |
+| `ab-banner` CSS class | `ab-image-only` |
+
+If you call Braze directly, search your codebase for **every** `appboy` reference and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, the `appboy.display` namespace was removed and its methods moved to `braze`:
+
 ```javascript
-window.appboy.display.destroyFeed();
+// V3
+window.appboy.display.showContentCards();
+
+// V6
+window.braze.showContentCards();
 ```
 
-Step 2: Roll out code changes prior to opting in to V4
-```javascript
-if (window.appboy) {
-	window.appboy.display.destroyFeed();
-} else if (window.braze) {
-	window.braze.destroyFeed();
-}
-```
-Step 3: Opt into Version 4.  Simply navigate to your connection settings and selection `Version 4` from the new Braze Web SDK Version drop down.  
+---
 
-Step 4: After you opt in, you can simplify your code. We recommend testing and waiting at least 24 hours between opting in and removing previous instances of `appboy` and doing thorough testing of your application in a development environment to ensure everything is working:
-```javascript
-window.braze.destroyFeed();
-```
+## Push notifications
 
-Step 5: Push Notifications via service-worker.js
-If you use Push Notifications, we have updated the `service-worker.js` file.  In our testing, Braze’s push notifications work as expected regardless of what version of the service-worker is used, but we recommend updating this file to ensure future compatibility.  In your `service-worker.js` file, update the code to reference `https://static.mparticle.com/sdk/js/braze/service-worker-4.2.1.js` instead of `https://static.mparticle.com/sdk/js/braze/service-worker-3.5.0.js`.  Your `service-worker.js` file should now contain:
+If you use push notifications, update your `service-worker.js` to import the V6 service worker that mParticle hosts:
 
 ```javascript
-self.imports('https://static.mparticle.com/sdk/js/braze/service-worker-4.2.1.js')
+self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-### Transition from @mparticle/web-appboy-kit to @mparticle/web-braze-kit
+The V3 kit references `service-worker-3.5.0.js`. mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
-The legacy @mparticle/web-appboy-kit from npm includes version 2 of the Braze Web SDK.  As part of this update, we've created a new [Braze web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze) to replace our deprecated [Appboy web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy).  If you are still using `@mparticle/web-appboy-kit`, you will need to consider the breaking changes Braze made between V2 and V3 of the Braze SDK (found [here](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog/#300)) as well as the instructions above to get from V2 to V4 of the Braze SDK.
+---
 
+## Transition from `@mparticle/web-appboy-kit` to `@mparticle/web-braze-kit`
 
+The legacy `@mparticle/web-appboy-kit` package on npm bundles **V2** of the Braze Web SDK and is deprecated. Its replacement is the Braze kit you are reading about now, which lives in this repository (the standalone [Braze web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze) superseded the deprecated [Appboy web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy)).
 
+If you are still on `@mparticle/web-appboy-kit`, you are on Braze V2. Account for the [V2 → V3 breaking changes](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md#v2-to-v3) — removal of the `appboy.ab` namespace, the `InAppMessage.Button` → `InAppMessageButton` rename, removal of the `openSession()` / `changeUser()` callback parameters, and `baseUrl` becoming required — then follow the V3 → V6 instructions above. We recommend updating straight to V6 for latest support of all Braze features.
+
+---
+
+## Reference
+
+- [mParticle Braze integration docs](https://docs.mparticle.com/integrations/braze/event/)
+- [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md)
+- [Braze Web SDK upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md)
+- [Braze Web SDK API reference](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html)
 
 # License
 

--- a/kits/braze/braze-3/README.md
+++ b/kits/braze/braze-3/README.md
@@ -101,7 +101,7 @@ If you use push notifications, update your `service-worker.js` to import the V6 
 self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-The V3 kit references `service-worker-3.5.0.js`. mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
+mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
 ---
 

--- a/kits/braze/braze-4/README.md
+++ b/kits/braze/braze-4/README.md
@@ -21,8 +21,9 @@ You already did the hard part: the `appboy` → `braze` rename happened in V4, s
    - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
    - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
    - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
-3. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
-4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+3. **Add defensive code**, if you call Braze directly, so your site works before and after the switch. See [Write version-tolerant code](#write-version-tolerant-code).
+4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
 
 ---
 
@@ -56,6 +57,26 @@ window.braze.logCardImpressions([card], true);
 // V6
 window.braze.logContentCardImpressions([card]);
 ```
+
+---
+
+## Write version-tolerant code
+
+Selecting `Version 6` in your connection settings swaps the kit that loads on your site, and that happens outside of your own deploy. If you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+The `braze` global is the same in V4 and V6, so guard on the method instead. For the card-analytics renames:
+
+```javascript
+if (window.braze.logContentCardImpressions) {
+    window.braze.logContentCardImpressions([card]);
+} else {
+    window.braze.logCardImpressions([card], true);
+}
+```
+
+Search your codebase for every remaining direct `braze` call and apply the same pattern, using the mapping table above and Braze's changelog to find the V6 equivalent of each one.
+
+Once V6 is live and verified, you can delete the fallbacks and call the V6 methods directly.
 
 ---
 

--- a/kits/braze/braze-4/README.md
+++ b/kits/braze/braze-4/README.md
@@ -88,7 +88,7 @@ If you use push notifications, update your `service-worker.js` to import the V6 
 self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-The V4 kit references `service-worker-4.2.1.js`. mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
+mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
 ---
 

--- a/kits/braze/braze-4/README.md
+++ b/kits/braze/braze-4/README.md
@@ -10,8 +10,6 @@ This kit bundles **Braze Web SDK V4** (`@braze/web-sdk@^4.2.1`) and exposes it o
 
 Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
-You already did the hard part: the `appboy` → `braze` rename happened in V4, so V4 → V6 is a much smaller change than V3 → V6.
-
 See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
 
 ### How to upgrade

--- a/kits/braze/braze-4/README.md
+++ b/kits/braze/braze-4/README.md
@@ -1,52 +1,82 @@
-![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png) 
+![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png)
 
-⚠️⚠️⚠️
-# Notice! Opt in is now available for Braze Web SDK V4 - Action Required
+# mParticle Braze Kit — Braze Web SDK V4
 
-You can now select what version of the Braze SDK you want to use when setting up a Braze connection in the mParticle UI.  Braze occasionally makes breaking changes to their SDK, so if you call `appboy` directly in your code, you will have to update your code to ensure your website performs as expected when updating versions of Braze.
+This kit bundles **Braze Web SDK V4** (`@braze/web-sdk@^4.2.1`) and exposes it on the page as `window.braze`.
 
-Please review the [Braze Changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog#400) and [V4 migration guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md) to learn about the differences between V3 and V4 and what changes you will need to make in your code. The most significant breaking changes are the replacement of the `appboy` class name with `braze`, in addition to the removal and renaming of several APIs.
+---
 
-You can opt into the latest major version of the Braze Web SDK whether you implement mParticle's Web SDK using npm or our snippet/CDN.
-* Customers who self-host mParticle via npm - You should add @mparticle/web-braze-kit version 4.0.0 or greater in your package.json.  You must also select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
-* Customers who load mParticle via snippet/CDN - You must  select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
+## ⚠️ We recommend upgrading to Braze Web SDK V6
 
-Note that the following is only one example.  Everywhere you manually call `appboy` needs to be updated similar to the below. If you are using NPM, you can skip to step 3.  Please be sure to test your site fully in development prior to releasing.
+Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
+You already did the hard part: the `appboy` → `braze` rename happened in V4, so V4 → V6 is a much smaller change than V3 → V6.
 
-* Step 1: Legacy code sample. Find all the places where your code references the `appboy.display` namespace.  Braze has removed all instances of the `display` namespace:
+**Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
+
+### How to upgrade
+
+1. **Audit the code you own.** If you call Braze directly, find every `braze` reference and compare it with the table below and Braze's upgrade documentation.
+2. **Move to the V6 kit.**
+   - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
+   - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
+3. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+
+---
+
+## What changed from V4 to V6
+
+The table below is the V4 API you have today mapped to the V6 API you should use.
+
+Primary sources: the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) and the [Braze upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md).
+
+| V4 | V6 |
+| --- | --- |
+| `braze.logCardClick()` | `braze.logContentCardClick()` — already exists in V4, so you can rename before you upgrade |
+| `braze.logCardImpressions()` | `braze.logContentCardImpressions()` — already exists in V4 |
+| `braze.logContentCardsDisplayed()` *(already a no-op)* | Delete it |
+| Legacy News Feed: `Feed`, `destroyFeed()`, `getCachedFeed()`, `logFeedDisplayed()`, `requestFeedRefresh()`, `showFeed()`, `subscribeToFeedUpdates()`, `toggleFeed()` | **No drop-in replacement.** Migrate to Content Cards |
+| `braze.Banner` card class *(deprecated since 4.9.0)* | `braze.ImageOnly` |
+| `ab-banner` CSS class | `ab-image-only` |
+| `enableHtmlInAppMessages` init option *(deprecated since 3.3.0)* | `allowUserSuppliedJavascript` |
+| `getDeviceId(callback)` / `User.getUserId(callback)` *(callback params deprecated since 4.10.0)* | Return values directly: `getDeviceId()`, `getUserId()` |
+| `Card.created`, `Card.categories` | No replacement; these were News Feed fields |
+| `ImageOnly.linkText` | No replacement; unused |
+
+If you call Braze directly, search your codebase for **every** `braze` reference and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, use the Content Card-specific analytics methods:
+
 ```javascript
-window.appboy.display.destroyFeed();
+// V4
+window.braze.logCardImpressions([card], true);
+
+// V6
+window.braze.logContentCardImpressions([card]);
 ```
 
-Step 2: Roll out code changes prior to opting in to V4
-```javascript
-if (window.appboy) {
-	window.appboy.display.destroyFeed();
-} else if (window.braze) {
-	window.braze.destroyFeed();
-}
-```
-Step 3: Whether you are using the snippet or self hosting, you need to navigate to your Braze connection settings and select `Version 4` from the `Braze Web SDK Version` drop down.
+---
 
-Step 4: After you opt in, you can simplify your code. We recommend testing and waiting at least 24 hours between opting in and removing previous instances of `appboy` and doing thorough testing of your application in a development environment to ensure everything is working:
-```javascript
-window.braze.destroyFeed();
-```
+## Push notifications
 
-Step 5: Push Notifications via service-worker.js
-If you use Push Notifications, we have updated the `service-worker.js` file.  In our testing, Braze’s push notifications work as expected regardless of what version of the service-worker is used, but we recommend updating this file to ensure future compatibility.  In your `service-worker.js` file, update the code to reference `https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js` instead of `https://static.mparticle.com/sdk/js/braze/service-worker-3.5.0.js`.  Your `service-worker.js` file should now contain:
+If you use push notifications, update your `service-worker.js` to import the V6 service worker that mParticle hosts:
 
 ```javascript
-self.imports('https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js')
+self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-### Transition from @mparticle/web-appboy-kit to @mparticle/web-braze-kit
+The V4 kit references `service-worker-4.2.1.js`. mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
-The legacy @mparticle/web-appboy-kit from npm includes version 2 of the Braze Web SDK.  As part of this update, we've created a new [Braze web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze) to replace our deprecated [Appboy web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy).  If you are still using `@mparticle/web-appboy-kit`, you will need to consider the breaking changes Braze made between V2 and V3 of the Braze SDK (found [here](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog/#300)) as well as the instructions above to get from V2 to V4 of the Braze SDK.
+---
 
+## Reference
 
-
+- [mParticle Braze integration docs](https://docs.mparticle.com/integrations/braze/event/)
+- [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md)
+- [Braze Web SDK upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md)
+- [Braze Web SDK API reference](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html)
 
 # License
 

--- a/kits/braze/braze-4/README.md
+++ b/kits/braze/braze-4/README.md
@@ -12,16 +12,16 @@ Braze is now on **V6**, and V6 is the version mParticle recommends for all custo
 
 You already did the hard part: the `appboy` → `braze` rename happened in V4, so V4 → V6 is a much smaller change than V3 → V6.
 
-**Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
+See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
 
 ### How to upgrade
 
 1. **Audit the code you own.** If you call Braze directly, find every `braze` reference and compare it with the table below and Braze's upgrade documentation.
 2. **Move to the V6 kit.**
-   - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
-   - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
+   - Self-hosting via npm with **core Web SDK v3 (latest)**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2 (legacy)**: `npm install @mparticle/web-braze-kit@^6`
    - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
-3. **Add defensive code**, if you call Braze directly, so your site works before and after the switch. See [Write version-tolerant code](#write-version-tolerant-code).
+3. **Add defensive code** if you load mParticle via the snippet and call Braze directly. Skip this if you self-host via npm. See [Write version-tolerant code](#write-version-tolerant-code).
 4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
 5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
 
@@ -62,7 +62,9 @@ window.braze.logContentCardImpressions([card]);
 
 ## Write version-tolerant code
 
-Selecting `Version 6` in your connection settings swaps the kit that loads on your site, and that happens outside of your own deploy. If you call Braze directly, ship code that works against both versions first, then flip the setting.
+Do this if you load mParticle via the snippet. After you select `Version 6`, cache busting can leave some visitors on the old kit for a while, so if you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+If you self-host via npm, you control when the kit version ships with your own deploy, so you do not need version-tolerant fallbacks — update your Braze calls and deploy them together with the V6 kit.
 
 The `braze` global is the same in V4 and V6, so guard on the method instead. For the card-analytics renames:
 

--- a/kits/braze/braze-5/README.md
+++ b/kits/braze/braze-5/README.md
@@ -21,8 +21,9 @@ This is the smallest of the Braze upgrades: the `braze` global, initialization o
    - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
    - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
    - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
-3. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
-4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+3. **Add defensive code**, if you call Braze directly, so your site works before and after the switch. See [Write version-tolerant code](#write-version-tolerant-code).
+4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
 
 ---
 
@@ -52,6 +53,26 @@ window.braze.logCardImpressions([card], true);
 // V6
 window.braze.logContentCardImpressions([card]);
 ```
+
+---
+
+## Write version-tolerant code
+
+Selecting `Version 6` in your connection settings swaps the kit that loads on your site, and that happens outside of your own deploy. If you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+The `braze` global is the same in V5 and V6, so guard on the method instead. For the card-analytics renames:
+
+```javascript
+if (window.braze.logContentCardImpressions) {
+    window.braze.logContentCardImpressions([card]);
+} else {
+    window.braze.logCardImpressions([card], true);
+}
+```
+
+Search your codebase for every remaining direct `braze` call and apply the same pattern, using the mapping table above and Braze's changelog to find the V6 equivalent of each one.
+
+Once V6 is live and verified, you can delete the fallbacks and call the V6 methods directly.
 
 ---
 

--- a/kits/braze/braze-5/README.md
+++ b/kits/braze/braze-5/README.md
@@ -10,7 +10,7 @@ This kit bundles **Braze Web SDK V5** (`@braze/web-sdk@^5.5.0`) and exposes it o
 
 Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
-This is the smallest of the Braze upgrades: the `braze` global, initialization options, and the vast majority of the API are unchanged. Only two areas break — the **legacy News Feed**, which V6 removes entirely, and **manual card-analytics method names**.
+The `braze` global, initialization options, and the vast majority of the API are unchanged. Two areas break — the **legacy News Feed**, which V6 removes entirely, and **manual card-analytics method names**.
 
 See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
 

--- a/kits/braze/braze-5/README.md
+++ b/kits/braze/braze-5/README.md
@@ -12,16 +12,16 @@ Braze is now on **V6**, and V6 is the version mParticle recommends for all custo
 
 This is the smallest of the Braze upgrades: the `braze` global, initialization options, and the vast majority of the API are unchanged. Only two areas break — the **legacy News Feed**, which V6 removes entirely, and **manual card-analytics method names**.
 
-**Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
+See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
 
 ### How to upgrade
 
 1. **Audit the code you own.** If you call Braze directly, find every `braze` reference and compare it with the table below and Braze's upgrade documentation.
 2. **Move to the V6 kit.**
-   - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
-   - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
+   - Self-hosting via npm with **core Web SDK v3 (latest)**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2 (legacy)**: `npm install @mparticle/web-braze-kit@^6`
    - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
-3. **Add defensive code**, if you call Braze directly, so your site works before and after the switch. See [Write version-tolerant code](#write-version-tolerant-code).
+3. **Add defensive code** if you load mParticle via the snippet and call Braze directly. Skip this if you self-host via npm. See [Write version-tolerant code](#write-version-tolerant-code).
 4. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
 5. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
 
@@ -58,7 +58,9 @@ window.braze.logContentCardImpressions([card]);
 
 ## Write version-tolerant code
 
-Selecting `Version 6` in your connection settings swaps the kit that loads on your site, and that happens outside of your own deploy. If you call Braze directly, ship code that works against both versions first, then flip the setting.
+Do this if you load mParticle via the snippet. After you select `Version 6`, cache busting can leave some visitors on the old kit for a while, so if you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+If you self-host via npm, you control when the kit version ships with your own deploy, so you do not need version-tolerant fallbacks — update your Braze calls and deploy them together with the V6 kit.
 
 The `braze` global is the same in V5 and V6, so guard on the method instead. For the card-analytics renames:
 

--- a/kits/braze/braze-5/README.md
+++ b/kits/braze/braze-5/README.md
@@ -1,46 +1,78 @@
-![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png) 
+![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png)
 
-⚠️⚠️⚠️
-# Notice! Opt in is now available for Braze Web SDK V5 - Action Required
+# mParticle Braze Kit — Braze Web SDK V5
 
-You can now select what version of the Braze SDK you want to use when setting up a Braze connection in the mParticle UI.  Braze occasionally makes breaking changes to their SDK, so if you call `appboy` directly in your code, you will have to update your code to ensure your website performs as expected when updating versions of Braze.
+This kit bundles **Braze Web SDK V5** (`@braze/web-sdk@^5.5.0`) and exposes it on the page as `window.braze`.
 
-Please review the [Braze Changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog#500) and [V5 migration guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md) to learn about the differences between V4 and V5 and what changes you will need to make in your code. The most significant breaking changes are the removal of the deprecated `enableHtmlInAppMessages` initialization option (replaced by `allowUserSuppliedJavascript`), in addition to the removal and renaming of several APIs.
+---
 
-You can opt into the latest major version of the Braze Web SDK whether you implement mParticle's Web SDK using npm or our snippet/CDN.
-* Customers who self-host mParticle via npm - You should add @mparticle/web-braze-kit version 5.0.0 or greater in your package.json.  You must also select `Version 5` under `Braze Web SDK Version`  in the Braze connection settings.
-* Customers who load mParticle via snippet/CDN - You must  select `Version 5` under `Braze Web SDK Version`  in the Braze connection settings.
+## ⚠️ We recommend upgrading to Braze Web SDK V6
 
-Note that the following is only one example of migrating from V3 to V5.  Everywhere you manually call `appboy` needs to be updated similar to the below. If you are using NPM, you can skip to step 3.  Please be sure to test your site fully in development prior to releasing.
+Braze is now on **V6**, and V6 is the version mParticle recommends for all customers. We recommend updating straight to V6 for latest support of all Braze features.
 
+This is the smallest of the Braze upgrades: the `braze` global, initialization options, and the vast majority of the API are unchanged. Only two areas break — the **legacy News Feed**, which V6 removes entirely, and **manual card-analytics method names**.
 
-* Step 1: Legacy code sample. Find all the places where your code references the `appboy.display` namespace. Braze has removed all instances of the `display` namespace:
+**Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
+
+### How to upgrade
+
+1. **Audit the code you own.** If you call Braze directly, find every `braze` reference and compare it with the table below and Braze's upgrade documentation.
+2. **Move to the V6 kit.**
+   - Self-hosting via npm with **core Web SDK v3**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2**: `npm install @mparticle/web-braze-kit@^6`
+   - Loading mParticle via snippet/CDN: nothing to install; the kit is delivered for you.
+3. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. This step is **required for both npm and snippet/CDN** integrations — installing the package alone does not switch you over.
+4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+
+---
+
+## What changed from V5 to V6
+
+The table below is the V5 API you have today mapped to the V6 API you should use.
+
+Primary sources: the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) and the [Braze upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md).
+
+| V5 | V6 |
+| --- | --- |
+| `braze.logCardClick()` | `braze.logContentCardClick()` — already exists in V5, so you can rename before you upgrade |
+| `braze.logCardImpressions()` | `braze.logContentCardImpressions()` — already exists in V5 |
+| Legacy News Feed: `Feed`, `destroyFeed()`, `getCachedFeed()`, `logFeedDisplayed()`, `requestFeedRefresh()`, `showFeed()`, `subscribeToFeedUpdates()`, `toggleFeed()` | **No drop-in replacement.** Migrate to Content Cards |
+| `Card.created`, `Card.categories` | No replacement; these were News Feed fields |
+| `ImageOnly.linkText` | No replacement; unused |
+| Custom banner HTML + `logBannerClick()` / `logBannerImpressions()` | `braze.insertBanner()`, which handles rendering, impressions, and clicks |
+
+If you call Braze directly, search your codebase for **every** `braze` reference and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, use the Content Card-specific analytics methods:
+
 ```javascript
-window.appboy.display.destroyFeed();
+// V5
+window.braze.logCardImpressions([card], true);
+
+// V6
+window.braze.logContentCardImpressions([card]);
 ```
 
-Step 2: Roll out code changes prior to opting in to V5
-```javascript
-if (window.appboy) {
-	window.appboy.display.destroyFeed();
-} else if (window.braze) {
-	window.braze.destroyFeed();
-}
-```
-Step 3: Whether you are using the snippet or self hosting, you need to navigate to your Braze connection settings and select `Version 5` from the `Braze Web SDK Version` drop down.
+---
 
-Step 4: After you opt in, you can simplify your code. We recommend testing and waiting at least 24 hours between opting in and removing previous instances of `appboy` and doing thorough testing of your application in a development environment to ensure everything is working:
-```javascript
-window.braze.destroyFeed();
-```
+## Push notifications
 
-Step 5: Push Notifications via service-worker.js
-If you use Push Notifications, we have updated the `service-worker.js` file.  In our testing, Braze’s push notifications work as expected regardless of what version of the service-worker is used, but we recommend updating this file to ensure future compatibility.  In your `service-worker.js` file, update the code to reference `https://static.mparticle.com/sdk/js/braze/service-worker-5.5.0.js` instead of `https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js`.  Your `service-worker.js` file should now contain:
+If you use push notifications, update your `service-worker.js` to import the V6 service worker that mParticle hosts:
 
 ```javascript
-self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-5.5.0.js')
+self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
+The V5 kit references `service-worker-5.5.0.js`. mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
+
+---
+
+## Reference
+
+- [mParticle Braze integration docs](https://docs.mparticle.com/integrations/braze/event/)
+- [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md)
+- [Braze Web SDK upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md)
+- [Braze Web SDK API reference](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html)
 
 # License
 

--- a/kits/braze/braze-5/README.md
+++ b/kits/braze/braze-5/README.md
@@ -86,7 +86,7 @@ If you use push notifications, update your `service-worker.js` to import the V6 
 self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-The V5 kit references `service-worker-5.5.0.js`. mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
+mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
 ---
 

--- a/kits/braze/braze-6/README.md
+++ b/kits/braze/braze-6/README.md
@@ -196,8 +196,6 @@ If you use push notifications, your `service-worker.js` should import the V6 ser
 self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-Earlier kits referenced `service-worker-3.5.0.js`, `service-worker-4.2.1.js`, and `service-worker-5.5.0.js` respectively. In mParticle's testing Braze's push notifications work regardless of which service worker version is used, but you should update this file to ensure future compatibility.
-
 mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
 ---

--- a/kits/braze/braze-6/README.md
+++ b/kits/braze/braze-6/README.md
@@ -15,6 +15,7 @@ If you are still on the V3, V4, or V5 kit, we recommend updating straight to V6 
 - [Upgrading from V3 to V6](#upgrading-from-v3-to-v6) — largest change; the `appboy` global goes away
 - [Upgrading from V4 to V6](#upgrading-from-v4-to-v6) — moderate; deprecated API cleanup plus News Feed removal
 - [Upgrading from V5 to V6](#upgrading-from-v5-to-v6) — smallest; News Feed removal and card-analytics renames
+- [Write version-tolerant code](#write-version-tolerant-code) — ship code that works before and after you select Version 6
 
 **Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
 
@@ -28,9 +29,10 @@ Regardless of which version you are coming from, the mechanics are the same:
    - Core Web SDK v3: `npm install @mparticle/web-braze-kit-6`
    - Core Web SDK v2: `npm install @mparticle/web-braze-kit@^6`
 2. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. **This is required for both npm and snippet/CDN integrations** — installing the package alone does not switch you over.
-3. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+3. **Add defensive code**, if you call Braze directly, so your site works before and after the switch. See [Write version-tolerant code](#write-version-tolerant-code) and use the example for the version you are coming from.
+4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
 
-If you never call Braze directly from your own code, steps 1–3 are the entire upgrade. The code samples below only matter if you reference `window.appboy` or `window.braze` yourself.
+If you never call Braze directly from your own code, skip step 3; steps 1, 2, and 4 are the entire upgrade. The code samples below only matter if you reference `window.appboy` or `window.braze` yourself.
 
 We recommend shipping your code changes **before** flipping the version setting wherever possible, so that the code change and the version change remain two separately revertible steps.
 
@@ -134,6 +136,52 @@ window.braze.logCardImpressions([card], true);
 
 // V6
 window.braze.logContentCardImpressions([card]);
+```
+
+---
+
+## Write version-tolerant code
+
+Selecting `Version 6` in your connection settings swaps the kit that loads on your site, and that happens outside of your own deploy. If you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+Use the example that matches the version you are coming from. Search your codebase for every remaining direct `appboy` or `braze` call and apply the same pattern, using the mapping table for your starting version and Braze's changelog to find the V6 equivalent of each one.
+
+Once V6 is live and verified, you can delete the fallbacks and call the V6 methods directly.
+
+### From V3
+
+The V3 → V6 change that matters most is the global rename, so guard on which global is present:
+
+```javascript
+if (window.braze) {
+    window.braze.showContentCards();
+} else if (window.appboy) {
+    window.appboy.display.showContentCards();
+}
+```
+
+### From V4
+
+The `braze` global is the same in V4 and V6, so guard on the method instead. For the card-analytics renames:
+
+```javascript
+if (window.braze.logContentCardImpressions) {
+    window.braze.logContentCardImpressions([card]);
+} else {
+    window.braze.logCardImpressions([card], true);
+}
+```
+
+### From V5
+
+The `braze` global is the same in V5 and V6, so guard on the method instead. For the card-analytics renames:
+
+```javascript
+if (window.braze.logContentCardImpressions) {
+    window.braze.logContentCardImpressions([card]);
+} else {
+    window.braze.logCardImpressions([card], true);
+}
 ```
 
 ---

--- a/kits/braze/braze-6/README.md
+++ b/kits/braze/braze-6/README.md
@@ -12,9 +12,9 @@ This kit bundles **Braze Web SDK V6** (`@braze/web-sdk@^6.0.0`) and exposes it o
 
 If you are still on the V3, V4, or V5 kit, we recommend updating straight to V6 for latest support of all Braze features. Jump to the section for your current version:
 
-- [Upgrading from V3 to V6](#upgrading-from-v3-to-v6) — largest change; the `appboy` global goes away
-- [Upgrading from V4 to V6](#upgrading-from-v4-to-v6) — moderate; deprecated API cleanup plus News Feed removal
-- [Upgrading from V5 to V6](#upgrading-from-v5-to-v6) — smallest; News Feed removal and card-analytics renames
+- [Upgrading from V3 to V6](#upgrading-from-v3-to-v6) — the `appboy` global goes away
+- [Upgrading from V4 to V6](#upgrading-from-v4-to-v6) — deprecated API cleanup plus News Feed removal
+- [Upgrading from V5 to V6](#upgrading-from-v5-to-v6) — News Feed removal and card-analytics renames
 - [Write version-tolerant code](#write-version-tolerant-code) — snippet/CDN only; ship code that works before and after you select Version 6
 
 See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
@@ -85,7 +85,7 @@ window.braze.showContentCards();
 
 ## Upgrading from V4 to V6
 
-We recommend updating straight to V6 for latest support of all Braze features. You already have the `braze` global.
+We recommend updating straight to V6 for latest support of all Braze features.
 
 | V4 | V6 |
 | --- | --- |

--- a/kits/braze/braze-6/README.md
+++ b/kits/braze/braze-6/README.md
@@ -15,9 +15,9 @@ If you are still on the V3, V4, or V5 kit, we recommend updating straight to V6 
 - [Upgrading from V3 to V6](#upgrading-from-v3-to-v6) — largest change; the `appboy` global goes away
 - [Upgrading from V4 to V6](#upgrading-from-v4-to-v6) — moderate; deprecated API cleanup plus News Feed removal
 - [Upgrading from V5 to V6](#upgrading-from-v5-to-v6) — smallest; News Feed removal and card-analytics renames
-- [Write version-tolerant code](#write-version-tolerant-code) — ship code that works before and after you select Version 6
+- [Write version-tolerant code](#write-version-tolerant-code) — snippet/CDN only; ship code that works before and after you select Version 6
 
-**Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
+See the [Braze Event Integration](https://docs.mparticle.com/integrations/braze/event/) docs.
 
 ---
 
@@ -26,13 +26,13 @@ If you are still on the V3, V4, or V5 kit, we recommend updating straight to V6 
 Regardless of which version you are coming from, the mechanics are the same:
 
 1. **Install the kit** (only if you self-host mParticle via npm — snippet/CDN users have it delivered automatically):
-   - Core Web SDK v3: `npm install @mparticle/web-braze-kit-6`
-   - Core Web SDK v2: `npm install @mparticle/web-braze-kit@^6`
+   - Self-hosting via npm with **core Web SDK v3 (latest)**: `npm install @mparticle/web-braze-kit-6`
+   - Self-hosting via npm with **core Web SDK v2 (legacy)**: `npm install @mparticle/web-braze-kit@^6`
 2. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. **This is required for both npm and snippet/CDN integrations** — installing the package alone does not switch you over.
-3. **Add defensive code**, if you call Braze directly, so your site works before and after the switch. See [Write version-tolerant code](#write-version-tolerant-code) and use the example for the version you are coming from.
+3. **Add defensive code** if you load mParticle via the snippet and call Braze directly. Skip this if you self-host via npm. See [Write version-tolerant code](#write-version-tolerant-code) and use the example for the version you are coming from.
 4. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
 
-If you never call Braze directly from your own code, skip step 3; steps 1, 2, and 4 are the entire upgrade. The code samples below only matter if you reference `window.appboy` or `window.braze` yourself.
+If you never call Braze directly from your own code, or you self-host via npm, skip step 3. The code samples below only matter if you reference `window.appboy` or `window.braze` yourself.
 
 We recommend shipping your code changes **before** flipping the version setting wherever possible, so that the code change and the version change remain two separately revertible steps.
 
@@ -142,7 +142,9 @@ window.braze.logContentCardImpressions([card]);
 
 ## Write version-tolerant code
 
-Selecting `Version 6` in your connection settings swaps the kit that loads on your site, and that happens outside of your own deploy. If you call Braze directly, ship code that works against both versions first, then flip the setting.
+Do this if you load mParticle via the snippet. After you select `Version 6`, cache busting can leave some visitors on the old kit for a while, so if you call Braze directly, ship code that works against both versions first, then flip the setting.
+
+If you self-host via npm, you control when the kit version ships with your own deploy, so you do not need version-tolerant fallbacks — update your Braze calls and deploy them together with the V6 kit.
 
 Use the example that matches the version you are coming from. Search your codebase for every remaining direct `appboy` or `braze` call and apply the same pattern, using the mapping table for your starting version and Braze's changelog to find the V6 equivalent of each one.
 

--- a/kits/braze/braze-6/README.md
+++ b/kits/braze/braze-6/README.md
@@ -1,52 +1,169 @@
-![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png) 
+![Braze Logo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/blob/master/braze-logo.png)
 
-⚠️⚠️⚠️
-# Notice! Opt in is now available for Braze Web SDK V4 - Action Required
+# mParticle Braze Kit — Braze Web SDK V6
 
-You can now select what version of the Braze SDK you want to use when setting up a Braze connection in the mParticle UI.  Braze occasionally makes breaking changes to their SDK, so if you call `appboy` directly in your code, you will have to update your code to ensure your website performs as expected when updating versions of Braze.
+This kit bundles **Braze Web SDK V6** (`@braze/web-sdk@^6.0.0`) and exposes it on the page as `window.braze`.
 
-Please review the [Braze Changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog#400) and [V4 migration guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md) to learn about the differences between V3 and V4 and what changes you will need to make in your code. The most significant breaking changes are the replacement of the `appboy` class name with `braze`, in addition to the removal and renaming of several APIs.
+---
 
-You can opt into the latest major version of the Braze Web SDK whether you implement mParticle's Web SDK using npm or our snippet/CDN.
-* Customers who self-host mParticle via npm - You should add @mparticle/web-braze-kit version 4.0.0 or greater in your package.json.  You must also select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
-* Customers who load mParticle via snippet/CDN - You must  select `Version 4` under `Braze Web SDK Version`  in the Braze connection settings.
+## ✅ This is the version we recommend
 
-Note that the following is only one example.  Everywhere you manually call `appboy` needs to be updated similar to the below. If you are using NPM, you can skip to step 3.  Please be sure to test your site fully in development prior to releasing.
+**V6 is the current major version of the Braze Web SDK and the version mParticle recommends for all customers.** Braze ships fixes and new features only on the V6 line, so if you are already here, you are on the right kit and there is nothing to upgrade.
 
+If you are still on the V3, V4, or V5 kit, we recommend updating straight to V6 for latest support of all Braze features. Jump to the section for your current version:
 
-* Step 1: Legacy code sample. Find all the places where your code references the `appboy.display` namespace.  Braze has removed all instances of the `display` namespace:
+- [Upgrading from V3 to V6](#upgrading-from-v3-to-v6) — largest change; the `appboy` global goes away
+- [Upgrading from V4 to V6](#upgrading-from-v4-to-v6) — moderate; deprecated API cleanup plus News Feed removal
+- [Upgrading from V5 to V6](#upgrading-from-v5-to-v6) — smallest; News Feed removal and card-analytics renames
+
+**Full, authoritative upgrade instructions live in the mParticle docs: [Braze Event Integration → Braze Web Kit Critical Updates and Timelines → Opt In to Braze SDK Version 6](https://docs.mparticle.com/integrations/braze/event/).**
+
+---
+
+## Installing and enabling V6
+
+Regardless of which version you are coming from, the mechanics are the same:
+
+1. **Install the kit** (only if you self-host mParticle via npm — snippet/CDN users have it delivered automatically):
+   - Core Web SDK v3: `npm install @mparticle/web-braze-kit-6`
+   - Core Web SDK v2: `npm install @mparticle/web-braze-kit@^6`
+2. **Select `Version 6`** under `Braze Web SDK Version` in your Braze connection settings in the mParticle UI. **This is required for both npm and snippet/CDN integrations** — installing the package alone does not switch you over.
+3. **Update your push service worker**, if you use push. See [Push notifications](#push-notifications).
+
+If you never call Braze directly from your own code, steps 1–3 are the entire upgrade. The code samples below only matter if you reference `window.appboy` or `window.braze` yourself.
+
+We recommend shipping your code changes **before** flipping the version setting wherever possible, so that the code change and the version change remain two separately revertible steps.
+
+---
+
+## Upgrading from V3 to V6
+
+We recommend updating straight to V6 for latest support of all Braze features.
+
+Primary sources: the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) and the [Braze upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md).
+
+| V3 | V6 |
+| --- | --- |
+| `appboy` global | `braze` |
+| `appboy.display.*` namespace | Methods moved to the top level: `braze.*` |
+| `appboy.registerAppboyPushMessages()` | `braze.requestPushPermission()` |
+| `appboy.unregisterAppboyPushMessages()` | `braze.unregisterPush()` |
+| `appboy.display.automaticallyShowNewInAppMessages()` | `braze.automaticallyShowInAppMessages()` — must run *before* `openSession()` |
+| `appboy.toggleAppboyLogging()` | `braze.toggleLogging()` |
+| `appboy.isPushGranted()` *(deprecated since 1.6.2)* | `braze.isPushPermissionGranted()` |
+| `appboy.subscribeToNewInAppMessages()` *(deprecated since 2.4.0)* | `braze.subscribeToInAppMessage()` |
+| `appboy.trackLocation()` *(deprecated since 3.3.0)* | Native Geolocation API + `User.setLastKnownLocation()` |
+| `appboy.stopWebTracking()` *(deprecated since 3.5.0)* | `braze.disableSDK()` |
+| `appboy.resumeWebTracking()` *(deprecated since 3.5.0)* | `braze.enableSDK()` |
+| `appboy.logCardClick()` | `braze.logContentCardClick()` |
+| `appboy.logCardImpressions()` | `braze.logContentCardImpressions()` |
+| `appboy.logContentCardsDisplayed()` | Delete it — it was already a no-op |
+| Legacy News Feed APIs | **No drop-in replacement.** Migrate to Content Cards |
+| `devicePropertyWhitelist` init option | `devicePropertyAllowlist` |
+| `enableHtmlInAppMessages` init option | `allowUserSuppliedJavascript` |
+| `language` init option | `localization` |
+| `safariWebsitePushId` param on `registerAppboyPushMessages()` | `safariWebsitePushId` initialization option |
+| `User.setAvatarImageUrl()` | No replacement |
+| `appboy.Banner` card class | `braze.ImageOnly` |
+| `ab-banner` CSS class | `ab-image-only` |
+
+Search your codebase for **every** `appboy` reference and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, the `appboy.display` namespace was removed and its methods moved to `braze`:
+
 ```javascript
-window.appboy.display.destroyFeed();
+// V3
+window.appboy.display.showContentCards();
+
+// V6
+window.braze.showContentCards();
 ```
 
-Step 2: Roll out code changes prior to opting in to V4
+---
+
+## Upgrading from V4 to V6
+
+We recommend updating straight to V6 for latest support of all Braze features. You already have the `braze` global.
+
+| V4 | V6 |
+| --- | --- |
+| `braze.logCardClick()` | `braze.logContentCardClick()` — already exists in V4 |
+| `braze.logCardImpressions()` | `braze.logContentCardImpressions()` — already exists in V4 |
+| `braze.logContentCardsDisplayed()` *(already a no-op)* | Delete it |
+| Legacy News Feed APIs | **No drop-in replacement.** Migrate to Content Cards |
+| `braze.Banner` card class *(deprecated since 4.9.0)* | `braze.ImageOnly` |
+| `ab-banner` CSS class | `ab-image-only` |
+| `enableHtmlInAppMessages` init option | `allowUserSuppliedJavascript` |
+| `getDeviceId(callback)` / `User.getUserId(callback)` | Return values directly |
+| `Card.created`, `Card.categories` | No replacement; these were News Feed fields |
+
+Search your codebase for **every** direct `braze` call and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, use the Content Card-specific analytics methods:
+
 ```javascript
-if (window.appboy) {
-	window.appboy.display.destroyFeed();
-} else if (window.braze) {
-	window.braze.destroyFeed();
-}
-```
-Step 3: Whether you are using the snippet or self hosting, you need to navigate to your Braze connection settings and select `Version 4` from the `Braze Web SDK Version` drop down.
+// V4
+window.braze.logCardImpressions([card], true);
 
-Step 4: After you opt in, you can simplify your code. We recommend testing and waiting at least 24 hours between opting in and removing previous instances of `appboy` and doing thorough testing of your application in a development environment to ensure everything is working:
+// V6
+window.braze.logContentCardImpressions([card]);
+```
+
+---
+
+## Upgrading from V5 to V6
+
+We recommend updating straight to V6 for latest support of all Braze features. The `braze` global, initialization options, and nearly the whole API are unchanged.
+
+| V5 | V6 |
+| --- | --- |
+| `braze.logCardClick()` | `braze.logContentCardClick()` — already exists in V5 |
+| `braze.logCardImpressions()` | `braze.logContentCardImpressions()` — already exists in V5 |
+| Legacy News Feed APIs | **No drop-in replacement.** Migrate to Content Cards |
+| `Card.created`, `Card.categories` | No replacement; these were News Feed fields |
+| `ImageOnly.linkText` | No replacement |
+| Custom banner HTML + `logBannerClick()` / `logBannerImpressions()` | `braze.insertBanner()` |
+
+Search your codebase for **every** direct `braze` call and use Braze's changelog and upgrade guide to determine the corresponding V6 change. The table above highlights common changes but is not a substitute for reviewing your implementation.
+
+For example, use the Content Card-specific analytics methods:
+
 ```javascript
-window.braze.destroyFeed();
+// V5
+window.braze.logCardImpressions([card], true);
+
+// V6
+window.braze.logContentCardImpressions([card]);
 ```
 
-Step 5: Push Notifications via service-worker.js
-If you use Push Notifications, we have updated the `service-worker.js` file.  In our testing, Braze’s push notifications work as expected regardless of what version of the service-worker is used, but we recommend updating this file to ensure future compatibility.  In your `service-worker.js` file, update the code to reference `https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js` instead of `https://static.mparticle.com/sdk/js/braze/service-worker-3.5.0.js`.  Your `service-worker.js` file should now contain:
+---
+
+## Push notifications
+
+If you use push notifications, your `service-worker.js` should import the V6 service worker that mParticle hosts:
 
 ```javascript
-self.imports('https://static.mparticle.com/sdk/js/braze/service-worker-4.2.0.js')
+self.importScripts('https://static.mparticle.com/sdk/js/braze/service-worker-6.5.0.js');
 ```
 
-### Transition from @mparticle/web-appboy-kit to @mparticle/web-braze-kit
+Earlier kits referenced `service-worker-3.5.0.js`, `service-worker-4.2.1.js`, and `service-worker-5.5.0.js` respectively. In mParticle's testing Braze's push notifications work regardless of which service worker version is used, but you should update this file to ensure future compatibility.
 
-The legacy @mparticle/web-appboy-kit from npm includes version 2 of the Braze Web SDK.  As part of this update, we've created a new [Braze web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze) to replace our deprecated [Appboy web kit repo](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy).  If you are still using `@mparticle/web-appboy-kit`, you will need to consider the breaking changes Braze made between V2 and V3 of the Braze SDK (found [here](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog/#300)) as well as the instructions above to get from V2 to V4 of the Braze SDK.
+mParticle hosts Braze's service worker to avoid unpredictable versioning issues — do not point at Braze's own service worker CDN.
 
+---
 
+## eCommerce Recommended Events
 
+If you enable the `Enable eCommerce Recommended Events` connection setting, mParticle maps commerce events to Braze's eCommerce Recommended Events schema. Client-side forwarding of these events requires **web Braze kit version 6.1.0 or later**. On earlier versions, mParticle falls back to forwarding commerce events as legacy custom and purchase events. See the [connection settings reference](https://docs.mparticle.com/integrations/braze/event/) for the full event and attribute mapping.
+
+---
+
+## Reference
+
+- [mParticle Braze integration docs](https://docs.mparticle.com/integrations/braze/event/)
+- [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md)
+- [Braze Web SDK upgrade guide](https://github.com/braze-inc/braze-web-sdk/blob/master/UPGRADE_GUIDE.md)
+- [Braze Web SDK API reference](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html)
 
 # License
 


### PR DESCRIPTION
## Summary
- Replace the stale, duplicated Braze kit READMEs (V6 was identical to V4 and still told people to opt into V4).
- Recommend going **straight to V6** from V3, V4, and V5 — no intermediate hops — with a single mapping table and code samples per starting version.
- Point customers at the [Braze event integration docs](https://docs.mparticle.com/integrations/braze/event/) plus the [Braze Web SDK changelog](https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md) for the authoritative upgrade path.

## Test plan
- [ ] Skim `kits/braze/braze-3/README.md` as a V3 customer: one hop to V6, no V4/V5 detour.
- [ ] Same for V4 and V5 READMEs.
- [ ] Confirm V6 README has headings for upgrading from V3, V4, and V5, each as a single hop.
- [ ] Click through the mParticle docs, Braze changelog, and service-worker URL links.