### PR TITLE
ci: drop semantic branch name check from PR workflows

### DIFF
--- a/.github/workflows/reusable-workflows.yml
+++ b/.github/workflows/reusable-workflows.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
 
 jobs:
-  pr-branch-check-name:
-    name: Check PR for semantic branch name
-    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-check-name.yml@stable
   pr-title-check:
     name: Check PR for semantic title
     uses: mParticle/mparticle-workflows/.github/workflows/pr-title-check.yml@stable


### PR DESCRIPTION
## Background
- Every PR runs `Reusable Workflows / Check PR for semantic branch name`, which calls `pr-branch-check-name.yml@stable` from `mParticle/mparticle-workflows`. Semantic PR *titles* are already checked separately, and the branch-name job is not a required status check in any repo ruleset — so it can fail a PR without gating the merge.

## What Has Changed
- Removed the `pr-branch-check-name` job from `.github/workflows/reusable-workflows.yml`. `pr-title-check`, `pr-branch-target` and `security-lint-checks` are unchanged.

## Screenshots/Video
- N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- Validated the remaining workflow parses as YAML; there is no local way to run the check itself.
- `pull_request` workflows run from the merge ref, so the check only disappears for PRs whose head branch carries this change. `main`, `master` and `development` still define the job — a follow-up is needed if it should go everywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks by removing a pull request branch-check job.
  * Pull request title validation, target branch validation, and security lint checks remain in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->