### PR TITLE
fix(ci): improve beta BrowserStack capture reliability

### DIFF
--- a/test/cross-browser-testing/browserstack.karma.beta.config.js
+++ b/test/cross-browser-testing/browserstack.karma.beta.config.js
@@ -82,11 +82,25 @@ const customLaunchers = {
 };
 
 module.exports = function(config) {
+  const sharedSettings = getSharedKarmaSettings({
+    files,
+    junitOutputFile: 'test-karma-beta.xml',
+    extra: {
+      // Beta browser sessions can take longer than Karma's 60s default
+      // to launch and capture.
+      captureTimeout: 180000,
+      // Retry a failed Karma browser launch or capture exactly once.
+      retryLimit: 1,
+    },
+  });
+
   config.set({
-    ...getSharedKarmaSettings({
-      files,
-      junitOutputFile: 'test-karma-beta.xml',
-    }),
+    ...sharedSettings,
+    browserStack: {
+      ...sharedSettings.browserStack,
+      // Keep the launcher's own capture retry path to one retry as well.
+      retryLimit: 1,
+    },
     customLaunchers,
     browsers: Object.keys(customLaunchers),
     logLevel: config.LOG_INFO,


### PR DESCRIPTION
## Summary
- increase the beta BrowserStack Karma capture timeout from 60 seconds to 180 seconds
- configure both Karma's launcher retry and the BrowserStack launcher's capture retry to exactly one
- keep stable BrowserStack configuration semantics unchanged

## Test plan
- [x] Load beta and stable Karma configs with Node
- [x] Assert beta `captureTimeout=180000`, top-level `retryLimit=1`, and `browserStack.retryLimit=1`
- [x] Assert stable timeout/retry settings remain unchanged
- [x] Run `git diff --check`

## Caveat
These are launcher-level retries for browser launch/capture failures. They do not rerun the entire GitHub Actions job or retry test assertion failures.