### PR TITLE
fix(release): prioritize Rokt kits release, accept v3 PR targets, increase registry audit timing

### DIFF
--- a/.github/workflows/reusable-workflows.yml
+++ b/.github/workflows/reusable-workflows.yml
@@ -10,9 +10,23 @@ jobs:
   pr-title-check:
     name: Check PR for semantic title
     uses: mParticle/mparticle-workflows/.github/workflows/pr-title-check.yml@stable
-  pr-branch-target-gitflow:
-    name: Check PR for semantic target branch
-    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@stable
+  pr-branch-target:
+    name: Check PR for semantic target branch / Confirm that target branch for PR is main or build/
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm supported PR target branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          case "$BASE_REF" in
+            master|development|main|v3-development|chore/dependabot*|build/*)
+              echo "Pull request target branch '$BASE_REF' is valid."
+              ;;
+            *)
+              echo "Pull request target branch '$BASE_REF' is not valid."
+              exit 1
+              ;;
+          esac
   security-lint-checks:
     name: Security Lint Checks
     uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@stable

--- a/.github/workflows/staging-step-3.yml
+++ b/.github/workflows/staging-step-3.yml
@@ -9,7 +9,7 @@ on:
                 required: true
                 type: string
             dryRun:
-                description: 'Validate the atomic synchronization without pushing [true/false]'
+                description: 'Do a dry run to validate without pushing [true/false]'
                 required: true
                 type: boolean
                 default: true

--- a/README.md
+++ b/README.md
@@ -153,10 +153,11 @@ workflows in order:
    bootstrap permits all kit tags to be absent so the first synchronized release
    can establish them. After building the target version, Step 1 also packs and
    registry-preflights all kit artifacts before publishing core. It then checks
-   out the immutable release tag, publishes all
-   packages in `kits/publish-matrix.json` sequentially, and verifies that the
-   core SDK and every kit have the expected version, artifact integrity, and
-   npm dist-tag. A rerun skips an existing kit only when its artifact is
+   out the immutable release tag and publishes all packages in
+   `kits/publish-matrix.json` sequentially. After all publishes finish, one
+   final audit waits up to five minutes for npm propagation and verifies that
+   the core SDK and every kit have the expected version, artifact integrity,
+   and npm dist-tag. A rerun skips an existing kit only when its artifact is
    identical. `dryRun=true` previews the merge and semantic-release result
    without creating a branch or publishing; `dryRun=false` creates/pushes the
    release branch and publishes. If core publishes but kit publication cannot

--- a/kits/publish-matrix.json
+++ b/kits/publish-matrix.json
@@ -1,5 +1,13 @@
 [
     {
+        "name": "@mparticle/web-rokt-kit",
+        "local_path": "kits/rokt"
+    },
+    {
+        "name": "@mparticle/web-rokt-pay-plus-kit",
+        "local_path": "kits/roktpayplus"
+    },
+    {
         "name": "@mparticle/web-adobe-target-kit",
         "local_path": "kits/adobe-target"
     },
@@ -96,10 +104,6 @@
         "local_path": "kits/optimizely"
     },
     {
-        "name": "@mparticle/web-rokt-kit",
-        "local_path": "kits/rokt"
-    },
-    {
         "name": "@mparticle/web-simplereach-kit",
         "local_path": "kits/simplereach"
     },
@@ -128,9 +132,5 @@
         "name": "@mparticle/web-adobe-server-kit",
         "local_path": "kits/adobe/packages/AdobeServer",
         "build_path": "kits/adobe"
-    },
-    {
-        "name": "@mparticle/web-rokt-pay-plus-kit",
-        "local_path": "kits/roktpayplus"
     }
 ]

--- a/scripts/publish-kits.js
+++ b/scripts/publish-kits.js
@@ -12,6 +12,8 @@ const {
 const repositoryRoot = path.resolve(__dirname, '..');
 const registry = 'https://registry.npmjs.org';
 const initialV3CoreVersion = '3.0.0';
+const remoteAuditAttempts = 60;
+const remoteAuditDelayMs = 5000;
 const npmExecutable = path.join(
     path.dirname(process.execPath),
     process.platform === 'win32' ? 'npm.cmd' : 'npm'
@@ -303,25 +305,54 @@ function verifyPublishedCore(packageInfo, version, distTag, options = {}) {
     verifyPackage(packageInfo, version, distTag);
 }
 
-function waitForRemotePackage(packageInfo, version, distTag) {
-    let lastError;
-    for (let attempt = 1; attempt <= 12; attempt++) {
-        try {
-            verifyRemotePackage(packageInfo, version, distTag);
-            return;
-        } catch (error) {
-            lastError = error;
-            if (attempt < 12) {
-                Atomics.wait(
-                    new Int32Array(new SharedArrayBuffer(4)),
-                    0,
-                    0,
-                    5000
-                );
+function waitForRemotePackages(packageInfos, version, distTag, options = {}) {
+    const verifyPackage = options.verifyRemotePackage || verifyRemotePackage;
+    const wait =
+        options.wait ||
+        (delayMs =>
+            Atomics.wait(
+                new Int32Array(new SharedArrayBuffer(4)),
+                0,
+                0,
+                delayMs
+            ));
+    const maxAttempts = options.maxAttempts || remoteAuditAttempts;
+    const delayMs = options.delayMs || remoteAuditDelayMs;
+    let pendingPackages = packageInfos.map(packageInfo => ({
+        packageInfo,
+        lastError: null,
+    }));
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const remainingPackages = [];
+        for (const pendingPackage of pendingPackages) {
+            try {
+                verifyPackage(pendingPackage.packageInfo, version, distTag);
+            } catch (error) {
+                remainingPackages.push({
+                    packageInfo: pendingPackage.packageInfo,
+                    lastError: error,
+                });
             }
         }
+
+        if (remainingPackages.length === 0) {
+            return;
+        }
+        pendingPackages = remainingPackages;
+        if (attempt < maxAttempts) {
+            wait(delayMs);
+        }
     }
-    throw lastError;
+
+    throw new Error(
+        `npm audit did not complete within five minutes: ${pendingPackages
+            .map(
+                pendingPackage =>
+                    `${pendingPackage.packageInfo.name}: ${pendingPackage.lastError.message}`
+            )
+            .join('; ')}`
+    );
 }
 
 function preflightTarball(packageInfo, version, distTag) {
@@ -399,7 +430,6 @@ function publishTarball(packageInfo, version, distTag) {
             stdio: 'inherit',
         }
     );
-    waitForRemotePackage(packageInfo, version, distTag);
     return 'published';
 }
 
@@ -569,9 +599,7 @@ function main() {
             results,
         });
 
-        for (const packageInfo of packageArtifacts) {
-            verifyRemotePackage(packageInfo, version, distTag);
-        }
+        waitForRemotePackages(packageArtifacts, version, distTag);
 
         appendSummary(version, distTag, results);
         console.log(
@@ -652,5 +680,5 @@ module.exports = {
     verifyCurrentReleaseComplete,
     verifyPublishedCore,
     verifyRemotePackage,
-    waitForRemotePackage,
+    waitForRemotePackages,
 };

--- a/test/jest/release-scripts.spec.ts
+++ b/test/jest/release-scripts.spec.ts
@@ -70,6 +70,10 @@ describe('kit release scripts', () => {
         expect(inventory.publishOutputPaths).toContain(
             'kits/adobe/packages/AdobeServer/dist'
         );
+        expect(packageNames.slice(0, 2)).toEqual([
+            '@mparticle/web-rokt-kit',
+            '@mparticle/web-rokt-pay-plus-kit',
+        ]);
     });
 
     it('terminates every serialized kit build path with a newline', () => {
@@ -78,7 +82,11 @@ describe('kit release scripts', () => {
 
         expect(serializedBuildPaths.endsWith('\n')).toBe(true);
         expect(serializedBuildPaths.trimEnd().split('\n')).toEqual(buildPaths);
-        expect(buildPaths[buildPaths.length - 1]).toBe('kits/roktpayplus');
+        expect(buildPaths.slice(0, 2)).toEqual([
+            'kits/rokt',
+            'kits/roktpayplus',
+        ]);
+        expect(buildPaths[buildPaths.length - 1]).toBe('kits/adobe');
     });
 
     it('requires a stable semantic version', () => {

--- a/test/jest/release-scripts.spec.ts
+++ b/test/jest/release-scripts.spec.ts
@@ -18,6 +18,7 @@ const {
     validatePackageManifest,
     verifyCurrentReleaseComplete,
     verifyPublishedCore,
+    waitForRemotePackages,
 } = require('../../scripts/publish-kits');
 const {
     previewKitRelease,
@@ -245,6 +246,44 @@ describe('kit release scripts', () => {
                 result: 'published',
             }))
         );
+    });
+
+    it('retries one final audit only for packages not yet visible', () => {
+        const artifacts = [
+            {name: 'available-kit'},
+            {name: 'delayed-kit'},
+        ];
+        let delayedAttempts = 0;
+        const verifyRemotePackage = jest.fn(
+            (packageInfo: {name: string}) => {
+                if (
+                    packageInfo.name === 'delayed-kit' &&
+                    ++delayedAttempts < 3
+                ) {
+                    throw new Error('package is not yet visible');
+                }
+            }
+        );
+        const wait = jest.fn();
+
+        waitForRemotePackages(artifacts, '3.0.1', 'next', {
+            verifyRemotePackage,
+            wait,
+            maxAttempts: 3,
+            delayMs: 1,
+        });
+
+        expect(
+            verifyRemotePackage.mock.calls.map(
+                ([packageInfo]: [{name: string}]) => packageInfo.name
+            )
+        ).toEqual([
+            'available-kit',
+            'delayed-kit',
+            'delayed-kit',
+            'delayed-kit',
+        ]);
+        expect(wait).toHaveBeenCalledTimes(2);
     });
 
     it('writes actionable recovery instructions for a partial release', () => {


### PR DESCRIPTION
## Summary
- publish the Rokt and Rokt Pay+ kits first, then publish all remaining kits without waiting for npm propagation after each package
- run one final registry audit after publication, retrying only packages that are not yet visible every five seconds for up to five minutes and reporting any packages still pending
- update the release-flow documentation and Step 3 dry-run wording, with regression coverage for publication order and pending-package retries
- validate normal v2 (`master`, `development`) and v3 (`main`, `v3-development`) PR targets locally while preserving the existing `build/*` and `chore/dependabot*` exceptions

## Test plan
- [x] `npm run test:jest -- --runTestsByPath test/jest/release-scripts.spec.ts`
- [x] `npx eslint scripts/publish-kits.js`
- [x] `npx prettier --check scripts/publish-kits.js test/jest/release-scripts.spec.ts`
- [x] Parse `.github/workflows/reusable-workflows.yml` with Prettier's YAML parser
- [x] Exercise representative accepted and rejected v2/v3 branch targets against the workflow shell policy
- [x] `git diff --check`