### PR TITLE
feat(braze): sync V6 recommended eCommerce events

### DIFF
--- a/kits/braze/braze-6/package-lock.json
+++ b/kits/braze/braze-6/package-lock.json
@@ -9,12 +9,13 @@
             "version": "3.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@braze/web-sdk": "^6.0.0",
+                "@braze/web-sdk": "^6.9.0",
                 "@mparticle/web-sdk": "^3.0.0"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "22.0.1",
                 "@rollup/plugin-node-resolve": "13.3.0",
+                "@rollup/plugin-replace": "^6.0.3",
                 "chai": "^4.2.0",
                 "karma": "^5.1.0",
                 "karma-chai": "^0.1.0",
@@ -40,10 +41,17 @@
             }
         },
         "node_modules/@braze/web-sdk": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-6.5.0.tgz",
-            "integrity": "sha512-MdfwZn+tfe7+tR8Ir5468/njQDGhgVB9tBthq7gwSETsjv6Q+Hw2bXiQy3scDcACI2RLqiq+dNXKh6fD+pN4/Q==",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-6.12.0.tgz",
+            "integrity": "sha512-VreAi6tnPheqwChFUm2EXzsWnCLpNYZT4CowFmx0BsUKWsCgVts7kP1BsoLLOP2IDuDvhgUPlp9M0wSr6PlHEA==",
             "license": "SEE LICENSE IN https://github.com/braze-inc/braze-web-sdk/blob/master/LICENSE"
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@mparticle/event-models": {
             "version": "1.3.1",
@@ -103,6 +111,81 @@
             },
             "peerDependencies": {
                 "rollup": "^2.42.0"
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rollup/pluginutils": {

--- a/kits/braze/braze-6/package.json
+++ b/kits/braze/braze-6/package.json
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
         "@rollup/plugin-node-resolve": "13.3.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "chai": "^4.2.0",
         "karma": "^5.1.0",
         "karma-chai": "^0.1.0",
@@ -38,7 +39,7 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@braze/web-sdk": "^6.0.0",
+        "@braze/web-sdk": "^6.9.0",
         "@mparticle/web-sdk": "^3.0.0"
     },
     "license": "Apache-2.0",

