### PR TITLE
ci: keep v2 release workflow in parity

### DIFF
--- a/.github/workflows/reusable-workflows.yml
+++ b/.github/workflows/reusable-workflows.yml
@@ -10,9 +10,23 @@ jobs:
   pr-title-check:
     name: Check PR for semantic title
     uses: mParticle/mparticle-workflows/.github/workflows/pr-title-check.yml@stable
-  pr-branch-target-gitflow:
-    name: Check PR for semantic target branch
-    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@stable
+  pr-branch-target:
+    name: Check PR for semantic target branch / Confirm that target branch for PR is main or build/
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm supported PR target branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          case "$BASE_REF" in
+            master|development|main|v3-development|chore/dependabot*|build/*)
+              echo "Pull request target branch '$BASE_REF' is valid."
+              ;;
+            *)
+              echo "Pull request target branch '$BASE_REF' is not valid."
+              exit 1
+              ;;
+          esac
   security-lint-checks:
     name: Security Lint Checks
     uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@stable

--- a/.github/workflows/staging-step-3.yml
+++ b/.github/workflows/staging-step-3.yml
@@ -9,7 +9,7 @@ on:
                 required: true
                 type: string
             dryRun:
-                description: 'Validate the atomic synchronization without pushing [true/false]'
+                description: 'Do a dry run to validate without pushing [true/false]'
                 required: true
                 type: boolean
                 default: true

--- a/README.md
+++ b/README.md
@@ -153,10 +153,11 @@ workflows in order:
    bootstrap permits all kit tags to be absent so the first synchronized release
    can establish them. After building the target version, Step 1 also packs and
    registry-preflights all kit artifacts before publishing core. It then checks
-   out the immutable release tag, publishes all
-   packages in `kits/publish-matrix.json` sequentially, and verifies that the
-   core SDK and every kit have the expected version, artifact integrity, and
-   npm dist-tag. A rerun skips an existing kit only when its artifact is
+   out the immutable release tag and publishes all packages in
+   `kits/publish-matrix.json` sequentially. After all publishes finish, one
+   final audit waits up to five minutes for npm propagation and verifies that
+   the core SDK and every kit have the expected version, artifact integrity,
+   and npm dist-tag. A rerun skips an existing kit only when its artifact is
    identical. `dryRun=true` previews the merge and semantic-release result
    without creating a branch or publishing; `dryRun=false` creates/pushes the
    release branch and publishes. If core publishes but kit publication cannot


### PR DESCRIPTION
## Summary
- port PR #1397's shared Step 3 dry-run label and v2/v3 PR-target policy to `master`
- update the release documentation for the deferred final npm propagation audit
- preserve v2 release behavior (`latest`, `master`, `development`, `staging`, and `release-order-*`) without importing v3-only publication scripts, kit inventory, or version state

The Rokt/Rokt Pay+ publication ordering and deferred audit implementation remain on `main`, where the shared Step 1 workflow exclusively runs kit publication for `track=v3`. The `master` counterpart intentionally carries only the shared workflow/documentation changes, matching the prior #1393/#1394 paired-release structure.

## Test plan
- [x] `git diff --check origin/master...HEAD`
- [x] parse modified workflow files with Ruby/Psych YAML
- [x] confirm modified workflow files are byte-identical to `origin/main`
- [x] verify the diff does not change Step 1's v2 `latest` channel or v2 branch mapping
- [x] attempt Prettier 1.18.2 check (reports repository-existing formatting differences in all three non-JS files; this repository's Prettier script only targets JavaScript)
- [ ] focused release-script Jest tests (not present/applicable on `master`; release scripts and their tests are intentionally v3-only)

Source: #1397