### PR TITLE
fix(braze): derive runtime versions from package manifests

### DIFF
--- a/kits/braze/braze-3/package-lock.json
+++ b/kits/braze/braze-3/package-lock.json
@@ -23,6 +23,7 @@
                 "rollup": "^1.13.1",
                 "rollup-plugin-commonjs": "^10.0.0",
                 "rollup-plugin-node-resolve": "^5.0.1",
+                "rollup-plugin-replace": "^2.2.0",
                 "shelljs": "^0.8.4",
                 "should": "^7.1.0",
                 "watchify": "^3.11.1"
@@ -3740,6 +3741,18 @@
             },
             "peerDependencies": {
                 "rollup": ">=1.11.0"
+            }
+        },
+        "node_modules/rollup-plugin-replace": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
+            "integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
+            "deprecated": "This module has moved and is now available at @rollup/plugin-replace. Please update your dependencies. This version is no longer maintained.",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "magic-string": "^0.25.2",
+                "rollup-pluginutils": "^2.6.0"
             }
         },
         "node_modules/rollup-pluginutils": {

--- a/kits/braze/braze-3/package.json
+++ b/kits/braze/braze-3/package.json
@@ -29,6 +29,7 @@
         "rollup": "^1.13.1",
         "rollup-plugin-commonjs": "^10.0.0",
         "rollup-plugin-node-resolve": "^5.0.1",
+        "rollup-plugin-replace": "^2.2.0",
         "shelljs": "^0.8.4",
         "should": "^7.1.0",
         "watchify": "^3.11.1"

--- a/kits/braze/braze-3/rollup.config.js
+++ b/kits/braze/braze-3/rollup.config.js
@@ -1,5 +1,17 @@
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import replace from 'rollup-plugin-replace';
+
+const packageVersion = process.env.npm_package_version;
+if (!packageVersion) {
+    throw new Error('npm_package_version is required to build the Braze kit');
+}
+
+function replacePackageVersion() {
+    return replace({
+        'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+    });
+}
 
 export default [
     {
@@ -12,6 +24,7 @@ export default [
             strict: false,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -28,6 +41,7 @@ export default [
             strict: false,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),

--- a/kits/braze/braze-3/src/BrazeKit-dev.js
+++ b/kits/braze/braze-3/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.appboy = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v3',
     moduleId = 28,
-    version = '3.0.9',
+    version = process.env.PACKAGE_VERSION,
     MessageType = {
         PageView: 3,
         PageEvent: 4,

--- a/kits/braze/braze-3/test/tests.js
+++ b/kits/braze/braze-3/test/tests.js
@@ -1,11 +1,13 @@
 /* eslint-disable no-undef */
 // If we are testing this in a node environemnt, we load the common.js Braze kit
 
-var brazeInstance;
+var brazeInstance, packageVersion;
 if (typeof require !== 'undefined') {
+    packageVersion = require('../package.json').version;
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
     brazeInstance = mpBrazeKitV3.default;
+    packageVersion = brazeInstance.getVersion();
 }
 
 describe('Appboy Forwarder', function () {
@@ -286,6 +288,10 @@ describe('Appboy Forwarder', function () {
 
     it('should have a property of suffix', function() {
         window.mParticle.forwarder.should.have.property('suffix', 'v3');
+    });
+
+    it('should expose its package version', function() {
+        brazeInstance.getVersion().should.equal(packageVersion);
     });
 
     it('should register a forwarder with version number onto a config', function() {

--- a/kits/braze/braze-4/package-lock.json
+++ b/kits/braze/braze-4/package-lock.json
@@ -15,6 +15,7 @@
             "devDependencies": {
                 "@rollup/plugin-commonjs": "22.0.1",
                 "@rollup/plugin-node-resolve": "13.3.0",
+                "@rollup/plugin-replace": "^6.0.3",
                 "chai": "^4.2.0",
                 "karma": "^5.1.0",
                 "karma-chai": "^0.1.0",
@@ -41,6 +42,13 @@
             "version": "4.8.0",
             "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-4.8.0.tgz",
             "integrity": "sha512-yWiZzg87GrbN9EvE7wQvVXQGE5/z6hm0murahxJTMD3KjtYXmwBunKAHNR2ILdRjpmaEqCdcg73+Flrt/yoYag=="
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@mparticle/event-models": {
             "version": "1.3.1",
@@ -81,12 +89,6 @@
             "peerDependencies": {
                 "rollup": "^2.68.0"
             }
-        },
-        "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true
         },
         "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
             "version": "7.2.3",
@@ -218,6 +220,71 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rollup/pluginutils": {
@@ -1630,6 +1697,13 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/eventemitter3": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
@@ -2861,6 +2935,16 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
             "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
             "dev": true
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
         },
         "node_modules/map-cache": {
             "version": "0.2.2",

--- a/kits/braze/braze-4/package.json
+++ b/kits/braze/braze-4/package.json
@@ -23,6 +23,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
         "@rollup/plugin-node-resolve": "13.3.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "chai": "^4.2.0",
         "karma": "^5.1.0",
         "karma-chai": "^0.1.0",

--- a/kits/braze/braze-4/rollup.config.js
+++ b/kits/braze/braze-4/rollup.config.js
@@ -1,5 +1,18 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+
+const packageVersion = process.env.npm_package_version;
+if (!packageVersion) {
+    throw new Error('npm_package_version is required to build the Braze kit');
+}
+
+function replacePackageVersion() {
+    return replace({
+        preventAssignment: true,
+        'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+    });
+}
 
 export default [
     {
@@ -13,6 +26,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -30,6 +44,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),

--- a/kits/braze/braze-4/src/BrazeKit-dev.js
+++ b/kits/braze/braze-4/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.braze = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v4',
     moduleId = 28,
-    version = '4.2.2',
+    version = process.env.PACKAGE_VERSION,
     MessageType = {
         PageView: 3,
         PageEvent: 4,

--- a/kits/braze/braze-4/test/tests.js
+++ b/kits/braze/braze-4/test/tests.js
@@ -1,10 +1,12 @@
 // If we are testing this in a node environemnt, we load the common.js Braze kit
 
-var brazeInstance;
+var brazeInstance, packageVersion;
 if (typeof require !== 'undefined') {
+    packageVersion = require('../package.json').version;
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
     brazeInstance = mpBrazeKitV4.default;
+    packageVersion = brazeInstance.getVersion();
 }
 
 describe('Braze Forwarder', function() {
@@ -317,6 +319,10 @@ describe('Braze Forwarder', function() {
 
     it('should have a property of suffix', function() {
         window.mParticle.forwarder.should.have.property('suffix', 'v4');
+    });
+
+    it('should expose its package version', function() {
+        brazeInstance.getVersion().should.equal(packageVersion);
     });
 
     it('should register a forwarder with version number onto a config', function() {

--- a/kits/braze/braze-5/package-lock.json
+++ b/kits/braze/braze-5/package-lock.json
@@ -15,6 +15,7 @@
             "devDependencies": {
                 "@rollup/plugin-commonjs": "22.0.1",
                 "@rollup/plugin-node-resolve": "13.3.0",
+                "@rollup/plugin-replace": "^6.0.3",
                 "chai": "^4.2.0",
                 "karma": "^5.1.0",
                 "karma-chai": "^0.1.0",
@@ -43,6 +44,13 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-5.5.0.tgz",
             "integrity": "sha512-1pSxzPbug6420DXieGruURbY5KORshIu9qwCF/Kabf5CAaJTNpW+hzjC+VUaendDPW0fgfDEHrkwt/g/yfafPQ=="
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@mparticle/event-models": {
             "version": "1.3.1",
@@ -102,6 +110,81 @@
             },
             "peerDependencies": {
                 "rollup": "^2.42.0"
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rollup/pluginutils": {

--- a/kits/braze/braze-5/package.json
+++ b/kits/braze/braze-5/package.json
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
         "@rollup/plugin-node-resolve": "13.3.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "chai": "^4.2.0",
         "karma": "^5.1.0",
         "karma-chai": "^0.1.0",

--- a/kits/braze/braze-5/rollup.config.js
+++ b/kits/braze/braze-5/rollup.config.js
@@ -1,5 +1,18 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+
+const packageVersion = process.env.npm_package_version;
+if (!packageVersion) {
+    throw new Error('npm_package_version is required to build the Braze kit');
+}
+
+function replacePackageVersion() {
+    return replace({
+        preventAssignment: true,
+        'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+    });
+}
 
 export default [
     {
@@ -13,6 +26,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -30,6 +44,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -46,6 +61,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),

--- a/kits/braze/braze-5/src/BrazeKit-dev.js
+++ b/kits/braze/braze-5/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.braze = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v5',
     moduleId = 28,
-    version = '5.0.3',
+    version = process.env.PACKAGE_VERSION,
     MessageType = {
         PageView: 3,
         PageEvent: 4,

--- a/kits/braze/braze-5/test/tests.js
+++ b/kits/braze/braze-5/test/tests.js
@@ -1,10 +1,12 @@
 // If we are testing this in a node environemnt, we load the common.js Braze kit
 
-var brazeInstance;
+var brazeInstance, packageVersion;
 if (typeof require !== 'undefined') {
+    packageVersion = require('../package.json').version;
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
     brazeInstance = mpBrazeKitV5.default;
+    packageVersion = brazeInstance.getVersion();
 }
 
 describe('Braze Forwarder', function() {
@@ -327,6 +329,10 @@ describe('Braze Forwarder', function() {
 
     it('should have a property of suffix', function() {
         window.mParticle.forwarder.should.have.property('suffix', 'v5');
+    });
+
+    it('should expose its package version', function() {
+        brazeInstance.getVersion().should.equal(packageVersion);
     });
 
     it('should register a forwarder with version number onto a config', function() {

--- a/test/jest/release-scripts.spec.ts
+++ b/test/jest/release-scripts.spec.ts
@@ -76,6 +76,76 @@ describe('kit release scripts', () => {
         ]);
     });
 
+    it('derives every runtime kit version from its package manifest', () => {
+        const sourceFiles: string[] = [];
+        const excludedDirectories = new Set(['dist', 'node_modules', 'test']);
+        const visitSourceDirectory = (directory: string): void => {
+            for (const entry of fs.readdirSync(directory, {
+                withFileTypes: true,
+            })) {
+                if (excludedDirectories.has(entry.name)) {
+                    continue;
+                }
+
+                const entryPath = path.join(directory, entry.name);
+                if (entry.isDirectory()) {
+                    visitSourceDirectory(entryPath);
+                } else if (/\.(?:js|ts)$/.test(entry.name)) {
+                    sourceFiles.push(entryPath);
+                }
+            }
+        };
+
+        visitSourceDirectory(path.join(__dirname, '../../kits'));
+
+        const versionSurfacePattern =
+            /(?:getVersion\s*:\s*function|const kitVersion\s*=)/;
+        const runtimeVersionFiles = sourceFiles
+            .filter((filePath) =>
+                versionSurfacePattern.test(fs.readFileSync(filePath, 'utf8'))
+            )
+            .map((filePath) =>
+                path.relative(path.join(__dirname, '../..'), filePath)
+            )
+            .sort();
+        const expectedRuntimeVersionFiles = [
+            'kits/braze/braze-3/src/BrazeKit-dev.js',
+            'kits/braze/braze-4/src/BrazeKit-dev.js',
+            'kits/braze/braze-5/src/BrazeKit-dev.js',
+            'kits/braze/braze-6/src/BrazeKit-dev.js',
+            'kits/rokt/src/Rokt-Kit.ts',
+        ];
+
+        expect(runtimeVersionFiles).toEqual(expectedRuntimeVersionFiles);
+
+        for (const filePath of runtimeVersionFiles) {
+            const source = fs.readFileSync(
+                path.join(__dirname, '../..', filePath),
+                'utf8'
+            );
+            expect(source).toContain('process.env.PACKAGE_VERSION');
+        }
+
+        const versionBuildConfigs = [
+            'kits/braze/braze-3/rollup.config.js',
+            'kits/braze/braze-4/rollup.config.js',
+            'kits/braze/braze-5/rollup.config.js',
+            'kits/braze/braze-6/rollup.config.js',
+            'kits/rokt/vite.config.ts',
+        ];
+        for (const configPath of versionBuildConfigs) {
+            const config = fs.readFileSync(
+                path.join(__dirname, '../..', configPath),
+                'utf8'
+            );
+            expect(config).toContain('process.env.npm_package_version');
+            expect(config).toContain('process.env.PACKAGE_VERSION');
+            if (configPath.includes('/braze/')) {
+                expect(config).toContain('if (!packageVersion)');
+            }
+        }
+    });
+
     it('terminates every serialized kit build path with a newline', () => {
         const buildPaths = loadReleaseInventory().buildPaths;
         const serializedBuildPaths = serializeBuildPaths(buildPaths);


### PR DESCRIPTION
## Summary
- replace Braze 3–6 hardcoded runtime versions with manifest-derived build values
- add Rollup-compatible version replacement with explicit missing-version failures
- cover each Braze runtime API and guard the complete kit version-surface inventory

## Test plan
- [x] Build Braze 3, 4, 5, and 6
- [x] Run Braze 3–6 suites in Chrome and Firefox
- [x] Run `test/jest/release-scripts.spec.ts`
- [x] Run ESLint and JavaScript/TypeScript Prettier checks
- [x] Inspect CJS, IIFE, and ESM outputs for `3.1.0` and stale version tokens

## Notes
- `npm run gts:check` still crashes on the existing generated `dist/types/src/audience.d.ts`; targeted Jest compilation and Prettier checks pass for the changed TypeScript test.