### PR TITLE
docs: document v3 trunk-based migration design

### DIFF
--- a/TRUNK_BASED_MIGRATION.md
+++ b/TRUNK_BASED_MIGRATION.md
@@ -1,0 +1,1098 @@
+# Trunk-Based Development Migration — Web SDK
+
+**Status:** Draft / agreed v3 direction; implementation pending
+
+**Owner:** Rob Ing
+
+**Scope of this revision:** v3 development topology and release workflow. v2
+behavior remains unchanged.
+
+## Overview
+
+The Web SDK has two active major-version tracks:
+
+- v2 uses `master` and its existing development, staging, and release-order
+  branches.
+- v3 uses `main` and contains the core SDK plus `kits/**` on one shared version.
+
+This migration makes `main` the sole development trunk for v3 and replaces the
+v3 semantic-release pipeline with an explicit, `VERSION`-driven candidate and
+publication process. It retires the active role of `v3-development` while
+retaining it indefinitely at its cutover commit as a fixed read-only
+compatibility ref, makes `v3-staging` the exact Rokt playground candidate, and
+retains `v3-release-order-a/b/c` until canary delivery replaces them.
+
+### Goals
+
+- Send all normal v3 feature, fix, and maintenance PRs to `main`.
+- Generate a reviewed `VERSION`-only release-intent PR from an explicit
+  patch/minor/major workflow input.
+- Freeze every v3 release candidate from an exact `main` commit.
+- Generate, test, and pack core plus every kit once, then publish those exact
+  approved artifacts without rebuilding.
+- Require Rokt playground approval before a stable tag or npm publication.
+- Keep the MPServer JavaScript service and production websites on the prior
+  approved `main/dist` until atomic Step 3 promotes the exact approved
+  candidate.
+- Remove semantic-release from the target v3 process.
+- Preserve the existing v3 release-order rollout until canary delivery exists.
+- Keep v2 release behavior unchanged.
+
+### Non-goals
+
+- Changing v2 branch mappings, npm tags, or release semantics.
+- Implementing canary delivery.
+- Allowing `v3-staging` to become a second development branch.
+- Committing generated package manifests, locks, changelog, or `dist` to
+  `main` before a candidate is approved.
+- Putting a rejected, pending, or otherwise unapproved generated distribution
+  on `main`, even temporarily.
+
+## Current state and migration baseline
+
+### v2 current state — unchanged
+
+The v2 track uses:
+
+- `development` as its integration branch;
+- `staging` as its release staging branch;
+- `master` as its release-tracking/CDN branch;
+- `release/<run_number>` as an ephemeral release branch; and
+- `release-order-a/b/c` for phased rollout.
+
+This document does not migrate that topology. Any future v2 trunk or
+`VERSION`-file proposal must be planned and approved separately.
+
+### v3 legacy flow — being migrated
+
+The legacy v3 flow is:
+
+```text
+feature PRs
+    |
+    v
+v3-development -> v3-staging -> main
+                       |
+                       +-> v3-release-order-a/b/c
+```
+
+The shared `staging-step-1/2/3.yml` workflows select this mapping with
+`track=v3`. Step 1 freezes `v3-development`, fast-forwards `v3-staging`, runs
+semantic-release, publishes the core SDK and kits to npm with the `next`
+dist-tag, and creates the release commit and tag. Step 2 optionally promotes
+the exact tag to a selected release-order branch. Step 3 atomically
+synchronizes `v3-development`, `main`, and all three release-order branches.
+
+This behavior successfully shipped v3 releases, but it makes
+`v3-development` the effective product trunk and gives `v3-staging` both
+release-source and testing responsibilities.
+
+### Confirmed production consumer
+
+The MPServer JavaScript service currently pulls generated bundles from
+`main/dist` and serves them to production websites. MPServer is the delivery
+owner and integration point for this path. Movement of `main` is therefore part
+of production delivery, not merely repository synchronization. A commit that
+changes `main/dist` may be fetched by MPServer through its existing refresh
+behavior and then served to production consumers.
+
+This confirmed dependency establishes three hard constraints:
+
+- the `VERSION`-only release-intent PR and any release-fix PR leave `main/dist`
+  unchanged, so MPServer continues serving the previous approved distribution
+  throughout candidate generation and playground testing;
+- generated candidate files exist only on `v3-staging` until approval,
+  publication verification, and Step 3 preflight succeed; and
+- only the exact playground-approved, checksum-verified `candidate_sha` may be
+  promoted to `main`.
+
+The production website URLs, bundle names, MPServer refresh path, and served-
+bundle validation procedure must be documented in the cutover inventory. No
+explicit CDN purge is currently required. Cache busting is deferred follow-up
+work and is not a trunk-migration blocker.
+
+### Legacy semantic-release responsibilities
+
+Semantic-release is part of the current v3 implementation only. It currently:
+
+- analyzes conventional commits and selects the next version;
+- generates release notes and updates `CHANGELOG.md`;
+- synchronizes core and kit package versions;
+- invokes release scripts that build and commit distribution bundles;
+- creates the release commit and stable Git tag;
+- publishes the core package and coordinates kit publication;
+- creates the GitHub Release; and
+- supports the current release-tag-based kit recovery path.
+
+The target v3 process removes semantic-release. Replacement automation must
+explicitly own every required capability instead of silently dropping one:
+
+- validate the reviewed `VERSION`;
+- synchronize root and kit manifests and lockfiles;
+- generate deterministic changelog content;
+- clean and build all release outputs;
+- run the complete core and kit test matrix;
+- pack core and every publishable kit once;
+- record package identities, versions, artifact hashes, and source/candidate
+  SHAs;
+- create the generated candidate commit;
+- enforce playground approval for that exact candidate;
+- create and verify the stable tag;
+- publish exact packed artifacts with npm provenance and the `next` dist-tag;
+- audit registry completeness and artifact integrity;
+- create or recover the GitHub Release; and
+- support safe pre-tag rejection and post-tag/npm recovery.
+
+### Existing constraints that must be preserved
+
+1. The current shared workflows enforce byte-for-byte parity between `master`
+   and `main` for `staging-step-1/2/3.yml`. That parity guard is removed at
+   cutover so v2 and v3 implementations can diverge. The v2 files and behavior
+   remain unchanged on their existing refs.
+2. v2 publishes with `latest`; v3 publishes with `next`. The target must
+   preserve those explicit mappings.
+3. Every phase must use its recorded full `source_sha` or `candidate_sha`;
+   workflows must never resolve a moving branch independently or conflate the
+   source and generated candidate commits.
+4. A release must have a reachable stable baseline tag and must use the exact
+   version computed by the reviewed patch/minor/major release-intent workflow.
+5. Core and all publishable kits are versioned, built, published, and audited
+   as one logical v3 release.
+6. npm trusted publishing depends on the repository and workflow identity.
+   Authentic `GITHUB_REF`, `GITHUB_REF_NAME`, and `GITHUB_SHA` must never be
+   overwritten.
+7. Dry runs validate workflow logic but cannot prove that npm accepts OIDC
+   provenance, because no real publish occurs.
+8. The v3 path initially remains in `staging-step-1.yml` so existing npm
+   trusted-publisher configuration for core and all kits keeps the same
+   workflow identity while branch contents diverge.
+
+## Agreed v3 target topology
+
+```text
+short-lived branch --PR--> main
+                              |
+                    release-intent PR changes VERSION only
+                              |
+                      freeze exact main SHA
+                              |
+                              v
+                     Step 1 generates one
+                     candidate commit on
+                        v3-staging
+                              |
+                    hard Rokt playground gate
+                              |
+                              v
+                  tag -> publish exact packs
+                    -> GitHub Release
+                              |
+                     Step 2 optional rollout
+                              |
+                  Step 3 required atomic production
+                            promotion
+                              |
+               main + v3-release-order-a/b/c
+```
+
+Branch responsibilities:
+
+- `main` — the only v3 product-development trunk and the source from which the
+  MPServer JavaScript service pulls `main/dist` bundles for production
+  websites. Normal v3 PRs target this branch. A reviewed release-intent PR
+  updates only the authoritative `VERSION`; it does not regenerate `dist`.
+- `v3-staging` — the exact generated candidate for Rokt-side playground
+  testing. Automation derives it from a frozen `main` SHA and adds one
+  generated candidate commit. No direct or product-only commit is releasable.
+- `v3-release-order-a/b/c` — phased delivery branches retained until canary
+  delivery is available.
+- `v3-development` — legacy integration branch retained indefinitely at its
+  recorded cutover commit as a fixed read-only compatibility ref after
+  in-flight work is drained. It is never a PR target, candidate source, release
+  source, mirror destination, or synchronization authority.
+- `v3-release/<run_number>` — legacy release branches to inventory and retire;
+  they have no role in the target process.
+
+The top-level `VERSION` file is the sole v3 release-intent source. The
+release-intent workflow accepts exactly one bump input: `patch`, `minor`, or
+`major`. It validates that:
+
+- current `VERSION` is valid stable semver;
+- current `VERSION` agrees with the latest stable tag and the fully published
+  core-and-kit npm baseline;
+- root and kit package identities expected for the release are complete;
+- the requested bump computes the intended next stable version; and
+- the computed stable tag and every target npm package version are absent.
+
+The workflow then opens a reviewed PR that changes only `VERSION`, for example:
+
+```text
+chore(release): set version to 3.0.2
+```
+
+Release-generated root and kit manifests, lockfiles, changelog, and
+distribution outputs remain unchanged on `main` throughout candidate
+generation, playground testing, and publication. This avoids leaving `main` in
+a partially generated or unapproved state. Candidate automation derives all of
+them from `VERSION`; only after approval and publication verification does Step
+3 fast-forward the generated candidate commit back to `main`.
+
+This separation is production-critical: while the release is prepared,
+`main/dist` remains the previous approved distribution. Neither candidate
+creation nor playground rejection changes the production-served files.
+
+### Production risk and safety rationale
+
+The highest-impact failure is advancing `main/dist` to generated files that
+were not the exact playground-approved and checksum-verified release. That can
+expose an unapproved bundle directly to production websites and cannot be
+treated as harmless branch drift.
+
+The main merge freeze prevents the recorded source parent from moving during
+release work. Full expected-SHA and fast-forward checks prevent stale
+automation from selecting a newer or unrelated commit. Atomic Step 3 prevents
+`main` and release-order refs from partially diverging. Together these controls
+make the production transition one auditable movement from the previous
+approved `main` SHA to the approved candidate SHA.
+
+## Target v3 release flow
+
+### Release intent and main freeze
+
+A maintainer dispatches the release-intent workflow with `patch`, `minor`, or
+`major`. The workflow revalidates current `VERSION`, the latest stable tag,
+and every core/kit npm baseline before calculating the target version and
+opening the `VERSION`-only PR described above. The preferred title and squash
+commit are:
+
+```text
+chore(release): set version to 3.0.2
+```
+
+Merging the generated release-intent PR does not build, publish, create a tag
+or GitHub Release, or alter generated manifests, locks, changelog, or `dist`.
+Production websites therefore continue consuming the prior approved
+`main/dist`.
+
+Immediately after merge, the release coordinator starts a merge freeze on
+`main`. Normal feature PRs may continue through review but may not merge.
+Release-fix PRs are the only exception. The freeze ends after successful Step
+3, including required MPServer refresh and served-bundle validation, or an
+authorized break-glass cleanup for a genuinely suspended release cycle.
+
+Automation enforces the freeze by creating or enabling a temporary GitHub
+ruleset scoped to `main`. It records the ruleset ID, release version,
+`source_sha`, creation time, and authorized bypass actors in durable release
+state. The ruleset blocks normal merges and direct pushes. A release-fix PR
+still requires normal review and checks, and only the designated release
+automation or release manager may merge it through the temporary bypass; the
+bypass never permits an unreviewed direct source push.
+
+Successful Step 3 finalization, after MPServer refresh and served-bundle
+validation, and authorized break-glass cleanup remove or disable only the
+recorded temporary ruleset ID, verify normal branch protections remain active,
+and record cleanup success. Cleanup runs idempotently under `always()` where
+safe. A separate manual unfreeze-recovery procedure accepts the release version
+and recorded ruleset ID, verifies that no active publish/promotion operation
+exists, removes only that matching temporary ruleset, and confirms `main` is
+writable under its normal protections. Monitoring must flag stale release
+rulesets so a failed workflow cannot leave `main` frozen indefinitely. It must
+not automatically remove a ruleset for a valid `awaiting_approval` candidate
+during its 30-day artifact lifetime; alerts do not silently shorten the
+approved waiting window.
+ruleset for a valid `awaiting_approval` candidate during its 30-day artifact
+lifetime; alerts do not silently shorten the approved waiting window.
+
+There is no normal `Abort` workflow. Rejection, a reviewed fix on `main`, and
+`Recreate candidate` are the standard pre-tag recovery. Break-glass cleanup is
+reserved for genuinely suspended release cycles and ruleset recovery; it
+requires explicit authorization and an audit record.
+
+The workflow records:
+
+- `source_sha`: the exact frozen `main` commit containing `VERSION`;
+- `version`: the validated contents of `VERSION`;
+- `candidate_sha`: the generated commit tested in the playground;
+- `artifact_manifest_sha256`: the hash of the artifact inventory;
+- `artifact_attestation_ids`: the GitHub artifact attestations bound to the
+  immutable candidate artifacts; and
+- later, `release_tag`: exactly `v${version}`, resolving to `candidate_sha`.
+
+These values must never be conflated or recomputed from a moving branch.
+Immutable artifact/manifest identity is separate from append-only lifecycle
+status history.
+
+### Step 1: generate the candidate
+
+For v3, Step 1 is dispatched from the `staging-step-1.yml` definition on
+`main`. Keeping this workflow identity initially avoids reconfiguring npm
+trusted publishers for core and every kit. The v3 implementation may use
+explicit `Create candidate`, `Recreate candidate`, and recovery operations,
+but it does not invoke semantic-release. It must:
+
+1. Require `refs/heads/main` and acquire the non-cancelling v3 release lock.
+2. Resolve and freeze `source_sha`, read `VERSION`, and validate the release
+   version against Git tags and every npm package.
+3. Verify that no stable tag or npm package already consumes the version.
+4. Record the expected old `v3-staging` SHA and update `v3-staging` from
+   `source_sha` using a pinned force-with-lease. This controlled reset is
+   required after a rejected candidate diverges; an unqualified force is
+   forbidden.
+5. In a clean worktree at `source_sha`:
+    - remove all prior generated outputs;
+    - set the root package manifest and lockfile to `VERSION`;
+    - use `scripts/prepare-kit-release.js` or its replacement to set every core
+      and kit manifest/lock to the same version;
+    - generate the changelog section from the previous stable tag through
+      `source_sha` using
+      `ROKT/rokt-workflows/actions/generate-changelog`, pinned to an immutable
+      version or commit SHA and following the established Apple/Rokt Android
+      release patterns;
+    - build all core and kit distributions;
+    - run lint, core, Jest, stub, integration, and all kit tests;
+    - pack the core package and every publishable kit exactly once; and
+    - create an inventory containing package name, version, tarball filename,
+      SHA-256, size, `source_sha`, and build-tool versions.
+6. Upload the packed tarballs and inventory as immutable GitHub Actions
+   artifacts with `retention-days: 30`, addressed by artifact ID and digest.
+   Generate GitHub artifact attestations binding those artifacts to the
+   workflow, repository, `source_sha`, version, and manifest digest. Store the
+   inventory and digest in the generated tree; do not commit tarballs to Git.
+7. Create exactly one generated commit on top of `source_sha`, for example:
+
+    ```text
+    chore(build): generate 3.0.2 candidate artifacts
+    ```
+
+    The commit contains synchronized manifests and locks, changelog, generated
+    `dist`, and the artifact inventory. It contains no product-source edits.
+
+8. Push that commit to `v3-staging` with a lease and report `candidate_sha`.
+9. Reverify that the uploaded artifact digest, attestation, and committed
+   inventory agree, then append the `prepared` Deployment status linking
+   `candidate_sha` to that immutable manifest and attestation identity.
+
+Candidate generation creates no stable tag, GitHub Release, or npm package.
+After the candidate is pushed, the same `staging-step-1.yml` run waits at the
+protected playground environment and, if approved, continues into exact-
+artifact publication. This preserves the existing trusted-publisher workflow
+identity without preserving the legacy semantic-release implementation.
+
+Lifecycle state is recorded as append-only GitHub Deployment statuses:
+
+```text
+prepared -> awaiting_approval -> rejected
+                            \-> approved -> publishing -> published -> promoted
+```
+
+Every status references the exact candidate SHA, version, immutable manifest
+digest, artifact ID, and attestation identity. Automation appends a new status;
+it never edits or deletes history. `rejected` is terminal for that candidate.
+Recreation starts a new candidate and status history.
+
+GitHub's Deployment Status API state values are mapped to the logical labels:
+`prepared=queued`, `awaiting_approval=pending`, `rejected=failure`,
+`approved=success`, `publishing=in_progress`, `published=success`, and
+`promoted=success`. The status description records the logical label, and the
+deployment/release metadata carries the immutable identities. Repeated API
+values such as `success` never replace prior records; consumers evaluate the
+ordered history and logical labels.
+
+### Rokt playground approval gate
+
+`v3-staging` must equal `candidate_sha` and is the exact Rokt playground
+candidate. Playground execution records its result against `candidate_sha`,
+`version`, and `artifact_manifest_sha256`. Entering the protected environment
+appends `awaiting_approval`; approval appends `approved`.
+
+Approval is implemented with a protected GitHub Environment and required
+reviewers. The waiting deployment job must be named with the exact version and
+full candidate SHA, for example:
+
+```text
+Review v3.0.2 candidate a1b2c3d4e5f678901234567890abcdef12345678
+```
+
+Authorized reviewers use GitHub's **Review deployments** UI. Approval is a hard
+publication gate. If a bug or rejection condition is found, a reviewer must
+explicitly click **Reject** and include a reason. Never leave the deployment
+pending or merely ignore it; explicit rejection is required to close the
+candidate and unblock controlled recreation.
+
+The candidate may remain `awaiting_approval` for up to the full 30-day artifact
+retention ceiling. The deployment summary and job output show artifact creation
+time, expiration time, and remaining lifetime; automation must not silently
+shorten that window. This means the temporary ruleset may keep `main` frozen
+for up to 30 days, blocking normal merges. Operators must treat that as an
+explicit release risk.
+
+At artifact expiry, an automated guard marks the deployment ineligible for
+approval and publication. A late approval cannot override expiration. Because
+expiration is an immutable eligibility fact rather than a lifecycle state, the
+candidate remains `awaiting_approval` until an authorized reviewer explicitly
+rejects it with an expiration reason. The operator then runs the normal
+`Recreate candidate` flow; no expired artifact or approval is reused.
+
+A rejection handler appends the `rejected` Deployment status with the exact
+`candidate_sha`, manifest digest, artifact/attestation identity, reviewer, and
+reason even though the waiting job terminates as rejected. The publication job
+must independently verify the append-only status history and approved evidence
+for the exact candidate. Approval attached only to a branch name, version
+string, expired artifact, or superseded candidate is invalid.
+
+### Rejection, fix, reset, and regeneration
+
+If the playground rejects the candidate:
+
+1. The authorized reviewer clicks **Reject** in **Review deployments**, enters
+   the rejection reason, and verifies the latest logical Deployment status is
+   `rejected`.
+2. Block publication and verify that neither `v${version}` nor any core/kit npm
+   package at that version exists.
+3. Preserve the rejected `candidate_sha`, reason, logs, artifact ID, and test
+   evidence for audit, but never merge the rejected candidate.
+4. Fix source or tests through a reviewed release-fix PR to frozen `main`,
+   merged only by the actor authorized for the temporary ruleset bypass.
+   `VERSION` remains unchanged, and the PR must not modify `dist`.
+5. Dispatch the `Recreate candidate` operation. It observes the rejected
+   `v3-staging` SHA, then resets staging to corrected `main` only with:
+
+    ```text
+    force-with-lease=v3-staging:<expected-rejected-candidate-sha>
+    ```
+
+6. Regenerate from clean inputs, producing a new artifact ID, manifest digest,
+   tarball hashes, and `candidate_sha` at the same version.
+7. Create a new protected-environment deployment for the new candidate. The
+   rejected deployment and its approval state are never reused.
+
+The version remains reusable only because no stable tag or npm publication
+consumed it. Any evidence that either exists ends this rejection path.
+Throughout rejection and recreation, `main/dist` remains byte-for-byte equal to
+the prior approved production distribution.
+
+Defense in depth prevents a stale rejected run from publishing even if someone
+later approves its old deployment. Immediately before tagging, the waiting
+Step 1 run must require all of the following to match its recorded values:
+
+- current `main` equals the candidate's `source_sha`;
+- current `v3-staging` equals its `candidate_sha`;
+- the latest append-only lifecycle status is `approved` and no `rejected`
+  status exists;
+- environment approval identifies that exact candidate and version; and
+- artifact ID, artifact digest, GitHub attestation, committed manifest, and
+  every tarball hash match.
+
+Any mismatch fails closed without creating a tag or publishing.
+
+### Publish the approved candidate
+
+After environment approval, the same `staging-step-1.yml` run continues with
+the approved `candidate_sha` and immutable artifact ID. A recovery invocation
+may resume an already tagged candidate, but it uses the same workflow identity
+and artifacts. Publication must never rebuild, repack, regenerate the
+changelog, or change any manifest.
+
+The safe order is:
+
+1. Acquire the same v3 release lock and verify the `main` freeze is active.
+2. Verify:
+    - `VERSION` on frozen `main` equals the requested version;
+    - `candidate_sha` has `source_sha` as its first parent;
+    - `v3-staging == candidate_sha`;
+    - the candidate contains only expected generated paths relative to
+      `source_sha`;
+    - playground approval matches the exact SHA and inventory digest;
+    - the append-only history is valid and its latest status is `approved` for
+      first publication or `publishing` for partial-publication recovery, with
+      no `rejected` status;
+    - downloaded artifact ID/digest, every tarball SHA-256, package name, and
+      version match the committed inventory;
+    - GitHub artifact attestations verify for the downloaded artifact subjects,
+      workflow identity, repository, source SHA, version, and manifest digest;
+    - for first publication, the stable tag and all target npm package versions
+      are absent; or
+    - for recovery, the stable tag already resolves to `candidate_sha` and
+      every existing package is byte-identical to the inventory.
+3. Append `publishing`, then for first publication create and push the annotated
+   stable tag
+   `v${version}` at `candidate_sha`. This is the irreversible
+   version-consumption boundary. Recovery reuses that exact tag and never
+   creates, deletes, or moves it.
+4. Publish the exact core and kit tarballs with `--tag next --provenance`.
+   Publish core and kits in the documented order and never substitute a rebuilt
+   tarball. Recovery publishes only missing packages, then audits the complete
+   inventory.
+5. Wait for registry propagation and audit every package's version, tarball
+   integrity, provenance, and `next` dist-tag.
+6. Create the GitHub Release from the existing stable tag only after the npm
+   completeness audit succeeds. Attach the inventory and relevant release
+   assets.
+7. Append `published` and report the exact tag and candidate SHA for Steps 2
+   and 3.
+
+Tag-before-npm makes the immutable Git identity explicit before publication.
+Once created, the stable tag is the recovery authority for that version. If npm
+partially fails, the tag remains fixed and publication resumes only for missing
+packages from the same attested artifacts. Never move, delete, or reuse the tag
+and never rebuild the artifacts. GitHub Release creation occurs only after the
+full core-plus-kits npm audit succeeds, so a normal release is not advertised
+before completeness is proven.
+
+If any required GitHub Actions artifact is missing or its 30-day retention has
+expired, approval and publication fail closed. Before stable tagging, an
+authorized reviewer explicitly rejects the candidate with the missing/expired
+artifact reason, then runs `Recreate candidate` to produce a distinct candidate
+and obtain a new approval; never rebuild or substitute the expired approved
+artifact set. After stable tagging, rebuilding is forbidden; stop the release,
+preserve the tag, and use the forward-version recovery policy if the original
+exact artifacts cannot be restored.
+
+### Step 2: optional release-order promotion
+
+Step 2 accepts only the exact stable tag emitted by the publish workflow. It:
+
+- validates that the remote tag resolves to the approved `candidate_sha`;
+- validates `VERSION`, core and kit manifests, npm completeness, and artifact
+  inventory;
+- verifies the selected release-order branch can fast-forward; and
+- fast-forwards one selected `v3-release-order-a/b/c` branch to the tag.
+
+Promotion remains optional. Operational guidance recommends A → B → C with
+observation between phases, but the workflow does not require that order.
+Step 2 never updates `main`; skipping or failing Step 2 leaves production
+`main/dist` unchanged and does not make Step 3 optional.
+
+### Step 3: required atomic production promotion
+
+Step 3 consumes the same stable tag and:
+
+- verifies the tag, candidate SHA, `VERSION`, npm completeness, GitHub Release,
+  and candidate artifact inventory;
+- verifies `main` still equals the recorded expected `source_sha`, and verifies
+  every release-order destination still equals its recorded expected SHA;
+- proves every destination can fast-forward to `candidate_sha`; and
+- atomically pushes `candidate_sha` to `main` and all three
+  `v3-release-order-a/b/c` branches.
+
+`v3-development` is absent from preflight and the atomic push. `v3-staging`
+already equals the candidate and is not an additional destination. All four
+destinations update or none do. The coordinator ends the `main` merge freeze
+only after Step 3 and required MPServer served-bundle validation succeed.
+
+Step 3 is production-critical and required to complete the release because
+the MPServer JavaScript service pulls `main/dist` for production websites. It
+may move `main` only to the exact playground-approved `candidate_sha` whose
+committed inventory and downloaded artifacts passed checksum verification. A
+rejected, stale, or publication-incomplete candidate must never become `main`'s
+tip. Failed preflight or failed atomic push must leave `main` and its
+production `dist` tree at the prior approved SHA.
+
+After `main` advances, operators verify that the MPServer JavaScript service
+observes the new commit through its existing refresh behavior and serves the
+exact approved bundle. Validation compares the served bundle identity or
+checksum with the approved `candidate_sha` inventory. No explicit CDN purge is
+part of Step 3. Step 3 is not complete until the MPServer observation and
+served-bundle checks succeed; only then append `promoted`.
+
+### Permanently fixed `v3-development` compatibility ref
+
+At cutover, record the exact `v3-development` SHA and make the branch
+read-only. It remains permanently fixed at that cutover commit:
+
+- no PR may target it;
+- no release workflow may read a candidate or version from it;
+- Steps 1–3 neither validate nor update it;
+- no mirror or post-release job may advance it; and
+- its SHA is never evidence that a release or synchronization succeeded.
+
+All consumers that require current v3 code must be inventoried and migrated to
+`main`, a stable tag, or the appropriate package/bundle delivery path before
+cutover. The fixed ref exists only for historical compatibility and audit.
+
+### Branch protection and concurrency
+
+Required target protections:
+
+- `main`: require PRs, one approval, CODEOWNER review where configured, and
+  required build/test checks; block deletion and force-push.
+- Require a `main` path-policy check that rejects `dist/**` changes from normal,
+  release-intent, and release-fix PRs. Only Step 3 automation may update
+  `main/dist`, and only by promoting the verified `candidate_sha`.
+- During a release, add the automation-controlled temporary ruleset described
+  above; do not edit or replace the permanent `main` protections.
+- `v3-staging`: block direct pushes for humans, block deletion and
+  general force-push, and allow only the candidate automation's pinned
+  force-with-lease update.
+- `v3-development`: record the cutover SHA, block all normal and automation
+  updates, deletion, and force-push, and alert on any attempted movement.
+- `v3-release-order-a/b/c`: block human direct/force pushes and allow only
+  release automation.
+- Grant the release bot or GitHub App a narrow bypass for candidate generation,
+  stable-tag creation, and atomic Step 3. Do not grant a general administrator
+  bypass.
+- Use durable release state plus one non-cancelling v3 release lock from
+  candidate generation through Step 3 so two versions or candidates cannot be
+  active simultaneously.
+- Recheck remote SHAs immediately before every push. A failed lease or
+  non-fast-forward is a safe failure, not a reason to force.
+
+## Later canary work
+
+Pre-publication playground approval and exact-artifact publication are part of
+the initial target. Future canary work is limited to replacing
+`v3-release-order-a/b/c` and their Step 2/3 promotion behavior; all other
+release gates and the single `main` development trunk remain unchanged.
+
+## Deferred cache-busting follow-up
+
+The current MPServer JavaScript delivery path requires no explicit CDN purge.
+The trunk migration relies on MPServer's existing refresh behavior and verifies
+the exact served bundle after Step 3. Designing cache-busting or explicit
+invalidation is separate future work; it is not required for migration
+cutover and must not delay this branch-model change.
+
+## Operator workflow guidance
+
+- For every v3 workflow, select `main` in GitHub's **Use workflow from**
+  dropdown. GitHub executes the workflow definition from the selected ref.
+- Merge the reviewed `VERSION`-only release-intent PR.
+- Start the `main` merge freeze and record `source_sha`.
+- Run candidate generation in preview mode, then create the real candidate.
+- Confirm `v3-staging`, the reported `candidate_sha`, and the committed
+  inventory digest match.
+- Run the Rokt playground against that exact candidate and record approval.
+- If rejected, explicitly click **Reject**, enter a reason, and run the
+  documented release-fix and `Recreate candidate` flow.
+- If approved, allow the waiting `staging-step-1.yml` run to continue with its
+  exact candidate SHA and artifact ID. Confirm tag, npm completeness,
+  provenance, and GitHub Release before promotion.
+- Optionally preview and run Step 2 for A, then B, then C.
+- Preview Step 3, verify all destinations, then run its atomic promotion.
+- Treat Step 3 as required production delivery. Wait for MPServer's existing
+  refresh, verify it serves the exact approved bundle checksum, then end the
+  merge freeze. Do not add an explicit CDN purge.
+- Confirm `v3-development` remains at its recorded cutover SHA.
+- For v2, continue using the existing documented refs, workflows, and
+  `track=v2`; none of these v3 steps changes v2.
+
+## Commit graph examples
+
+### First candidate
+
+```text
+v3.0.1
+   |
+   A---B---R                         main (frozen at source_sha)
+            \
+             C                      v3-staging (candidate_sha)
+
+R = chore(release): set version to 3.0.2
+C = chore(build): generate 3.0.2 candidate artifacts
+```
+
+There is no `v3.0.2` tag and no npm `3.0.2` package at this point.
+
+### Rejection, fix, reset, and regeneration
+
+```text
+v3.0.1---A---B---R---F               main (corrected source_sha)
+                   \
+                    C1               rejected candidate (preserved by SHA)
+                         [lease reset v3-staging from C1 to F]
+                           \
+                            C2        v3-staging (new candidate_sha)
+
+F  = reviewed release-fix PR; VERSION remains 3.0.2
+C1 = rejected generated candidate
+C2 = regenerated 3.0.2 candidate with new artifacts and hashes
+```
+
+`C1` is never merged or tagged. Reusing `3.0.2` is allowed only after proving
+that no stable tag or npm package consumed it.
+
+### Successful release
+
+```text
+v3.0.1---A---B---R---F---C2          main after Step 3
+                         ^  ^
+                         |  +-------- v3-staging
+                         +----------- tag v3.0.2
+                         +----------- v3-release-order-a/b/c after Step 3
+```
+
+The stable tag points directly to the approved generated candidate commit.
+
+## Migration implementation phases
+
+### Phase A: prepare and isolate v2
+
+- Announce the v3 cutover and stop new PRs to `v3-development`.
+- Retarget in-flight work to `main`.
+- Inventory and migrate every `v3-development` consumer before cutover, then
+  record the branch's permanent cutover SHA.
+- Document the MPServer JavaScript service as the owner and integration point
+  that pulls `main/dist` for production websites, including bundle URLs, bundle
+  names, existing refresh behavior, and served-checksum validation procedure.
+- Inventory all other `v3-staging` and legacy-workflow consumers, package
+  names, npm trusted publishers, branch protections, and workflow parity
+  requirements.
+- Plan removal of the `master`/`main` byte-parity guard at cutover. Preserve
+  the existing v2 workflow content and behavior on its current refs.
+
+### Phase B: build replacement automation
+
+- Add the authoritative `VERSION` and a patch/minor/major release-intent
+  workflow that validates current VERSION/tag/npm state and opens a
+  `VERSION`-only PR without release side effects.
+- Refactor existing release scripts so candidate generation can synchronize
+  versions and build without creating intermediate commits or publishing.
+- Pin `ROKT/rokt-workflows/actions/generate-changelog` immutably and implement
+  one generated candidate commit.
+- Implement 30-day GitHub Actions artifact storage, inventory hashing, artifact
+  attestations, remaining-lifetime display, expiry enforcement, and exact-
+  artifact download.
+- Implement append-only GitHub Deployment lifecycle statuses plus the protected
+  GitHub Environment, exact candidate/version deployment job, required
+  reviewers, and explicit rejection reason.
+- Keep v3 publication in `staging-step-1.yml` and audit every existing core/kit
+  trusted publisher against that workflow identity.
+- Implement the temporary freeze ruleset, reviewed release-fix bypass,
+  idempotent cleanup, manual unfreeze recovery, and stale-ruleset monitoring.
+- Document the absence of a normal Abort workflow and restrict manual
+  break-glass cleanup to genuinely suspended cycles and ruleset recovery.
+- Adapt Steps 2 and 3 to the new tag/candidate contract and remove
+  `v3-development` from all authoritative mappings.
+
+### Phase C: prove failure behavior
+
+- Dry-run first candidate creation and verify no tag/npm side effects.
+- Verify patch, minor, and major inputs calculate and open the expected
+  `VERSION`-only PR only after current VERSION/tag/npm validation; merging that
+  PR must not tag, publish, build, or change `dist`.
+- Test stale `main`, invalid `VERSION`, existing tag/version, staging lease
+  failure, generated-path allowlist failure, artifact hash mismatch, missing or
+  expired artifact, partial npm publication, GitHub Release retry, and Step 3
+  atomic-push rejection.
+- Verify explicit rejection records its reason and candidate status, prevents
+  publication, permits the authorized release-fix bypass, and drives
+  lease-protected same-version `Recreate candidate`.
+- Verify a stale rejected deployment fails publication even if later approved,
+  including independent mismatches in main SHA, staging SHA, candidate status,
+  artifact ID, manifest digest, and tarball hash.
+- Verify the only valid lifecycle paths are:
+    - `prepared -> awaiting_approval -> rejected`; or
+    - `prepared -> awaiting_approval -> approved -> publishing -> published -> promoted`.
+      Immutable manifest identity remains separate from append-only status
+      history.
+- Verify artifact attestations against subject digest, workflow identity,
+  repository, source SHA, version, and manifest digest before publication.
+- Verify the approval UI displays the full remaining artifact lifetime up to 30
+  days, late approval/publication fails after expiry, and expired candidates
+  require explicit rejection and recreation.
+- Verify freeze-ruleset cleanup after success, authorized break-glass
+  suspension, job failure, and manual unfreeze recovery.
+- Verify the real publish job retains the `staging-step-1.yml` trusted-
+  publisher identity.
+- Verify the stable-tag recovery path never rebuilds or moves the tag.
+- Verify candidate rejection and recreation leave `main` and `main/dist` at
+  the prior approved SHA.
+- Verify normal, release-intent, and release-fix PRs that modify `dist/**` fail
+  the required path-policy check.
+- Verify failed or partial publication cannot invoke Step 3 and leaves
+  `main/dist` unchanged.
+- Verify skipped or failed Step 2 leaves `main/dist` unchanged and does not
+  waive required Step 3.
+- Verify every Step 3 expected-SHA or fast-forward preflight failure leaves all
+  destinations unchanged.
+- Force an atomic-push rejection and prove no destination moves, especially
+  `main` and its `dist` tree.
+- Verify successful Step 3 exposes only the approved `dist` checksums after
+  MPServer's existing refresh, without invoking an explicit CDN purge.
+- Verify `v3-development` cannot move from its recorded cutover SHA and no
+  release or mirror job targets it.
+- Force partial npm publication and verify the stable tag remains the recovery
+  authority, only missing packages resume from exact attested artifacts, and
+  the tag is never moved or reused.
+- Verify the GitHub Release cannot be created until the full core-plus-kits npm
+  audit succeeds.
+- Verify no routine Abort workflow exists and manual cleanup enforces the
+  documented break-glass suspension criteria.
+- Run complete v2 regression validation.
+
+### Phase D: controlled cutover
+
+- Land branch protections and freeze enforcement.
+- Remove the cross-branch byte-parity guard while leaving the v2 workflow
+  implementation unchanged.
+- Generate and merge the first `VERSION`-only release-intent PR.
+- Execute candidate generation, hard playground approval, exact-artifact
+  publication, optional release-order rollout, and Step 3.
+- Keep `main` frozen throughout.
+- Audit Git, npm, provenance, GitHub Release, and all destination SHAs before
+  declaring success.
+- Make `v3-development` read-only and verify it remains permanently fixed at
+  the recorded cutover commit.
+
+### Acceptance criteria
+
+- Normal v3 PRs and all release fixes merge through `main`.
+- `VERSION` is the only authoritative release intent on `main`.
+- The release-intent workflow accepts patch/minor/major, validates current
+  VERSION/tag/npm state, and generates a reviewed `VERSION`-only PR whose merge
+  does not publish, tag, build, or modify `dist`.
+- Step 1 produces one generated candidate commit from the exact frozen
+  `source_sha`.
+- `v3-staging` equals the tested `candidate_sha`; direct product commits are
+  rejected.
+- Playground approval uses the protected environment, required reviewers, and
+  an exact candidate/version job name.
+- Explicit rejection with a reason marks the candidate rejected and blocks
+  publication.
+- `Recreate candidate` resets staging only with a pinned lease, retains
+  `VERSION` when unconsumed, regenerates exact artifacts, and creates a new
+  approval deployment.
+- Stale rejected runs fail publication even if later approved because current
+  main SHA, staging SHA, candidate status, artifact ID, manifest digest, and
+  tarball hashes are independently revalidated.
+- Publication uses the tested tarballs without rebuilding.
+- Tarballs and checksum manifest are GitHub Actions artifacts retained for 30
+  days; missing or expired artifacts fail closed.
+- The approval job shows artifact expiration and remaining lifetime, permits
+  waiting through the full 30-day ceiling, and makes approval/publication
+  ineligible at expiry until explicit rejection and recreation.
+- GitHub artifact attestations verify every candidate artifact before
+  publication.
+- Lifecycle state follows the required append-only GitHub Deployment status
+  transitions, while manifest/artifact identity remains immutable and separate.
+- Candidate creation, rejection, failed publication, and Step 2 never modify
+  the production-served `main/dist`.
+- The stable tag resolves to `candidate_sha`.
+- Core and every kit publish with expected integrity, provenance, and `next`.
+- GitHub Release creation is idempotently recoverable from the existing tag.
+- The stable tag is created before npm, is the immutable authority for partial-
+  publication recovery, and is never moved or reused; the GitHub Release is
+  created only after the complete npm audit.
+- Steps 2 and 3 consume the exact stable tag; Step 3 is atomic and excludes
+  `v3-development`.
+- Step 3 is required production delivery and advances `main` only from its
+  expected SHA to the exact approved candidate; any failed preflight or atomic
+  push leaves `main/dist` unchanged.
+- After `main` advances, MPServer must observe the commit through its existing
+  refresh behavior and serve the exact approved bundle checksum; no explicit
+  CDN purge is required.
+- The merge freeze ends only after successful Step 3 plus required production
+  MPServer served-bundle validation, or authorized break-glass cleanup for a
+  genuinely suspended cycle.
+- Temporary-ruleset cleanup is idempotent, manually recoverable, and leaves
+  permanent branch protections intact.
+- v3 publication retains the existing `staging-step-1.yml` npm trusted-
+  publisher identity after workflow parity is removed.
+- Changelog generation uses the pinned organization-owned action.
+- `v3-development` remains fixed at its cutover SHA and is never mirrored or
+  advanced.
+- All `v3-development` consumers are inventoried and migrated before cutover.
+- No normal Abort workflow exists; only audited manual break-glass cleanup may
+  suspend a release cycle or recover its temporary ruleset.
+- v2 behavior is unchanged.
+
+## Failure states and recovery
+
+### Before stable tag and npm publication
+
+- Build/test/pack failure: fix automation or source through `main`; clean and
+  rerun candidate generation.
+- Playground rejection: explicitly reject with a reason, mark the candidate
+  rejected, then use the authorized release-fix PR, pinned staging reset,
+  `Recreate candidate`, and same-version regeneration flow.
+- Stale approval: fail publication unless current main SHA, staging SHA,
+  candidate status, environment approval, artifact ID, manifest digest, and
+  tarball hashes all match.
+- Missing or expired artifact: fail closed, explicitly reject with the artifact
+  reason, then recreate/reapprove the candidate while the version remains
+  unconsumed.
+- Hash, ancestry, approval, or lease mismatch: stop without tagging or
+  publishing.
+- Rejection or failed publication: do not run Step 3; `main/dist` remains the
+  prior approved production distribution.
+- Do not use a routine abort to abandon a candidate or unfreeze `main`. Follow
+  Reject + fix + Recreate unless the release cycle is genuinely suspended and
+  the break-glass criteria below are met.
+
+### Stable tag exists, npm absent
+
+The version is consumed. Do not delete or move the tag and do not regenerate
+artifacts at that version. Diagnose the publish blocker and retry using the
+same approved tarballs. If publication is permanently abandoned, advance
+`VERSION` with a new release-intent PR and use a forward patch; retain the tag
+as audit evidence.
+
+### Partial or uncertain npm publication
+
+- Stop all newer releases.
+- Wait for registry propagation; timeout is not proof of absence.
+- Compare every published tarball integrity to the committed inventory.
+- Resume only missing packages from the same immutable artifact set.
+- Never republish an existing package unless the registry confirms the
+  artifact is byte-identical and the operation is an idempotent recovery.
+- Complete the full core-plus-kits audit before creating the GitHub Release or
+  allowing Step 2/3.
+
+### npm complete, GitHub Release absent
+
+Retry only GitHub Release creation against the existing stable tag. Do not
+rebuild, retag, or republish.
+
+### Step 2 or Step 3 failure
+
+Step 2 may be retried against the same tag and never changes `main`. A failed
+Step 2 therefore leaves production `main/dist` unchanged.
+
+A failed Step 3 preflight must make no push. A rejected atomic Step 3 push must
+leave all four destinations unchanged, including the production-serving
+`main/dist`. Keep `main` frozen, correct the preflight or permission issue, and
+retry against the same approved candidate.
+
+If the atomic push succeeds but MPServer does not observe the expected commit
+or served-bundle checksum through its existing refresh behavior, `main` has
+already advanced. Keep the freeze active and never reset or force-push `main`.
+Retry observation and diagnose the existing refresh path without introducing
+an ad hoc purge. If the promoted bundle is defective, use the forward-patch
+rollback path.
+
+If an unauthorized `main` merge makes the published candidate unable to
+fast-forward, do not force-push, move the tag, or reuse the version. Escalate
+to a reviewed reconciliation procedure that preserves both histories, then
+ship a forward patch if exact atomic promotion is no longer possible.
+
+### Fixed compatibility-ref violation
+
+Any movement of `v3-development` after cutover is an unauthorized branch-policy
+violation. Stop the actor or automation responsible, preserve audit evidence,
+and restore the recorded cutover SHA only through the approved administrative
+recovery procedure. Never treat the branch as release authority.
+
+## Break-glass suspension and forward recovery
+
+There is no normal Abort operation. Before the stable tag is pushed, an
+authorized maintainer may use documented manual break-glass cleanup only when
+the entire release cycle is genuinely suspended rather than rejected for a
+fix. The procedure must:
+
+1. disable real v3 dispatches and record authorization plus suspension reason;
+2. preserve source/candidate SHAs, Deployment status history, attestations,
+   artifacts, and logs for audit;
+3. prove `v${version}` and every npm package version are absent;
+4. append `rejected` for any still-active candidate and never merge it;
+5. merge a reviewed replacement `VERSION` PR if required;
+6. remove only the recorded temporary ruleset through the idempotent manual
+   recovery procedure;
+7. verify permanent protections and the fixed `v3-development` cutover SHA;
+   and
+8. release the `main` freeze.
+
+Do not package this path as a routine Abort workflow. Normal candidate problems,
+including artifact expiration, use explicit Reject + fix if needed + Recreate.
+
+After the stable tag or any npm publication, the version is consumed: retain
+the tag, never reuse the version, and finish exact-artifact publication only
+when safe. Do not advance `main` until publication is complete and the
+candidate remains approved. If a defect is found before Step 3, leave
+production `main/dist` unchanged and prepare a new forward version and
+candidate instead of promoting the defective commit.
+
+After Step 3 advances `main`, never reset or force `main` back to an older
+distribution. MPServer or production websites may already have fetched the new
+bundle. Rollback is a reviewed forward patch with a new `VERSION`, candidate,
+playground approval, checksums, tag, publication, and atomic Step 3. Verify the
+corrected bundle through MPServer's existing refresh and served-bundle
+validation behavior; do not reset `main` or add an ad hoc purge.
+
+`v3-development` remains fixed at its cutover SHA throughout suspension and
+forward recovery.
+
+## Hotfix policy
+
+v3 hotfixes follow the same trunk path as normal changes:
+
+1. branch from `main`;
+2. open and merge a reviewed fix PR to `main`;
+3. dispatch the release-intent workflow with `patch` and merge its reviewed
+   `VERSION`-only PR;
+4. generate and approve a new candidate on `v3-staging`; and
+5. run exact-artifact publication, optional Step 2, and required Step 3.
+
+Do not patch `v3-staging` or a release-order branch directly. If a regression
+appears during phased rollout, stop promotion, fix forward through `main`, and
+restart with a new version.
+
+The v2 hotfix policy and release flow are unchanged.
+
+## Decisions finalized
+
+No migration-blocking product decisions remain:
+
+- Semantic-release is removed from the target v3 process.
+- A workflow accepts patch/minor/major input, validates current VERSION/tag/npm
+  state, and generates the reviewed `VERSION`-only PR that is the sole release
+  intent.
+- Generated manifests, locks, changelog, and `dist` are produced in the
+  candidate commit, not the release-intent PR.
+- The MPServer JavaScript service is the confirmed delivery owner that pulls
+  `main/dist` for production websites; Step 3 is a required production
+  transition, not optional synchronization.
+- Rokt playground approval is a hard pre-publication gate.
+- The stable tag is created before exact-artifact npm publication; the GitHub
+  Release is created after npm completeness succeeds.
+- Tested tarballs and their checksum manifest are immutable GitHub Actions
+  artifacts retained for 30 days, covered by GitHub artifact attestations, and
+  never rebuilt after approval.
+- Approval may remain pending for the full 30-day artifact lifetime, with
+  remaining time visible. Expiration makes approval/publication ineligible and
+  requires explicit rejection and recreation; `main` may remain frozen for the
+  full duration.
+- Lifecycle state uses append-only GitHub Deployment statuses:
+    - `prepared -> awaiting_approval -> rejected`; or
+    - `prepared -> awaiting_approval -> approved -> publishing -> published -> promoted`.
+      Immutable manifest identity remains separate from status history.
+- Playground approval uses a protected GitHub Environment, required reviewers,
+  explicit rejection reasons, and GitHub's **Review deployments** UI.
+- The main freeze uses an automation-controlled temporary ruleset with a
+  reviewed release-fix bypass and reliable cleanup/unfreeze recovery.
+- v3 initially retains the `staging-step-1.yml` workflow identity while
+  cross-branch byte-parity is removed and v2/v3 contents diverge.
+- Changelog generation uses the established organization-owned action pinned
+  to an immutable version or SHA.
+- `main` remains frozen from candidate cut through successful Step 3 and
+  required MPServer served-bundle validation, potentially for the full 30-day
+  artifact lifetime while approval is pending.
+- No explicit CDN purge is currently required. Cache busting is deferred future
+  work and is not a trunk-migration blocker.
+- `v3-development` remains permanently fixed at its recorded cutover commit,
+  with no PR, candidate, release, mirror, or synchronization authority; its
+  consumers migrate before cutover.
+- The stable tag is created before npm and becomes immutable recovery authority;
+  the GitHub Release follows only after the full npm audit.
+- There is no normal Abort workflow. Reject + fix + Recreate is standard, with
+  manual break-glass cleanup reserved for genuinely suspended cycles and
+  ruleset recovery.
+- Release-order promotions remain optional; operational guidance recommends
+  A → B → C with observation between stages.
+- Future canary work may replace release-order branches only.
+
+## Implementation details to record before cutover
+
+No migration-blocking architecture decisions remain. The implementation PR
+must record these concrete configuration values for audit:
+
+- the protected environment name and required reviewer users/teams;
+- the temporary ruleset template, bypass actor IDs, and manual recovery owners;
+- the immutable `generate-changelog` action version or commit SHA;
+- the existing npm trusted-publisher inventory for core and every kit;
+- the GitHub Actions artifact names and explicit 30-day retention setting;
+- the GitHub Deployment environment and append-only status metadata;
+- the GitHub artifact-attestation identities and verification command;
+- production bundle URLs and expected checksums used for post-Step 3
+  validation; and
+- MPServer JavaScript ownership, existing refresh behavior, and the success
+  check proving it serves the approved bundle.