--- a/kits/braze/braze-6/rollup.config.js
+++ b/kits/braze/braze-6/rollup.config.js
@@ -1,5 +1,18 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+
+const packageVersion = process.env.npm_package_version;
+if (!packageVersion) {
+    throw new Error('npm_package_version is required to build the Braze kit');
+}
+
+function replacePackageVersion() {
+    return replace({
+        preventAssignment: true,
+        'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+    });
+}
 
 export default [
     {
@@ -13,6 +26,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -30,6 +44,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),
@@ -46,6 +61,7 @@ export default [
             inlineDynamicImports: true,
         },
         plugins: [
+            replacePackageVersion(),
             resolve({
                 browser: true,
             }),

--- a/kits/braze/braze-6/src/BrazeKit-dev.js
+++ b/kits/braze/braze-6/src/BrazeKit-dev.js
@@ -96,13 +96,6 @@ var constructor = function() {
     var mappedImageUrlAttribute = null;
     var mappedProductUrlAttribute = null;
     var mappedSubtotalValueAttribute = null;
-    // Custom attributes promoted to typed recommended-event fields; excluded from metadata.
-    var RECOMMENDED_PROMOTED_METADATA_ATTRIBUTES = [
-        'cart_id',
-        'checkout_id',
-        'total_discounts',
-        'subtotal_value',
-    ];
 
     var brazeConsentKeys = [
         '$google_ad_user_data',
@@ -552,18 +545,38 @@ var constructor = function() {
             : RECOMMENDED_PRODUCT_URL_ATTRIBUTES;
     }
 
-    function getRecommendedPromotedEventAttributes() {
-        var promoted = RECOMMENDED_PROMOTED_METADATA_ATTRIBUTES.slice();
-        if (mappedCartIdAttribute) {
-            promoted.push(mappedCartIdAttribute);
+    function getRecommendedPromotedEventAttributes(eventCategory) {
+        var cartIdAttribute =
+            mappedCartIdAttribute || RECOMMENDED_CART_ID_ATTRIBUTE;
+        var checkoutIdAttribute =
+            mappedCheckoutIdAttribute || RECOMMENDED_CHECKOUT_ID_ATTRIBUTE;
+        var subtotalValueAttribute =
+            mappedSubtotalValueAttribute ||
+            RECOMMENDED_SUBTOTAL_VALUE_ATTRIBUTE;
+
+        switch (eventCategory) {
+            case CommerceEventType.ProductAddToCart:
+            case CommerceEventType.ProductRemoveFromCart:
+                return [cartIdAttribute, subtotalValueAttribute];
+            case CommerceEventType.ProductCheckout:
+                return [
+                    checkoutIdAttribute,
+                    cartIdAttribute,
+                    subtotalValueAttribute,
+                ];
+            case CommerceEventType.ProductViewDetail:
+                return [subtotalValueAttribute];
+            case CommerceEventType.ProductPurchase:
+                return [
+                    cartIdAttribute,
+                    'total_discounts',
+                    subtotalValueAttribute,
+                ];
+            case CommerceEventType.ProductRefund:
+                return ['total_discounts', subtotalValueAttribute];
+            default:
+                return [];
         }
-        if (mappedCheckoutIdAttribute) {
-            promoted.push(mappedCheckoutIdAttribute);
-        }
-        if (mappedSubtotalValueAttribute) {
-            promoted.push(mappedSubtotalValueAttribute);
-        }
-        return promoted;
     }
 
     function getRecommendedProductAttribute(product, keys) {
@@ -613,11 +626,14 @@ var constructor = function() {
     function buildRecommendedEventMetadata(event) {
         var metadata = {};
         var attributes = event.EventAttributes || {};
+        var promotedAttributes = getRecommendedPromotedEventAttributes(
+            event.EventCategory
+        );
         Object.keys(attributes).forEach(function(key) {
-            // Skip attributes already promoted to typed recommended-event fields to avoid
-            // emitting them both at the top level and inside metadata.
+            // Skip only attributes promoted by this event type so unrelated values
+            // remain available to Braze as metadata.
             if (
-                getRecommendedPromotedEventAttributes().indexOf(key) === -1 &&
+                promotedAttributes.indexOf(key) === -1 &&
                 attributes[key] != null &&
                 attributes[key] !== ''
             ) {

--- a/kits/braze/braze-6/src/BrazeKit-dev.js
+++ b/kits/braze/braze-6/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.braze = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v6',
     moduleId = 28,
-    version = '6.0.0',
+    version = process.env.PACKAGE_VERSION,
     MessageType = {
         PageView: 3,
         PageEvent: 4,
@@ -75,6 +75,34 @@ var constructor = function() {
 
     var bundleCommerceEventData = false;
     var forwardSkuAsProductName = false;
+    var useEcommerceRecommendedEvents = false;
+
+    var RECOMMENDED_ECOMMERCE_SOURCE = 'web';
+    var RECOMMENDED_CART_UPDATED_EVENT_NAME = 'ecommerce.cart_updated';
+    var RECOMMENDED_CHECKOUT_STARTED_EVENT_NAME = 'ecommerce.checkout_started';
+    var RECOMMENDED_PRODUCT_VIEWED_EVENT_NAME = 'ecommerce.product_viewed';
+    var RECOMMENDED_ORDER_PLACED_EVENT_NAME = 'ecommerce.order_placed';
+    var RECOMMENDED_ORDER_REFUNDED_EVENT_NAME = 'ecommerce.order_refunded';
+    var RECOMMENDED_IMAGE_URL_ATTRIBUTES = ['image_url', 'Image URL'];
+    var RECOMMENDED_PRODUCT_URL_ATTRIBUTES = ['product_url', 'Product URL'];
+    var RECOMMENDED_CART_ID_ATTRIBUTE = 'cart_id';
+    var RECOMMENDED_CHECKOUT_ID_ATTRIBUTE = 'checkout_id';
+    var RECOMMENDED_SUBTOTAL_VALUE_ATTRIBUTE = 'subtotal_value';
+    // Attribute-name overrides from the connection settings. Each is the
+    // customer-configured attribute that holds the value, or null when
+    // unconfigured, in which case the defaults above are used.
+    var mappedCartIdAttribute = null;
+    var mappedCheckoutIdAttribute = null;
+    var mappedImageUrlAttribute = null;
+    var mappedProductUrlAttribute = null;
+    var mappedSubtotalValueAttribute = null;
+    // Custom attributes promoted to typed recommended-event fields; excluded from metadata.
+    var RECOMMENDED_PROMOTED_METADATA_ATTRIBUTES = [
+        'cart_id',
+        'checkout_id',
+        'total_discounts',
+        'subtotal_value',
+    ];
 
     var brazeConsentKeys = [
         '$google_ad_user_data',
@@ -253,6 +281,554 @@ var constructor = function() {
         return [eventNamePrefix, eventName].join(' - ');
     }
 
+    // The Braze Web SDK only exposes logEcommerceEvent in v6.8.0+. Guard against
+    // older host SDKs so we can fall back to legacy forwarding when unsupported.
+    function recommendedEcommerceEventsSupported() {
+        return typeof braze.logEcommerceEvent === 'function';
+    }
+
+    // The forwarder event carries the session id, so prefer it over reaching for a
+    // global: it needs no feature detection and works on every core SDK version.
+    //
+    // The previous implementation relied on mParticle.getSession(), which is not
+    // exposed on the global object by any core version (verified on 2.23.0 and
+    // 2.75.0), so the lookup silently returned null and every cart/checkout fell
+    // back to a freshly generated id, leaving Braze unable to correlate a cart
+    // across add/remove/checkout/order. mParticle.sessionManager.getSession() is
+    // the supported public accessor, kept here only as a secondary fallback.
+    function getSessionIdForBraze(event) {
+        if (event && event.SessionId) {
+            return String(event.SessionId);
+        }
+        try {
+            if (
+                mParticle &&
+                mParticle.sessionManager &&
+                typeof mParticle.sessionManager.getSession === 'function'
+            ) {
+                return mParticle.sessionManager.getSession();
+            }
+        } catch (e) {
+            // no-op: session id is a best-effort fallback
+        }
+        return null;
+    }
+
+    function generateEcommerceId() {
+        if (
+            typeof window !== 'undefined' &&
+            window.crypto &&
+            typeof window.crypto.randomUUID === 'function'
+        ) {
+            return window.crypto.randomUUID();
+        }
+        return (
+            'mp-' +
+            new Date().getTime() +
+            '-' +
+            Math.floor(Math.random() * 1000000000)
+        );
+    }
+
+    // Attribute-mapping settings are "custom JSON" (setting data type 7). The config
+    // API delivers them with the quotes HTML-escaped, so they must be decoded before
+    // parsing (same as decodeSubscriptionGroupMappings, decodeClusterSetting and the
+    // consent mapping):
+    //   [{&quot;jsmap&quot;:null,&quot;map&quot;:null,
+    //     &quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,
+    //     &quot;value&quot;:&quot;attr_name&quot;}]
+    //
+    // maptype varies by what the setting selects (EventAttributeClass.Name for the
+    // cart/checkout/subtotal settings, ProductAttributeSelector.Name for the URL
+    // ones) and is deliberately ignored: the settings are single-select, so the
+    // first entry with a value is the mapping. This matches the iOS kit and avoids
+    // maptype strings drifting out of sync with the platform.
+    //
+    // Never throws: a malformed setting must not break event forwarding.
+    function getMappedAttributeName(settingValue) {
+        if (!settingValue) {
+            return null;
+        }
+        // No-op when the value is already unescaped, so both shapes work.
+        var decodedSetting = settingValue.replace(/&quot;/g, '"');
+        try {
+            var mappings = JSON.parse(decodedSetting);
+            if (!Array.isArray(mappings)) {
+                return null;
+            }
+            for (var i = 0; i < mappings.length; i++) {
+                var mapping = mappings[i];
+                if (
+                    mapping &&
+                    typeof mapping.value === 'string' &&
+                    mapping.value !== ''
+                ) {
+                    return mapping.value;
+                }
+            }
+            return null;
+        } catch (e) {
+            // Deliberately stricter than the iOS kit, which treats an unparseable
+            // setting as a plain attribute name. The config API always sends the
+            // JSON array form, so a string that does not parse is malformed rather
+            // than a bare name, and returning null keeps the documented default
+            // attribute in play instead of looking up a garbage key.
+            kitLogger(
+                'Braze kit could not parse attribute mapping setting',
+                settingValue
+            );
+            return null;
+        }
+    }
+
+    function getEcommerceCustomAttribute(event, key) {
+        var attributes = event.EventAttributes || {};
+        if (attributes[key] != null && attributes[key] !== '') {
+            return String(attributes[key]);
+        }
+        return null;
+    }
+
+    function getRecommendedCartId(event) {
+        // Fall back to the mParticle session id, then a generated id, matching the
+        // Android and iOS kits (a missing session id is unlikely but possible).
+        return (
+            getEcommerceCustomAttribute(
+                event,
+                mappedCartIdAttribute || RECOMMENDED_CART_ID_ATTRIBUTE
+            ) ||
+            getSessionIdForBraze(event) ||
+            generateEcommerceId()
+        );
+    }
+
+    function getRecommendedCheckoutId(event) {
+        return (
+            getEcommerceCustomAttribute(
+                event,
+                mappedCheckoutIdAttribute || RECOMMENDED_CHECKOUT_ID_ATTRIBUTE
+            ) ||
+            getSessionIdForBraze(event) ||
+            generateEcommerceId()
+        );
+    }
+
+    function getRecommendedOrderId(event) {
+        if (event.ProductAction && event.ProductAction.TransactionId) {
+            return String(event.ProductAction.TransactionId);
+        }
+        return getSessionIdForBraze(event) || generateEcommerceId();
+    }
+
+    function getRecommendedProductList(event) {
+        if (event.ProductAction && event.ProductAction.ProductList) {
+            return event.ProductAction.ProductList;
+        }
+        return [];
+    }
+
+    // Product quantity is a count, so coerce to an integer >= 1 (mirrors the
+    // Android kit's toLong().coerceAtLeast(1)).
+    function getRecommendedQuantity(product) {
+        var quantity = parseInt(product.Quantity, 10);
+        if (isNaN(quantity) || quantity < 1) {
+            quantity = 1;
+        }
+        return quantity;
+    }
+
+    function getRecommendedTotalValue(event) {
+        if (
+            event.ProductAction &&
+            event.ProductAction.TotalAmount != null &&
+            event.ProductAction.TotalAmount !== ''
+        ) {
+            return parseFloat(event.ProductAction.TotalAmount) || 0;
+        }
+        var total = 0;
+        getRecommendedProductList(event).forEach(function(product) {
+            total +=
+                (parseFloat(product.Price) || 0) *
+                getRecommendedQuantity(product);
+        });
+        return total;
+    }
+
+    function getRecommendedTotalDiscounts(event) {
+        var value = getEcommerceCustomAttribute(event, 'total_discounts');
+        if (value == null) {
+            return null;
+        }
+        var parsed = parseFloat(value);
+        return isNaN(parsed) ? null : parsed;
+    }
+
+    function parseRecommendedFloat(value) {
+        if (value == null || value === '') {
+            return null;
+        }
+        var parsed = parseFloat(value);
+        return isNaN(parsed) ? null : parsed;
+    }
+
+    function getRecommendedTax(event) {
+        return parseRecommendedFloat(
+            event.ProductAction && event.ProductAction.TaxAmount
+        );
+    }
+
+    function getRecommendedShipping(event) {
+        return parseRecommendedFloat(
+            event.ProductAction && event.ProductAction.ShippingAmount
+        );
+    }
+
+    // mParticle has no native subtotal field, so subtotal_value is sourced from a
+    // `subtotal_value` commerce custom attribute (like cart_id/total_discounts).
+    function getRecommendedSubtotalValue(event) {
+        return parseRecommendedFloat(
+            getEcommerceCustomAttribute(
+                event,
+                mappedSubtotalValueAttribute ||
+                    RECOMMENDED_SUBTOTAL_VALUE_ATTRIBUTE
+            )
+        );
+    }
+
+    // tax, shipping, and subtotal_value are optional recognized top-level attributes
+    // on cart_updated/checkout_started/order_placed. Set only when present.
+    function applyRecommendedMonetaryAttributes(properties, event) {
+        var tax = getRecommendedTax(event);
+        if (tax != null) {
+            properties.tax = tax;
+        }
+        var shipping = getRecommendedShipping(event);
+        if (shipping != null) {
+            properties.shipping = shipping;
+        }
+        var subtotalValue = getRecommendedSubtotalValue(event);
+        if (subtotalValue != null) {
+            properties.subtotal_value = subtotalValue;
+        }
+    }
+
+    // product_viewed and order_refunded have no recognized top-level tax/shipping/
+    // subtotal_value fields, so when present these are preserved in metadata rather
+    // than dropped.
+    function buildRecommendedMonetaryMetadata(event) {
+        var metadata = {};
+        var tax = getRecommendedTax(event);
+        if (tax != null) {
+            metadata.tax = tax;
+        }
+        var shipping = getRecommendedShipping(event);
+        if (shipping != null) {
+            metadata.shipping = shipping;
+        }
+        var subtotalValue = getRecommendedSubtotalValue(event);
+        if (subtotalValue != null) {
+            metadata.subtotal_value = subtotalValue;
+        }
+        return metadata;
+    }
+
+    function getRecommendedVariantId(product) {
+        return String(product.Variant || product.Sku);
+    }
+
+    // A configured attribute name takes precedence over the built-in defaults, and
+    // is also excluded from metadata so a promoted value is not emitted twice.
+    function getRecommendedImageUrlAttributes() {
+        return mappedImageUrlAttribute
+            ? [mappedImageUrlAttribute].concat(RECOMMENDED_IMAGE_URL_ATTRIBUTES)
+            : RECOMMENDED_IMAGE_URL_ATTRIBUTES;
+    }
+
+    function getRecommendedProductUrlAttributes() {
+        return mappedProductUrlAttribute
+            ? [mappedProductUrlAttribute].concat(
+                  RECOMMENDED_PRODUCT_URL_ATTRIBUTES
+              )
+            : RECOMMENDED_PRODUCT_URL_ATTRIBUTES;
+    }
+
+    function getRecommendedPromotedEventAttributes() {
+        var promoted = RECOMMENDED_PROMOTED_METADATA_ATTRIBUTES.slice();
+        if (mappedCartIdAttribute) {
+            promoted.push(mappedCartIdAttribute);
+        }
+        if (mappedCheckoutIdAttribute) {
+            promoted.push(mappedCheckoutIdAttribute);
+        }
+        if (mappedSubtotalValueAttribute) {
+            promoted.push(mappedSubtotalValueAttribute);
+        }
+        return promoted;
+    }
+
+    function getRecommendedProductAttribute(product, keys) {
+        var attributes = product.Attributes || {};
+        for (var i = 0; i < keys.length; i++) {
+            var value = attributes[keys[i]];
+            if (value != null && value !== '') {
+                return String(value);
+            }
+        }
+        return null;
+    }
+
+    function emptyObjectToUndefined(obj) {
+        return obj && Object.keys(obj).length ? obj : undefined;
+    }
+
+    function buildRecommendedProductMetadata(product) {
+        var metadata = {};
+        if (product.Brand) {
+            metadata.brand = product.Brand;
+        }
+        if (product.Category) {
+            metadata.category = product.Category;
+        }
+        if (product.CouponCode) {
+            metadata.coupon_code = product.CouponCode;
+        }
+        if (product.Position != null) {
+            metadata.position = product.Position;
+        }
+        metadata.sku = product.Sku;
+        var attributes = product.Attributes || {};
+        Object.keys(attributes).forEach(function(key) {
+            if (
+                getRecommendedImageUrlAttributes().indexOf(key) === -1 &&
+                getRecommendedProductUrlAttributes().indexOf(key) === -1 &&
+                attributes[key] != null &&
+                attributes[key] !== ''
+            ) {
+                metadata[key] = attributes[key];
+            }
+        });
+        return metadata;
+    }
+
+    function buildRecommendedEventMetadata(event) {
+        var metadata = {};
+        var attributes = event.EventAttributes || {};
+        Object.keys(attributes).forEach(function(key) {
+            // Skip attributes already promoted to typed recommended-event fields to avoid
+            // emitting them both at the top level and inside metadata.
+            if (
+                getRecommendedPromotedEventAttributes().indexOf(key) === -1 &&
+                attributes[key] != null &&
+                attributes[key] !== ''
+            ) {
+                metadata[key] = attributes[key];
+            }
+        });
+        var productAction = event.ProductAction || {};
+        if (productAction.Affiliation) {
+            metadata.affiliation = productAction.Affiliation;
+        }
+        if (productAction.CouponCode) {
+            metadata.coupon_code = productAction.CouponCode;
+        }
+        // tax/shipping are recognized top-level recommended-event attributes
+        // (see applyRecommendedMonetaryAttributes), so they are not duplicated here.
+        return metadata;
+    }
+
+    function buildRecommendedLineItem(product) {
+        var lineItem = {
+            product_id: String(product.Sku),
+            product_name: String(product.Name),
+            variant_id: getRecommendedVariantId(product),
+            quantity: getRecommendedQuantity(product),
+            price: parseFloat(product.Price) || 0,
+        };
+        var imageUrl = getRecommendedProductAttribute(
+            product,
+            getRecommendedImageUrlAttributes()
+        );
+        if (imageUrl) {
+            lineItem.image_url = imageUrl;
+        }
+        var productUrl = getRecommendedProductAttribute(
+            product,
+            getRecommendedProductUrlAttributes()
+        );
+        if (productUrl) {
+            lineItem.product_url = productUrl;
+        }
+        var metadata = emptyObjectToUndefined(
+            buildRecommendedProductMetadata(product)
+        );
+        if (metadata) {
+            lineItem.metadata = metadata;
+        }
+        return lineItem;
+    }
+
+    function buildRecommendedLineItems(productList) {
+        return (productList || []).map(buildRecommendedLineItem);
+    }
+
+    // Forwards a commerce event using Braze's recommended eCommerce schema.
+    // Returns true/false when the event was handled, or null to signal the caller
+    // to fall back to legacy forwarding (no products, or an unsupported action).
+    function logRecommendedCommerceEvent(event) {
+        var productList = getRecommendedProductList(event);
+        if (!productList.length) {
+            return null;
+        }
+        var currency = event.CurrencyCode || 'USD';
+        var source = RECOMMENDED_ECOMMERCE_SOURCE;
+        var eventMetadata = emptyObjectToUndefined(
+            buildRecommendedEventMetadata(event)
+        );
+        var reportEvent = false;
+        var properties;
+
+        switch (event.EventCategory) {
+            case CommerceEventType.ProductAddToCart:
+            case CommerceEventType.ProductRemoveFromCart:
+                properties = {
+                    cart_id: getRecommendedCartId(event),
+                    currency: currency,
+                    source: source,
+                    total_value: getRecommendedTotalValue(event),
+                    products: buildRecommendedLineItems(productList),
+                    action:
+                        event.EventCategory ===
+                        CommerceEventType.ProductAddToCart
+                            ? 'add'
+                            : 'remove',
+                };
+                applyRecommendedMonetaryAttributes(properties, event);
+                if (eventMetadata) {
+                    properties.metadata = eventMetadata;
+                }
+                reportEvent = braze.logEcommerceEvent({
+                    name: RECOMMENDED_CART_UPDATED_EVENT_NAME,
+                    properties: properties,
+                });
+                break;
+            case CommerceEventType.ProductCheckout:
+                properties = {
+                    checkout_id: getRecommendedCheckoutId(event),
+                    currency: currency,
+                    source: source,
+                    total_value: getRecommendedTotalValue(event),
+                    products: buildRecommendedLineItems(productList),
+                    cart_id: getRecommendedCartId(event),
+                };
+                applyRecommendedMonetaryAttributes(properties, event);
+                if (eventMetadata) {
+                    properties.metadata = eventMetadata;
+                }
+                reportEvent = braze.logEcommerceEvent({
+                    name: RECOMMENDED_CHECKOUT_STARTED_EVENT_NAME,
+                    properties: properties,
+                });
+                break;
+            case CommerceEventType.ProductViewDetail:
+                reportEvent = false;
+                productList.forEach(function(product) {
+                    var viewedProperties = {
+                        product_id: String(product.Sku),
+                        product_name: String(product.Name),
+                        variant_id: getRecommendedVariantId(product),
+                        price: parseFloat(product.Price) || 0,
+                        currency: currency,
+                        source: source,
+                    };
+                    var imageUrl = getRecommendedProductAttribute(
+                        product,
+                        getRecommendedImageUrlAttributes()
+                    );
+                    if (imageUrl) {
+                        viewedProperties.image_url = imageUrl;
+                    }
+                    var productUrl = getRecommendedProductAttribute(
+                        product,
+                        getRecommendedProductUrlAttributes()
+                    );
+                    if (productUrl) {
+                        viewedProperties.product_url = productUrl;
+                    }
+                    var viewedMetadata = emptyObjectToUndefined(
+                        mergeObjects(
+                            mergeObjects(
+                                buildRecommendedProductMetadata(product),
+                                eventMetadata || {}
+                            ),
+                            buildRecommendedMonetaryMetadata(event)
+                        )
+                    );
+                    if (viewedMetadata) {
+                        viewedProperties.metadata = viewedMetadata;
+                    }
+                    reportEvent =
+                        braze.logEcommerceEvent({
+                            name: RECOMMENDED_PRODUCT_VIEWED_EVENT_NAME,
+                            properties: viewedProperties,
+                        }) === true || reportEvent;
+                });
+                break;
+            case CommerceEventType.ProductPurchase:
+                properties = {
+                    order_id: getRecommendedOrderId(event),
+                    currency: currency,
+                    source: source,
+                    total_value: getRecommendedTotalValue(event),
+                    products: buildRecommendedLineItems(productList),
+                    cart_id: getRecommendedCartId(event),
+                };
+                var totalDiscounts = getRecommendedTotalDiscounts(event);
+                if (totalDiscounts != null) {
+                    properties.total_discounts = totalDiscounts;
+                }
+                applyRecommendedMonetaryAttributes(properties, event);
+                if (eventMetadata) {
+                    properties.metadata = eventMetadata;
+                }
+                reportEvent = braze.logEcommerceEvent({
+                    name: RECOMMENDED_ORDER_PLACED_EVENT_NAME,
+                    properties: properties,
+                });
+                break;
+            case CommerceEventType.ProductRefund:
+                // Braze has no typed order_refunded event; forward it as a custom
+                // event that mirrors the recommended ecommerce.order_refunded schema.
+                var refundProperties = {
+                    order_id: getRecommendedOrderId(event),
+                    total_value: getRecommendedTotalValue(event),
+                    currency: currency,
+                    source: source,
+                    products: buildRecommendedLineItems(productList),
+                };
+                var refundDiscounts = getRecommendedTotalDiscounts(event);
+                if (refundDiscounts != null) {
+                    refundProperties.total_discounts = refundDiscounts;
+                }
+                var refundMetadata = emptyObjectToUndefined(
+                    mergeObjects(
+                        eventMetadata || {},
+                        buildRecommendedMonetaryMetadata(event)
+                    )
+                );
+                if (refundMetadata) {
+                    refundProperties.metadata = refundMetadata;
+                }
+                reportEvent = braze.logCustomEvent(
+                    RECOMMENDED_ORDER_REFUNDED_EVENT_NAME,
+                    refundProperties
+                );
+                break;
+            default:
+                return null;
+        }
+        return reportEvent === true;
+    }
+
     function logBrazePageViewEvent(event) {
         var sanitizedEventName,
             sanitizedAttrs,
@@ -403,6 +979,18 @@ var constructor = function() {
     // a purchase event or a non-purchase commerce event
     function logCommerceEvent(event) {
         var reportEvent = false;
+        // When opted in (and the host Braze SDK supports it), forward supported
+        // commerce actions using Braze's recommended eCommerce schema. Unsupported
+        // actions (or a host SDK without the API) fall back to legacy forwarding.
+        if (
+            useEcommerceRecommendedEvents &&
+            recommendedEcommerceEventsSupported()
+        ) {
+            var recommendedResult = logRecommendedCommerceEvent(event);
+            if (recommendedResult !== null) {
+                return recommendedResult === true;
+            }
+        }
         if (event.EventCategory === CommerceEventType.ProductPurchase) {
             reportEvent = logPurchaseEvent(event);
             return reportEvent === true;
@@ -882,6 +1470,25 @@ var constructor = function() {
                 forwarderSettings.bundleCommerceEventData === 'True';
             forwardSkuAsProductName =
                 forwarderSettings.forwardSkuAsProductName === 'True';
+            useEcommerceRecommendedEvents =
+                forwarderSettings.useEcommerceRecommendedEvents === 'True';
+            // Customer-configured attribute names for the recommended eCommerce
+            // fields. Unset settings leave these null and the defaults apply.
+            mappedCartIdAttribute = getMappedAttributeName(
+                forwarderSettings.cartIdAttribute
+            );
+            mappedCheckoutIdAttribute = getMappedAttributeName(
+                forwarderSettings.checkoutIdAttribute
+            );
+            mappedImageUrlAttribute = getMappedAttributeName(
+                forwarderSettings.imageUrlAttribute
+            );
+            mappedProductUrlAttribute = getMappedAttributeName(
+                forwarderSettings.productUrlAttribute
+            );
+            mappedSubtotalValueAttribute = getMappedAttributeName(
+                forwarderSettings.subtotalValueAttribute
+            );
             reportingService = service;
             // 30 min is Braze default
             options.sessionTimeoutInSeconds =

--- a/kits/braze/braze-6/test/tests.js
+++ b/kits/braze/braze-6/test/tests.js
@@ -2660,7 +2660,12 @@ user.getUserIdentities is not a function,\n`;
                 EventDataType: MessageType.Commerce,
                 EventCategory: CommerceEventType.ProductAddToCart,
                 CurrencyCode: 'USD',
-                EventAttributes: { cart_id: 'cart-123' },
+                EventAttributes: {
+                    cart_id: 'cart-123',
+                    checkout_id: 'checkout-9',
+                    total_discounts: '3.5',
+                    subtotal_value: '18',
+                },
                 ProductAction: {
                     TotalAmount: 20,
                     ProductList: [recommendedProduct()],
@@ -2692,6 +2697,12 @@ user.getUserIdentities is not a function,\n`;
             (event.properties.metadata || {}).should.not.have.property(
                 'cart_id'
             );
+            event.properties.subtotal_value.should.equal(18);
+            event.properties.metadata.should.not.have.property(
+                'subtotal_value'
+            );
+            event.properties.metadata.checkout_id.should.equal('checkout-9');
+            event.properties.metadata.total_discounts.should.equal('3.5');
         });
 
         // Mirrors what the config API actually delivers: "custom JSON" with the
@@ -2758,6 +2769,9 @@ user.getUserIdentities is not a function,\n`;
             event.properties.products[0].image_url.should.equal(
                 'https://example.com/hero.jpg'
             );
+            (event.properties.metadata || {}).should.not.have.property(
+                'test_cart_id'
+            );
         });
 
         function processAddToCart(eventAttributes, product) {
@@ -2785,6 +2799,52 @@ user.getUserIdentities is not a function,\n`;
             // the mapped attribute is promoted, so it must not also sit in metadata
             (event.properties.metadata || {}).should.not.have.property(
                 'my_basket_ref'
+            );
+        });
+
+        it('should preserve configured identifier aliases on event types that do not promote them', function() {
+            initRecommended({
+                cartIdAttribute: attributeMapping('my_basket_ref'),
+                checkoutIdAttribute: attributeMapping('my_checkout_ref'),
+            });
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                CurrencyCode: 'USD',
+                EventAttributes: {
+                    my_basket_ref: 'basket-999',
+                    my_checkout_ref: 'checkout-9',
+                },
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 20,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            var purchase = window.braze.loggedEcommerceEvents[0];
+            purchase.properties.cart_id.should.equal('basket-999');
+            purchase.properties.metadata.my_checkout_ref.should.equal(
+                'checkout-9'
+            );
+            purchase.properties.metadata.should.not.have.property(
+                'my_basket_ref'
+            );
+
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - refund',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductRefund,
+                CurrencyCode: 'USD',
+                EventAttributes: { my_basket_ref: 'basket-999' },
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 20,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.loggedEvents[0].eventProperties.metadata.my_basket_ref.should.equal(
+                'basket-999'
             );
         });
 
@@ -2937,7 +2997,12 @@ user.getUserIdentities is not a function,\n`;
                 EventDataType: MessageType.Commerce,
                 EventCategory: CommerceEventType.ProductCheckout,
                 CurrencyCode: 'USD',
-                EventAttributes: { checkout_id: 'checkout-9', cart_id: 'cart-123' },
+                EventAttributes: {
+                    checkout_id: 'checkout-9',
+                    cart_id: 'cart-123',
+                    total_discounts: '3.5',
+                    subtotal_value: '18',
+                },
                 ProductAction: {
                     TotalAmount: 20,
                     ProductList: [recommendedProduct()],
@@ -2949,6 +3014,13 @@ user.getUserIdentities is not a function,\n`;
             event.properties.checkout_id.should.equal('checkout-9');
             event.properties.cart_id.should.equal('cart-123');
             event.properties.total_value.should.equal(20);
+            event.properties.subtotal_value.should.equal(18);
+            event.properties.metadata.total_discounts.should.equal('3.5');
+            event.properties.metadata.should.not.have.property('checkout_id');
+            event.properties.metadata.should.not.have.property('cart_id');
+            event.properties.metadata.should.not.have.property(
+                'subtotal_value'
+            );
         });
 
         it('should forward view_detail as one ecommerce.product_viewed per product', function() {
@@ -2957,6 +3029,12 @@ user.getUserIdentities is not a function,\n`;
                 EventDataType: MessageType.Commerce,
                 EventCategory: CommerceEventType.ProductViewDetail,
                 CurrencyCode: 'USD',
+                EventAttributes: {
+                    cart_id: 'cart-123',
+                    checkout_id: 'checkout-9',
+                    total_discounts: '3.5',
+                    subtotal_value: '18',
+                },
                 ProductAction: {
                     ProductList: [
                         recommendedProduct(),
@@ -2976,6 +3054,10 @@ user.getUserIdentities is not a function,\n`;
             first.properties.image_url.should.equal(
                 'https://example.com/img.jpg'
             );
+            first.properties.metadata.cart_id.should.equal('cart-123');
+            first.properties.metadata.checkout_id.should.equal('checkout-9');
+            first.properties.metadata.total_discounts.should.equal('3.5');
+            first.properties.metadata.subtotal_value.should.equal(18);
             var second = window.braze.loggedEcommerceEvents[1];
             second.properties.product_id.should.equal('sku2');
             // variant_id falls back to sku when the product has no variant
@@ -2988,7 +3070,12 @@ user.getUserIdentities is not a function,\n`;
                 EventDataType: MessageType.Commerce,
                 EventCategory: CommerceEventType.ProductPurchase,
                 CurrencyCode: 'USD',
-                EventAttributes: { total_discounts: '3.5', subtotal_value: '40' },
+                EventAttributes: {
+                    cart_id: 'cart-123',
+                    checkout_id: 'checkout-9',
+                    total_discounts: '3.5',
+                    subtotal_value: '40',
+                },
                 ProductAction: {
                     TransactionId: 'order-42',
                     TotalAmount: 50,
@@ -3002,6 +3089,7 @@ user.getUserIdentities is not a function,\n`;
             var event = window.braze.loggedEcommerceEvents[0];
             event.name.should.equal('ecommerce.order_placed');
             event.properties.order_id.should.equal('order-42');
+            event.properties.cart_id.should.equal('cart-123');
             event.properties.total_value.should.equal(50);
             event.properties.total_discounts.should.equal(3.5);
             // tax/shipping/subtotal_value are recognized top-level attributes (Braze 6.9+)
@@ -3019,6 +3107,8 @@ user.getUserIdentities is not a function,\n`;
             event.properties.metadata.should.not.have.property(
                 'subtotal_value'
             );
+            event.properties.metadata.should.not.have.property('cart_id');
+            event.properties.metadata.checkout_id.should.equal('checkout-9');
         });
 
         it('should send tax/shipping/subtotal_value as top-level attributes on cart_updated', function() {
@@ -3048,7 +3138,12 @@ user.getUserIdentities is not a function,\n`;
                 EventDataType: MessageType.Commerce,
                 EventCategory: CommerceEventType.ProductRefund,
                 CurrencyCode: 'USD',
-                EventAttributes: { subtotal_value: '40' },
+                EventAttributes: {
+                    cart_id: 'cart-123',
+                    checkout_id: 'checkout-9',
+                    total_discounts: '3.5',
+                    subtotal_value: '40',
+                },
                 ProductAction: {
                     TransactionId: 'order-42',
                     TotalAmount: 50,
@@ -3065,6 +3160,16 @@ user.getUserIdentities is not a function,\n`;
             loggedEvent.eventProperties.order_id.should.equal('order-42');
             loggedEvent.eventProperties.source.should.equal('web');
             loggedEvent.eventProperties.products.should.have.lengthOf(1);
+            loggedEvent.eventProperties.total_discounts.should.equal(3.5);
+            loggedEvent.eventProperties.metadata.cart_id.should.equal(
+                'cart-123'
+            );
+            loggedEvent.eventProperties.metadata.checkout_id.should.equal(
+                'checkout-9'
+            );
+            loggedEvent.eventProperties.metadata.should.not.have.property(
+                'total_discounts'
+            );
             // order_refunded has no recognized top-level tax/shipping/subtotal_value,
             // so they are preserved in metadata rather than dropped.
             loggedEvent.eventProperties.metadata.tax.should.equal(5);

--- a/kits/braze/braze-6/test/tests.js
+++ b/kits/braze/braze-6/test/tests.js
@@ -1,10 +1,12 @@
 // If we are testing this in a node environemnt, we load the common.js Braze kit
 
-var brazeInstance;
+var brazeInstance, packageVersion;
 if (typeof require !== 'undefined') {
+    packageVersion = require('../package.json').version;
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
     brazeInstance = mpBrazeKitV5.default;
+    packageVersion = brazeInstance.getVersion();
 }
 
 describe('Braze Forwarder', function() {
@@ -167,6 +169,8 @@ describe('Braze Forwarder', function() {
             this.subscribeToInAppMessageCalled = false;
             this.eventProperties = [];
             this.purchaseEventProperties = [];
+            this.logEcommerceEventCalled = false;
+            this.loggedEcommerceEvents = [];
 
             this.user = new MockBrazeUser();
             this.display = new MockDisplay();
@@ -230,6 +234,14 @@ describe('Braze Forwarder', function() {
                     quantity,
                     attributes,
                 ]);
+
+                // Return true to indicate event should be reported
+                return true;
+            };
+
+            this.logEcommerceEvent = function(event) {
+                self.logEcommerceEventCalled = true;
+                self.loggedEcommerceEvents.push(event);
 
                 // Return true to indicate event should be reported
                 return true;
@@ -327,6 +339,10 @@ describe('Braze Forwarder', function() {
 
     it('should have a property of suffix', function() {
         window.mParticle.forwarder.should.have.property('suffix', 'v6');
+    });
+
+    it('should expose its package version', function() {
+        brazeInstance.getVersion().should.equal(packageVersion);
     });
 
     it('should register a forwarder with version number onto a config', function() {
@@ -2591,6 +2607,546 @@ user.getUserIdentities is not a function,\n`;
             };
 
             impressionEvent.should.eql(expectedImpressionEvent);
+        });
+    });
+    describe('Recommended eCommerce Events (useEcommerceRecommendedEvents)', function() {
+        function initRecommended(extraSettings) {
+            var settings = {
+                apiKey: '123456',
+                useEcommerceRecommendedEvents: 'True',
+            };
+            if (extraSettings) {
+                for (var key in extraSettings) {
+                    settings[key] = extraSettings[key];
+                }
+            }
+            mParticle.forwarder.init(
+                settings,
+                reportService.cb,
+                true,
+                null,
+                { gender: 'm' },
+                [{ Identity: 'testUser', Type: IdentityType.CustomerId }],
+                '1.1',
+                'My App'
+            );
+        }
+
+        function recommendedProduct() {
+            return {
+                Sku: 'sku1',
+                Name: 'Product Name',
+                Price: '10',
+                Quantity: 2,
+                Brand: 'brandX',
+                Category: 'catY',
+                Variant: 'variantZ',
+                Position: 3,
+                Attributes: {
+                    image_url: 'https://example.com/img.jpg',
+                    product_url: 'https://example.com/product',
+                    customKey: 'customVal',
+                },
+            };
+        }
+
+        beforeEach(function() {
+            initRecommended();
+        });
+
+        it('should forward add_to_cart as ecommerce.cart_updated with action add', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                EventAttributes: { cart_id: 'cart-123' },
+                ProductAction: {
+                    TotalAmount: 20,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.should.have.property('logEcommerceEventCalled', true);
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(1);
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.cart_updated');
+            event.properties.action.should.equal('add');
+            event.properties.cart_id.should.equal('cart-123');
+            event.properties.currency.should.equal('USD');
+            event.properties.source.should.equal('web');
+            event.properties.total_value.should.equal(20);
+            event.properties.products.should.have.lengthOf(1);
+            var lineItem = event.properties.products[0];
+            lineItem.product_id.should.equal('sku1');
+            lineItem.product_name.should.equal('Product Name');
+            lineItem.variant_id.should.equal('variantZ');
+            lineItem.quantity.should.equal(2);
+            lineItem.price.should.equal(10);
+            lineItem.image_url.should.equal('https://example.com/img.jpg');
+            lineItem.product_url.should.equal('https://example.com/product');
+            // custom/extra props live in metadata, never at the top level
+            lineItem.metadata.brand.should.equal('brandX');
+            lineItem.metadata.category.should.equal('catY');
+            lineItem.metadata.customKey.should.equal('customVal');
+            // cart_id is promoted to the typed cart_id field, so it must not be duplicated in metadata
+            (event.properties.metadata || {}).should.not.have.property(
+                'cart_id'
+            );
+        });
+
+        // Mirrors what the config API actually delivers: "custom JSON" with the
+        // quotes HTML-escaped, e.g.
+        //   [{&quot;jsmap&quot;:null,&quot;map&quot;:null,
+        //     &quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,
+        //     &quot;value&quot;:&quot;my_attr&quot;}]
+        // maptype varies (EventAttributeClass.Name for event attributes,
+        // ProductAttributeSelector.Name for product ones) and is not used.
+        function attributeMapping(attributeName, mapType) {
+            return JSON.stringify([
+                {
+                    jsmap: null,
+                    map: null,
+                    maptype: mapType || 'EventAttributeClass.Name',
+                    value: attributeName,
+                },
+            ]).replace(/"/g, '&quot;');
+        }
+
+        // Verbatim setting values from the /config endpoint of the QA1 workspace
+        // used to validate this feature. Every mapping test below is built on
+        // attributeMapping, so if that helper drifts from what the server really
+        // sends, those tests keep passing while the kit is broken in production -
+        // which is how the HTML escaping was missed the first time. Pinning the
+        // helper against real payloads is what makes the rest trustworthy.
+        var LIVE_EVENT_ATTRIBUTE_SETTING =
+            '[{&quot;jsmap&quot;:null,&quot;map&quot;:null,&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;test_cart_id&quot;}]';
+        var LIVE_PRODUCT_ATTRIBUTE_SETTING =
+            '[{&quot;jsmap&quot;:null,&quot;map&quot;:null,&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Variant&quot;}]';
+
+        it('should build fixtures byte for byte identical to the live config', function() {
+            attributeMapping('test_cart_id').should.equal(
+                LIVE_EVENT_ATTRIBUTE_SETTING
+            );
+            attributeMapping(
+                'Variant',
+                'ProductAttributeSelector.Name'
+            ).should.equal(LIVE_PRODUCT_ATTRIBUTE_SETTING);
+        });
+
+        // Belt and braces: drive the kit with the live strings directly, so the
+        // mapping is proven even if the helper is wrong.
+        it('should honor the live config setting strings verbatim', function() {
+            initRecommended({
+                checkoutIdAttribute: LIVE_EVENT_ATTRIBUTE_SETTING,
+                imageUrlAttribute: LIVE_PRODUCT_ATTRIBUTE_SETTING,
+            });
+            var product = recommendedProduct();
+            product.Attributes = { Variant: 'https://example.com/hero.jpg' };
+
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - checkout',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductCheckout,
+                CurrencyCode: 'USD',
+                SessionId: 'session-abc',
+                EventAttributes: { test_cart_id: 'live-checkout-1' },
+                ProductAction: { TotalAmount: 20, ProductList: [product] },
+            });
+
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.properties.checkout_id.should.equal('live-checkout-1');
+            event.properties.products[0].image_url.should.equal(
+                'https://example.com/hero.jpg'
+            );
+        });
+
+        function processAddToCart(eventAttributes, product) {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                SessionId: 'session-abc',
+                EventAttributes: eventAttributes || {},
+                ProductAction: {
+                    TotalAmount: 20,
+                    ProductList: [product || recommendedProduct()],
+                },
+            });
+            return window.braze.loggedEcommerceEvents[0];
+        }
+
+        it('should read cart_id from the configured cartIdAttribute', function() {
+            initRecommended({
+                cartIdAttribute: attributeMapping('my_basket_ref'),
+            });
+            var event = processAddToCart({ my_basket_ref: 'basket-999' });
+            event.properties.cart_id.should.equal('basket-999');
+            // the mapped attribute is promoted, so it must not also sit in metadata
+            (event.properties.metadata || {}).should.not.have.property(
+                'my_basket_ref'
+            );
+        });
+
+        it('should read image_url and product_url from configured attributes', function() {
+            initRecommended({
+                imageUrlAttribute: attributeMapping('hero_shot'),
+                productUrlAttribute: attributeMapping('pdp_link'),
+            });
+            var product = recommendedProduct();
+            product.Attributes = {
+                hero_shot: 'https://example.com/hero.jpg',
+                pdp_link: 'https://example.com/pdp',
+            };
+            var lineItem = processAddToCart({}, product).properties.products[0];
+            lineItem.image_url.should.equal('https://example.com/hero.jpg');
+            lineItem.product_url.should.equal('https://example.com/pdp');
+            // promoted to typed fields, so not duplicated in product metadata
+            lineItem.metadata.should.not.have.property('hero_shot');
+            lineItem.metadata.should.not.have.property('pdp_link');
+        });
+
+        // The image/product URL settings select a product attribute, so the live
+        // config carries ProductAttributeSelector.Name rather than the event
+        // maptype. maptype is ignored, so both must behave identically.
+        it('should honor product-scoped maptype for URL attributes', function() {
+            initRecommended({
+                imageUrlAttribute: attributeMapping(
+                    'hero_shot',
+                    'ProductAttributeSelector.Name'
+                ),
+                productUrlAttribute: attributeMapping(
+                    'pdp_link',
+                    'ProductAttributeSelector.Name'
+                ),
+            });
+            var product = recommendedProduct();
+            product.Attributes = {
+                hero_shot: 'https://example.com/hero.jpg',
+                pdp_link: 'https://example.com/pdp',
+            };
+            var lineItem = processAddToCart({}, product).properties.products[0];
+            lineItem.image_url.should.equal('https://example.com/hero.jpg');
+            lineItem.product_url.should.equal('https://example.com/pdp');
+        });
+
+        // The configured name is prepended to the defaults rather than replacing
+        // them, so a product that uses the conventional key still resolves when the
+        // mapped attribute is absent.
+        it('should fall back to default URL keys when the mapped attribute is absent', function() {
+            initRecommended({
+                imageUrlAttribute: attributeMapping(
+                    'hero_shot',
+                    'ProductAttributeSelector.Name'
+                ),
+            });
+            var product = recommendedProduct();
+            product.Attributes = {
+                image_url: 'https://example.com/default.jpg',
+            };
+            var lineItem = processAddToCart({}, product).properties.products[0];
+            lineItem.image_url.should.equal(
+                'https://example.com/default.jpg'
+            );
+        });
+
+        // The same setting delivered without HTML escaping must still work.
+        it('should parse an attribute mapping that is not HTML escaped', function() {
+            initRecommended({
+                cartIdAttribute: JSON.stringify([
+                    {
+                        jsmap: null,
+                        map: null,
+                        maptype: 'EventAttributeClass.Name',
+                        value: 'my_basket_ref',
+                    },
+                ]),
+            });
+            processAddToCart({
+                my_basket_ref: 'basket-777',
+            }).properties.cart_id.should.equal('basket-777');
+        });
+
+        // maptype is not inspected, so a new selector type added by the platform
+        // cannot silently disable an otherwise valid mapping.
+        it('should honor a mapping regardless of maptype', function() {
+            initRecommended({
+                cartIdAttribute: attributeMapping(
+                    'my_basket_ref',
+                    'SomeFutureClass.Name'
+                ),
+            });
+            processAddToCart({
+                my_basket_ref: 'basket-999',
+            }).properties.cart_id.should.equal('basket-999');
+        });
+
+        it('should read subtotal_value from the configured subtotalValueAttribute', function() {
+            initRecommended({
+                subtotalValueAttribute: attributeMapping('order_subtotal'),
+            });
+            var event = processAddToCart({ order_subtotal: 42.5 });
+            event.properties.subtotal_value.should.equal(42.5);
+            // promoted to a typed field, so not duplicated in metadata
+            (event.properties.metadata || {}).should.not.have.property(
+                'order_subtotal'
+            );
+        });
+
+        it('should fall back to default attribute names when settings are unset', function() {
+            initRecommended({ cartIdAttribute: '[]', imageUrlAttribute: '[]' });
+            var event = processAddToCart({ cart_id: 'cart-123' });
+            event.properties.cart_id.should.equal('cart-123');
+            event.properties.products[0].image_url.should.equal(
+                'https://example.com/img.jpg'
+            );
+        });
+
+        it('should ignore a malformed attribute mapping setting', function() {
+            initRecommended({ cartIdAttribute: 'not-json' });
+            var event = processAddToCart({ cart_id: 'cart-123' });
+            event.properties.cart_id.should.equal('cart-123');
+        });
+
+        // Without this the kit generates a fresh id per event and Braze cannot
+        // correlate a cart across add/remove/checkout/order.
+        it('should fall back to the session id when no cart_id attribute exists', function() {
+            initRecommended();
+            var event = processAddToCart({});
+            event.properties.cart_id.should.equal('session-abc');
+        });
+
+        it('should forward remove_from_cart as ecommerce.cart_updated with action remove', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - remove_from_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductRemoveFromCart,
+                CurrencyCode: 'USD',
+                EventAttributes: { cart_id: 'cart-123' },
+                ProductAction: { ProductList: [recommendedProduct()] },
+            });
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(1);
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.cart_updated');
+            event.properties.action.should.equal('remove');
+        });
+
+        it('should forward checkout as ecommerce.checkout_started', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - checkout',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductCheckout,
+                CurrencyCode: 'USD',
+                EventAttributes: { checkout_id: 'checkout-9', cart_id: 'cart-123' },
+                ProductAction: {
+                    TotalAmount: 20,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(1);
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.checkout_started');
+            event.properties.checkout_id.should.equal('checkout-9');
+            event.properties.cart_id.should.equal('cart-123');
+            event.properties.total_value.should.equal(20);
+        });
+
+        it('should forward view_detail as one ecommerce.product_viewed per product', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - view_detail',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductViewDetail,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    ProductList: [
+                        recommendedProduct(),
+                        {
+                            Sku: 'sku2',
+                            Name: 'Second',
+                            Price: '5',
+                            Quantity: 1,
+                        },
+                    ],
+                },
+            });
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(2);
+            var first = window.braze.loggedEcommerceEvents[0];
+            first.name.should.equal('ecommerce.product_viewed');
+            first.properties.product_id.should.equal('sku1');
+            first.properties.image_url.should.equal(
+                'https://example.com/img.jpg'
+            );
+            var second = window.braze.loggedEcommerceEvents[1];
+            second.properties.product_id.should.equal('sku2');
+            // variant_id falls back to sku when the product has no variant
+            second.properties.variant_id.should.equal('sku2');
+        });
+
+        it('should forward purchase as ecommerce.order_placed', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                CurrencyCode: 'USD',
+                EventAttributes: { total_discounts: '3.5', subtotal_value: '40' },
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 50,
+                    TaxAmount: 5,
+                    ShippingAmount: 7,
+                    Affiliation: 'the affiliation',
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.loggedEcommerceEvents.should.have.lengthOf(1);
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.order_placed');
+            event.properties.order_id.should.equal('order-42');
+            event.properties.total_value.should.equal(50);
+            event.properties.total_discounts.should.equal(3.5);
+            // tax/shipping/subtotal_value are recognized top-level attributes (Braze 6.9+)
+            event.properties.tax.should.equal(5);
+            event.properties.shipping.should.equal(7);
+            event.properties.subtotal_value.should.equal(40);
+            // affiliation has no typed field; preserved in metadata
+            event.properties.metadata.affiliation.should.equal(
+                'the affiliation'
+            );
+            // promoted top-level attrs must not be duplicated in metadata
+            event.properties.metadata.should.not.have.property(
+                'total_discounts'
+            );
+            event.properties.metadata.should.not.have.property(
+                'subtotal_value'
+            );
+        });
+
+        it('should send tax/shipping/subtotal_value as top-level attributes on cart_updated', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                EventAttributes: { cart_id: 'cart-123', subtotal_value: '40' },
+                ProductAction: {
+                    TotalAmount: 50,
+                    TaxAmount: 5,
+                    ShippingAmount: 7,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            var event = window.braze.loggedEcommerceEvents[0];
+            event.name.should.equal('ecommerce.cart_updated');
+            event.properties.tax.should.equal(5);
+            event.properties.shipping.should.equal(7);
+            event.properties.subtotal_value.should.equal(40);
+        });
+
+        it('should forward refund as an ecommerce.order_refunded custom event', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - refund',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductRefund,
+                CurrencyCode: 'USD',
+                EventAttributes: { subtotal_value: '40' },
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 50,
+                    TaxAmount: 5,
+                    ShippingAmount: 7,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            // Refund has no typed Braze event; it is forwarded as a custom event.
+            window.braze.should.have.property('logEcommerceEventCalled', false);
+            window.braze.should.have.property('logCustomEventCalled', true);
+            var loggedEvent = window.braze.loggedEvents[0];
+            loggedEvent.name.should.equal('ecommerce.order_refunded');
+            loggedEvent.eventProperties.order_id.should.equal('order-42');
+            loggedEvent.eventProperties.source.should.equal('web');
+            loggedEvent.eventProperties.products.should.have.lengthOf(1);
+            // order_refunded has no recognized top-level tax/shipping/subtotal_value,
+            // so they are preserved in metadata rather than dropped.
+            loggedEvent.eventProperties.metadata.tax.should.equal(5);
+            loggedEvent.eventProperties.metadata.shipping.should.equal(7);
+            loggedEvent.eventProperties.metadata.subtotal_value.should.equal(40);
+        });
+
+        it('should fall back to legacy forwarding when the toggle is off', function() {
+            initRecommended({ useEcommerceRecommendedEvents: 'False' });
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 50,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.should.have.property('logEcommerceEventCalled', false);
+            window.braze.should.have.property('logPurchaseEventCalled', true);
+        });
+
+        it('should fall back to legacy forwarding for unsupported actions', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_wishlist',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToWishlist,
+                CurrencyCode: 'USD',
+                ProductAction: { ProductList: [recommendedProduct()] },
+            });
+            // add_to_wishlist is not a recommended eCommerce event
+            window.braze.should.have.property('logEcommerceEventCalled', false);
+            window.braze.should.have.property('logCustomEventCalled', true);
+        });
+
+        it('should fall back to legacy forwarding when the host Braze SDK lacks logEcommerceEvent', function() {
+            delete window.braze.logEcommerceEvent;
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    TransactionId: 'order-42',
+                    TotalAmount: 50,
+                    ProductList: [recommendedProduct()],
+                },
+            });
+            window.braze.should.have.property('logPurchaseEventCalled', true);
+        });
+
+        it('should fall back to a session/generated cart_id when none is provided', function() {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                ProductAction: { ProductList: [recommendedProduct()] },
+            });
+            var event = window.braze.loggedEcommerceEvents[0];
+            // Matches Android/iOS: cart_id always resolves (custom attr ->
+            // session id -> generated id), never empty/undefined.
+            event.properties.cart_id.should.be.a.String();
+            event.properties.cart_id.should.not.be.empty();
+        });
+
+        it('should send an integer quantity even when the product quantity is fractional', function() {
+            var product = recommendedProduct();
+            product.Quantity = 2.9;
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - add_to_cart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                ProductAction: { ProductList: [product] },
+            });
+            var lineItem =
+                window.braze.loggedEcommerceEvents[0].properties.products[0];
+            lineItem.quantity.should.equal(2);
+            Number.isInteger(lineItem.quantity).should.equal(true);
         });
     });
 });


### PR DESCRIPTION
## Summary
- port the canonical Braze `master-v6` opt-in recommended eCommerce forwarding from `1b8a4ca3`, superseding the stale draft in #1310
- update the bundled Braze dependency floor to `^6.9.0` and add the upstream browser coverage
- preserve V3 monorepo package identity, core SDK dependency, repository docs, and package-manifest runtime version injection from #1399
- exclude generated `dist/**` files and changes to every other kit

## Comparison notes
- `src/BrazeKit-dev.js` matches #1310/canonical `master-v6` except that runtime `version` is injected from this package manifest
- `test/tests.js` matches #1310/canonical behavior plus the manifest-version assertion from #1399
- the current monorepo README is newer than upstream and already documents the recommended-event setting; legacy upstream changelog numbering is intentionally not copied into the V3 lockstep release track

## Test plan
- [x] `cd kits/braze/braze-6 && npm run build && npm test` (Chrome Headless + Firefox Headless, 206 successful assertions)
- [x] Prettier 1.18.2 check on changed source, test, config, and manifest files
- [x] `npm run lint`
- [x] Confirm generated CJS/IIFE/ESM bundles replace the runtime version token during build