### PR TITLE
ci: report core and Rokt kit coverage to Codecov

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -149,6 +149,86 @@ jobs:
                   name: npm-logs-kit-${{ matrix.kit.name }}
                   path: ~/.npm/_logs
 
+    # Coverage is uploaded separately so instrumentation can't affect the
+    # assertions in the test jobs above. Needs a CODECOV_TOKEN secret.
+    coverage-core:
+        name: Core Coverage
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
+
+            - name: NPM install
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22.x
+
+            - name: Run NPM CI
+              run: npm ci
+
+            - name: Run Jest Tests with Coverage
+              run: npm run test:jest:coverage
+
+            - name: Upload Core Coverage to Codecov
+              uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  files: ./coverage/lcov.info
+                  flags: core
+
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v6
+              if: failure()
+              with:
+                  name: npm-logs-coverage-core
+                  path: ~/.npm/_logs
+
+    coverage-rokt-kit:
+        name: Rokt Kit Coverage
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
+
+            - name: NPM install
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22.x
+
+            - name: Run NPM CI
+              working-directory: kits/rokt
+              run: npm ci
+
+            - name: Run Vitest with Coverage
+              working-directory: kits/rokt
+              run: npm run test:coverage
+
+            # Vitest emits kit-relative paths; Codecov needs repo-relative.
+            - name: Re-root coverage paths onto the repository root
+              run: sed -i 's|^SF:|SF:kits/rokt/|' kits/rokt/coverage/lcov.info
+
+            - name: Upload Rokt Kit Coverage to Codecov
+              uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  files: ./kits/rokt/coverage/lcov.info
+                  flags: rokt-kit
+
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v6
+              if: failure()
+              with:
+                  name: npm-logs-coverage-rokt-kit
+                  path: ~/.npm/_logs
+
     # Test Stub can be run independent of other tests
     test-stub:
         name: 'Test Stub'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,7 @@ npm run test                # Full suite (Karma + Jest)
 npm run test:debug          # Interactive Chrome debug mode
 npm run test:jest           # Jest unit tests only (TypeScript)
 npm run test:jest:watch     # Jest watch mode
+npm run test:jest:coverage  # Jest unit tests with a coverage report
 npm run test:browserstack   # BrowserStack cross-browser tests
 npm run test:integrations   # All integrations (CJS, ESM, RequireJS)
 ```
@@ -412,6 +413,28 @@ npm run test:integrations   # All integrations (CJS, ESM, RequireJS)
   - Mock global.fetch with `jest.fn().mockResolvedValue()`
   - Create mock mpInstance objects as needed
   - Jest matchers: `toBe()`, `toEqual()`, `toBeDefined()`, `toHaveBeenCalled()`
+
+**Code Coverage (Codecov):**
+
+| Flag | Suite | Measures | Local command |
+| --- | --- | --- | --- |
+| `core` | Jest | `src/` | `npm run test:jest:coverage` |
+| `rokt-kit` | Vitest | `kits/rokt/src/` | `cd kits/rokt && npm run test:coverage` |
+
+Both run as their own job on every pull request. `codecov.yml` allows project
+and patch coverage to drop by at most 1% against the base branch; if a change
+exceeds that, add tests rather than moving the threshold.
+
+Things that surprise people:
+
+- `core` counts all of `src/` but only Jest is instrumented. The Karma suites
+  run against a built bundle and are not measured, so `core` understates real
+  coverage. Read it as a trend.
+- Uploads need a `CODECOV_TOKEN` secret and an activated repo on codecov.io.
+  Without them the upload step logs an error and passes, so coverage goes
+  missing rather than breaking CI. Fork PRs never upload — they get no secrets.
+- The kit job re-roots its lcov paths before upload. Codecov's `fixes:` key is
+  repo-global, so using it would rewrite the `core` upload's paths too.
 
 ### Storage Strategy
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+flags:
+  core:
+    paths:
+      - src/
+  rokt-kit:
+    paths:
+      - kits/rokt/src/
+
+comment:
+  layout: "condensed_header, diff, flags, files"
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,7 +16,3 @@ flags:
   rokt-kit:
     paths:
       - kits/rokt/src/
-
-comment:
-  layout: "condensed_header, diff, flags, files"
-  require_changes: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,4 +20,7 @@ module.exports = {
             },
         },
     },
+    // Cover all of src/, not only the files a test imported.
+    collectCoverageFrom: ['src/**/*.{ts,js}', '!src/**/*.d.ts'],
+    coverageReporters: ['text-summary', 'lcov'],
 };

--- a/kits/rokt/vite.config.ts
+++ b/kits/rokt/vite.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         coverage: {
             provider: 'v8',
             include: ['src/**/*.ts'],
+            reporter: ['text', 'lcov'],
         },
     },
 });

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "test:karma:webpack:module": "cross-env BUNDLER=webpack karma start test/integrations/module/karma.webpack.config.js",
         "test:karma:rollup:module": "cross-env BUNDLER=rollup karma start test/integrations/module/karma.rollup.config.js",
         "test:jest": "jest --config jest.config.js",
+        "test:jest:coverage": "jest --config jest.config.js --coverage",
         "test:jest:watch": "jest --config jest.config.js --watch",
         "watch": "cross-env ENVIRONMENT=dev BUILD=iife rollup --config rollup.config.js -w",
         "watch:all": "cross-env ENVIRONMENT=prod BUILDALL=true rollup --config rollup.config.js -w",


### PR DESCRIPTION
## Background
- The Web SDK reports no coverage anywhere, so nothing shows whether a change adds or removes test coverage. Codecov is already in use across our other SDK repos.

## What Has Changed
- Adds `codecov.yml` and two PR jobs: `Core Coverage` (Jest over `src/`) and `Rokt Kit Coverage` (Vitest over `kits/rokt/src/`), each uploading under its own flag.
- Thresholds match our other repos: project and patch coverage may each drop by at most 1% against the base branch.
- Adds `npm run test:jest:coverage`; the Rokt kit's existing `test:coverage` now also emits lcov. `AGENTS.md` documents both.

## Screenshots/Video
- None — this changes CI configuration only and has no user-facing surface. The two new jobs appear as `Core Coverage` and `Rokt Kit Coverage` in this PR's own checks.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works. — n/a, CI configuration only.
- [x] I have tested this locally.

## Additional Notes
- `CODECOV_TOKEN` is already configured. Codecov activates the repo on its first successful upload, so these jobs running here is what switches coverage on. Fork PRs never upload, as they receive no secrets.
- `core` reads ~33% because it counts all of `src/` while only Jest is instrumented — the Karma suites run against a built bundle and aren't measured. Read it as a trend, not an absolute. `rokt-kit` is ~94%.
- Vitest reports kit-relative paths, so that job re-roots them before upload; Codecov's declarative `fixes:` is repo-global and would corrupt the core upload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing**
  * Added automated coverage reporting for the core and Rokt Kit test suites.
  * Coverage results are uploaded to Codecov with separate areas and pull-request targets.
  * Added LCOV and text coverage reports for improved visibility.
  * Coverage checks now run automatically in pull-request workflows.

* **Documentation**
  * Documented local coverage commands, reporting behavior, coverage thresholds, and generated report locations.
  * Added guidance for interpreting coverage results in pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->