--- a/docs/plans/2026-09-08-v3-trunk-based-migration-design.md
+++ b/docs/plans/2026-09-08-v3-trunk-based-migration-design.md
@@ -139,6 +139,8 @@ SHAs;
 - create or recover the GitHub Release; and
 - support safe pre-tag rejection and post-tag/npm recovery.
 
+
+
 ### Existing constraints that must be preserved
 
 1. v2 and v3 are release tracks in the same repository on different branches.
@@ -246,20 +248,25 @@ source, mirror destination, or synchronization authority.
 - `v3-release/<run_number>` — legacy release branches to inventory and retire;
 they have no role in the target process.
 
-The top-level `VERSION` file is the sole v3 release-intent source.  The release-intent workflow accepts exactly one bump input: `patch`, `minor`, or `major`. It validates that:
+The top-level `VERSION` file is the sole v3 release-intent source. The release-
+intent workflow:
 
-- current `VERSION` is valid stable semver;
-- current `VERSION` agrees with the latest stable tag and the fully published
-core-and-kit npm baseline;
-- root and kit package identities expected for the release are complete;
-- the requested bump computes the intended next stable version; and
-- the computed stable tag and every target npm package version are absent.
-
-The workflow then opens a reviewed PR that changes only `VERSION`, for example:
+- reads top-level `VERSION` from the exact protected `main` commit;
+- validates that it is stable semver;
+- accepts exactly one bump input (`patch`, `minor`, or `major`) and computes the
+intended target version;
+- rejects a duplicate active release cycle; and
+- opens a reviewed PR that changes only `VERSION`, for example:
 
 ```text
 chore(release): set version to 3.0.2
 ```
+
+Latest-stable-tag discovery, the authoritative core/kit package inventory and
+published baseline, target tag/npm absence, and recovery-state checks are
+locked Step 1 gates after `source_sha` is frozen. The release-intent workflow
+may report those conditions as optional early warnings, but they are not
+release-intent correctness gates.
 
 Release-generated root and kit manifests, lockfiles, changelog, and
 distribution outputs remain unchanged on `main` throughout candidate
@@ -274,14 +281,11 @@ creation nor playground rejection changes the production-served files.
 
 ### Production risk and safety rationale
 
-The highest-impact failure is advancing `main/dist` to generated files that
-were not the exact playground-approved and checksum-verified release. That can
-expose an unapproved bundle directly to production websites and cannot be
-treated as harmless branch drift.
+The highest-impact failure is advancing `main/dist` to generated files that were not the exact playground-approved and checksum-verified release. That can expose an unapproved bundle directly to production websites.
 
 The main merge freeze prevents the recorded source parent from moving during
 release work. Full expected-SHA and fast-forward checks prevent stale
-automation from selecting a newer or unrelated commit. Atomic Step 3 prevents
+automation from selecting a newer or unrelated commit.  Step 3 prevents
 `main` and release-order refs from partially diverging. Together these controls
 make the production transition one auditable movement from the previous
 approved `main` SHA to the approved candidate SHA.
