### PR TITLE
fix(release): wait for core npm visibility before publishing kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,10 @@ workflows in order:
    bootstrap permits all kit tags to be absent so the first synchronized release
    can establish them. After building the target version, Step 1 also packs and
    registry-preflights all kit artifacts before publishing core. It then checks
-   out the immutable release tag and publishes all packages in
-   `kits/publish-matrix.json` sequentially. After all publishes finish, one
-   final audit waits up to five minutes for npm propagation and verifies that
+   out the immutable release tag, waits up to five minutes for core to become
+   visible on npm, and publishes all packages in `kits/publish-matrix.json`
+   sequentially. After all publishes finish, one final audit waits up to five
+   minutes for npm propagation and verifies that
    the core SDK and every kit have the expected version, artifact integrity,
    and npm dist-tag. A rerun skips an existing kit only when its artifact is
    identical. `dryRun=true` previews the merge and semantic-release result

--- a/scripts/publish-kits.js
+++ b/scripts/publish-kits.js
@@ -279,6 +279,17 @@ function verifyRemotePackage(packageInfo, version, distTag) {
     }
 }
 
+function defaultWait(delayMs) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+}
+
+function isIntegrityMismatchError(error) {
+    return (
+        typeof error.message === 'string' &&
+        error.message.includes('integrity mismatch')
+    );
+}
+
 function verifyPublishedCore(packageInfo, version, distTag, options = {}) {
     const viewPackage = options.npmView || npmView;
     const verifyPackage = options.verifyRemotePackage || verifyRemotePackage;
@@ -305,17 +316,47 @@ function verifyPublishedCore(packageInfo, version, distTag, options = {}) {
     verifyPackage(packageInfo, version, distTag);
 }
 
+function waitForPublishedCore(packageInfo, version, distTag, options = {}) {
+    const verifyCore = options.verifyPublishedCore || verifyPublishedCore;
+    const wait = options.wait || defaultWait;
+    const maxAttempts = options.maxAttempts || remoteAuditAttempts;
+    const delayMs = options.delayMs || remoteAuditDelayMs;
+    let lastError = null;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            verifyCore(packageInfo, version, distTag, options);
+            return;
+        } catch (error) {
+            lastError = error;
+            if (isIntegrityMismatchError(error) || attempt === maxAttempts) {
+                break;
+            }
+            console.log(
+                `Core ${
+                    packageInfo.name
+                }@${version} is not yet confirmed on npm; retrying in ${delayMs /
+                    1000}s (attempt ${attempt}/${maxAttempts})`
+            );
+            wait(delayMs);
+        }
+    }
+
+    if (
+        lastError &&
+        !isIntegrityMismatchError(lastError) &&
+        lastError.code !== 'CORE_NOT_PUBLISHED'
+    ) {
+        throw new Error(
+            `Core ${packageInfo.name}@${version} did not become visible on npm within five minutes: ${lastError.message}`
+        );
+    }
+    throw lastError;
+}
+
 function waitForRemotePackages(packageInfos, version, distTag, options = {}) {
     const verifyPackage = options.verifyRemotePackage || verifyRemotePackage;
-    const wait =
-        options.wait ||
-        (delayMs =>
-            Atomics.wait(
-                new Int32Array(new SharedArrayBuffer(4)),
-                0,
-                0,
-                delayMs
-            ));
+    const wait = options.wait || defaultWait;
     const maxAttempts = options.maxAttempts || remoteAuditAttempts;
     const delayMs = options.delayMs || remoteAuditDelayMs;
     let pendingPackages = packageInfos.map(packageInfo => ({
@@ -590,7 +631,7 @@ function main() {
             );
         }
 
-        verifyPublishedCore(packageArtifacts[0], version, distTag, {
+        waitForPublishedCore(packageArtifacts[0], version, distTag, {
             isRecovery: process.env.KIT_RELEASE_RECOVERY === 'true',
         });
         results.push({ name: packageArtifacts[0].name, result: 'verified' });
@@ -680,5 +721,6 @@ module.exports = {
     verifyCurrentReleaseComplete,
     verifyPublishedCore,
     verifyRemotePackage,
+    waitForPublishedCore,
     waitForRemotePackages,
 };

--- a/scripts/publish-kits.js
+++ b/scripts/publish-kits.js
@@ -265,6 +265,9 @@ function packKitArtifacts(inventory, version, destination) {
 function verifyRemotePackage(packageInfo, version, distTag) {
     const spec = `${packageInfo.name}@${version}`;
     const remoteIntegrity = npmView(spec, 'dist.integrity');
+    if (!remoteIntegrity) {
+        throw new Error(`${spec} is not yet visible on npm`);
+    }
     if (remoteIntegrity !== packageInfo.integrity) {
         throw new Error(
             `${spec} integrity mismatch: expected ${packageInfo.integrity}, received ${remoteIntegrity}`
@@ -284,10 +287,20 @@ function defaultWait(delayMs) {
 }
 
 function isIntegrityMismatchError(error) {
-    return (
-        typeof error.message === 'string' &&
-        error.message.includes('integrity mismatch')
-    );
+    if (
+        !error ||
+        typeof error.message !== 'string' ||
+        !error.message.includes('integrity mismatch')
+    ) {
+        return false;
+    }
+
+    const received = /received (\S+)$/.exec(error.message);
+    if (!received) {
+        return true;
+    }
+
+    return received[1] !== 'null' && received[1] !== 'undefined';
 }
 
 function verifyPublishedCore(packageInfo, version, distTag, options = {}) {

--- a/test/jest/release-scripts.spec.ts
+++ b/test/jest/release-scripts.spec.ts
@@ -18,6 +18,7 @@ const {
     validatePackageManifest,
     verifyCurrentReleaseComplete,
     verifyPublishedCore,
+    waitForPublishedCore,
     waitForRemotePackages,
 } = require('../../scripts/publish-kits');
 const {
@@ -201,6 +202,35 @@ describe('kit release scripts', () => {
         }
     });
 
+    it('retries missing core during recovery before reporting CORE_NOT_PUBLISHED', () => {
+        const wait = jest.fn();
+        const npmView = jest.fn(() => null);
+
+        try {
+            waitForPublishedCore(
+                {
+                    name: '@mparticle/web-sdk',
+                    integrity: 'sha512-local',
+                },
+                '3.0.1',
+                'next',
+                {
+                    isRecovery: true,
+                    npmView,
+                    wait,
+                    maxAttempts: 3,
+                    delayMs: 1,
+                }
+            );
+            throw new Error('Expected missing core recovery to fail');
+        } catch (error) {
+            const recoveryError = error as Error & {code?: string};
+            expect(recoveryError.code).toBe('CORE_NOT_PUBLISHED');
+            expect(npmView).toHaveBeenCalledTimes(3);
+            expect(wait).toHaveBeenCalledTimes(2);
+        }
+    });
+
     it('publishes nothing when any kit preflight conflicts', () => {
         const artifacts = Array.from({length: 33}, (_, index) => ({
             name: `kit-${index + 1}`,
@@ -254,6 +284,54 @@ describe('kit release scripts', () => {
                 result: 'published',
             }))
         );
+    });
+
+    it('waits for core npm visibility before treating the package as missing', () => {
+        const coreArtifact = {
+            name: '@mparticle/web-sdk',
+            integrity: 'sha512-local',
+        };
+        let attempts = 0;
+        const verifyPublishedCoreFn = jest.fn(() => {
+            if (++attempts < 3) {
+                throw new Error(
+                    'Core @mparticle/web-sdk@3.0.1 is not yet visible on npm'
+                );
+            }
+        });
+        const wait = jest.fn();
+
+        waitForPublishedCore(coreArtifact, '3.0.1', 'next', {
+            verifyPublishedCore: verifyPublishedCoreFn,
+            wait,
+            maxAttempts: 3,
+            delayMs: 1,
+        });
+
+        expect(verifyPublishedCoreFn).toHaveBeenCalledTimes(3);
+        expect(wait).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails immediately when published core integrity does not match', () => {
+        const wait = jest.fn();
+
+        expect(() =>
+            waitForPublishedCore(
+                {
+                    name: '@mparticle/web-sdk',
+                    integrity: 'sha512-local',
+                },
+                '3.0.1',
+                'next',
+                {
+                    npmView: () => 'sha512-remote',
+                    wait,
+                    maxAttempts: 3,
+                    delayMs: 1,
+                }
+            )
+        ).toThrow('integrity mismatch');
+        expect(wait).not.toHaveBeenCalled();
     });
 
     it('retries one final audit only for packages not yet visible', () => {

--- a/test/jest/release-scripts.spec.ts
+++ b/test/jest/release-scripts.spec.ts
@@ -334,6 +334,37 @@ describe('kit release scripts', () => {
         expect(wait).not.toHaveBeenCalled();
     });
 
+    it('retries when a nested core lookup returns no integrity yet', () => {
+        const wait = jest.fn();
+        let nestedAttempts = 0;
+        const verifyRemotePackage = jest.fn(() => {
+            if (++nestedAttempts < 3) {
+                throw new Error(
+                    '@mparticle/web-sdk@3.0.1 integrity mismatch: expected sha512-local, received null'
+                );
+            }
+        });
+
+        waitForPublishedCore(
+            {
+                name: '@mparticle/web-sdk',
+                integrity: 'sha512-local',
+            },
+            '3.0.1',
+            'next',
+            {
+                npmView: () => 'sha512-local',
+                verifyRemotePackage,
+                wait,
+                maxAttempts: 3,
+                delayMs: 1,
+            }
+        );
+
+        expect(verifyRemotePackage).toHaveBeenCalledTimes(3);
+        expect(wait).toHaveBeenCalledTimes(2);
+    });
+
     it('retries one final audit only for packages not yet visible', () => {
         const artifacts = [
             {name: 'available-kit'},


### PR DESCRIPTION
## Background

- Staging Step 1 can publish core, then fail kit publish on the first `npm view` miss while the registry is still catching up. That is what happened on [run 34530918523](https://github.com/mParticle/mparticle-web-sdk/actions/runs/34530918523/job/103054484467) for `@mparticle/web-sdk@3.2.0`.
- [#1397](https://github.com/mParticle/mparticle-web-sdk/pull/1397) already waits up to five minutes for the post-publish kit audit. That retry does not cover the pre-kit core visibility gate.

## What Has Changed

- Retry core npm visibility for up to five minutes (60 attempts, 5s apart) before publishing kits.
- Fail immediately on integrity mismatches so a wrong artifact does not sit in the retry loop.
- Keep recovery's `CORE_NOT_PUBLISHED` path, but only after the same wait.
- Document the pre-kit wait in the Step 1 release notes.

## Screenshots/Video

- N/A

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally

## Test plan

- [ ] `npm run test:jest -- --runTestsByPath test/jest/release-scripts.spec.ts`
- [ ] Confirm a later v3 Step 1 kit job logs retry attempts if core is not visible immediately, instead of failing in ~40s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package release reliability by waiting for the core package to become visible on npm before publishing related packages.
  * Added retry handling for temporary publication delays and immediate detection of integrity mismatches to prevent unsafe releases.
  * Improved recovery when package metadata or integrity information is temporarily unavailable.

* **Documentation**
  * Updated release workflow documentation to describe the npm visibility check and waiting period before package publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->