### PR TITLE
ci: remove PR target branch check

### DIFF
--- a/.github/workflows/reusable-workflows.yml
+++ b/.github/workflows/reusable-workflows.yml
@@ -10,23 +10,6 @@ jobs:
   pr-title-check:
     name: Check PR for semantic title
     uses: mParticle/mparticle-workflows/.github/workflows/pr-title-check.yml@stable
-  pr-branch-target:
-    name: Check PR for semantic target branch / Confirm that target branch for PR is main or build/
-    runs-on: ubuntu-latest
-    steps:
-      - name: Confirm supported PR target branch
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          case "$BASE_REF" in
-            master|development|main|v3-development|chore/dependabot*|build/*)
-              echo "Pull request target branch '$BASE_REF' is valid."
-              ;;
-            *)
-              echo "Pull request target branch '$BASE_REF' is not valid."
-              exit 1
-              ;;
-          esac
   security-lint-checks:
     name: Security Lint Checks
     uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@stable


### PR DESCRIPTION
## Background
- `reusable-workflows.yml` ran a `pr-branch-target` job that validated a PR's base branch against a hardcoded allowlist of branch names. That allowlist has already drifted once from the branches this repo actually uses, and it duplicates a guardrail that branch rulesets express better.
- The job was never a required status check, so it only ever produced an advisory red X.

## What Has Changed
- Removed the `pr-branch-target` job from `.github/workflows/reusable-workflows.yml`.
- `pr-branch-check-name`, `pr-title-check` and `security-lint-checks` are unchanged.

## Screenshots/Video
- n/a — CI configuration change, no user-visible surface.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation. — n/a
- [ ] I have added tests that prove my fix is effective or that my feature works. — n/a, CI config removal
- [x] I have tested this locally. — YAML parses; the three remaining jobs are byte-identical

## Additional Notes
- After this merges, `v3-development` has no base-branch validation, required or advisory. Worth a ruleset rule if we want that signal back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed validation that restricted pull requests to an approved list of target branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->