@@ -293,10 +297,10 @@ approved `main` SHA to the approved candidate SHA.
 ### Release intent and main freeze
 
 A maintainer dispatches the release-intent workflow with `patch`, `minor`, or
-`major`. The workflow revalidates current `VERSION`, the latest stable tag,
-and every core/kit npm baseline before calculating the target version and
-opening the `VERSION`-only PR described above. The preferred title and squash
-commit are:
+`major`. From the exact protected `main` commit, the workflow reads and
+validates stable-semver `VERSION`, computes the requested target, rejects a
+duplicate active release cycle, and opens the `VERSION`-only PR described
+above. The preferred title and squash commit are:
 
 ```text
 chore(release): set version to 3.0.2
@@ -825,9 +829,10 @@ the existing v2 workflow content and behavior on its current refs.
 ### Phase B: build replacement automation
 
 - Add v3's authoritative top-level `VERSION`, plus a patch/minor/major release-
-intent workflow that validates current VERSION/tag/npm state and opens a
-`VERSION`-only PR without release side effects. Leave v2's current semantic-
-release and versioning mechanism unchanged.
+intent workflow that reads it from the exact protected `main` commit, validates
+stable semver, computes the target, rejects duplicate active release cycles,
+and opens a `VERSION`-only PR without release side effects. Leave v2's current
+semantic-release and versioning mechanism unchanged.
 - Refactor existing release scripts so candidate generation can synchronize
 versions and build without creating intermediate commits or publishing.
 - Integrate `ROKT/rokt-workflows/actions/generate-changelog`, review and pin its
@@ -864,13 +869,15 @@ break-glass cleanup to genuinely suspended cycles and ruleset recovery.
 - Before migration, publish a throwaway package/version through
 `staging-step-1.yml` and the selected reusable workflow to validate the real
 OIDC token exchange, protected-environment controls, and npm provenance.
-- Verify patch, minor, and major inputs calculate and open the expected
-`VERSION`-only PR only after current VERSION/tag/npm validation; merging that
-PR must not tag, publish, build, or change `dist`.
-- Test stale `main`, invalid `VERSION`, existing tag/version, staging lease
-failure, generated-path allowlist failure, artifact hash mismatch, missing or
-expired artifact, partial npm publication, GitHub Release retry, and Step 3
-atomic-push rejection.
+- Verify patch, minor, and major inputs read `VERSION` from the exact protected
+`main` commit, validate stable semver, calculate the expected target, reject a
+duplicate active release cycle, and open the expected `VERSION`-only PR;
+merging that PR must not tag, publish, build, or change `dist`.
+- In locked Step 1, test stale `main`, existing tag/version, incomplete
+core/kit inventory or baseline, and recovery-state conflicts. Also test invalid
+`VERSION`, staging lease failure, generated-path allowlist failure, artifact
+hash mismatch, missing or expired artifact, partial npm publication, GitHub
+Release retry, and Step 3 atomic-push rejection.
 - Verify explicit rejection records its reason and candidate status, prevents
 publication, permits the authorized release-fix bypass, and drives
 lease-protected same-version `Recreate candidate`.
@@ -944,9 +951,10 @@ the recorded cutover commit.
 
 - Normal v3 PRs and all release fixes merge through `main`.
 - `VERSION` is the only authoritative release intent on `main`.
-- The release-intent workflow accepts patch/minor/major, validates current
-VERSION/tag/npm state, and generates a reviewed `VERSION`-only PR whose merge
-does not publish, tag, build, or modify `dist`.
+- The release-intent workflow reads `VERSION` from the exact protected `main`
+commit, validates stable semver, accepts patch/minor/major and computes the
+target, rejects duplicate active release cycles, and generates a reviewed
+`VERSION`-only PR whose merge does not publish, tag, build, or modify `dist`.
 - Step 1 produces one generated candidate commit from the exact frozen
 `source_sha`.
 - Step 1 invokes the reviewed, full-SHA-pinned
@@ -1158,9 +1166,10 @@ The v2 hotfix policy and release flow are unchanged.
 No migration-blocking product decisions remain:
 
 - Semantic-release is removed from the target v3 process.
-- A workflow accepts patch/minor/major input, validates current VERSION/tag/npm
-state, and generates the reviewed `VERSION`-only PR that is the sole release
-intent.
+- A workflow reads `VERSION` from the exact protected `main` commit, validates
+stable semver, accepts patch/minor/major and computes the target, rejects
+duplicate active release cycles, and generates the reviewed `VERSION`-only PR
+that is the sole release intent.
 - Generated manifests, locks, changelog, and `dist` are produced in the
 candidate commit, not the release-intent PR.
 - The MPServer JavaScript service is the confirmed delivery owner that pulls

--- a/docs/plans/2026-09-08-v3-trunk-based-migration-design.md
+++ b/docs/plans/2026-09-08-v3-trunk-based-migration-design.md
@@ -1,54 +1,50 @@
-# Trunk-Based Development Migration — Web SDK
+# Web SDK v3 Trunk-Based Migration Design
 
-**Status:** Draft / agreed v3 direction; implementation pending
-
-**Owner:** Rob Ing
-
-**Scope of this revision:** v3 development topology and release workflow. v2
-behavior remains unchanged.
-
-## Overview
+## TL;DR
 
 The Web SDK has two active major-version tracks:
 
-- v2 uses `master` and its existing development, staging, and release-order
-  branches.
-- v3 uses `main` and contains the core SDK plus `kits/**` on one shared version.
+- v2 uses `master` and its existing `development`, `staging`, and `release-order-a/b/c` branches. Only contains core SDK
+- v3 uses `main` , `v3-development`, `v3-staging`, `v3-release-order-a/b/c`, and contains the core SDK plus `kits/**` on one shared version.
 
-This migration makes `main` the sole development trunk for v3 and replaces the
+This trunk migration makes `main` the sole development trunk for v3 and replaces the
 v3 semantic-release pipeline with an explicit, `VERSION`-driven candidate and
-publication process. It retires the active role of `v3-development` while
-retaining it indefinitely at its cutover commit as a fixed read-only
-compatibility ref, makes `v3-staging` the exact Rokt playground candidate, and
-retains `v3-release-order-a/b/c` until canary delivery replaces them.
+publication process. It retires the active role of `v3-development`, makes `v3-staging` the testable artifact (can be used for Rokt playground), and retains `v3-release-order-a/b/c` until canary delivery replaces them.
+
+## Scope
+
+This design covers the v3 development and release workflow. The v2 development and release behavior remains unchanged
 
 ### Goals
 
 - Send all normal v3 feature, fix, and maintenance PRs to `main`.
-- Generate a reviewed `VERSION`-only release-intent PR from an explicit
-  patch/minor/major workflow input.
+- Generate a reviewed `VERSION`-only release-intent PR from an explicit patch/minor/major workflow input.
 - Freeze every v3 release candidate from an exact `main` commit.
-- Generate, test, and pack core plus every kit once, then publish those exact
-  approved artifacts without rebuilding.
+- Generate, test, and pack core plus every kit once, then publish those exact approved artifacts without rebuilding.
 - Require Rokt playground approval before a stable tag or npm publication.
 - Keep the MPServer JavaScript service and production websites on the prior
-  approved `main/dist` until atomic Step 3 promotes the exact approved
-  candidate.
+approved `main/dist` until Step 3 promotes the exact newly approved candidate.
 - Remove semantic-release from the target v3 process.
 - Preserve the existing v3 release-order rollout until canary delivery exists.
 - Keep v2 release behavior unchanged.
 
-### Non-goals
 
-- Changing v2 branch mappings, npm tags, or release semantics.
-- Implementing canary delivery.
-- Allowing `v3-staging` to become a second development branch.
-- Committing generated package manifests, locks, changelog, or `dist` to
-  `main` before a candidate is approved.
-- Putting a rejected, pending, or otherwise unapproved generated distribution
-  on `main`, even temporarily.
 
-## Current state and migration baseline
+### This migration will not:
+
+- Change v2 branch mappings, npm tags, or release semantics.
+- Implement canary delivery.
+- Allow `v3-staging` to become a second development branch.
+- Commit generated package manifests, locks, changelog, or `dist` to
+`main` before a candidate is approved.
+- Put a rejected, pending, or otherwise unapproved generated distribution  
+on `main`, even temporarily.
+
+
+
+## Current State and Migration Baseline
+
+
 
 ### v2 current state — unchanged
 
@@ -60,8 +56,10 @@ The v2 track uses:
 - `release/<run_number>` as an ephemeral release branch; and
 - `release-order-a/b/c` for phased rollout.
 
-This document does not migrate that topology. Any future v2 trunk or
-`VERSION`-file proposal must be planned and approved separately.
+This document does not migrate the v2 release topology. v2 and v3 remain
+separate release tracks in this repository. v2 retains its existing versioning
+and release semantics, while the future v3 process uses a top-level `VERSION`
+file as its authoritative release version.
 
 ### v3 legacy flow — being migrated
 
@@ -77,11 +75,7 @@ v3-development -> v3-staging -> main
 ```
 
 The shared `staging-step-1/2/3.yml` workflows select this mapping with
-`track=v3`. Step 1 freezes `v3-development`, fast-forwards `v3-staging`, runs
-semantic-release, publishes the core SDK and kits to npm with the `next`
-dist-tag, and creates the release commit and tag. Step 2 optionally promotes
-the exact tag to a selected release-order branch. Step 3 atomically
-synchronizes `v3-development`, `main`, and all three release-order branches.
+`track=v3`. Step 1 freezes v3-development, fast-forwards v3-staging, runs semantic-release, publishes the core SDK and kits to npm with the `next` dist-tag, and creates the release commit and version tag. Step 2 optionally promotes the exact tag to a selected release-order branch. Step 3 synchronizes `v3-development`, `main`, and all three release-order branches to latest.
 
 This behavior successfully shipped v3 releases, but it makes
 `v3-development` the effective product trunk and gives `v3-staging` both
@@ -99,12 +93,12 @@ behavior and then served to production consumers.
 This confirmed dependency establishes three hard constraints:
 
 - the `VERSION`-only release-intent PR and any release-fix PR leave `main/dist`
-  unchanged, so MPServer continues serving the previous approved distribution
-  throughout candidate generation and playground testing;
+unchanged, so MPServer continues serving the previous approved distribution
+throughout candidate generation and playground testing;
 - generated candidate files exist only on `v3-staging` until approval,
-  publication verification, and Step 3 preflight succeed; and
+publication verification, and Step 3 preflight succeed; and
 - only the exact playground-approved, checksum-verified `candidate_sha` may be
-  promoted to `main`.
+promoted to `main`.
 
 The production website URLs, bundle names, MPServer refresh path, and served-
 bundle validation procedure must be documented in the cutover inventory. No
@@ -129,12 +123,14 @@ explicitly own every required capability instead of silently dropping one:
 
 - validate the reviewed `VERSION`;
 - synchronize root and kit manifests and lockfiles;
-- generate deterministic changelog content;
+- generate candidate changelog content with the shared
+`[ROKT/rokt-workflows/actions/generate-changelog](https://github.com/ROKT/rokt-workflows/tree/c5c93e92107c520fb8b8cf71070995abdf4c403f/actions/generate-changelog)`
+action at a reviewed immutable commit SHA;
 - clean and build all release outputs;
 - run the complete core and kit test matrix;
 - pack core and every publishable kit once;
 - record package identities, versions, artifact hashes, and source/candidate
-  SHAs;
+SHAs;
 - create the generated candidate commit;
 - enforce playground approval for that exact candidate;
 - create and verify the stable tag;
@@ -145,29 +141,67 @@ explicitly own every required capability instead of silently dropping one:
 
 ### Existing constraints that must be preserved
 
-1. The current shared workflows enforce byte-for-byte parity between `master`
-   and `main` for `staging-step-1/2/3.yml`. That parity guard is removed at
+1. v2 and v3 are release tracks in the same repository on different branches.
+  Their workflow implementations and branch conditions may differ; byte-for-
+   byte workflow identity is not required.
+2. The future v3 process keeps its authoritative release version in the top-
+  level `VERSION`. v2 retains its current semantic-release and versioning
+   mechanism. The independently selected track workflows therefore read their
+   own release-version sources. This is separate from npm trusted-publisher/
+   OIDC authorization.
+3. The current shared workflows enforce byte-for-byte parity between `master`
+  and `main` for `staging-step-1/2/3.yml`. That parity guard is removed at
    cutover so v2 and v3 implementations can diverge. The v2 files and behavior
    remain unchanged on their existing refs.
-2. v2 publishes with `latest`; v3 publishes with `next`. The target must
-   preserve those explicit mappings.
-3. Every phase must use its recorded full `source_sha` or `candidate_sha`;
-   workflows must never resolve a moving branch independently or conflate the
+4. v2 publishes with `latest`; v3 publishes with `next`. The target must
+  preserve those explicit mappings.
+5. Every phase must use its recorded full `source_sha` or `candidate_sha`;
+  workflows must never resolve a moving branch independently or conflate the
    source and generated candidate commits.
-4. A release must have a reachable stable baseline tag and must use the exact
-   version computed by the reviewed patch/minor/major release-intent workflow.
-5. Core and all publishable kits are versioned, built, published, and audited
-   as one logical v3 release.
-6. npm trusted publishing depends on the repository and workflow identity.
-   Authentic `GITHUB_REF`, `GITHUB_REF_NAME`, and `GITHUB_SHA` must never be
-   overwritten.
-7. Dry runs validate workflow logic but cannot prove that npm accepts OIDC
-   provenance, because no real publish occurs.
-8. The v3 path initially remains in `staging-step-1.yml` so existing npm
-   trusted-publisher configuration for core and all kits keeps the same
-   workflow identity while branch contents diverge.
+6. A release must have a reachable stable baseline tag and must use the exact
+  version computed by the reviewed patch/minor/major release-intent workflow.
+7. Core and all publishable kits are versioned, built, published, and audited
+  as one logical v3 release.
+8. npm trusted publishing/OIDC validates the top-level calling workflow
+  filename, `staging-step-1.yml`, even when `npm publish` executes in a called
+   reusable workflow. Keep that file as the small, stable npm-registered Step 1
+   dispatcher for both tracks.
+9. Dry runs validate workflow logic but cannot prove that npm accepts OIDC
+  provenance, because no real token exchange or publish occurs.
+10. The dispatcher may call independently maintained same-repository v2 and v3
+  reusable workflows, such as `release-v2.yml` and `release-v3.yml`, where
+    publication may physically execute. npm does not use the child workflow
+    filename or branch as an authorization boundary.
+11. Because `jobs.<id>.uses` does not accept dynamic expressions, the
+  dispatcher declares two static reusable-workflow jobs with mutually
+    exclusive `if` conditions. Same-repository `./.github/workflows/...` calls
+    resolve the called workflow from the same commit as the caller.
+12. The configured protected npm environment, deployment-branch rules,
+  required approval, and caller-side track/ref/SHA validation constrain
+    releases. Authentic `GITHUB_REF`, `GITHUB_REF_NAME`, and `GITHUB_SHA` must
+    never be overwritten.
+13. The caller makes `id-token: write` available to the selected reusable-
+  workflow job, and the called publishing workflow/job retains or requests
+    it. Other jobs remain least-privileged; do not use broad `secrets: inherit`.   Steps 2 and 3 need no OIDC permission because they don't currently publish to npm.
 
-## Agreed v3 target topology
+
+
+## Approaches Considered
+
+
+| Approach                                                                                                                  | Benefits                                                                                                                                                                                    | Drawbacks                                                                                        | Decision |
+| ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- |
+| Keep `v3-development` as the effective product trunk and promote through `v3-staging`                                     | Preserves the legacy workflow and semantic-release implementation                                                                                                                           | Inconsistency with how Rokt manages their development workflow.                                  | Rejected |
+| Make `main` the sole v3 trunk, generate an exact candidate on `v3-staging`, and promote the approved candidate atomically | Establishes one development authority, keeps unapproved `dist` off the MPServer production path, and publishes the exact tested artifacts.Closer adherance to Rokt trunk based develpoment | Requires replacement release automation, a temporary merge freeze, and exact-SHA lifecycle state | Selected |
+
+
+
+
+## Proposed Design
+
+
+
+### Target v3 topology
 
 ```text
 short-lived branch --PR--> main
@@ -181,16 +215,15 @@ short-lived branch --PR--> main
                      candidate commit on
                         v3-staging
                               |
-                    hard Rokt playground gate
+                    hard approval gate
                               |
                               v
-                  tag -> publish exact packs
-                    -> GitHub Release
+            tag -> publish exact packs -> GitHub Release
                               |
-                     Step 2 optional rollout
+                 Step 2 optional phased rollout
                               |
-                  Step 3 required atomic production
-                            promotion
+                  Step 3 required full production
+                  promotion to main branch / CDN
                               |
                main + v3-release-order-a/b/c
 ```
@@ -198,28 +231,26 @@ short-lived branch --PR--> main
 Branch responsibilities:
 
 - `main` — the only v3 product-development trunk and the source from which the
-  MPServer JavaScript service pulls `main/dist` bundles for production
-  websites. Normal v3 PRs target this branch. A reviewed release-intent PR
-  updates only the authoritative `VERSION`; it does not regenerate `dist`.
+MPServer JavaScript service pulls `main/dist` bundles for production
+websites. Normal v3 PRs target this branch. A reviewed release-intent PR
+updates only the authoritative `VERSION`; it does not regenerate `dist`.
 - `v3-staging` — the exact generated candidate for Rokt-side playground
-  testing. Automation derives it from a frozen `main` SHA and adds one
-  generated candidate commit. No direct or product-only commit is releasable.
+testing. Automation derives it from a frozen `main` SHA and adds one
+generated candidate commit. No direct or product-only commit is releasable.
 - `v3-release-order-a/b/c` — phased delivery branches retained until canary
-  delivery is available.
+delivery is available.
 - `v3-development` — legacy integration branch retained indefinitely at its
-  recorded cutover commit as a fixed read-only compatibility ref after
-  in-flight work is drained. It is never a PR target, candidate source, release
-  source, mirror destination, or synchronization authority.
+recorded cutover commit as a fixed read-only compatibility ref after
+in-flight work is drained. It is never a PR target, candidate source, release
+source, mirror destination, or synchronization authority.
 - `v3-release/<run_number>` — legacy release branches to inventory and retire;
-  they have no role in the target process.
+they have no role in the target process.
 
-The top-level `VERSION` file is the sole v3 release-intent source. The
-release-intent workflow accepts exactly one bump input: `patch`, `minor`, or
-`major`. It validates that:
+The top-level `VERSION` file is the sole v3 release-intent source.  The release-intent workflow accepts exactly one bump input: `patch`, `minor`, or `major`. It validates that:
 
 - current `VERSION` is valid stable semver;
 - current `VERSION` agrees with the latest stable tag and the fully published
-  core-and-kit npm baseline;
+core-and-kit npm baseline;
 - root and kit package identities expected for the release are complete;
 - the requested bump computes the intended next stable version; and
 - the computed stable tag and every target npm package version are absent.
@@ -255,7 +286,9 @@ automation from selecting a newer or unrelated commit. Atomic Step 3 prevents
 make the production transition one auditable movement from the previous
 approved `main` SHA to the approved candidate SHA.
 
-## Target v3 release flow
+## Detailed Release Flow
+
+
 
 ### Release intent and main freeze
 
@@ -273,6 +306,11 @@ Merging the generated release-intent PR does not build, publish, create a tag
 or GitHub Release, or alter generated manifests, locks, changelog, or `dist`.
 Production websites therefore continue consuming the prior approved
 `main/dist`.
+
+Changelog generation therefore does not run in the release-intent workflow or
+add files to its `VERSION`-only PR. Step 1 derives the changelog from that
+reviewed release intent and freezes both the updated `CHANGELOG.md` and the
+action's `release-notes` Markdown output with the immutable candidate artifacts.
 
 Immediately after merge, the release coordinator starts a merge freeze on
 `main`. Normal feature PRs may continue through review but may not merge.
@@ -300,9 +338,6 @@ rulesets so a failed workflow cannot leave `main` frozen indefinitely. It must
 not automatically remove a ruleset for a valid `awaiting_approval` candidate
 during its 30-day artifact lifetime; alerts do not silently shorten the
 approved waiting window.
-ruleset for a valid `awaiting_approval` candidate during its 30-day artifact
-lifetime; alerts do not silently shorten the approved waiting window.
-
 There is no normal `Abort` workflow. Rejection, a reviewed fix on `main`, and
 `Recreate candidate` are the standard pre-tag recovery. Break-glass cleanup is
 reserved for genuinely suspended release cycles and ruleset recovery; it
@@ -315,7 +350,7 @@ The workflow records:
 - `candidate_sha`: the generated commit tested in the playground;
 - `artifact_manifest_sha256`: the hash of the artifact inventory;
 - `artifact_attestation_ids`: the GitHub artifact attestations bound to the
-  immutable candidate artifacts; and
+immutable candidate artifacts; and
 - later, `release_tag`: exactly `v${version}`, resolving to `candidate_sha`.
 
 These values must never be conflated or recomputed from a moving branch.
@@ -324,59 +359,82 @@ status history.
 
 ### Step 1: generate the candidate
 
-For v3, Step 1 is dispatched from the `staging-step-1.yml` definition on
-`main`. Keeping this workflow identity initially avoids reconfiguring npm
-trusted publishers for core and every kit. The v3 implementation may use
+For v3, Step 1 is dispatched through the small, stable
+`.github/workflows/staging-step-1.yml` top-level caller on `main`. npm trusted
+publishing validates that caller filename even when publication executes in a
+called reusable workflow. The dispatcher declares separate static jobs for
+`./.github/workflows/release-v2.yml` and
+`./.github/workflows/release-v3.yml`, guarded by mutually exclusive `if`
+conditions; `jobs.<id>.uses` cannot select the workflow dynamically. Relative
+same-repository calls resolve the child workflow from the caller's commit, so
+each branch selects its matching committed implementation. The track workflows
+may evolve independently without byte-for-byte parity. The v3 workflow may use
 explicit `Create candidate`, `Recreate candidate`, and recovery operations,
 but it does not invoke semantic-release. It must:
 
 1. Require `refs/heads/main` and acquire the non-cancelling v3 release lock.
 2. Resolve and freeze `source_sha`, read `VERSION`, and validate the release
-   version against Git tags and every npm package.
+  version against Git tags and every npm package.
 3. Verify that no stable tag or npm package already consumes the version.
 4. Record the expected old `v3-staging` SHA and update `v3-staging` from
-   `source_sha` using a pinned force-with-lease. This controlled reset is
+  `source_sha` using a pinned force-with-lease. This controlled reset is
    required after a rejected candidate diverges; an unqualified force is
    forbidden.
 5. In a clean worktree at `source_sha`:
-    - remove all prior generated outputs;
+  - remove all prior generated outputs;
     - set the root package manifest and lockfile to `VERSION`;
     - use `scripts/prepare-kit-release.js` or its replacement to set every core
-      and kit manifest/lock to the same version;
+    and kit manifest/lock to the same version;
     - generate the changelog section from the previous stable tag through
-      `source_sha` using
-      `ROKT/rokt-workflows/actions/generate-changelog`, pinned to an immutable
-      version or commit SHA and following the established Apple/Rokt Android
-      release patterns;
+    `source_sha` using the shared
+    `[ROKT/rokt-workflows/actions/generate-changelog](https://github.com/ROKT/rokt-workflows/tree/c5c93e92107c520fb8b8cf71070995abdf4c403f/actions/generate-changelog)`
+    composite action. Pin it to a reviewed full commit SHA, never `@main` or
+    another mutable tag. The initial implementation should review and may adopt
+    `c5c93e92107c520fb8b8cf71070995abdf4c403f`, the immutable revision already
+    used by the mParticle Android release-draft workflow. Pass the reviewed
+    `VERSION`, repository URL, `v` tag prefix, `CHANGELOG.md` path, chosen
+    conventional-commit exclusions, and `kits` path. The action updates
+    `CHANGELOG.md` in place and returns the generated Markdown as
+    `release-notes`;
+    - run the action from a full-history checkout whose detached `HEAD` is
+    exactly `source_sha`. The pinned action currently selects the highest
+    stable semver tag matching `tag-prefix` and reads first-parent commits from
+    that tag through `HEAD`; fail before generation unless that selected tag is
+    the recorded previous stable baseline. It has no explicit start/end ref
+    inputs. If this repository's tag topology cannot represent the required
+    range, extend the shared action with explicit start/end inputs, review that
+    change in `ROKT/rokt-workflows`, and pin the resulting full SHA. Add a local
+    generator only if the shared action cannot be extended, documenting the
+    incompatibility rather than silently changing range semantics;
     - build all core and kit distributions;
     - run lint, core, Jest, stub, integration, and all kit tests;
     - pack the core package and every publishable kit exactly once; and
     - create an inventory containing package name, version, tarball filename,
-      SHA-256, size, `source_sha`, and build-tool versions.
+    SHA-256, size, `source_sha`, build-tool versions, and the generated
+    `release-notes` content hash.
 6. Upload the packed tarballs and inventory as immutable GitHub Actions
-   artifacts with `retention-days: 30`, addressed by artifact ID and digest.
+  artifacts, including the generated `release-notes` Markdown, with
+   `retention-days: 30`, addressed by artifact ID and digest.
    Generate GitHub artifact attestations binding those artifacts to the
    workflow, repository, `source_sha`, version, and manifest digest. Store the
    inventory and digest in the generated tree; do not commit tarballs to Git.
 7. Create exactly one generated commit on top of `source_sha`, for example:
-
-    ```text
+  ```text
     chore(build): generate 3.0.2 candidate artifacts
-    ```
-
+  ```
     The commit contains synchronized manifests and locks, changelog, generated
     `dist`, and the artifact inventory. It contains no product-source edits.
-
 8. Push that commit to `v3-staging` with a lease and report `candidate_sha`.
 9. Reverify that the uploaded artifact digest, attestation, and committed
-   inventory agree, then append the `prepared` Deployment status linking
+  inventory agree, then append the `prepared` Deployment status linking
    `candidate_sha` to that immutable manifest and attestation identity.
 
 Candidate generation creates no stable tag, GitHub Release, or npm package.
-After the candidate is pushed, the same `staging-step-1.yml` run waits at the
-protected playground environment and, if approved, continues into exact-
-artifact publication. This preserves the existing trusted-publisher workflow
-identity without preserving the legacy semantic-release implementation.
+After the candidate is pushed, the same `staging-step-1.yml` invocation and
+selected v3 reusable workflow wait at the protected playground environment and,
+if approved, continue into exact-artifact publication. This preserves the
+npm-registered top-level caller filename without preserving the legacy
+semantic-release implementation.
 
 Lifecycle state is recorded as append-only GitHub Deployment statuses:
 
@@ -445,26 +503,24 @@ string, expired artifact, or superseded candidate is invalid.
 If the playground rejects the candidate:
 
 1. The authorized reviewer clicks **Reject** in **Review deployments**, enters
-   the rejection reason, and verifies the latest logical Deployment status is
+  the rejection reason, and verifies the latest logical Deployment status is
    `rejected`.
 2. Block publication and verify that neither `v${version}` nor any core/kit npm
-   package at that version exists.
+  package at that version exists.
 3. Preserve the rejected `candidate_sha`, reason, logs, artifact ID, and test
-   evidence for audit, but never merge the rejected candidate.
+  evidence for audit, but never merge the rejected candidate.
 4. Fix source or tests through a reviewed release-fix PR to frozen `main`,
-   merged only by the actor authorized for the temporary ruleset bypass.
+  merged only by the actor authorized for the temporary ruleset bypass.
    `VERSION` remains unchanged, and the PR must not modify `dist`.
 5. Dispatch the `Recreate candidate` operation. It observes the rejected
-   `v3-staging` SHA, then resets staging to corrected `main` only with:
-
-    ```text
-    force-with-lease=v3-staging:<expected-rejected-candidate-sha>
-    ```
-
+  `v3-staging` SHA, then resets staging to corrected `main` only with:
+   This succeeds only if remote `v3-staging` still equals the exact rejected
+   candidate SHA. Any mismatch fails closed, and plain or unqualified `--force`
+   is prohibited.
 6. Regenerate from clean inputs, producing a new artifact ID, manifest digest,
-   tarball hashes, and `candidate_sha` at the same version.
+  tarball hashes, and `candidate_sha` at the same version.
 7. Create a new protected-environment deployment for the new candidate. The
-   rejected deployment and its approval state are never reused.
+  rejected deployment and its approval state are never reused.
 
 The version remains reusable only because no stable tag or npm publication
 consumed it. Any evidence that either exists ends this rejection path.
@@ -478,58 +534,66 @@ Step 1 run must require all of the following to match its recorded values:
 - current `main` equals the candidate's `source_sha`;
 - current `v3-staging` equals its `candidate_sha`;
 - the latest append-only lifecycle status is `approved` and no `rejected`
-  status exists;
+status exists;
 - environment approval identifies that exact candidate and version; and
 - artifact ID, artifact digest, GitHub attestation, committed manifest, and
-  every tarball hash match.
+every tarball hash match.
 
 Any mismatch fails closed without creating a tag or publishing.
 
 ### Publish the approved candidate
 
-After environment approval, the same `staging-step-1.yml` run continues with
-the approved `candidate_sha` and immutable artifact ID. A recovery invocation
-may resume an already tagged candidate, but it uses the same workflow identity
-and artifacts. Publication must never rebuild, repack, regenerate the
-changelog, or change any manifest.
+After environment approval, the selected v3 reusable workflow under the same
+`staging-step-1.yml` invocation continues with the approved `candidate_sha` and
+immutable artifact ID. A recovery invocation may resume an already tagged
+candidate through the same top-level caller and exact artifacts. Publication
+must never rebuild, repack, regenerate the changelog, or change any manifest.
+
+The npm publishing job uses the configured protected npm environment,
+deployment-branch rules, and required approval. The caller validates the track,
+ref, and recorded SHAs before invoking the child. It makes `id-token: write`
+available to the reusable-workflow job, and the called publishing workflow/job
+retains or requests that permission for OIDC; unrelated jobs remain least-
+privileged and broad `secrets: inherit` is forbidden. npm does not treat the
+child reusable workflow filename or branch as an authorization boundary.
 
 The safe order is:
 
 1. Acquire the same v3 release lock and verify the `main` freeze is active.
 2. Verify:
-    - `VERSION` on frozen `main` equals the requested version;
+  - `VERSION` on frozen `main` equals the requested version;
     - `candidate_sha` has `source_sha` as its first parent;
     - `v3-staging == candidate_sha`;
     - the candidate contains only expected generated paths relative to
-      `source_sha`;
+    `source_sha`;
     - playground approval matches the exact SHA and inventory digest;
     - the append-only history is valid and its latest status is `approved` for
-      first publication or `publishing` for partial-publication recovery, with
-      no `rejected` status;
+    first publication or `publishing` for partial-publication recovery, with
+    no `rejected` status;
     - downloaded artifact ID/digest, every tarball SHA-256, package name, and
-      version match the committed inventory;
+    version match the committed inventory;
     - GitHub artifact attestations verify for the downloaded artifact subjects,
-      workflow identity, repository, source SHA, version, and manifest digest;
+    workflow identity, repository, source SHA, version, and manifest digest;
     - for first publication, the stable tag and all target npm package versions
-      are absent; or
+    are absent; or
     - for recovery, the stable tag already resolves to `candidate_sha` and
-      every existing package is byte-identical to the inventory.
+    every existing package is byte-identical to the inventory.
 3. Append `publishing`, then for first publication create and push the annotated
-   stable tag
+  stable tag
    `v${version}` at `candidate_sha`. This is the irreversible
    version-consumption boundary. Recovery reuses that exact tag and never
    creates, deletes, or moves it.
 4. Publish the exact core and kit tarballs with `--tag next --provenance`.
-   Publish core and kits in the documented order and never substitute a rebuilt
+  Publish core and kits in the documented order and never substitute a rebuilt
    tarball. Recovery publishes only missing packages, then audits the complete
    inventory.
 5. Wait for registry propagation and audit every package's version, tarball
-   integrity, provenance, and `next` dist-tag.
+  integrity, provenance, and `next` dist-tag.
 6. Create the GitHub Release from the existing stable tag only after the npm
-   completeness audit succeeds. Attach the inventory and relevant release
+  completeness audit succeeds. Attach the inventory and relevant release
    assets.
 7. Append `published` and report the exact tag and candidate SHA for Steps 2
-   and 3.
+  and 3.
 
 Tag-before-npm makes the immutable Git identity explicit before publication.
 Once created, the stable tag is the recovery authority for that version. If npm
@@ -554,26 +618,30 @@ Step 2 accepts only the exact stable tag emitted by the publish workflow. It:
 
 - validates that the remote tag resolves to the approved `candidate_sha`;
 - validates `VERSION`, core and kit manifests, npm completeness, and artifact
-  inventory;
+inventory;
 - verifies the selected release-order branch can fast-forward; and
 - fast-forwards one selected `v3-release-order-a/b/c` branch to the tag.
 
 Promotion remains optional. Operational guidance recommends A → B → C with
 observation between phases, but the workflow does not require that order.
 Step 2 never updates `main`; skipping or failing Step 2 leaves production
-`main/dist` unchanged and does not make Step 3 optional.
+`main/dist` unchanged and does not make Step 3 optional. Step 2 needs no
+`id-token: write` unless it is changed to publish an npm package.
 
 ### Step 3: required atomic production promotion
 
 Step 3 consumes the same stable tag and:
 
 - verifies the tag, candidate SHA, `VERSION`, npm completeness, GitHub Release,
-  and candidate artifact inventory;
+and candidate artifact inventory;
 - verifies `main` still equals the recorded expected `source_sha`, and verifies
-  every release-order destination still equals its recorded expected SHA;
+every release-order destination still equals its recorded expected SHA;
 - proves every destination can fast-forward to `candidate_sha`; and
 - atomically pushes `candidate_sha` to `main` and all three
-  `v3-release-order-a/b/c` branches.
+`v3-release-order-a/b/c` branches.
+
+Step 3 needs no `id-token: write` unless it is changed to publish an npm
+package.
 
 `v3-development` is absent from preflight and the atomic push. `v3-staging`
 already equals the candidate and is not an additional destination. All four
@@ -615,36 +683,42 @@ cutover. The fixed ref exists only for historical compatibility and audit.
 Required target protections:
 
 - `main`: require PRs, one approval, CODEOWNER review where configured, and
-  required build/test checks; block deletion and force-push.
+required build/test checks; block deletion and force-push.
 - Require a `main` path-policy check that rejects `dist/**` changes from normal,
-  release-intent, and release-fix PRs. Only Step 3 automation may update
-  `main/dist`, and only by promoting the verified `candidate_sha`.
+release-intent, and release-fix PRs. Only Step 3 automation may update
+`main/dist`, and only by promoting the verified `candidate_sha`.
 - During a release, add the automation-controlled temporary ruleset described
-  above; do not edit or replace the permanent `main` protections.
+above; do not edit or replace the permanent `main` protections.
 - `v3-staging`: block direct pushes for humans, block deletion and
-  general force-push, and allow only the candidate automation's pinned
-  force-with-lease update.
+general force-push, and allow only the candidate automation's pinned
+force-with-lease update.
 - `v3-development`: record the cutover SHA, block all normal and automation
-  updates, deletion, and force-push, and alert on any attempted movement.
+updates, deletion, and force-push, and alert on any attempted movement.
 - `v3-release-order-a/b/c`: block human direct/force pushes and allow only
-  release automation.
+release automation.
 - Grant the release bot or GitHub App a narrow bypass for candidate generation,
-  stable-tag creation, and atomic Step 3. Do not grant a general administrator
-  bypass.
+stable-tag creation, and atomic Step 3. Do not grant a general administrator
+bypass.
 - Use durable release state plus one non-cancelling v3 release lock from
-  candidate generation through Step 3 so two versions or candidates cannot be
-  active simultaneously.
+candidate generation through Step 3 so two versions or candidates cannot be
+active simultaneously.
 - Recheck remote SHAs immediately before every push. A failed lease or
-  non-fast-forward is a safe failure, not a reason to force.
+non-fast-forward is a safe failure, not a reason to force.
 
-## Later canary work
+
+
+## Deferred Work
+
+
+
+### Canary delivery
 
 Pre-publication playground approval and exact-artifact publication are part of
 the initial target. Future canary work is limited to replacing
 `v3-release-order-a/b/c` and their Step 2/3 promotion behavior; all other
 release gates and the single `main` development trunk remain unchanged.
 
-## Deferred cache-busting follow-up
+### Cache busting
 
 The current MPServer JavaScript delivery path requires no explicit CDN purge.
 The trunk migration relies on MPServer's existing refresh behavior and verifies
@@ -652,31 +726,35 @@ the exact served bundle after Step 3. Designing cache-busting or explicit
 invalidation is separate future work; it is not required for migration
 cutover and must not delay this branch-model change.
 
-## Operator workflow guidance
+## Operator Workflow
 
 - For every v3 workflow, select `main` in GitHub's **Use workflow from**
-  dropdown. GitHub executes the workflow definition from the selected ref.
+dropdown. GitHub executes the workflow definition from the selected ref.
 - Merge the reviewed `VERSION`-only release-intent PR.
 - Start the `main` merge freeze and record `source_sha`.
 - Run candidate generation in preview mode, then create the real candidate.
 - Confirm `v3-staging`, the reported `candidate_sha`, and the committed
-  inventory digest match.
+inventory digest match.
 - Run the Rokt playground against that exact candidate and record approval.
 - If rejected, explicitly click **Reject**, enter a reason, and run the
-  documented release-fix and `Recreate candidate` flow.
+documented release-fix and `Recreate candidate` flow.
 - If approved, allow the waiting `staging-step-1.yml` run to continue with its
-  exact candidate SHA and artifact ID. Confirm tag, npm completeness,
-  provenance, and GitHub Release before promotion.
+exact candidate SHA and artifact ID. Confirm tag, npm completeness,
+provenance, and GitHub Release before promotion.
 - Optionally preview and run Step 2 for A, then B, then C.
 - Preview Step 3, verify all destinations, then run its atomic promotion.
 - Treat Step 3 as required production delivery. Wait for MPServer's existing
-  refresh, verify it serves the exact approved bundle checksum, then end the
-  merge freeze. Do not add an explicit CDN purge.
+refresh, verify it serves the exact approved bundle checksum, then end the
+merge freeze. Do not add an explicit CDN purge.
 - Confirm `v3-development` remains at its recorded cutover SHA.
 - For v2, continue using the existing documented refs, workflows, and
-  `track=v2`; none of these v3 steps changes v2.
+`track=v2`; none of these v3 steps changes v2.
 
-## Commit graph examples
+
+
+## Commit Graph Examples
+
+
 
 ### First candidate
 
@@ -723,201 +801,246 @@ v3.0.1---A---B---R---F---C2          main after Step 3
 
 The stable tag points directly to the approved generated candidate commit.
 
-## Migration implementation phases
+## Implementation Plan
+
+
 
 ### Phase A: prepare and isolate v2
 
 - Announce the v3 cutover and stop new PRs to `v3-development`.
 - Retarget in-flight work to `main`.
 - Inventory and migrate every `v3-development` consumer before cutover, then
-  record the branch's permanent cutover SHA.
+record the branch's permanent cutover SHA.
 - Document the MPServer JavaScript service as the owner and integration point
-  that pulls `main/dist` for production websites, including bundle URLs, bundle
-  names, existing refresh behavior, and served-checksum validation procedure.
+that pulls `main/dist` for production websites, including bundle URLs, bundle
+names, existing refresh behavior, and served-checksum validation procedure.
 - Inventory all other `v3-staging` and legacy-workflow consumers, package
-  names, npm trusted publishers, branch protections, and workflow parity
-  requirements.
+names, npm trusted publishers, branch protections, the v3 top-level `VERSION`
+path, and the npm-registered shared top-level caller filename.
 - Plan removal of the `master`/`main` byte-parity guard at cutover. Preserve
-  the existing v2 workflow content and behavior on its current refs.
+the existing v2 workflow content and behavior on its current refs.
+
+
 
 ### Phase B: build replacement automation
 
-- Add the authoritative `VERSION` and a patch/minor/major release-intent
-  workflow that validates current VERSION/tag/npm state and opens a
-  `VERSION`-only PR without release side effects.
+- Add v3's authoritative top-level `VERSION`, plus a patch/minor/major release-
+intent workflow that validates current VERSION/tag/npm state and opens a
+`VERSION`-only PR without release side effects. Leave v2's current semantic-
+release and versioning mechanism unchanged.
 - Refactor existing release scripts so candidate generation can synchronize
-  versions and build without creating intermediate commits or publishing.
-- Pin `ROKT/rokt-workflows/actions/generate-changelog` immutably and implement
-  one generated candidate commit.
+versions and build without creating intermediate commits or publishing.
+- Integrate `ROKT/rokt-workflows/actions/generate-changelog`, review and pin its
+full immutable commit SHA, validate its selected stable-tag-to-`source_sha`
+range, and retain both its `CHANGELOG.md` update and `release-notes` output in
+the generated candidate. If explicit endpoints are required, extend and pin
+the shared action before considering repository-local generation.
 - Implement 30-day GitHub Actions artifact storage, inventory hashing, artifact
-  attestations, remaining-lifetime display, expiry enforcement, and exact-
-  artifact download.
+attestations, remaining-lifetime display, expiry enforcement, and exact-
+artifact download.
 - Implement append-only GitHub Deployment lifecycle statuses plus the protected
-  GitHub Environment, exact candidate/version deployment job, required
-  reviewers, and explicit rejection reason.
-- Keep v3 publication in `staging-step-1.yml` and audit every existing core/kit
-  trusted publisher against that workflow identity.
+GitHub Environment, exact candidate/version deployment job, required
+reviewers, and explicit rejection reason.
+- Keep `staging-step-1.yml` as the small npm-registered dispatcher. Add two
+static reusable-workflow jobs with mutually exclusive `if` conditions that
+call same-repository `release-v2.yml` and `release-v3.yml`; allow the called
+track workflow to execute publication.
+- Configure caller-side track/ref/SHA validation, the protected npm
+environment, deployment-branch rules, and required approval. Grant
+`id-token: write` only through the selected reusable-workflow call and its
+publishing workflow/job, and avoid broad `secrets: inherit`.
 - Implement the temporary freeze ruleset, reviewed release-fix bypass,
-  idempotent cleanup, manual unfreeze recovery, and stale-ruleset monitoring.
+idempotent cleanup, manual unfreeze recovery, and stale-ruleset monitoring.
 - Document the absence of a normal Abort workflow and restrict manual
-  break-glass cleanup to genuinely suspended cycles and ruleset recovery.
+break-glass cleanup to genuinely suspended cycles and ruleset recovery.
 - Adapt Steps 2 and 3 to the new tag/candidate contract and remove
-  `v3-development` from all authoritative mappings.
+`v3-development` from all authoritative mappings.
+
+
 
 ### Phase C: prove failure behavior
 
 - Dry-run first candidate creation and verify no tag/npm side effects.
+- Before migration, publish a throwaway package/version through
+`staging-step-1.yml` and the selected reusable workflow to validate the real
+OIDC token exchange, protected-environment controls, and npm provenance.
 - Verify patch, minor, and major inputs calculate and open the expected
-  `VERSION`-only PR only after current VERSION/tag/npm validation; merging that
-  PR must not tag, publish, build, or change `dist`.
+`VERSION`-only PR only after current VERSION/tag/npm validation; merging that
+PR must not tag, publish, build, or change `dist`.
 - Test stale `main`, invalid `VERSION`, existing tag/version, staging lease
-  failure, generated-path allowlist failure, artifact hash mismatch, missing or
-  expired artifact, partial npm publication, GitHub Release retry, and Step 3
-  atomic-push rejection.
+failure, generated-path allowlist failure, artifact hash mismatch, missing or
+expired artifact, partial npm publication, GitHub Release retry, and Step 3
+atomic-push rejection.
 - Verify explicit rejection records its reason and candidate status, prevents
-  publication, permits the authorized release-fix bypass, and drives
-  lease-protected same-version `Recreate candidate`.
+publication, permits the authorized release-fix bypass, and drives
+lease-protected same-version `Recreate candidate`.
 - Verify a stale rejected deployment fails publication even if later approved,
-  including independent mismatches in main SHA, staging SHA, candidate status,
-  artifact ID, manifest digest, and tarball hash.
+including independent mismatches in main SHA, staging SHA, candidate status,
+artifact ID, manifest digest, and tarball hash.
 - Verify the only valid lifecycle paths are:
-    - `prepared -> awaiting_approval -> rejected`; or
-    - `prepared -> awaiting_approval -> approved -> publishing -> published -> promoted`.
-      Immutable manifest identity remains separate from append-only status
-      history.
+  - `prepared -> awaiting_approval -> rejected`; or
+  - `prepared -> awaiting_approval -> approved -> publishing -> published -> promoted`.
+  Immutable manifest identity remains separate from append-only status
+  history.
 - Verify artifact attestations against subject digest, workflow identity,
-  repository, source SHA, version, and manifest digest before publication.
+repository, source SHA, version, and manifest digest before publication.
 - Verify the approval UI displays the full remaining artifact lifetime up to 30
-  days, late approval/publication fails after expiry, and expired candidates
-  require explicit rejection and recreation.
+days, late approval/publication fails after expiry, and expired candidates
+require explicit rejection and recreation.
 - Verify freeze-ruleset cleanup after success, authorized break-glass
-  suspension, job failure, and manual unfreeze recovery.
-- Verify the real publish job retains the `staging-step-1.yml` trusted-
-  publisher identity.
+suspension, job failure, and manual unfreeze recovery.
+- Verify npm recognizes `staging-step-1.yml` as the top-level calling workflow
+when `npm publish` runs in each statically selected track workflow.
+- Verify the two reusable-workflow jobs are static and mutually exclusive,
+relative calls resolve from the caller commit, and child filenames or
+branches are not relied on as npm authorization boundaries.
+- Verify only the selected publishing path receives `id-token: write`, no broad
+`secrets: inherit` is used, and Steps 2/3 have no OIDC permission.
 - Verify the stable-tag recovery path never rebuilds or moves the tag.
 - Verify candidate rejection and recreation leave `main` and `main/dist` at
-  the prior approved SHA.
+the prior approved SHA.
 - Verify normal, release-intent, and release-fix PRs that modify `dist/**` fail
-  the required path-policy check.
+the required path-policy check.
 - Verify failed or partial publication cannot invoke Step 3 and leaves
-  `main/dist` unchanged.
+`main/dist` unchanged.
 - Verify skipped or failed Step 2 leaves `main/dist` unchanged and does not
-  waive required Step 3.
+waive required Step 3.
 - Verify every Step 3 expected-SHA or fast-forward preflight failure leaves all
-  destinations unchanged.
+destinations unchanged.
 - Force an atomic-push rejection and prove no destination moves, especially
-  `main` and its `dist` tree.
+`main` and its `dist` tree.
 - Verify successful Step 3 exposes only the approved `dist` checksums after
-  MPServer's existing refresh, without invoking an explicit CDN purge.
+MPServer's existing refresh, without invoking an explicit CDN purge.
 - Verify `v3-development` cannot move from its recorded cutover SHA and no
-  release or mirror job targets it.
+release or mirror job targets it.
 - Force partial npm publication and verify the stable tag remains the recovery
-  authority, only missing packages resume from exact attested artifacts, and
-  the tag is never moved or reused.
+authority, only missing packages resume from exact attested artifacts, and
+the tag is never moved or reused.
 - Verify the GitHub Release cannot be created until the full core-plus-kits npm
-  audit succeeds.
+audit succeeds.
 - Verify no routine Abort workflow exists and manual cleanup enforces the
-  documented break-glass suspension criteria.
+documented break-glass suspension criteria.
 - Run complete v2 regression validation.
+
+
 
 ### Phase D: controlled cutover
 
 - Land branch protections and freeze enforcement.
 - Remove the cross-branch byte-parity guard while leaving the v2 workflow
-  implementation unchanged.
+implementation unchanged.
 - Generate and merge the first `VERSION`-only release-intent PR.
 - Execute candidate generation, hard playground approval, exact-artifact
-  publication, optional release-order rollout, and Step 3.
+publication, optional release-order rollout, and Step 3.
 - Keep `main` frozen throughout.
 - Audit Git, npm, provenance, GitHub Release, and all destination SHAs before
-  declaring success.
+declaring success.
 - Make `v3-development` read-only and verify it remains permanently fixed at
-  the recorded cutover commit.
+the recorded cutover commit.
 
-### Acceptance criteria
+
+
+## Acceptance Criteria
 
 - Normal v3 PRs and all release fixes merge through `main`.
 - `VERSION` is the only authoritative release intent on `main`.
 - The release-intent workflow accepts patch/minor/major, validates current
-  VERSION/tag/npm state, and generates a reviewed `VERSION`-only PR whose merge
-  does not publish, tag, build, or modify `dist`.
+VERSION/tag/npm state, and generates a reviewed `VERSION`-only PR whose merge
+does not publish, tag, build, or modify `dist`.
 - Step 1 produces one generated candidate commit from the exact frozen
-  `source_sha`.
+`source_sha`.
+- Step 1 invokes the reviewed, full-SHA-pinned
+`ROKT/rokt-workflows/actions/generate-changelog` action against the validated
+previous-stable-tag-to-`source_sha` range and freezes its `CHANGELOG.md` and
+`release-notes` outputs with the candidate artifacts.
 - `v3-staging` equals the tested `candidate_sha`; direct product commits are
-  rejected.
+rejected.
 - Playground approval uses the protected environment, required reviewers, and
-  an exact candidate/version job name.
+an exact candidate/version job name.
 - Explicit rejection with a reason marks the candidate rejected and blocks
-  publication.
+publication.
 - `Recreate candidate` resets staging only with a pinned lease, retains
-  `VERSION` when unconsumed, regenerates exact artifacts, and creates a new
-  approval deployment.
+`VERSION` when unconsumed, regenerates exact artifacts, and creates a new
+approval deployment.
 - Stale rejected runs fail publication even if later approved because current
-  main SHA, staging SHA, candidate status, artifact ID, manifest digest, and
-  tarball hashes are independently revalidated.
+main SHA, staging SHA, candidate status, artifact ID, manifest digest, and
+tarball hashes are independently revalidated.
 - Publication uses the tested tarballs without rebuilding.
 - Tarballs and checksum manifest are GitHub Actions artifacts retained for 30
-  days; missing or expired artifacts fail closed.
+days; missing or expired artifacts fail closed.
 - The approval job shows artifact expiration and remaining lifetime, permits
-  waiting through the full 30-day ceiling, and makes approval/publication
-  ineligible at expiry until explicit rejection and recreation.
+waiting through the full 30-day ceiling, and makes approval/publication
+ineligible at expiry until explicit rejection and recreation.
 - GitHub artifact attestations verify every candidate artifact before
-  publication.
+publication.
 - Lifecycle state follows the required append-only GitHub Deployment status
-  transitions, while manifest/artifact identity remains immutable and separate.
+transitions, while manifest/artifact identity remains immutable and separate.
 - Candidate creation, rejection, failed publication, and Step 2 never modify
-  the production-served `main/dist`.
+the production-served `main/dist`.
 - The stable tag resolves to `candidate_sha`.
 - Core and every kit publish with expected integrity, provenance, and `next`.
 - GitHub Release creation is idempotently recoverable from the existing tag.
 - The stable tag is created before npm, is the immutable authority for partial-
-  publication recovery, and is never moved or reused; the GitHub Release is
-  created only after the complete npm audit.
+publication recovery, and is never moved or reused; the GitHub Release is
+created only after the complete npm audit.
 - Steps 2 and 3 consume the exact stable tag; Step 3 is atomic and excludes
-  `v3-development`.
+`v3-development`.
 - Step 3 is required production delivery and advances `main` only from its
-  expected SHA to the exact approved candidate; any failed preflight or atomic
-  push leaves `main/dist` unchanged.
+expected SHA to the exact approved candidate; any failed preflight or atomic
+push leaves `main/dist` unchanged.
 - After `main` advances, MPServer must observe the commit through its existing
-  refresh behavior and serve the exact approved bundle checksum; no explicit
-  CDN purge is required.
+refresh behavior and serve the exact approved bundle checksum; no explicit
+CDN purge is required.
 - The merge freeze ends only after successful Step 3 plus required production
-  MPServer served-bundle validation, or authorized break-glass cleanup for a
-  genuinely suspended cycle.
+MPServer served-bundle validation, or authorized break-glass cleanup for a
+genuinely suspended cycle.
 - Temporary-ruleset cleanup is idempotent, manually recoverable, and leaves
-  permanent branch protections intact.
-- v3 publication retains the existing `staging-step-1.yml` npm trusted-
-  publisher identity after workflow parity is removed.
+permanent branch protections intact.
+- The future v3 process keeps its authoritative release version in top-level
+`VERSION`; v2 retains its current semantic-release and versioning mechanism.
+- `staging-step-1.yml` remains the npm-registered top-level dispatcher for both
+tracks. It statically selects an independently maintained v2 or v3 reusable
+workflow, where npm publication may execute; byte-for-byte parity is not
+required.
+- Protected npm environment controls, deployment-branch rules, required
+approval, caller validation, and least-privilege OIDC permissions constrain
+delegated publication.
 - Changelog generation uses the pinned organization-owned action.
 - `v3-development` remains fixed at its cutover SHA and is never mirrored or
-  advanced.
+advanced.
 - All `v3-development` consumers are inventoried and migrated before cutover.
 - No normal Abort workflow exists; only audited manual break-glass cleanup may
-  suspend a release cycle or recover its temporary ruleset.
+suspend a release cycle or recover its temporary ruleset.
 - v2 behavior is unchanged.
 
-## Failure states and recovery
+
+
+## Failure Behavior and Recovery
+
+
 
 ### Before stable tag and npm publication
 
 - Build/test/pack failure: fix automation or source through `main`; clean and
-  rerun candidate generation.
+rerun candidate generation.
 - Playground rejection: explicitly reject with a reason, mark the candidate
-  rejected, then use the authorized release-fix PR, pinned staging reset,
-  `Recreate candidate`, and same-version regeneration flow.
+rejected, then use the authorized release-fix PR, pinned staging reset,
+`Recreate candidate`, and same-version regeneration flow.
 - Stale approval: fail publication unless current main SHA, staging SHA,
-  candidate status, environment approval, artifact ID, manifest digest, and
-  tarball hashes all match.
+candidate status, environment approval, artifact ID, manifest digest, and
+tarball hashes all match.
 - Missing or expired artifact: fail closed, explicitly reject with the artifact
-  reason, then recreate/reapprove the candidate while the version remains
-  unconsumed.
+reason, then recreate/reapprove the candidate while the version remains
+unconsumed.
 - Hash, ancestry, approval, or lease mismatch: stop without tagging or
-  publishing.
+publishing.
 - Rejection or failed publication: do not run Step 3; `main/dist` remains the
-  prior approved production distribution.
+prior approved production distribution.
 - Do not use a routine abort to abandon a candidate or unfreeze `main`. Follow
-  Reject + fix + Recreate unless the release cycle is genuinely suspended and
-  the break-glass criteria below are met.
+Reject + fix + Recreate unless the release cycle is genuinely suspended and
+the break-glass criteria below are met.
+
+
 
 ### Stable tag exists, npm absent
 
@@ -934,9 +1057,11 @@ as audit evidence.
 - Compare every published tarball integrity to the committed inventory.
 - Resume only missing packages from the same immutable artifact set.
 - Never republish an existing package unless the registry confirms the
-  artifact is byte-identical and the operation is an idempotent recovery.
+artifact is byte-identical and the operation is an idempotent recovery.
 - Complete the full core-plus-kits audit before creating the GitHub Release or
-  allowing Step 2/3.
+allowing Step 2/3.
+
+
 
 ### npm complete, GitHub Release absent
 
@@ -972,7 +1097,7 @@ violation. Stop the actor or automation responsible, preserve audit evidence,
 and restore the recorded cutover SHA only through the approved administrative
 recovery procedure. Never treat the branch as release authority.
 
-## Break-glass suspension and forward recovery
+## Break-Glass Suspension and Forward Recovery
 
 There is no normal Abort operation. Before the stable tag is pushed, an
 authorized maintainer may use documented manual break-glass cleanup only when
@@ -981,14 +1106,14 @@ fix. The procedure must:
 
 1. disable real v3 dispatches and record authorization plus suspension reason;
 2. preserve source/candidate SHAs, Deployment status history, attestations,
-   artifacts, and logs for audit;
+  artifacts, and logs for audit;
 3. prove `v${version}` and every npm package version are absent;
 4. append `rejected` for any still-active candidate and never merge it;
 5. merge a reviewed replacement `VERSION` PR if required;
 6. remove only the recorded temporary ruleset through the idempotent manual
-   recovery procedure;
+  recovery procedure;
 7. verify permanent protections and the fixed `v3-development` cutover SHA;
-   and
+  and
 8. release the `main` freeze.
 
 Do not package this path as a routine Abort workflow. Normal candidate problems,
@@ -1011,14 +1136,14 @@ validation behavior; do not reset `main` or add an ad hoc purge.
 `v3-development` remains fixed at its cutover SHA throughout suspension and
 forward recovery.
 
-## Hotfix policy
+## Hotfix Policy
 
 v3 hotfixes follow the same trunk path as normal changes:
 
 1. branch from `main`;
 2. open and merge a reviewed fix PR to `main`;
 3. dispatch the release-intent workflow with `patch` and merge its reviewed
-   `VERSION`-only PR;
+  `VERSION`-only PR;
 4. generate and approve a new candidate on `v3-staging`; and
 5. run exact-artifact publication, optional Step 2, and required Step 3.
 
@@ -1028,59 +1153,68 @@ restart with a new version.
 
 The v2 hotfix policy and release flow are unchanged.
 
-## Decisions finalized
+## Decision Summary
 
 No migration-blocking product decisions remain:
 
 - Semantic-release is removed from the target v3 process.
 - A workflow accepts patch/minor/major input, validates current VERSION/tag/npm
-  state, and generates the reviewed `VERSION`-only PR that is the sole release
-  intent.
+state, and generates the reviewed `VERSION`-only PR that is the sole release
+intent.
 - Generated manifests, locks, changelog, and `dist` are produced in the
-  candidate commit, not the release-intent PR.
+candidate commit, not the release-intent PR.
 - The MPServer JavaScript service is the confirmed delivery owner that pulls
-  `main/dist` for production websites; Step 3 is a required production
-  transition, not optional synchronization.
+`main/dist` for production websites; Step 3 is a required production
+transition, not optional synchronization.
 - Rokt playground approval is a hard pre-publication gate.
 - The stable tag is created before exact-artifact npm publication; the GitHub
-  Release is created after npm completeness succeeds.
+Release is created after npm completeness succeeds.
 - Tested tarballs and their checksum manifest are immutable GitHub Actions
-  artifacts retained for 30 days, covered by GitHub artifact attestations, and
-  never rebuilt after approval.
+artifacts retained for 30 days, covered by GitHub artifact attestations, and
+never rebuilt after approval.
 - Approval may remain pending for the full 30-day artifact lifetime, with
-  remaining time visible. Expiration makes approval/publication ineligible and
-  requires explicit rejection and recreation; `main` may remain frozen for the
-  full duration.
+remaining time visible. Expiration makes approval/publication ineligible and
+requires explicit rejection and recreation; `main` may remain frozen for the
+full duration.
 - Lifecycle state uses append-only GitHub Deployment statuses:
-    - `prepared -> awaiting_approval -> rejected`; or
-    - `prepared -> awaiting_approval -> approved -> publishing -> published -> promoted`.
-      Immutable manifest identity remains separate from status history.
+  - `prepared -> awaiting_approval -> rejected`; or
+  - `prepared -> awaiting_approval -> approved -> publishing -> published -> promoted`.
+  Immutable manifest identity remains separate from status history.
 - Playground approval uses a protected GitHub Environment, required reviewers,
-  explicit rejection reasons, and GitHub's **Review deployments** UI.
+explicit rejection reasons, and GitHub's **Review deployments** UI.
 - The main freeze uses an automation-controlled temporary ruleset with a
-  reviewed release-fix bypass and reliable cleanup/unfreeze recovery.
-- v3 initially retains the `staging-step-1.yml` workflow identity while
-  cross-branch byte-parity is removed and v2/v3 contents diverge.
+reviewed release-fix bypass and reliable cleanup/unfreeze recovery.
+- Top-level `VERSION` is authoritative only for the future v3 process; v2
+retains its current semantic-release and versioning mechanism.
+- `staging-step-1.yml` remains the npm-registered top-level caller and
+statically dispatches to independently maintained same-repository v2 or v3
+reusable workflows. Publication may execute in the selected child; npm does
+not use that child filename or branch as its authorization boundary.
+- Delegated publication is constrained by the protected npm environment,
+deployment-branch rules, required approval, caller-side validation, and
+least-privilege `id-token: write`; Steps 2/3 receive no OIDC permission.
 - Changelog generation uses the established organization-owned action pinned
-  to an immutable version or SHA.
+to an immutable version or SHA.
 - `main` remains frozen from candidate cut through successful Step 3 and
-  required MPServer served-bundle validation, potentially for the full 30-day
-  artifact lifetime while approval is pending.
+required MPServer served-bundle validation, potentially for the full 30-day
+artifact lifetime while approval is pending.
 - No explicit CDN purge is currently required. Cache busting is deferred future
-  work and is not a trunk-migration blocker.
+work and is not a trunk-migration blocker.
 - `v3-development` remains permanently fixed at its recorded cutover commit,
-  with no PR, candidate, release, mirror, or synchronization authority; its
-  consumers migrate before cutover.
+with no PR, candidate, release, mirror, or synchronization authority; its
+consumers migrate before cutover.
 - The stable tag is created before npm and becomes immutable recovery authority;
-  the GitHub Release follows only after the full npm audit.
+the GitHub Release follows only after the full npm audit.
 - There is no normal Abort workflow. Reject + fix + Recreate is standard, with
-  manual break-glass cleanup reserved for genuinely suspended cycles and
-  ruleset recovery.
+manual break-glass cleanup reserved for genuinely suspended cycles and
+ruleset recovery.
 - Release-order promotions remain optional; operational guidance recommends
-  A → B → C with observation between stages.
+A → B → C with observation between stages.
 - Future canary work may replace release-order branches only.
 
-## Implementation details to record before cutover
+
+
+## Open Implementation Details
 
 No migration-blocking architecture decisions remain. The implementation PR
 must record these concrete configuration values for audit:
@@ -1088,11 +1222,18 @@ must record these concrete configuration values for audit:
 - the protected environment name and required reviewer users/teams;
 - the temporary ruleset template, bypass actor IDs, and manual recovery owners;
 - the immutable `generate-changelog` action version or commit SHA;
-- the existing npm trusted-publisher inventory for core and every kit;
+- the existing npm trusted-publisher inventory for core and every kit,
+including the registered `staging-step-1.yml` caller filename;
+- the static v2/v3 reusable-workflow job names, mutually exclusive conditions,
+same-repository child filenames, caller validations, and permission flow;
+- the protected npm environment name, deployment-branch rules, and required
+approval configuration;
+- the throwaway package and version used for pre-migration OIDC validation;
 - the GitHub Actions artifact names and explicit 30-day retention setting;
 - the GitHub Deployment environment and append-only status metadata;
 - the GitHub artifact-attestation identities and verification command;
 - production bundle URLs and expected checksums used for post-Step 3
-  validation; and
+validation; and
 - MPServer JavaScript ownership, existing refresh behavior, and the success
-  check proving it serves the approved bundle.
+check proving it serves the approved bundle.
+

--- a/docs/plans/2026-09-08-v3-trunk-based-migration-design.md
+++ b/docs/plans/2026-09-08-v3-trunk-based-migration-design.md
@@ -319,8 +319,7 @@ action's `release-notes` Markdown output with the immutable candidate artifacts.
 Immediately after merge, the release coordinator starts a merge freeze on
 `main`. Normal feature PRs may continue through review but may not merge.
 Release-fix PRs are the only exception. The freeze ends after successful Step
-3, including required MPServer refresh and served-bundle validation, or an
-authorized break-glass cleanup for a genuinely suspended release cycle.
+3, including required MPServer refresh and served-bundle validation.
 
 Automation enforces the freeze by creating or enabling a temporary GitHub
 ruleset scoped to `main`. It records the ruleset ID, release version,
@@ -331,21 +330,16 @@ automation or release manager may merge it through the temporary bypass; the
 bypass never permits an unreviewed direct source push.
 
 Successful Step 3 finalization, after MPServer refresh and served-bundle
-validation, and authorized break-glass cleanup remove or disable only the
-recorded temporary ruleset ID, verify normal branch protections remain active,
-and record cleanup success. Cleanup runs idempotently under `always()` where
-safe. A separate manual unfreeze-recovery procedure accepts the release version
-and recorded ruleset ID, verifies that no active publish/promotion operation
-exists, removes only that matching temporary ruleset, and confirms `main` is
-writable under its normal protections. Monitoring must flag stale release
-rulesets so a failed workflow cannot leave `main` frozen indefinitely. It must
-not automatically remove a ruleset for a valid `awaiting_approval` candidate
-during its 30-day artifact lifetime; alerts do not silently shorten the
-approved waiting window.
-There is no normal `Abort` workflow. Rejection, a reviewed fix on `main`, and
-`Recreate candidate` are the standard pre-tag recovery. Break-glass cleanup is
-reserved for genuinely suspended release cycles and ruleset recovery; it
-requires explicit authorization and an audit record.
+validation, removes or disables only the recorded temporary ruleset ID, verifies
+normal branch protections remain active, and records cleanup success. Cleanup
+is idempotent and may be retried only after the required Step 3 and served-
+bundle validation have succeeded. Monitoring must flag stale release rulesets
+so the release coordinator can resume the blocked release or retry eligible
+post-validation cleanup. It must not automatically remove a ruleset for a valid
+`awaiting_approval` candidate during its 30-day artifact lifetime; alerts do
+not silently shorten the approved waiting window. Rejection, a reviewed fix on
+`main`, and `Recreate candidate` are the standard pre-tag recovery, and the
+freeze remains active throughout that flow.
 
 The workflow records:
 
@@ -855,9 +849,7 @@ environment, deployment-branch rules, and required approval. Grant
 `id-token: write` only through the selected reusable-workflow call and its
 publishing workflow/job, and avoid broad `secrets: inherit`.
 - Implement the temporary freeze ruleset, reviewed release-fix bypass,
-idempotent cleanup, manual unfreeze recovery, and stale-ruleset monitoring.
-- Document the absence of a normal Abort workflow and restrict manual
-break-glass cleanup to genuinely suspended cycles and ruleset recovery.
+idempotent post-validation cleanup, and stale-ruleset monitoring.
 - Adapt Steps 2 and 3 to the new tag/candidate contract and remove
 `v3-development` from all authoritative mappings.
 
@@ -894,8 +886,9 @@ repository, source SHA, version, and manifest digest before publication.
 - Verify the approval UI displays the full remaining artifact lifetime up to 30
 days, late approval/publication fails after expiry, and expired candidates
 require explicit rejection and recreation.
-- Verify freeze-ruleset cleanup after success, authorized break-glass
-suspension, job failure, and manual unfreeze recovery.
+- Verify freeze-ruleset cleanup after successful required Step 3 and served-
+bundle validation, and verify job failures leave the freeze active and alert
+the release coordinator.
 - Verify npm recognizes `staging-step-1.yml` as the top-level calling workflow
 when `npm publish` runs in each statically selected track workflow.
 - Verify the two reusable-workflow jobs are static and mutually exclusive,
@@ -925,8 +918,6 @@ authority, only missing packages resume from exact attested artifacts, and
 the tag is never moved or reused.
 - Verify the GitHub Release cannot be created until the full core-plus-kits npm
 audit succeeds.
-- Verify no routine Abort workflow exists and manual cleanup enforces the
-documented break-glass suspension criteria.
 - Run complete v2 regression validation.
 
 
@@ -1000,10 +991,9 @@ push leaves `main/dist` unchanged.
 refresh behavior and serve the exact approved bundle checksum; no explicit
 CDN purge is required.
 - The merge freeze ends only after successful Step 3 plus required production
-MPServer served-bundle validation, or authorized break-glass cleanup for a
-genuinely suspended cycle.
-- Temporary-ruleset cleanup is idempotent, manually recoverable, and leaves
-permanent branch protections intact.
+MPServer served-bundle validation.
+- Temporary-ruleset cleanup is idempotent, retryable only after that validation,
+and leaves permanent branch protections intact.
 - The future v3 process keeps its authoritative release version in top-level
 `VERSION`; v2 retains its current semantic-release and versioning mechanism.
 - `staging-step-1.yml` remains the npm-registered top-level dispatcher for both
@@ -1017,8 +1007,6 @@ delegated publication.
 - `v3-development` remains fixed at its cutover SHA and is never mirrored or
 advanced.
 - All `v3-development` consumers are inventoried and migrated before cutover.
-- No normal Abort workflow exists; only audited manual break-glass cleanup may
-suspend a release cycle or recover its temporary ruleset.
 - v2 behavior is unchanged.
 
 
@@ -1044,9 +1032,8 @@ unconsumed.
 publishing.
 - Rejection or failed publication: do not run Step 3; `main/dist` remains the
 prior approved production distribution.
-- Do not use a routine abort to abandon a candidate or unfreeze `main`. Follow
-Reject + fix + Recreate unless the release cycle is genuinely suspended and
-the break-glass criteria below are met.
+- Reject the candidate, fix `main` if needed, and recreate the same unpublished
+`VERSION`; keep `main` frozen throughout.
 
 
 
@@ -1105,27 +1092,7 @@ violation. Stop the actor or automation responsible, preserve audit evidence,
 and restore the recorded cutover SHA only through the approved administrative
 recovery procedure. Never treat the branch as release authority.
 
-## Break-Glass Suspension and Forward Recovery
-
-There is no normal Abort operation. Before the stable tag is pushed, an
-authorized maintainer may use documented manual break-glass cleanup only when
-the entire release cycle is genuinely suspended rather than rejected for a
-fix. The procedure must:
-
-1. disable real v3 dispatches and record authorization plus suspension reason;
-2. preserve source/candidate SHAs, Deployment status history, attestations,
-  artifacts, and logs for audit;
-3. prove `v${version}` and every npm package version are absent;
-4. append `rejected` for any still-active candidate and never merge it;
-5. merge a reviewed replacement `VERSION` PR if required;
-6. remove only the recorded temporary ruleset through the idempotent manual
-  recovery procedure;
-7. verify permanent protections and the fixed `v3-development` cutover SHA;
-  and
-8. release the `main` freeze.
-
-Do not package this path as a routine Abort workflow. Normal candidate problems,
-including artifact expiration, use explicit Reject + fix if needed + Recreate.
+## Forward Recovery
 
 After the stable tag or any npm publication, the version is consumed: retain
 the tag, never reuse the version, and finish exact-artifact publication only
@@ -1141,8 +1108,7 @@ playground approval, checksums, tag, publication, and atomic Step 3. Verify the
 corrected bundle through MPServer's existing refresh and served-bundle
 validation behavior; do not reset `main` or add an ad hoc purge.
 
-`v3-development` remains fixed at its cutover SHA throughout suspension and
-forward recovery.
+`v3-development` remains fixed at its cutover SHA throughout forward recovery.
 
 ## Hotfix Policy
 
@@ -1192,7 +1158,7 @@ full duration.
 - Playground approval uses a protected GitHub Environment, required reviewers,
 explicit rejection reasons, and GitHub's **Review deployments** UI.
 - The main freeze uses an automation-controlled temporary ruleset with a
-reviewed release-fix bypass and reliable cleanup/unfreeze recovery.
+reviewed release-fix bypass and reliable post-validation cleanup.
 - Top-level `VERSION` is authoritative only for the future v3 process; v2
 retains its current semantic-release and versioning mechanism.
 - `staging-step-1.yml` remains the npm-registered top-level caller and
@@ -1214,9 +1180,6 @@ with no PR, candidate, release, mirror, or synchronization authority; its
 consumers migrate before cutover.
 - The stable tag is created before npm and becomes immutable recovery authority;
 the GitHub Release follows only after the full npm audit.
-- There is no normal Abort workflow. Reject + fix + Recreate is standard, with
-manual break-glass cleanup reserved for genuinely suspended cycles and
-ruleset recovery.
 - Release-order promotions remain optional; operational guidance recommends
 A → B → C with observation between stages.
 - Future canary work may replace release-order branches only.
@@ -1229,7 +1192,8 @@ No migration-blocking architecture decisions remain. The implementation PR
 must record these concrete configuration values for audit:
 
 - the protected environment name and required reviewer users/teams;
-- the temporary ruleset template, bypass actor IDs, and manual recovery owners;
+- the temporary ruleset template, bypass actor IDs, and post-validation cleanup
+owners;
 - the immutable `generate-changelog` action version or commit SHA;
 - the existing npm trusted-publisher inventory for core and every kit,
 including the registered `staging-step-1.yml` caller filename;

--- a/docs/plans/2026-09-08-v3-trunk-based-migration-design.md
+++ b/docs/plans/2026-09-08-v3-trunk-based-migration-design.md
@@ -1,67 +1,69 @@
 # Web SDK v3 Trunk-Based Migration Design
 
-## TL;DR
+## 1. Summary and scope
 
-The Web SDK has two active major-version tracks:
+The Web SDK has two independent major-version release tracks in one repository.
+This design changes only v3:
 
-- v2 uses `master` and its existing `development`, `staging`, and `release-order-a/b/c` branches. Only contains core SDK
-- v3 uses `main` , `v3-development`, `v3-staging`, `v3-release-order-a/b/c`, and contains the core SDK plus `kits/**` on one shared version.
+- v2 continues to use `master`, `development`, `staging`, and the unprefixed
+`release-order-a/b/c` branches. Its versioning, semantic-release process, and npm behavior remain unchanged.
+- v3 moves all development to `main`. It uses `v3-staging` for one generated,
+testable release candidate and retains `v3-release-order-a/b/c` until canary delivery replaces them. `v3-development` is deprecated.
 
-This trunk migration makes `main` the sole development trunk for v3 and replaces the
-v3 semantic-release pipeline with an explicit, `VERSION`-driven candidate and
-publication process. It retires the active role of `v3-development`, makes `v3-staging` the testable artifact (can be used for Rokt playground), and retains `v3-release-order-a/b/c` until canary delivery replaces them.
-
-## Scope
-
-This design covers the v3 development and release workflow. The v2 development and release behavior remains unchanged
+The target v3 process replaces semantic-release with an explicit, top-level
+`VERSION` file and an exact-artifact release lifecycle. It freezes an exact
+`main` commit, generates and tests core plus every publishable kit once, obtains
+playground approval for that exact candidate, and publishes the same packed
+artifacts without rebuilding.
 
 ### Goals
 
-- Send all normal v3 feature, fix, and maintenance PRs to `main`.
-- Generate a reviewed `VERSION`-only release-intent PR from an explicit patch/minor/major workflow input.
-- Freeze every v3 release candidate from an exact `main` commit.
-- Generate, test, and pack core plus every kit once, then publish those exact approved artifacts without rebuilding.
-- Require Rokt playground approval before a stable tag or npm publication.
-- Keep the MPServer JavaScript service and production websites on the prior
-approved `main/dist` until Step 3 promotes the exact newly approved candidate.
-- Remove semantic-release from the target v3 process.
-- Preserve the existing v3 release-order rollout until canary delivery exists.
-- Keep v2 release behavior unchanged.
+- Make `main` the sole v3 product-development trunk.
+- Express v3 release intent through a reviewed `VERSION`-only PR.
+- Keep unapproved generated files away from `main`.
+- Make `v3-staging` the exact Rokt playground testing surface.
+- Publish the exact approved core and kit tarballs under npm tag `next`.
+- Preserve phased v3 release-order delivery until canary delivery exists.
+- Make production promotion atomic and independently verifiable.
+- Replace every v3 responsibility currently supplied by semantic-release.
 
 
 
-### This migration will not:
+### Out of scope
 
-- Change v2 branch mappings, npm tags, or release semantics.
-- Implement canary delivery.
-- Allow `v3-staging` to become a second development branch.
-- Commit generated package manifests, locks, changelog, or `dist` to
-`main` before a candidate is approved.
-- Put a rejected, pending, or otherwise unapproved generated distribution  
-on `main`, even temporarily.
-
-
-
-## Current State and Migration Baseline
+- Any change to v2 branch mappings, versioning, npm tags, or release semantics.
+- Canary delivery or removal of v3 release-order branches.
+- Cache-busting design; it remains deferred work.
+- Product development or direct fixes on `v3-staging`.
+- Generated manifests, locks, changelog, or `dist` in the release-intent PR.
+- Promotion of a rejected, pending, stale, or incompletely published candidate.
 
 
 
-### v2 current state — unchanged
+### Approaches considered
 
-The v2 track uses:
+
+| Approach                                                                                                                                                       | Outcome                                                                                                                                 |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep `v3-development` as the effective trunk and promote through `v3-staging`                                                                                  | Rejected. Retains semantic-release but splits development authority and diverges from trunk-based development.                          |
+| Make `main` the sole trunk, generate one exact candidate on `v3-staging`, require approval before publication, then promote to release order branches and main | Selected. Establishes one development authority, keeps unapproved distributions off the production path, and publishes exact artifacts. |
+
+
+
+
+## 2. Current and target topology
+
+
+
+### Current topology
+
+The unchanged v2 track uses:
 
 - `development` as its integration branch;
 - `staging` as its release staging branch;
-- `master` as its release-tracking/CDN branch;
+- `master` as its release-tracking branch;
 - `release/<run_number>` as an ephemeral release branch; and
-- `release-order-a/b/c` for phased rollout.
-
-This document does not migrate the v2 release topology. v2 and v3 remain
-separate release tracks in this repository. v2 retains its existing versioning
-and release semantics, while the future v3 process uses a top-level `VERSION`
-file as its authoritative release version.
-
-### v3 legacy flow — being migrated
+- unprefixed `release-order-a/b/c` for phased rollout.
 
 The legacy v3 flow is:
 
@@ -74,1139 +76,685 @@ v3-development -> v3-staging -> main
                        +-> v3-release-order-a/b/c
 ```
 
-The shared `staging-step-1/2/3.yml` workflows select this mapping with
-`track=v3`. Step 1 freezes v3-development, fast-forwards v3-staging, runs semantic-release, publishes the core SDK and kits to npm with the `next` dist-tag, and creates the release commit and version tag. Step 2 optionally promotes the exact tag to a selected release-order branch. Step 3 synchronizes `v3-development`, `main`, and all three release-order branches to latest.
+Shared Step 1–3 workflows currently select this mapping with `track=v3`.
+Semantic-release chooses a version, updates release files, builds, tags,
+publishes core and kits, and creates the GitHub Release. The legacy model makes
+`v3-development` the effective product trunk and gives `v3-staging` both source
+and testing responsibilities.
 
-This behavior successfully shipped v3 releases, but it makes
-`v3-development` the effective product trunk and gives `v3-staging` both
-release-source and testing responsibilities.
-
-### Confirmed production consumer
-
-The MPServer JavaScript service currently pulls generated bundles from
-`main/dist` and serves them to production websites. MPServer is the delivery
-owner and integration point for this path. Movement of `main` is therefore part
-of production delivery, not merely repository synchronization. A commit that
-changes `main/dist` may be fetched by MPServer through its existing refresh
-behavior and then served to production consumers.
-
-This confirmed dependency establishes three hard constraints:
-
-- the `VERSION`-only release-intent PR and any release-fix PR leave `main/dist`
-unchanged, so MPServer continues serving the previous approved distribution
-throughout candidate generation and playground testing;
-- generated candidate files exist only on `v3-staging` until approval,
-publication verification, and Step 3 preflight succeed; and
-- only the exact playground-approved, checksum-verified `candidate_sha` may be
-promoted to `main`.
-
-The production website URLs, bundle names, MPServer refresh path, and served-
-bundle validation procedure must be documented in the cutover inventory. No
-explicit CDN purge is currently required. Cache busting is deferred follow-up
-work and is not a trunk-migration blocker.
-
-### Legacy semantic-release responsibilities
-
-Semantic-release is part of the current v3 implementation only. It currently:
-
-- analyzes conventional commits and selects the next version;
-- generates release notes and updates `CHANGELOG.md`;
-- synchronizes core and kit package versions;
-- invokes release scripts that build and commit distribution bundles;
-- creates the release commit and stable Git tag;
-- publishes the core package and coordinates kit publication;
-- creates the GitHub Release; and
-- supports the current release-tag-based kit recovery path.
-
-The target v3 process removes semantic-release. Replacement automation must
-explicitly own every required capability instead of silently dropping one:
-
-- validate the reviewed `VERSION`;
-- synchronize root and kit manifests and lockfiles;
-- generate candidate changelog content with the shared
-`[ROKT/rokt-workflows/actions/generate-changelog](https://github.com/ROKT/rokt-workflows/tree/c5c93e92107c520fb8b8cf71070995abdf4c403f/actions/generate-changelog)`
-action at a reviewed immutable commit SHA;
-- clean and build all release outputs;
-- run the complete core and kit test matrix;
-- pack core and every publishable kit once;
-- record package identities, versions, artifact hashes, and source/candidate
-SHAs;
-- create the generated candidate commit;
-- enforce playground approval for that exact candidate;
-- create and verify the stable tag;
-- publish exact packed artifacts with npm provenance and the `next` dist-tag;
-- audit registry completeness and artifact integrity;
-- create or recover the GitHub Release; and
-- support safe pre-tag rejection and post-tag/npm recovery.
-
-
-
-### Existing constraints that must be preserved
-
-1. v2 and v3 are release tracks in the same repository on different branches.
-  Their workflow implementations and branch conditions may differ; byte-for-
-   byte workflow identity is not required.
-2. The future v3 process keeps its authoritative release version in the top-
-  level `VERSION`. v2 retains its current semantic-release and versioning
-   mechanism. The independently selected track workflows therefore read their
-   own release-version sources. This is separate from npm trusted-publisher/
-   OIDC authorization.
-3. The current shared workflows enforce byte-for-byte parity between `master`
-  and `main` for `staging-step-1/2/3.yml`. That parity guard is removed at
-   cutover so v2 and v3 implementations can diverge. The v2 files and behavior
-   remain unchanged on their existing refs.
-4. v2 publishes with `latest`; v3 publishes with `next`. The target must
-  preserve those explicit mappings.
-5. Every phase must use its recorded full `source_sha` or `candidate_sha`;
-  workflows must never resolve a moving branch independently or conflate the
-   source and generated candidate commits.
-6. A release must have a reachable stable baseline tag and must use the exact
-  version computed by the reviewed patch/minor/major release-intent workflow.
-7. Core and all publishable kits are versioned, built, published, and audited
-  as one logical v3 release.
-8. npm trusted publishing/OIDC validates the top-level calling workflow
-  filename, `staging-step-1.yml`, even when `npm publish` executes in a called
-   reusable workflow. Keep that file as the small, stable npm-registered Step 1
-   dispatcher for both tracks.
-9. Dry runs validate workflow logic but cannot prove that npm accepts OIDC
-  provenance, because no real token exchange or publish occurs.
-10. The dispatcher may call independently maintained same-repository v2 and v3
-  reusable workflows, such as `release-v2.yml` and `release-v3.yml`, where
-    publication may physically execute. npm does not use the child workflow
-    filename or branch as an authorization boundary.
-11. Because `jobs.<id>.uses` does not accept dynamic expressions, the
-  dispatcher declares two static reusable-workflow jobs with mutually
-    exclusive `if` conditions. Same-repository `./.github/workflows/...` calls
-    resolve the called workflow from the same commit as the caller.
-12. The configured protected npm environment, deployment-branch rules,
-  required approval, and caller-side track/ref/SHA validation constrain
-    releases. Authentic `GITHUB_REF`, `GITHUB_REF_NAME`, and `GITHUB_SHA` must
-    never be overwritten.
-13. The caller makes `id-token: write` available to the selected reusable-
-  workflow job, and the called publishing workflow/job retains or requests
-    it. Other jobs remain least-privileged; do not use broad `secrets: inherit`.   Steps 2 and 3 need no OIDC permission because they don't currently publish to npm.
-
-
-
-## Approaches Considered
-
-
-| Approach                                                                                                                  | Benefits                                                                                                                                                                                    | Drawbacks                                                                                        | Decision |
-| ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- |
-| Keep `v3-development` as the effective product trunk and promote through `v3-staging`                                     | Preserves the legacy workflow and semantic-release implementation                                                                                                                           | Inconsistency with how Rokt manages their development workflow.                                  | Rejected |
-| Make `main` the sole v3 trunk, generate an exact candidate on `v3-staging`, and promote the approved candidate atomically | Establishes one development authority, keeps unapproved `dist` off the MPServer production path, and publishes the exact tested artifacts.Closer adherance to Rokt trunk based develpoment | Requires replacement release automation, a temporary merge freeze, and exact-SHA lifecycle state | Selected |
-
-
-
-
-## Proposed Design
-
-
-
-### Target v3 topology
+### Target topology
 
 ```text
 short-lived branch --PR--> main
                               |
-                    release-intent PR changes VERSION only
+                    VERSION-only intent PR
                               |
-                      freeze exact main SHA
-                              |
-                              v
-                     Step 1 generates one
-                     candidate commit on
-                        v3-staging
-                              |
-                    hard approval gate
+                    freeze exact source_sha
                               |
                               v
-            tag -> publish exact packs -> GitHub Release
+              Step 1: one generated candidate commit
+                         on v3-staging
                               |
-                 Step 2 optional phased rollout
+                 protected-environment approval
                               |
-                  Step 3 required full production
-                  promotion to main branch / CDN
+                              v
+                stable tag -> exact npm packs
+                         -> GitHub Release
+                              |
+                 Step 2: optional one-branch
+                         phased promotion
+                              |
+                 Step 3: required atomic full
+                         production promotion
                               |
                main + v3-release-order-a/b/c
 ```
 
-Branch responsibilities:
+Branch responsibilities are:
 
-- `main` — the only v3 product-development trunk and the source from which the
-MPServer JavaScript service pulls `main/dist` bundles for production
-websites. Normal v3 PRs target this branch. A reviewed release-intent PR
-updates only the authoritative `VERSION`; it does not regenerate `dist`.
-- `v3-staging` — the exact generated candidate for Rokt-side playground
-testing. Automation derives it from a frozen `main` SHA and adds one
-generated candidate commit. No direct or product-only commit is releasable.
-- `v3-release-order-a/b/c` — phased delivery branches retained until canary
-delivery is available.
-- `v3-development` — legacy integration branch retained indefinitely at its
-recorded cutover commit as a fixed read-only compatibility ref after
-in-flight work is drained. It is never a PR target, candidate source, release
-source, mirror destination, or synchronization authority.
-- `v3-release/<run_number>` — legacy release branches to inventory and retire;
-they have no role in the target process.
+- `main` is the sole v3 development trunk. Normal feature, fix, maintenance,
+hotfix, and release-fix PRs target it.
+- `v3-staging` contains exactly one generated candidate commit over the frozen
+`main` source. It is the Rokt playground testing surface, never a development
+branch or an independently authored release source.
+- `v3-release-order-a/b/c` remain phased v3 delivery branches until canary
+delivery replaces them.
+- `v3-development` is fixed at its recorded cutover SHA. It is read-only and non-authoritative: no PR, workflow, mirror, candidate, release, or synchronization process may read from or advance it. Can be deleted at an agreed upon time after trunk based development is implemented.
+- Legacy `v3-release/<run_number>` branches are retired.
 
-The top-level `VERSION` file is the sole v3 release-intent source. The release-
-intent workflow:
+Unprefixed release-order branches always belong to v2. v3 workflows must never interpret them as v3 destinations. In a future point in time, when v3 becomes the main branch, we can switch names so that v3 is the default.
 
-- reads top-level `VERSION` from the exact protected `main` commit;
-- validates that it is stable semver;
-- accepts exactly one bump input (`patch`, `minor`, or `major`) and computes the
-intended target version;
-- rejects a duplicate active release cycle; and
-- opens a reviewed PR that changes only `VERSION`, for example:
+### Production-delivery invariant
 
-```text
-chore(release): set version to 3.0.2
-```
+A downstream production delivery system consumes approved distribution
+artifacts after Step 3. Therefore movement of `main` is a production transition,
+not repository housekeeping.
 
-Latest-stable-tag discovery, the authoritative core/kit package inventory and
-published baseline, target tag/npm absence, and recovery-state checks are
-locked Step 1 gates after `source_sha` is frozen. The release-intent workflow
-may report those conditions as optional early warnings, but they are not
-release-intent correctness gates.
+Until Step 3, `main` and its generated distribution remain at the previous
+approved release. Step 3 may advance `main` only to the exact approved
+`candidate_sha`, and promotion is complete only after downstream validation
+confirms the approved served artifact.
 
-Release-generated root and kit manifests, lockfiles, changelog, and
-distribution outputs remain unchanged on `main` throughout candidate
-generation, playground testing, and publication. This avoids leaving `main` in
-a partially generated or unapproved state. Candidate automation derives all of
-them from `VERSION`; only after approval and publication verification does Step
-3 fast-forward the generated candidate commit back to `main`.
+Concrete production endpoints, checksums, privileged environment configuration,
+and operational procedures belong in an access-controlled operational
+inventory. Public implementation records contain only non-sensitive invariants
+and references to that inventory.
 
-This separation is production-critical: while the release is prepared,
-`main/dist` remains the previous approved distribution. Neither candidate
-creation nor playground rejection changes the production-served files.
+### Migration baseline
 
-### Production risk and safety rationale
+Before cutover:
 
-The highest-impact failure is advancing `main/dist` to generated files that were not the exact playground-approved and checksum-verified release. That can expose an unapproved bundle directly to production websites.
-
-The main merge freeze prevents the recorded source parent from moving during
-release work. Full expected-SHA and fast-forward checks prevent stale
-automation from selecting a newer or unrelated commit.  Step 3 prevents
-`main` and release-order refs from partially diverging. Together these controls
-make the production transition one auditable movement from the previous
-approved `main` SHA to the approved candidate SHA.
-
-## Detailed Release Flow
+1. Drain or retarget all in-flight v3 work to `main`.
+2. Migrate every current-code consumer away from `v3-development`.
+3. Record its cutover SHA and enforce permanent read-only protection.
+4. Inventory core and kit package names, current release tags, trusted
+  publishers, branch protections, and legacy release consumers.
+5. Bootstrap top-level `VERSION` to the latest stable v3 version.
+6. Remove the cross-track workflow parity guard at cutover while preserving
+  the existing v2 files and behavior on their refs.
 
 
 
-### Release intent and main freeze
+## 3. Release lifecycle
 
-A maintainer dispatches the release-intent workflow with `patch`, `minor`, or
-`major`. From the exact protected `main` commit, the workflow reads and
-validates stable-semver `VERSION`, computes the requested target, rejects a
-duplicate active release cycle, and opens the `VERSION`-only PR described
-above. The preferred title and squash commit are:
+
+
+### Definitions
+
+
+
+#### Release intent
+
+Top-level `VERSION` is authoritative only for v3. A release-intent workflow:
+
+1. runs from the exact protected `main` commit selected by the maintainer;
+2. reads and validates `VERSION` as stable semver;
+3. accepts exactly one of `patch`, `minor`, or `major`;
+4. computes the target version;
+5. rejects a new intent while another v3 release cycle is active; and
+6. opens a reviewed PR that changes only `VERSION`.
+
+The preferred title and squash commit are:
 
 ```text
 chore(release): set version to 3.0.2
 ```
 
-Merging the generated release-intent PR does not build, publish, create a tag
-or GitHub Release, or alter generated manifests, locks, changelog, or `dist`.
-Production websites therefore continue consuming the prior approved
-`main/dist`.
+The intent workflow does not perform authoritative tag, npm, package-inventory,
+or recovery validation. Those potentially slow and race-sensitive checks occur
+under the Step 1 release lock. Intent may show advisory warnings, but they are
+not correctness gates.
 
-Changelog generation therefore does not run in the release-intent workflow or
-add files to its `VERSION`-only PR. Step 1 derives the changelog from that
-reviewed release intent and freezes both the updated `CHANGELOG.md` and the
-action's `release-notes` Markdown output with the immutable candidate artifacts.
+Merging the intent PR creates no build, candidate, changelog, tag, package,
+GitHub Release, or `dist` change. It begins the `main` merge freeze. Normal PRs
+may continue through review but may not merge; a reviewed, narrowly scoped
+release-fix PR is the only exception. The freeze ends only after successful
+Step 3 and downstream served-artifact validation.
 
-Immediately after merge, the release coordinator starts a merge freeze on
-`main`. Normal feature PRs may continue through review but may not merge.
-Release-fix PRs are the only exception. The freeze ends after successful Step
-3, including required MPServer refresh and served-bundle validation.
+#### Artifact identity
 
-Automation enforces the freeze by creating or enabling a temporary GitHub
-ruleset scoped to `main`. It records the ruleset ID, release version,
-`source_sha`, creation time, and authorized bypass actors in durable release
-state. The ruleset blocks normal merges and direct pushes. A release-fix PR
-still requires normal review and checks, and only the designated release
-automation or release manager may merge it through the temporary bypass; the
-bypass never permits an unreviewed direct source push.
+Each candidate records immutable identity:
 
-Successful Step 3 finalization, after MPServer refresh and served-bundle
-validation, removes or disables only the recorded temporary ruleset ID, verifies
-normal branch protections remain active, and records cleanup success. Cleanup
-is idempotent and may be retried only after the required Step 3 and served-
-bundle validation have succeeded. Monitoring must flag stale release rulesets
-so the release coordinator can resume the blocked release or retry eligible
-post-validation cleanup. It must not automatically remove a ruleset for a valid
-`awaiting_approval` candidate during its 30-day artifact lifetime; alerts do
-not silently shorten the approved waiting window. Rejection, a reviewed fix on
-`main`, and `Recreate candidate` are the standard pre-tag recovery, and the
-freeze remains active throughout that flow.
+- `version`: validated top-level `VERSION`;
+- `source_sha`: the frozen `main` commit;
+- `candidate_sha`: the one generated commit whose first parent is `source_sha`;
+- artifact ID and artifact subject digests;
+- `artifact_manifest_sha256`: digest of the signed inventory; and
+- after tagging, `release_tag`: `v${version}` resolving to `candidate_sha`.
 
-The workflow records:
+The inventory links version, source SHA, candidate SHA, package names, versions,
+tarball filenames, SHA-256 digests, sizes, build-tool versions, and the
+release-notes digest. It is attested or signed so that this linkage is
+verifiable.
 
-- `source_sha`: the exact frozen `main` commit containing `VERSION`;
-- `version`: the validated contents of `VERSION`;
-- `candidate_sha`: the generated commit tested in the playground;
-- `artifact_manifest_sha256`: the hash of the artifact inventory;
-- `artifact_attestation_ids`: the GitHub artifact attestations bound to the
-immutable candidate artifacts; and
-- later, `release_tag`: exactly `v${version}`, resolving to `candidate_sha`.
+A GitHub attestation proves one narrow thing: a file with a given SHA-256 was
+produced by a specific workflow run in this repository. It says nothing about
+what that file claims to be.
 
-These values must never be conflated or recomputed from a moving branch.
-Immutable artifact/manifest identity is separate from append-only lifecycle
-status history.
+The inventory supplies that missing meaning, so it is attested or signed too.
+Verification then covers both halves:
 
-### Step 1: generate the candidate
+- the tarball digests prove the files are the ones Step 1 built; and
+- the inventory digest proves nobody altered which version, commit, or package
+those files belong to.
 
-For v3, Step 1 is dispatched through the small, stable
-`.github/workflows/staging-step-1.yml` top-level caller on `main`. npm trusted
-publishing validates that caller filename even when publication executes in a
-called reusable workflow. The dispatcher declares separate static jobs for
-`./.github/workflows/release-v2.yml` and
-`./.github/workflows/release-v3.yml`, guarded by mutually exclusive `if`
-conditions; `jobs.<id>.uses` cannot select the workflow dynamically. Relative
-same-repository calls resolve the child workflow from the caller's commit, so
-each branch selects its matching committed implementation. The track workflows
-may evolve independently without byte-for-byte parity. The v3 workflow may use
-explicit `Create candidate`, `Recreate candidate`, and recovery operations,
-but it does not invoke semantic-release. It must:
+Recorded identity is read back from the release record and never re-derived
+from a branch tip, because a branch can move. Identity is fixed for the life of
+the candidate; lifecycle status is a separate append-only history.
 
-1. Require `refs/heads/main` and acquire the non-cancelling v3 release lock.
-2. Resolve and freeze `source_sha`, read `VERSION`, and validate the release
-  version against Git tags and every npm package.
-3. Verify that no stable tag or npm package already consumes the version.
-4. Record the expected old `v3-staging` SHA and update `v3-staging` from
-  `source_sha` using a pinned force-with-lease. This controlled reset is
-   required after a rejected candidate diverges; an unqualified force is
-   forbidden.
-5. In a clean worktree at `source_sha`:
-  - remove all prior generated outputs;
-    - set the root package manifest and lockfile to `VERSION`;
-    - use `scripts/prepare-kit-release.js` or its replacement to set every core
-    and kit manifest/lock to the same version;
-    - generate the changelog section from the previous stable tag through
-    `source_sha` using the shared
-    `[ROKT/rokt-workflows/actions/generate-changelog](https://github.com/ROKT/rokt-workflows/tree/c5c93e92107c520fb8b8cf71070995abdf4c403f/actions/generate-changelog)`
-    composite action. Pin it to a reviewed full commit SHA, never `@main` or
-    another mutable tag. The initial implementation should review and may adopt
-    `c5c93e92107c520fb8b8cf71070995abdf4c403f`, the immutable revision already
-    used by the mParticle Android release-draft workflow. Pass the reviewed
-    `VERSION`, repository URL, `v` tag prefix, `CHANGELOG.md` path, chosen
-    conventional-commit exclusions, and `kits` path. The action updates
-    `CHANGELOG.md` in place and returns the generated Markdown as
-    `release-notes`;
-    - run the action from a full-history checkout whose detached `HEAD` is
-    exactly `source_sha`. The pinned action currently selects the highest
-    stable semver tag matching `tag-prefix` and reads first-parent commits from
-    that tag through `HEAD`; fail before generation unless that selected tag is
-    the recorded previous stable baseline. It has no explicit start/end ref
-    inputs. If this repository's tag topology cannot represent the required
-    range, extend the shared action with explicit start/end inputs, review that
-    change in `ROKT/rokt-workflows`, and pin the resulting full SHA. Add a local
-    generator only if the shared action cannot be extended, documenting the
-    incompatibility rather than silently changing range semantics;
-    - build all core and kit distributions;
-    - run lint, core, Jest, stub, integration, and all kit tests;
-    - pack the core package and every publishable kit exactly once; and
-    - create an inventory containing package name, version, tarball filename,
-    SHA-256, size, `source_sha`, build-tool versions, and the generated
-    `release-notes` content hash.
-6. Upload the packed tarballs and inventory as immutable GitHub Actions
-  artifacts, including the generated `release-notes` Markdown, with
-   `retention-days: 30`, addressed by artifact ID and digest.
-   Generate GitHub artifact attestations binding those artifacts to the
-   workflow, repository, `source_sha`, version, and manifest digest. Store the
-   inventory and digest in the generated tree; do not commit tarballs to Git.
-7. Create exactly one generated commit on top of `source_sha`, for example:
-  ```text
-    chore(build): generate 3.0.2 candidate artifacts
-  ```
-    The commit contains synchronized manifests and locks, changelog, generated
-    `dist`, and the artifact inventory. It contains no product-source edits.
-8. Push that commit to `v3-staging` with a lease and report `candidate_sha`.
-9. Reverify that the uploaded artifact digest, attestation, and committed
-  inventory agree, then append the `prepared` Deployment status linking
-   `candidate_sha` to that immutable manifest and attestation identity.
+#### Lifecycle states
 
-Candidate generation creates no stable tag, GitHub Release, or npm package.
-After the candidate is pushed, the same `staging-step-1.yml` invocation and
-selected v3 reusable workflow wait at the protected playground environment and,
-if approved, continue into exact-artifact publication. This preserves the
-npm-registered top-level caller filename without preserving the legacy
-semantic-release implementation.
-
-Lifecycle state is recorded as append-only GitHub Deployment statuses:
+Logical lifecycle state is append-only:
 
 ```text
 prepared -> awaiting_approval -> rejected
                             \-> approved -> publishing -> published -> promoted
 ```
 
-Every status references the exact candidate SHA, version, immutable manifest
-digest, artifact ID, and attestation identity. Automation appends a new status;
-it never edits or deletes history. `rejected` is terminal for that candidate.
-Recreation starts a new candidate and status history.
+`rejected` is terminal for that candidate. Recreation produces a new candidate,
+artifact identity, deployment, and status history, even when the unpublished
+version is unchanged.
 
-GitHub's Deployment Status API state values are mapped to the logical labels:
-`prepared=queued`, `awaiting_approval=pending`, `rejected=failure`,
-`approved=success`, `publishing=in_progress`, `published=success`, and
-`promoted=success`. The status description records the logical label, and the
-deployment/release metadata carries the immutable identities. Repeated API
-values such as `success` never replace prior records; consumers evaluate the
-ordered history and logical labels.
+GitHub Deployment status values map to the logical labels:
 
-### Rokt playground approval gate
+- `prepared=queued`;
+- `awaiting_approval=pending`;
+- `rejected=failure`;
+- `approved=success`;
+- `publishing=in_progress`;
+- `published=success`; and
+- `promoted=success`.
 
-`v3-staging` must equal `candidate_sha` and is the exact Rokt playground
-candidate. Playground execution records its result against `candidate_sha`,
-`version`, and `artifact_manifest_sha256`. Entering the protected environment
-appends `awaiting_approval`; approval appends `approved`.
+Descriptions and release metadata carry the logical label and immutable
+identity. Repeated API values do not overwrite earlier status records.
 
-Approval is implemented with a protected GitHub Environment and required
-reviewers. The waiting deployment job must be named with the exact version and
-full candidate SHA, for example:
+The Step 1 workflow completes at `published`. The overall release lifecycle
+completes only at `promoted`, after required Step 3 and downstream validation.
+
+#### Approval and expiration
+
+The exact candidate publication job uses one protected GitHub Environment.
+That environment is both:
+
+- the playground approval gate for the named version and full candidate SHA;
+and
+- the npm-authorized publication environment.
+
+This is one approval gate, not two independent approvals unless a future
+security requirement explicitly adds another. Approval merely resumes the same
+waiting Step 1 job. Approval itself creates no commit, branch movement, tag,
+package, or GitHub Release; resumed automation performs and records subsequent
+mutations.
+
+The deployment name includes the exact version and full SHA:
 
 ```text
 Review v3.0.2 candidate a1b2c3d4e5f678901234567890abcdef12345678
 ```
 
-Authorized reviewers use GitHub's **Review deployments** UI. Approval is a hard
-publication gate. If a bug or rejection condition is found, a reviewer must
-explicitly click **Reject** and include a reason. Never leave the deployment
-pending or merely ignore it; explicit rejection is required to close the
-candidate and unblock controlled recreation.
+Reviewers approve or explicitly reject through GitHub's deployment review.
+Rejection includes a reason and closes the candidate so controlled recreation
+can proceed.
 
-The candidate may remain `awaiting_approval` for up to the full 30-day artifact
-retention ceiling. The deployment summary and job output show artifact creation
-time, expiration time, and remaining lifetime; automation must not silently
-shorten that window. This means the temporary ruleset may keep `main` frozen
-for up to 30 days, blocking normal merges. Operators must treat that as an
-explicit release risk.
+Candidate artifacts are retained for 30 days. The job displays creation,
+expiration, and remaining-lifetime information and may wait for that full
+period. Expiration makes approval and publication ineligible and cannot be
+overridden by late approval. An expired candidate is explicitly rejected and
+recreated; its artifact set and approval are never reused.
 
-At artifact expiry, an automated guard marks the deployment ineligible for
-approval and publication. A late approval cannot override expiration. Because
-expiration is an immutable eligibility fact rather than a lifecycle state, the
-candidate remains `awaiting_approval` until an authorized reviewer explicitly
-rejects it with an expiration reason. The operator then runs the normal
-`Recreate candidate` flow; no expired artifact or approval is reused.
+### Step 1: prepare, approve, and publish
 
-A rejection handler appends the `rejected` Deployment status with the exact
-`candidate_sha`, manifest digest, artifact/attestation identity, reviewer, and
-reason even though the waiting job terminates as rejected. The publication job
-must independently verify the append-only status history and approved evidence
-for the exact candidate. Approval attached only to a branch name, version
-string, expired artifact, or superseded candidate is invalid.
+For both tracks, `.github/workflows/staging-step-1.yml` remains the small,
+stable, npm-registered top-level caller. It declares static v2 and v3 reusable
+workflow jobs with mutually exclusive `if` conditions because
+`jobs.<id>.uses` cannot be dynamic. Same-repository relative calls resolve from
+the caller commit.
 
-### Rejection, fix, reset, and regeneration
+The v2 and v3 reusable workflows may differ and need not have byte parity. v2
+continues its existing behavior. The selected v3 workflow implements the
+following locked lifecycle without semantic-release.
 
-If the playground rejects the candidate:
+#### Candidate preparation
 
-1. The authorized reviewer clicks **Reject** in **Review deployments**, enters
-  the rejection reason, and verifies the latest logical Deployment status is
-   `rejected`.
-2. Block publication and verify that neither `v${version}` nor any core/kit npm
-  package at that version exists.
-3. Preserve the rejected `candidate_sha`, reason, logs, artifact ID, and test
-  evidence for audit, but never merge the rejected candidate.
-4. Fix source or tests through a reviewed release-fix PR to frozen `main`,
-  merged only by the actor authorized for the temporary ruleset bypass.
-   `VERSION` remains unchanged, and the PR must not modify `dist`.
-5. Dispatch the `Recreate candidate` operation. It observes the rejected
-  `v3-staging` SHA, then resets staging to corrected `main` only with:
-   This succeeds only if remote `v3-staging` still equals the exact rejected
-   candidate SHA. Any mismatch fails closed, and plain or unqualified `--force`
-   is prohibited.
-6. Regenerate from clean inputs, producing a new artifact ID, manifest digest,
-  tarball hashes, and `candidate_sha` at the same version.
-7. Create a new protected-environment deployment for the new candidate. The
-  rejected deployment and its approval state are never reused.
+1. Require `refs/heads/main` and acquire one non-cancelling v3 release lock.
+2. Freeze `source_sha`; read and validate `VERSION`.
+3. Authoritatively inventory the stable baseline tag and every publishable core
+  and kit package.
+4. Reject conflicts with lifecycle state, an existing target tag, or any target
+  npm package version.
+5. Record the expected old `v3-staging` SHA and perform only a
+  force-with-lease update. Plain force is forbidden.
+6. In a clean worktree at `source_sha`:
+  - remove prior generated outputs;
+  - synchronize root and kit manifests and lockfiles to `VERSION`;
+  - generate changelog and release notes;
+  - build all core and kit distributions;
+  - run lint, core, Jest, stub, integration, and all kit tests;
+  - pack core and every publishable kit exactly once; and
+  - generate the artifact inventory.
+7. Upload tarballs, inventory, and release notes as immutable Actions artifacts
+  with `retention-days: 30`.
+8. Generate standard artifact attestations for artifact subject digests and
+  workflow provenance, and sign or attest the inventory digest.
+9. Create exactly one generated commit over `source_sha`, for example:
+  ```text
+   chore(build): generate 3.0.2 candidate artifacts
+  ```
+   It contains synchronized manifests and locks, changelog, generated `dist`,
+   and inventory, but no product-source edits or tarballs.
+10. Push that commit to `v3-staging` with a lease.
+11. Revalidate artifact subjects against the inventory linkage, append
+  `prepared`, then enter `awaiting_approval`.
 
-The version remains reusable only because no stable tag or npm publication
-consumed it. Any evidence that either exists ends this rejection path.
-Throughout rejection and recreation, `main/dist` remains byte-for-byte equal to
-the prior approved production distribution.
+Candidate preparation creates no stable tag, npm package, or GitHub Release.
+`v3-staging` must equal `candidate_sha` before playground testing or approval.
 
-Defense in depth prevents a stale rejected run from publishing even if someone
-later approves its old deployment. Immediately before tagging, the waiting
-Step 1 run must require all of the following to match its recorded values:
+#### Changelog generation
 
-- current `main` equals the candidate's `source_sha`;
-- current `v3-staging` equals its `candidate_sha`;
-- the latest append-only lifecycle status is `approved` and no `rejected`
-status exists;
-- environment approval identifies that exact candidate and version; and
-- artifact ID, artifact digest, GitHub attestation, committed manifest, and
-every tarball hash match.
+Step 1 uses
+`[ROKT/rokt-workflows/actions/generate-changelog](https://github.com/ROKT/rokt-workflows/tree/c5c93e92107c520fb8b8cf71070995abdf4c403f/actions/generate-changelog)`
+pinned to reviewed immutable SHA
+`c5c93e92107c520fb8b8cf71070995abdf4c403f`.
 
-Any mismatch fails closed without creating a tag or publishing.
+It runs from a full-history checkout detached at `source_sha`, with the reviewed
+version, repository URL, `v` prefix, changelog path, commit exclusions, and kits
+path. Step 1 verifies that the action-selected prior stable tag is the recorded
+baseline and that the generated range ends at `source_sha`.
 
-### Publish the approved candidate
+If repository tag topology cannot represent that exact range, extend the shared
+action with explicit endpoints, review the extension, and pin its resulting
+immutable SHA. Use a local fallback only if the shared action cannot be
+extended, and document the incompatibility.
 
-After environment approval, the selected v3 reusable workflow under the same
-`staging-step-1.yml` invocation continues with the approved `candidate_sha` and
-immutable artifact ID. A recovery invocation may resume an already tagged
-candidate through the same top-level caller and exact artifacts. Publication
-must never rebuild, repack, regenerate the changelog, or change any manifest.
+Both the updated `CHANGELOG.md` and release-notes output are frozen into
+candidate identity; publication never regenerates them.
 
-The npm publishing job uses the configured protected npm environment,
-deployment-branch rules, and required approval. The caller validates the track,
-ref, and recorded SHAs before invoking the child. It makes `id-token: write`
-available to the reusable-workflow job, and the called publishing workflow/job
-retains or requests that permission for OIDC; unrelated jobs remain least-
-privileged and broad `secrets: inherit` is forbidden. npm does not treat the
-child reusable workflow filename or branch as an authorization boundary.
+#### Approval and resumed publication
 
-The safe order is:
+The same selected v3 Step 1 job waits at the protected environment. Playground
+approval resumes that job with its recorded candidate and artifacts.
 
-1. Acquire the same v3 release lock and verify the `main` freeze is active.
-2. Verify:
-  - `VERSION` on frozen `main` equals the requested version;
-    - `candidate_sha` has `source_sha` as its first parent;
-    - `v3-staging == candidate_sha`;
-    - the candidate contains only expected generated paths relative to
-    `source_sha`;
-    - playground approval matches the exact SHA and inventory digest;
-    - the append-only history is valid and its latest status is `approved` for
-    first publication or `publishing` for partial-publication recovery, with
-    no `rejected` status;
-    - downloaded artifact ID/digest, every tarball SHA-256, package name, and
-    version match the committed inventory;
-    - GitHub artifact attestations verify for the downloaded artifact subjects,
-    workflow identity, repository, source SHA, version, and manifest digest;
-    - for first publication, the stable tag and all target npm package versions
-    are absent; or
-    - for recovery, the stable tag already resolves to `candidate_sha` and
-    every existing package is byte-identical to the inventory.
-3. Append `publishing`, then for first publication create and push the annotated
-  stable tag
-   `v${version}` at `candidate_sha`. This is the irreversible
-   version-consumption boundary. Recovery reuses that exact tag and never
-   creates, deletes, or moves it.
-4. Publish the exact core and kit tarballs with `--tag next --provenance`.
-  Publish core and kits in the documented order and never substitute a rebuilt
-   tarball. Recovery publishes only missing packages, then audits the complete
-   inventory.
-5. Wait for registry propagation and audit every package's version, tarball
-  integrity, provenance, and `next` dist-tag.
-6. Create the GitHub Release from the existing stable tag only after the npm
-  completeness audit succeeds. Attach the inventory and relevant release
-   assets.
-7. Append `published` and report the exact tag and candidate SHA for Steps 2
-  and 3.
+Before any irreversible mutation, resumed automation revalidates:
 
-Tag-before-npm makes the immutable Git identity explicit before publication.
-Once created, the stable tag is the recovery authority for that version. If npm
-partially fails, the tag remains fixed and publication resumes only for missing
-packages from the same attested artifacts. Never move, delete, or reuse the tag
-and never rebuild the artifacts. GitHub Release creation occurs only after the
-full core-plus-kits npm audit succeeds, so a normal release is not advertised
-before completeness is proven.
+- the `main` freeze and release lock;
+- `main == source_sha`;
+- `v3-staging == candidate_sha`;
+- first-parent ancestry and generated-path allowlist;
+- exact approved lifecycle evidence with no rejection;
+- the unexpired artifact ID and subject digests;
+- the signed or attested inventory linkage;
+- every tarball name, package name, version, digest, and size; and
+- absence of target tag and package versions for first publication.
 
-If any required GitHub Actions artifact is missing or its 30-day retention has
-expired, approval and publication fail closed. Before stable tagging, an
-authorized reviewer explicitly rejects the candidate with the missing/expired
-artifact reason, then runs `Recreate candidate` to produce a distinct candidate
-and obtain a new approval; never rebuild or substitute the expired approved
-artifact set. After stable tagging, rebuilding is forbidden; stop the release,
-preserve the tag, and use the forward-version recovery policy if the original
-exact artifacts cannot be restored.
+Any mismatch fails closed without tagging or publishing.
 
-### Step 2: optional release-order promotion
+The publication order is:
 
-Step 2 accepts only the exact stable tag emitted by the publish workflow. It:
+1. Append `publishing`.
+2. Create and push annotated stable tag `v${version}` at `candidate_sha`.
+3. Publish the exact core and kit tarballs in the documented order with
+  `--tag next --provenance`.
+4. Audit all core and kit versions, registry integrity, provenance, and `next`
+  dist-tags after propagation.
+5. Create the GitHub Release from the existing stable tag, attaching the
+  inventory and appropriate release assets.
+6. Append `published` and expose the exact tag and candidate identity to Steps
+  2 and 3.
 
-- validates that the remote tag resolves to the approved `candidate_sha`;
-- validates `VERSION`, core and kit manifests, npm completeness, and artifact
-inventory;
-- verifies the selected release-order branch can fast-forward; and
-- fast-forwards one selected `v3-release-order-a/b/c` branch to the tag.
+The stable tag is the irreversible authority and is created before npm. It is
+never deleted, moved, or reused. Publication never rebuilds, repacks, changes
+the inventory, or regenerates release notes.
 
-Promotion remains optional. Operational guidance recommends A → B → C with
-observation between phases, but the workflow does not require that order.
-Step 2 never updates `main`; skipping or failing Step 2 leaves production
-`main/dist` unchanged and does not make Step 3 optional. Step 2 needs no
-`id-token: write` unless it is changed to publish an npm package.
+npm trusted publishing validates the top-level caller filename
+`staging-step-1.yml`; byte parity between branch workflow files is not required.
+The child reusable workflow filename or branch is not an npm authorization
+boundary.
 
-### Step 3: required atomic production promotion
+The caller validates track, ref, and SHAs. Branch and protected-environment
+controls enforce authorization. `id-token: write` flows only through the
+selected reusable-workflow job and its publishing job. Other jobs remain
+least-privileged, and broad `secrets: inherit` is prohibited.
 
-Step 3 consumes the same stable tag and:
+### Step 2: optional phased promotion
 
-- verifies the tag, candidate SHA, `VERSION`, npm completeness, GitHub Release,
-and candidate artifact inventory;
-- verifies `main` still equals the recorded expected `source_sha`, and verifies
-every release-order destination still equals its recorded expected SHA;
-- proves every destination can fast-forward to `candidate_sha`; and
-- atomically pushes `candidate_sha` to `main` and all three
-`v3-release-order-a/b/c` branches.
+After Step 1 reaches `published`, Step 2 may fast-forward one selected
+`v3-release-order-a/b/c` branch to the exact stable tag. It:
 
-Step 3 needs no `id-token: write` unless it is changed to publish an npm
-package.
+- proves the tag resolves to approved `candidate_sha`;
+- verifies version, inventory, npm completeness, and branch expected SHA;
+- requires a fast-forward update; and
+- advances exactly one v3-prefixed release-order branch.
 
-`v3-development` is absent from preflight and the atomic push. `v3-staging`
-already equals the candidate and is not an additional destination. All four
-destinations update or none do. The coordinator ends the `main` merge freeze
-only after Step 3 and required MPServer served-bundle validation succeed.
+Step 2 is optional. A → B → C with observation is recommended but not enforced.
+Skipping or failing Step 2 does not waive Step 3. Manual pushes, including
+pre-approval pushes, are prohibited. Step 2 never updates `main`, publishes npm,
+or needs OIDC permission.
 
-Step 3 is production-critical and required to complete the release because
-the MPServer JavaScript service pulls `main/dist` for production websites. It
-may move `main` only to the exact playground-approved `candidate_sha` whose
-committed inventory and downloaded artifacts passed checksum verification. A
-rejected, stale, or publication-incomplete candidate must never become `main`'s
-tip. Failed preflight or failed atomic push must leave `main` and its
-production `dist` tree at the prior approved SHA.
+### Step 3: required full promotion
 
-After `main` advances, operators verify that the MPServer JavaScript service
-observes the new commit through its existing refresh behavior and serves the
-exact approved bundle. Validation compares the served bundle identity or
-checksum with the approved `candidate_sha` inventory. No explicit CDN purge is
-part of Step 3. Step 3 is not complete until the MPServer observation and
-served-bundle checks succeed; only then append `promoted`.
+Step 3 consumes the same published stable tag. It:
 
-### Permanently fixed `v3-development` compatibility ref
+1. verifies tag, candidate, version, inventory, complete npm publication, and
+  GitHub Release;
+2. verifies `main` still equals `source_sha`;
+3. verifies all v3 release-order branches equal recorded expected SHAs;
+4. proves every destination can fast-forward; and
+5. advances `main` plus all `v3-release-order-a/b/c` branches to
+  `candidate_sha`.
 
-At cutover, record the exact `v3-development` SHA and make the branch
-read-only. It remains permanently fixed at that cutover commit:
+All four destinations update or none do. `v3-development` is excluded.
+`v3-staging` already equals the candidate and is not another destination.
+Step 3 does not publish npm and needs no OIDC permission.
 
-- no PR may target it;
-- no release workflow may read a candidate or version from it;
-- Steps 1–3 neither validate nor update it;
-- no mirror or post-release job may advance it; and
-- its SHA is never evidence that a release or synchronization succeeded.
+After the push, downstream validation confirms the approved served artifact. Only then does automation append `promoted` and end the merge freeze.
+Cache busting remains deferred and is not part of this design.
 
-All consumers that require current v3 code must be inventoried and migrated to
-`main`, a stable tag, or the appropriate package/bundle delivery path before
-cutover. The fixed ref exists only for historical compatibility and audit.
+## 4. Safety invariants
+
+Each invariant below must hold at all times, and each is covered by the Phase C
+contract tests. Step ordering, lifecycle vocabulary, and scope are defined
+elsewhere and are deliberately not restated here.
+
+1. The downstream production delivery system consumes only the approved
+  distribution, and only after successful Step 3. Every other invariant exists
+  to protect this one.
+2. v2 is unchanged: its branches, versioning mechanism, semantic-release
+  process, npm tag `latest`, and release workflow. v3 alone uses top-level
+  `VERSION` and npm tag `next`.
+3. `main` is the sole v3 development and release-intent authority.
+4. `v3-development` remains fixed, read-only, and non-authoritative.
+5. `v3-staging` is exactly one generated commit whose first parent is the
+  frozen `main` source.
+6. Core and every publishable kit form one versioned, built, published, and
+  audited logical release.
+7. Workflows act only on recorded full SHAs and never treat a moving ref as
+  identity.
+8. Candidate artifacts are built and packed once and are never substituted
+  after approval.
+9. Approval applies to one exact candidate. Approval scoped to a branch,
+  version string, or superseded candidate is invalid, and a rejected candidate
+  can never be revived by a later approval.
+10. The stable tag precedes npm publication and is irreversible release
+  authority. Partial publication resumes only missing, byte-identical
+  artifacts.
+11. The freeze lasts from merged intent PR through Step 3 and downstream
+  validation. A reviewed release-fix PR is its only exception.
+12. Promotion updates `main` and all v3 release-order branches atomically.
+
+
 
 ### Branch protection and concurrency
 
-Required target protections:
+- `main` requires PRs, review, configured ownership, and required checks;
+deletion and force-push are blocked.
+- A required path-policy check rejects `dist/**` changes from normal,
+release-intent, and release-fix PRs. Only Step 3 promotion may update them.
+- The temporary release ruleset blocks normal merges and direct pushes without
+weakening permanent protections.
+- A release-fix still requires normal review and checks and uses only the
+narrowly configured automation path.
+- `v3-staging` blocks human direct pushes, deletion, and general force-push.
+Candidate automation may perform only expected-SHA force-with-lease updates.
+- v3 release-order branches block human direct and force pushes.
+- `v3-development` blocks all updates, deletion, and force-push.
+- One durable, non-cancelling lock prevents concurrent v3 cycles.
+- Remote SHAs are rechecked immediately before every push. Lease or
+fast-forward failure is a safe stop, never a reason to force.
 
-- `main`: require PRs, one approval, CODEOWNER review where configured, and
-required build/test checks; block deletion and force-push.
-- Require a `main` path-policy check that rejects `dist/**` changes from normal,
-release-intent, and release-fix PRs. Only Step 3 automation may update
-`main/dist`, and only by promoting the verified `candidate_sha`.
-- During a release, add the automation-controlled temporary ruleset described
-above; do not edit or replace the permanent `main` protections.
-- `v3-staging`: block direct pushes for humans, block deletion and
-general force-push, and allow only the candidate automation's pinned
-force-with-lease update.
-- `v3-development`: record the cutover SHA, block all normal and automation
-updates, deletion, and force-push, and alert on any attempted movement.
-- `v3-release-order-a/b/c`: block human direct/force pushes and allow only
-release automation.
-- Grant the release bot or GitHub App a narrow bypass for candidate generation,
-stable-tag creation, and atomic Step 3. Do not grant a general administrator
-bypass.
-- Use durable release state plus one non-cancelling v3 release lock from
-candidate generation through Step 3 so two versions or candidates cannot be
-active simultaneously.
-- Recheck remote SHAs immediately before every push. A failed lease or
-non-fast-forward is a safe failure, not a reason to force.
+Privileged reviewer identities, actor IDs, environment names, environment
+configuration, recovery ownership, and production validation details are
+maintained only in the access-controlled operational inventory.
+
+## 5. Failure and recovery
 
 
 
-## Deferred Work
+### Pre-tag rejection, fix, and recreation
+
+Before the stable tag exists, a version remains unconsumed if no core or kit npm
+package exists at that version.
+
+For a playground rejection:
+
+1. A reviewer explicitly selects **Reject**, supplies a reason, and automation
+  appends `rejected` for the exact candidate.
+2. Step 1 confirms no target stable tag or npm package exists.
+3. The rejected SHA, artifacts, logs, and test evidence remain audit records,
+  but the candidate is never merged or tagged.
+4. Any fix lands through a reviewed release-fix PR on frozen `main`.
+  `VERSION` remains unchanged and the PR cannot modify `dist`.
+5. `Recreate candidate` resets staging from the exact rejected SHA to corrected
+  `main` using:
+
+   ```bash
+   git push --force-with-lease=refs/heads/v3-staging:${rejected_candidate_sha} origin ${corrected_main_sha}:refs/heads/v3-staging
+   ```
+
+   This succeeds only if remote `v3-staging` still equals
+   `rejected_candidate_sha`. Any mismatch fails closed; plain force is
+   forbidden.
+6. Step 1 regenerates clean artifacts at the same unpublished `VERSION`,
+  producing a new candidate SHA, artifact ID, digests, and approval deployment.
+
+Missing or expired pre-tag artifacts follow the same explicit
+Reject → reviewed fix if needed → Recreate path. The rejected or expired
+candidate and its approval are never reused. The `main` freeze remains active
+throughout.
+
+Immediately before tagging, Step 1 independently checks source SHA, staging
+SHA, lifecycle history, approval evidence, expiration, artifact identity,
+inventory linkage, and every tarball digest. Stale approval or any mismatch
+cannot publish.
+
+### Stable tag or partial publication
+
+After stable tagging, the version is consumed even if npm is empty. The tag
+remains fixed at `candidate_sha`; automation never deletes, moves, or reuses it
+and never rebuilds that version.
+
+If npm publication is absent, partial, or uncertain:
+
+- stop newer releases and allow registry propagation;
+- verify every existing package against the immutable inventory;
+- resume only missing packages from the same exact artifacts;
+- audit all core and kit packages before GitHub Release or promotion; and
+- retry GitHub Release creation from the existing tag if npm is complete.
+
+If the original exact artifacts cannot be restored, do not rebuild under the
+consumed version. Preserve the tag and move to a new forward version.
+
+Step 1 recovery may resume through the same stable top-level caller. Its
+preflight requires the existing tag to resolve to `candidate_sha` and every
+already published package to be byte-identical to inventory.
+
+### Promotion failures
+
+A failed Step 2 leaves `main` unchanged and may be retried against the same tag.
+
+A failed Step 3 preflight performs no push. An atomic-push rejection leaves all
+four destinations unchanged. Keep the freeze active, correct the blocking
+condition, and retry against the same approved candidate.
+
+If the atomic push succeeds but downstream validation fails, `main` has already
+advanced. Keep the freeze active, diagnose and retry validation, and never
+reset or force-push `main`.
+
+If an unauthorized merge prevents fast-forward promotion, preserve both
+histories. Do not force, move the tag, or reuse the version. Use a reviewed
+reconciliation and a forward version when exact promotion is no longer safe.
+
+### Forward recovery
+
+If a defect is found after the stable tag but before Step 3, leave `main`
+unchanged and prepare a new forward version instead of promoting the defective
+candidate.
+
+After Step 3, rollback is a reviewed forward patch:
+
+1. branch from current `main`;
+2. merge a reviewed fix PR;
+3. create and merge a new patch release-intent PR;
+4. generate and approve a new candidate;
+5. publish exact artifacts under a new stable tag; and
+6. run required Step 3 and downstream validation.
+
+Never reset production history or patch staging or release-order branches
+directly. v2 recovery and hotfix behavior remain unchanged.
+
+## 6. Migration implementation
 
 
 
-### Canary delivery
+### Phase A: prepare
 
-Pre-publication playground approval and exact-artifact publication are part of
-the initial target. Future canary work is limited to replacing
-`v3-release-order-a/b/c` and their Step 2/3 promotion behavior; all other
-release gates and the single `main` development trunk remain unchanged.
-
-### Cache busting
-
-The current MPServer JavaScript delivery path requires no explicit CDN purge.
-The trunk migration relies on MPServer's existing refresh behavior and verifies
-the exact served bundle after Step 3. Designing cache-busting or explicit
-invalidation is separate future work; it is not required for migration
-cutover and must not delay this branch-model change.
-
-## Operator Workflow
-
-- For every v3 workflow, select `main` in GitHub's **Use workflow from**
-dropdown. GitHub executes the workflow definition from the selected ref.
-- Merge the reviewed `VERSION`-only release-intent PR.
-- Start the `main` merge freeze and record `source_sha`.
-- Run candidate generation in preview mode, then create the real candidate.
-- Confirm `v3-staging`, the reported `candidate_sha`, and the committed
-inventory digest match.
-- Run the Rokt playground against that exact candidate and record approval.
-- If rejected, explicitly click **Reject**, enter a reason, and run the
-documented release-fix and `Recreate candidate` flow.
-- If approved, allow the waiting `staging-step-1.yml` run to continue with its
-exact candidate SHA and artifact ID. Confirm tag, npm completeness,
-provenance, and GitHub Release before promotion.
-- Optionally preview and run Step 2 for A, then B, then C.
-- Preview Step 3, verify all destinations, then run its atomic promotion.
-- Treat Step 3 as required production delivery. Wait for MPServer's existing
-refresh, verify it serves the exact approved bundle checksum, then end the
-merge freeze. Do not add an explicit CDN purge.
-- Confirm `v3-development` remains at its recorded cutover SHA.
-- For v2, continue using the existing documented refs, workflows, and
-`track=v2`; none of these v3 steps changes v2.
+- Announce cutover and retarget all v3 development to `main`.
+- Inventory and migrate every `v3-development` consumer.
+- Record and protect the fixed `v3-development` cutover SHA.
+- Bootstrap `VERSION` from the latest stable v3 tag and package inventory.
+- Inventory core/kits, trusted-publisher registrations, branch consumers, and
+current protections.
+- Store privileged operational configuration in the access-controlled
+inventory and reference it from public implementation records.
+- Plan removal of cross-track parity checks without altering v2 behavior.
 
 
 
-## Commit Graph Examples
+### Phase B: build automation
+
+- Add the v3-only release-intent workflow and active-cycle detection.
+- Refactor release scripts to synchronize versions, build, test, and pack
+without intermediate release commits or publication.
+- Integrate the pinned changelog action and validate its exact range.
+- Implement immutable 30-day artifacts, standard subject/provenance
+attestations, and signed or attested inventory linkage.
+- Implement append-only lifecycle statuses and one exact-candidate protected
+publication job.
+- Keep `staging-step-1.yml` stable and declare static, mutually exclusive v2 and
+v3 reusable-workflow jobs.
+- Implement caller-side validation, branch/environment controls, and
+least-privilege OIDC.
+- Implement temporary freeze enforcement and idempotent cleanup after
+downstream validation.
+- Adapt Steps 2 and 3 to exact tag/candidate identity and remove
+`v3-development` from all mappings.
 
 
 
-### First candidate
-
-```text
-v3.0.1
-   |
-   A---B---R                         main (frozen at source_sha)
-            \
-             C                      v3-staging (candidate_sha)
-
-R = chore(release): set version to 3.0.2
-C = chore(build): generate 3.0.2 candidate artifacts
-```
-
-There is no `v3.0.2` tag and no npm `3.0.2` package at this point.
-
-### Rejection, fix, reset, and regeneration
-
-```text
-v3.0.1---A---B---R---F               main (corrected source_sha)
-                   \
-                    C1               rejected candidate (preserved by SHA)
-                         [lease reset v3-staging from C1 to F]
-                           \
-                            C2        v3-staging (new candidate_sha)
-
-F  = reviewed release-fix PR; VERSION remains 3.0.2
-C1 = rejected generated candidate
-C2 = regenerated 3.0.2 candidate with new artifacts and hashes
-```
-
-`C1` is never merged or tagged. Reusing `3.0.2` is allowed only after proving
-that no stable tag or npm package consumed it.
-
-### Successful release
-
-```text
-v3.0.1---A---B---R---F---C2          main after Step 3
-                         ^  ^
-                         |  +-------- v3-staging
-                         +----------- tag v3.0.2
-                         +----------- v3-release-order-a/b/c after Step 3
-```
-
-The stable tag points directly to the approved generated candidate commit.
-
-## Implementation Plan
+### Phase C: contract verification
 
 
 
-### Phase A: prepare and isolate v2
+#### Intent and isolation contracts
 
-- Announce the v3 cutover and stop new PRs to `v3-development`.
-- Retarget in-flight work to `main`.
-- Inventory and migrate every `v3-development` consumer before cutover, then
-record the branch's permanent cutover SHA.
-- Document the MPServer JavaScript service as the owner and integration point
-that pulls `main/dist` for production websites, including bundle URLs, bundle
-names, existing refresh behavior, and served-checksum validation procedure.
-- Inventory all other `v3-staging` and legacy-workflow consumers, package
-names, npm trusted publishers, branch protections, the v3 top-level `VERSION`
-path, and the npm-registered shared top-level caller filename.
-- Plan removal of the `master`/`main` byte-parity guard at cutover. Preserve
-the existing v2 workflow content and behavior on its current refs.
+- Verify patch, minor, and major calculations from exact protected `main`.
+- Reject invalid semver and active-cycle conflicts.
+- Prove the intent PR changes only `VERSION` and creates no release side effect.
+- Run complete v2 regression validation and prove v2 uses no v3 `VERSION`.
 
 
 
-### Phase B: build replacement automation
+#### Candidate and identity contracts
 
-- Add v3's authoritative top-level `VERSION`, plus a patch/minor/major release-
-intent workflow that reads it from the exact protected `main` commit, validates
-stable semver, computes the target, rejects duplicate active release cycles,
-and opens a `VERSION`-only PR without release side effects. Leave v2's current
-semantic-release and versioning mechanism unchanged.
-- Refactor existing release scripts so candidate generation can synchronize
-versions and build without creating intermediate commits or publishing.
-- Integrate `ROKT/rokt-workflows/actions/generate-changelog`, review and pin its
-full immutable commit SHA, validate its selected stable-tag-to-`source_sha`
-range, and retain both its `CHANGELOG.md` update and `release-notes` output in
-the generated candidate. If explicit endpoints are required, extend and pin
-the shared action before considering repository-local generation.
-- Implement 30-day GitHub Actions artifact storage, inventory hashing, artifact
-attestations, remaining-lifetime display, expiry enforcement, and exact-
-artifact download.
-- Implement append-only GitHub Deployment lifecycle statuses plus the protected
-GitHub Environment, exact candidate/version deployment job, required
-reviewers, and explicit rejection reason.
-- Keep `staging-step-1.yml` as the small npm-registered dispatcher. Add two
-static reusable-workflow jobs with mutually exclusive `if` conditions that
-call same-repository `release-v2.yml` and `release-v3.yml`; allow the called
-track workflow to execute publication.
-- Configure caller-side track/ref/SHA validation, the protected npm
-environment, deployment-branch rules, and required approval. Grant
-`id-token: write` only through the selected reusable-workflow call and its
-publishing workflow/job, and avoid broad `secrets: inherit`.
-- Implement the temporary freeze ruleset, reviewed release-fix bypass,
-idempotent post-validation cleanup, and stale-ruleset monitoring.
-- Adapt Steps 2 and 3 to the new tag/candidate contract and remove
-`v3-development` from all authoritative mappings.
+- Verify baseline/package inventory, stale-main, existing-version, staging
+lease, ancestry, generated-path allowlist, build, and test failures stop
+before tagging.
+- Verify core plus all kits are packed once and match inventory.
+- Verify subject/provenance attestations and inventory-digest linkage.
+- Verify changelog range and both frozen outputs.
+- Verify missing, altered, or expired artifacts fail closed.
 
 
 
-### Phase C: prove failure behavior
+#### Approval and lifecycle contracts
 
-- Dry-run first candidate creation and verify no tag/npm side effects.
-- Before migration, publish a throwaway package/version through
-`staging-step-1.yml` and the selected reusable workflow to validate the real
-OIDC token exchange, protected-environment controls, and npm provenance.
-- Verify patch, minor, and major inputs read `VERSION` from the exact protected
-`main` commit, validate stable semver, calculate the expected target, reject a
-duplicate active release cycle, and open the expected `VERSION`-only PR;
-merging that PR must not tag, publish, build, or change `dist`.
-- In locked Step 1, test stale `main`, existing tag/version, incomplete
-core/kit inventory or baseline, and recovery-state conflicts. Also test invalid
-`VERSION`, staging lease failure, generated-path allowlist failure, artifact
-hash mismatch, missing or expired artifact, partial npm publication, GitHub
-Release retry, and Step 3 atomic-push rejection.
-- Verify explicit rejection records its reason and candidate status, prevents
-publication, permits the authorized release-fix bypass, and drives
-lease-protected same-version `Recreate candidate`.
-- Verify a stale rejected deployment fails publication even if later approved,
-including independent mismatches in main SHA, staging SHA, candidate status,
-artifact ID, manifest digest, and tarball hash.
-- Verify the only valid lifecycle paths are:
-  - `prepared -> awaiting_approval -> rejected`; or
-  - `prepared -> awaiting_approval -> approved -> publishing -> published -> promoted`.
-  Immutable manifest identity remains separate from append-only status
-  history.
-- Verify artifact attestations against subject digest, workflow identity,
-repository, source SHA, version, and manifest digest before publication.
-- Verify the approval UI displays the full remaining artifact lifetime up to 30
-days, late approval/publication fails after expiry, and expired candidates
-require explicit rejection and recreation.
-- Verify freeze-ruleset cleanup after successful required Step 3 and served-
-bundle validation, and verify job failures leave the freeze active and alert
-the release coordinator.
-- Verify npm recognizes `staging-step-1.yml` as the top-level calling workflow
-when `npm publish` runs in each statically selected track workflow.
-- Verify the two reusable-workflow jobs are static and mutually exclusive,
-relative calls resolve from the caller commit, and child filenames or
-branches are not relied on as npm authorization boundaries.
-- Verify only the selected publishing path receives `id-token: write`, no broad
-`secrets: inherit` is used, and Steps 2/3 have no OIDC permission.
-- Verify the stable-tag recovery path never rebuilds or moves the tag.
-- Verify candidate rejection and recreation leave `main` and `main/dist` at
-the prior approved SHA.
-- Verify normal, release-intent, and release-fix PRs that modify `dist/**` fail
-the required path-policy check.
-- Verify failed or partial publication cannot invoke Step 3 and leaves
-`main/dist` unchanged.
-- Verify skipped or failed Step 2 leaves `main/dist` unchanged and does not
-waive required Step 3.
-- Verify every Step 3 expected-SHA or fast-forward preflight failure leaves all
-destinations unchanged.
-- Force an atomic-push rejection and prove no destination moves, especially
-`main` and its `dist` tree.
-- Verify successful Step 3 exposes only the approved `dist` checksums after
-MPServer's existing refresh, without invoking an explicit CDN purge.
-- Verify `v3-development` cannot move from its recorded cutover SHA and no
-release or mirror job targets it.
-- Force partial npm publication and verify the stable tag remains the recovery
-authority, only missing packages resume from exact attested artifacts, and
-the tag is never moved or reused.
-- Verify the GitHub Release cannot be created until the full core-plus-kits npm
-audit succeeds.
-- Run complete v2 regression validation.
+- Verify only the two defined lifecycle paths are accepted.
+- Verify the exact candidate remains eligible for up to 30 days and becomes
+ineligible at expiration.
+- Verify approval itself causes no repository or registry mutation.
+- Verify explicit rejection is terminal and records non-sensitive audit
+evidence.
+- Verify a stale rejected deployment cannot publish even if later approved.
+- Verify same-version recreation uses the exact lease command and new identity.
+
+
+
+#### Publication and authorization contracts
+
+- Perform an authorized pre-migration test publication to validate actual npm
+OIDC exchange and provenance; dry runs alone cannot prove this.
+- Verify npm recognizes `staging-step-1.yml` as top-level caller for each
+statically selected track workflow.
+- Verify static conditions are mutually exclusive and relative child calls use
+the caller commit.
+- Verify only publication receives `id-token: write`, no broad
+`secrets: inherit` is used, and Steps 2/3 receive no OIDC permission.
+- Force partial publication and prove only missing exact artifacts resume.
+- Verify stable tag immutability and that GitHub Release waits for full audit.
+
+
+
+#### Promotion and protection contracts
+
+- Verify rejected, failed, or partial publication cannot invoke promotion.
+- Verify skipped or failed Step 2 does not affect `main` or waive Step 3.
+- Verify every Step 3 preflight or atomic-push failure moves no destination.
+- Verify successful Step 3 advances only the approved candidate and downstream
+validation completes promotion.
+- Verify normal and release-fix PRs cannot modify `dist/**`.
+- Verify freeze cleanup occurs only after full completion and preserves
+permanent protections.
+- Verify `v3-development` cannot move and no workflow targets it.
 
 
 
 ### Phase D: controlled cutover
 
-- Land branch protections and freeze enforcement.
-- Remove the cross-branch byte-parity guard while leaving the v2 workflow
-implementation unchanged.
-- Generate and merge the first `VERSION`-only release-intent PR.
-- Execute candidate generation, hard playground approval, exact-artifact
-publication, optional release-order rollout, and Step 3.
-- Keep `main` frozen throughout.
-- Audit Git, npm, provenance, GitHub Release, and all destination SHAs before
-declaring success.
-- Make `v3-development` read-only and verify it remains permanently fixed at
-the recorded cutover commit.
+1. Land permanent protections, freeze controls, and replacement workflows.
+2. Remove the cross-track parity guard while retaining unchanged v2 behavior.
+3. Fix `v3-development` at its recorded cutover SHA.
+4. Generate and merge the first `VERSION`-only intent PR.
+5. Execute Step 1 through exact publication and `published`.
+6. Optionally exercise Step 2.
+7. Run required atomic Step 3 and downstream validation.
+8. Confirm `promoted`, remove the temporary freeze, and audit final refs, tag,
+  registry inventory, provenance, and GitHub Release.
 
 
 
-## Acceptance Criteria
+## 7. Acceptance criteria
 
-- Normal v3 PRs and all release fixes merge through `main`.
-- `VERSION` is the only authoritative release intent on `main`.
-- The release-intent workflow reads `VERSION` from the exact protected `main`
-commit, validates stable semver, accepts patch/minor/major and computes the
-target, rejects duplicate active release cycles, and generates a reviewed
-`VERSION`-only PR whose merge does not publish, tag, build, or modify `dist`.
-- Step 1 produces one generated candidate commit from the exact frozen
-`source_sha`.
-- Step 1 invokes the reviewed, full-SHA-pinned
-`ROKT/rokt-workflows/actions/generate-changelog` action against the validated
-previous-stable-tag-to-`source_sha` range and freezes its `CHANGELOG.md` and
-`release-notes` outputs with the candidate artifacts.
-- `v3-staging` equals the tested `candidate_sha`; direct product commits are
-rejected.
-- Playground approval uses the protected environment, required reviewers, and
-an exact candidate/version job name.
-- Explicit rejection with a reason marks the candidate rejected and blocks
-publication.
-- `Recreate candidate` resets staging only with a pinned lease, retains
-`VERSION` when unconsumed, regenerates exact artifacts, and creates a new
-approval deployment.
-- Stale rejected runs fail publication even if later approved because current
-main SHA, staging SHA, candidate status, artifact ID, manifest digest, and
-tarball hashes are independently revalidated.
-- Publication uses the tested tarballs without rebuilding.
-- Tarballs and checksum manifest are GitHub Actions artifacts retained for 30
-days; missing or expired artifacts fail closed.
-- The approval job shows artifact expiration and remaining lifetime, permits
-waiting through the full 30-day ceiling, and makes approval/publication
-ineligible at expiry until explicit rejection and recreation.
-- GitHub artifact attestations verify every candidate artifact before
-publication.
-- Lifecycle state follows the required append-only GitHub Deployment status
-transitions, while manifest/artifact identity remains immutable and separate.
-- Candidate creation, rejection, failed publication, and Step 2 never modify
-the production-served `main/dist`.
-- The stable tag resolves to `candidate_sha`.
-- Core and every kit publish with expected integrity, provenance, and `next`.
-- GitHub Release creation is idempotently recoverable from the existing tag.
-- The stable tag is created before npm, is the immutable authority for partial-
-publication recovery, and is never moved or reused; the GitHub Release is
-created only after the complete npm audit.
-- Steps 2 and 3 consume the exact stable tag; Step 3 is atomic and excludes
-`v3-development`.
-- Step 3 is required production delivery and advances `main` only from its
-expected SHA to the exact approved candidate; any failed preflight or atomic
-push leaves `main/dist` unchanged.
-- After `main` advances, MPServer must observe the commit through its existing
-refresh behavior and serve the exact approved bundle checksum; no explicit
-CDN purge is required.
-- The merge freeze ends only after successful Step 3 plus required production
-MPServer served-bundle validation.
-- Temporary-ruleset cleanup is idempotent, retryable only after that validation,
-and leaves permanent branch protections intact.
-- The future v3 process keeps its authoritative release version in top-level
-`VERSION`; v2 retains its current semantic-release and versioning mechanism.
-- `staging-step-1.yml` remains the npm-registered top-level dispatcher for both
-tracks. It statically selects an independently maintained v2 or v3 reusable
-workflow, where npm publication may execute; byte-for-byte parity is not
-required.
-- Protected npm environment controls, deployment-branch rules, required
-approval, caller validation, and least-privilege OIDC permissions constrain
-delegated publication.
-- Changelog generation uses the pinned organization-owned action.
-- `v3-development` remains fixed at its cutover SHA and is never mirrored or
-advanced.
-- All `v3-development` consumers are inventoried and migrated before cutover.
-- v2 behavior is unchanged.
+The migration is accepted when:
+
+- v2 regression tests pass and its branch, versioning, semantic-release,
+workflow, and npm behavior are unchanged.
+- All normal v3 work targets `main`, and `v3-development` remains fixed and
+non-authoritative.
+- v3 release intent is a reviewed top-level `VERSION`-only change with no
+release side effects.
+- Locked Step 1 rejects conflicting Git, npm, package, artifact, and lifecycle
+state before irreversible mutation.
+- `v3-staging` contains exactly one generated candidate commit over frozen
+`main`, and the playground reviews that exact candidate.
+- Core and every kit are built, tested, packed once, and linked by a verifiable
+inventory to authenticated artifact subjects and workflow provenance.
+- One protected-environment approval resumes the exact publication job;
+approval alone mutates nothing.
+- Explicit rejection prevents publication, and same-version recreation is safe
+only while the version remains unconsumed.
+- Approved artifacts remain usable for at most 30 days; missing or expired
+artifacts cannot publish.
+- Stable tag creation precedes npm and fixes the authority for all recovery.
+- npm receives only exact approved tarballs under `next`, and the GitHub Release
+follows a complete core-and-kits audit.
+- Step 1 ends at `published`; optional Step 2 advances at most one v3
+release-order branch; required Step 3 atomically advances all final
+destinations without publishing npm.
+- Failed or incomplete work leaves `main` at the previous approved
+distribution, except after a successful atomic Step 3 push.
+- Downstream validation confirms the approved served artifact before
+`promoted` is recorded and the freeze ends.
+- Fixed-SHA, lease, branch-protection, lifecycle, and least-privilege contracts
+pass the grouped verification suite.
 
 
 
-## Failure Behavior and Recovery
+## 8. Open implementation details
 
+No migration-blocking architecture decisions remain. Implementation must settle
+these non-sensitive details:
 
+- exact workflow and job names for static v2/v3 dispatch;
+- release-state storage schema and Deployment status metadata;
+- inventory format, signature or attestation mechanism, and verification
+command;
+- generated-path allowlist and package publication order;
+- freeze-ruleset lifecycle and idempotent cleanup implementation;
+- changelog action extension, only if exact range validation requires it;
+- test package/version strategy for real OIDC validation; and
+- canary migration plan that eventually replaces v3 release-order branches.
 
-### Before stable tag and npm publication
-
-- Build/test/pack failure: fix automation or source through `main`; clean and
-rerun candidate generation.
-- Playground rejection: explicitly reject with a reason, mark the candidate
-rejected, then use the authorized release-fix PR, pinned staging reset,
-`Recreate candidate`, and same-version regeneration flow.
-- Stale approval: fail publication unless current main SHA, staging SHA,
-candidate status, environment approval, artifact ID, manifest digest, and
-tarball hashes all match.
-- Missing or expired artifact: fail closed, explicitly reject with the artifact
-reason, then recreate/reapprove the candidate while the version remains
-unconsumed.
-- Hash, ancestry, approval, or lease mismatch: stop without tagging or
-publishing.
-- Rejection or failed publication: do not run Step 3; `main/dist` remains the
-prior approved production distribution.
-- Reject the candidate, fix `main` if needed, and recreate the same unpublished
-`VERSION`; keep `main` frozen throughout.
-
-
-
-### Stable tag exists, npm absent
-
-The version is consumed. Do not delete or move the tag and do not regenerate
-artifacts at that version. Diagnose the publish blocker and retry using the
-same approved tarballs. If publication is permanently abandoned, advance
-`VERSION` with a new release-intent PR and use a forward patch; retain the tag
-as audit evidence.
-
-### Partial or uncertain npm publication
-
-- Stop all newer releases.
-- Wait for registry propagation; timeout is not proof of absence.
-- Compare every published tarball integrity to the committed inventory.
-- Resume only missing packages from the same immutable artifact set.
-- Never republish an existing package unless the registry confirms the
-artifact is byte-identical and the operation is an idempotent recovery.
-- Complete the full core-plus-kits audit before creating the GitHub Release or
-allowing Step 2/3.
-
-
-
-### npm complete, GitHub Release absent
-
-Retry only GitHub Release creation against the existing stable tag. Do not
-rebuild, retag, or republish.
-
-### Step 2 or Step 3 failure
-
-Step 2 may be retried against the same tag and never changes `main`. A failed
-Step 2 therefore leaves production `main/dist` unchanged.
-
-A failed Step 3 preflight must make no push. A rejected atomic Step 3 push must
-leave all four destinations unchanged, including the production-serving
-`main/dist`. Keep `main` frozen, correct the preflight or permission issue, and
-retry against the same approved candidate.
-
-If the atomic push succeeds but MPServer does not observe the expected commit
-or served-bundle checksum through its existing refresh behavior, `main` has
-already advanced. Keep the freeze active and never reset or force-push `main`.
-Retry observation and diagnose the existing refresh path without introducing
-an ad hoc purge. If the promoted bundle is defective, use the forward-patch
-rollback path.
-
-If an unauthorized `main` merge makes the published candidate unable to
-fast-forward, do not force-push, move the tag, or reuse the version. Escalate
-to a reviewed reconciliation procedure that preserves both histories, then
-ship a forward patch if exact atomic promotion is no longer possible.
-
-### Fixed compatibility-ref violation
-
-Any movement of `v3-development` after cutover is an unauthorized branch-policy
-violation. Stop the actor or automation responsible, preserve audit evidence,
-and restore the recorded cutover SHA only through the approved administrative
-recovery procedure. Never treat the branch as release authority.
-
-## Forward Recovery
-
-After the stable tag or any npm publication, the version is consumed: retain
-the tag, never reuse the version, and finish exact-artifact publication only
-when safe. Do not advance `main` until publication is complete and the
-candidate remains approved. If a defect is found before Step 3, leave
-production `main/dist` unchanged and prepare a new forward version and
-candidate instead of promoting the defective commit.
-
-After Step 3 advances `main`, never reset or force `main` back to an older
-distribution. MPServer or production websites may already have fetched the new
-bundle. Rollback is a reviewed forward patch with a new `VERSION`, candidate,
-playground approval, checksums, tag, publication, and atomic Step 3. Verify the
-corrected bundle through MPServer's existing refresh and served-bundle
-validation behavior; do not reset `main` or add an ad hoc purge.
-
-`v3-development` remains fixed at its cutover SHA throughout forward recovery.
-
-## Hotfix Policy
-
-v3 hotfixes follow the same trunk path as normal changes:
-
-1. branch from `main`;
-2. open and merge a reviewed fix PR to `main`;
-3. dispatch the release-intent workflow with `patch` and merge its reviewed
-  `VERSION`-only PR;
-4. generate and approve a new candidate on `v3-staging`; and
-5. run exact-artifact publication, optional Step 2, and required Step 3.
-
-Do not patch `v3-staging` or a release-order branch directly. If a regression
-appears during phased rollout, stop promotion, fix forward through `main`, and
-restart with a new version.
-
-The v2 hotfix policy and release flow are unchanged.
-
-## Decision Summary
-
-No migration-blocking product decisions remain:
-
-- Semantic-release is removed from the target v3 process.
-- A workflow reads `VERSION` from the exact protected `main` commit, validates
-stable semver, accepts patch/minor/major and computes the target, rejects
-duplicate active release cycles, and generates the reviewed `VERSION`-only PR
-that is the sole release intent.
-- Generated manifests, locks, changelog, and `dist` are produced in the
-candidate commit, not the release-intent PR.
-- The MPServer JavaScript service is the confirmed delivery owner that pulls
-`main/dist` for production websites; Step 3 is a required production
-transition, not optional synchronization.
-- Rokt playground approval is a hard pre-publication gate.
-- The stable tag is created before exact-artifact npm publication; the GitHub
-Release is created after npm completeness succeeds.
-- Tested tarballs and their checksum manifest are immutable GitHub Actions
-artifacts retained for 30 days, covered by GitHub artifact attestations, and
-never rebuilt after approval.
-- Approval may remain pending for the full 30-day artifact lifetime, with
-remaining time visible. Expiration makes approval/publication ineligible and
-requires explicit rejection and recreation; `main` may remain frozen for the
-full duration.
-- Lifecycle state uses append-only GitHub Deployment statuses:
-  - `prepared -> awaiting_approval -> rejected`; or
-  - `prepared -> awaiting_approval -> approved -> publishing -> published -> promoted`.
-  Immutable manifest identity remains separate from status history.
-- Playground approval uses a protected GitHub Environment, required reviewers,
-explicit rejection reasons, and GitHub's **Review deployments** UI.
-- The main freeze uses an automation-controlled temporary ruleset with a
-reviewed release-fix bypass and reliable post-validation cleanup.
-- Top-level `VERSION` is authoritative only for the future v3 process; v2
-retains its current semantic-release and versioning mechanism.
-- `staging-step-1.yml` remains the npm-registered top-level caller and
-statically dispatches to independently maintained same-repository v2 or v3
-reusable workflows. Publication may execute in the selected child; npm does
-not use that child filename or branch as its authorization boundary.
-- Delegated publication is constrained by the protected npm environment,
-deployment-branch rules, required approval, caller-side validation, and
-least-privilege `id-token: write`; Steps 2/3 receive no OIDC permission.
-- Changelog generation uses the established organization-owned action pinned
-to an immutable version or SHA.
-- `main` remains frozen from candidate cut through successful Step 3 and
-required MPServer served-bundle validation, potentially for the full 30-day
-artifact lifetime while approval is pending.
-- No explicit CDN purge is currently required. Cache busting is deferred future
-work and is not a trunk-migration blocker.
-- `v3-development` remains permanently fixed at its recorded cutover commit,
-with no PR, candidate, release, mirror, or synchronization authority; its
-consumers migrate before cutover.
-- The stable tag is created before npm and becomes immutable recovery authority;
-the GitHub Release follows only after the full npm audit.
-- Release-order promotions remain optional; operational guidance recommends
-A → B → C with observation between stages.
-- Future canary work may replace release-order branches only.
-
-
-
-## Open Implementation Details
-
-No migration-blocking architecture decisions remain. The implementation PR
-must record these concrete configuration values for audit:
-
-- the protected environment name and required reviewer users/teams;
-- the temporary ruleset template, bypass actor IDs, and post-validation cleanup
-owners;
-- the immutable `generate-changelog` action version or commit SHA;
-- the existing npm trusted-publisher inventory for core and every kit,
-including the registered `staging-step-1.yml` caller filename;
-- the static v2/v3 reusable-workflow job names, mutually exclusive conditions,
-same-repository child filenames, caller validations, and permission flow;
-- the protected npm environment name, deployment-branch rules, and required
-approval configuration;
-- the throwaway package and version used for pre-migration OIDC validation;
-- the GitHub Actions artifact names and explicit 30-day retention setting;
-- the GitHub Deployment environment and append-only status metadata;
-- the GitHub artifact-attestation identities and verification command;
-- production bundle URLs and expected checksums used for post-Step 3
-validation; and
-- MPServer JavaScript ownership, existing refresh behavior, and the success
-check proving it serves the approved bundle.
-
+Concrete reviewer identities, actor IDs, environment names and configuration,
+production URLs or checksums, and recovery ownership are intentionally excluded
+from public implementation PRs. They belong in an access-controlled operational
+inventory; public records should state only the invariant and link to that
+inventory.


### PR DESCRIPTION
## Summary
- define `main` as the sole v3 development trunk while preserving the v2 release track
- document the VERSION-driven candidate, approval, exact-artifact publication, and atomic promotion lifecycle
- specify failure recovery, safety invariants, migration phases, and acceptance criteria

## Test plan
- [x] Run `git diff --check`
- [x] Verify the Markdown structure and code fences
- [x] Confirm only the design document is included